### PR TITLE
feat: allow piping multiline secrets

### DIFF
--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -362,9 +362,12 @@ impl Secrets {
         let value = if let Some(v) = value {
             SecretString::new(v.into())
         } else if io::stdin().is_terminal() {
-            print!("Enter value for {} (profile: {}): ", name, profile_display);
-            io::stdout().flush()?;
-            SecretString::new(rpassword::read_password()?.into())
+            // Use rpassword for single-line input (most common case)
+            // For multiline secrets, users should pipe the content
+            let secret = rpassword::prompt_password(format!(
+                "Enter value for {name} (profile: {profile_display}): "
+            ))?;
+            SecretString::new(secret.into())
         } else {
             // Read from stdin when input is piped
             let mut buffer = String::new();


### PR DESCRIPTION
Part of #32.

This is more of an escape hatch. I haven't figured out a good way of getting the interactive case to work with multi-line secrets.