### PR TITLE
refactor: unify provider parsing logic in init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Integrate `secrecy` crate for secure secret handling with automatic memory zeroing
+- Add `reflect()` method to Provider trait for provider introspection
 
 ### Changed
 - Made keyring provider optional via `keyring` feature flag (enabled by default)
+- Unified provider parsing logic in init command to support all provider formats consistently
 
 ## [0.2.0] - 2025-07-17
 

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -52,6 +52,7 @@
 
 use crate::{Result, SecretSpecError};
 use secrecy::SecretString;
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use url::Url;
 
@@ -234,6 +235,32 @@ pub trait Provider: Send + Sync {
     ///
     /// This should match the name registered with the provider macro.
     fn name(&self) -> &'static str;
+
+    /// Discovers and returns all secrets available in this provider.
+    ///
+    /// This method is used to introspect the provider and find all available secrets.
+    /// It's particularly useful for importing secrets from external sources.
+    ///
+    /// # Returns
+    ///
+    /// A HashMap where keys are secret names and values are `Secret` configurations.
+    /// The default implementation returns an empty map, indicating the provider
+    /// doesn't support reflection.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let secrets = provider.reflect()?;
+    /// for (name, secret) in secrets {
+    ///     println!("Found secret: {} = {:?}", name, secret);
+    /// }
+    /// ```
+    fn reflect(&self) -> Result<HashMap<String, crate::config::Secret>> {
+        Err(SecretSpecError::ProviderOperationFailed(format!(
+            "Provider '{}' does not support reflection",
+            self.name()
+        )))
+    }
 }
 
 impl TryFrom<String> for Box<dyn Provider> {

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -405,4 +405,22 @@ mod integration_tests {
             }
         }
     }
+
+    #[test]
+    fn test_default_reflect_returns_error() {
+        // Test that the default reflect implementation returns an error
+        let provider = MockProvider::new();
+        let result = provider.reflect();
+        assert!(
+            result.is_err(),
+            "Default reflect implementation should return an error"
+        );
+
+        let error = result.unwrap_err();
+        let error_msg = error.to_string();
+        assert!(
+            error_msg.contains("does not support reflection"),
+            "Error message should indicate reflection is not supported"
+        );
+    }
 }

--- a/tests/cli-integration.sh
+++ b/tests/cli-integration.sh
@@ -149,7 +149,33 @@ check_success "Set secret in production profile"
 secretspec config show > /dev/null
 check_success "Config show command works"
 
-# Test 11: Default value handling
+# Test 11: Init from provider
+# Create a .env file to import from
+cat > .env.source << EOF
+API_KEY=test-api-key
+DATABASE_URL=postgres://localhost/test
+EOF
+
+# Test init with bare provider name
+rm -f secretspec.toml
+secretspec init --from dotenv:.env.source
+check_success "Init from dotenv provider with path"
+
+# Verify secrets were imported
+grep -q "API_KEY" secretspec.toml && grep -q "DATABASE_URL" secretspec.toml
+check_success "Init imported secrets from .env file"
+
+# Test init with bare provider name (should use default .env)
+echo "DEFAULT_KEY=default-value" > .env
+rm -f secretspec.toml
+secretspec init --from dotenv
+check_success "Init from dotenv provider (bare name)"
+
+# Verify it found the default .env
+grep -q "DEFAULT_KEY" secretspec.toml
+check_success "Init found default .env file"
+
+# Test 12: Default value handling
 cat > secretspec.toml << EOF
 [project]
 name = "test-app"


### PR DESCRIPTION
- Add reflect() method to Provider trait with default error implementation
- Move DotEnvProvider's reflect implementation to Provider trait impl
- Update init --from to use Box<dyn Provider>::try_from() for consistency
- Now supports all provider formats: "dotenv", "dotenv:.env", "dotenv://.env"
- Add integration tests for init --from with various provider formats
- Add unit test for default reflect() error behavior

This ensures consistent provider specification parsing across all CLI commands.

🤖 Generated with [Claude Code](https://claude.ai/code)