### PR TITLE
feat: add as_path option for secrets to write values to temporary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile-level default configuration: `profiles.<name>.defaults` section for shared settings across secrets in a profile
 - Default providers for profiles: define common providers once and have all secrets use them unless overridden
 - Default values and required settings can now be specified at profile level to reduce repetition
+- `as_path` option for secrets: write secret values to temporary files and return the file path instead of the value. Temporary files are automatically cleaned up when the resolved secrets are dropped in Rust SDK usage. For CLI commands (`get` and `check`), temporary files are persisted and NOT deleted after the command exits. In the Rust SDK, fields with `as_path = true` are generated as `PathBuf` or `Option<PathBuf>` instead of `String`
 
 ### Changed
 - Secret `required` field is now `Option<bool>` to allow profile-level defaults to apply when not explicitly set

--- a/secretspec-derive/src/tests.rs
+++ b/secretspec-derive/src/tests.rs
@@ -202,6 +202,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         valid_secrets.insert(
@@ -211,6 +212,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
 
@@ -247,6 +249,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         invalid_secrets.insert(
@@ -256,6 +259,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
 
@@ -315,6 +319,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         keyword_secrets.insert(
@@ -324,6 +329,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         keyword_secrets.insert(
@@ -333,6 +339,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
 
@@ -391,6 +398,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         duplicate_secrets.insert(
@@ -400,6 +408,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         duplicate_secrets.insert(
@@ -409,6 +418,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
 
@@ -549,6 +559,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
             required: Some(true),
             default: None,
             providers: None,
+            as_path: None,
         };
         assert!(!is_secret_optional(&required_no_default));
 
@@ -558,6 +569,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
             required: Some(true),
             default: Some("default_value".to_string()),
             providers: None,
+            as_path: None,
         };
         assert!(!is_secret_optional(&required_with_default));
 
@@ -567,6 +579,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
             required: Some(false),
             default: None,
             providers: None,
+            as_path: None,
         };
         assert!(is_secret_optional(&not_required));
 
@@ -576,6 +589,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
             required: Some(false),
             default: Some("default_value".to_string()),
             providers: None,
+            as_path: None,
         };
         assert!(is_secret_optional(&not_required_with_default));
     }
@@ -598,6 +612,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         default_secrets.insert(
@@ -607,6 +622,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(false),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         profiles.insert(
@@ -626,6 +642,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: Some("dev-key".to_string()),
                 providers: None,
+                as_path: None,
             },
         );
         dev_secrets.insert(
@@ -635,6 +652,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         // Note: CACHE_URL only exists in development
@@ -645,6 +663,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         profiles.insert(
@@ -683,6 +702,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         let mut strict_dev = HashMap::new();
@@ -693,6 +713,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         strict_profiles.insert(
@@ -743,6 +764,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         default_secrets.insert(
@@ -752,6 +774,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(false),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         default_secrets.insert(
@@ -761,6 +784,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: Some("default_value".to_string()),
                 providers: None,
+                as_path: None,
             },
         );
         profiles.insert(
@@ -780,6 +804,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         dev_secrets.insert(
@@ -789,6 +814,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         profiles.insert(
@@ -836,7 +862,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
         use quote::quote;
 
         // Test required field
-        let required_field = FieldInfo::new("API_KEY".to_string(), quote! { String }, false);
+        let required_field = FieldInfo::new("API_KEY".to_string(), quote! { String }, false, false);
 
         assert_eq!(required_field.name, "API_KEY");
         assert!(!required_field.is_optional);
@@ -848,8 +874,12 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
         assert_eq!(struct_field.to_string(), expected_struct.to_string());
 
         // Test optional field
-        let optional_field =
-            FieldInfo::new("DATABASE_URL".to_string(), quote! { Option<String> }, true);
+        let optional_field = FieldInfo::new(
+            "DATABASE_URL".to_string(),
+            quote! { Option<String> },
+            true,
+            false,
+        );
 
         assert!(optional_field.is_optional);
         assert_eq!(optional_field.field_name().to_string(), "database_url");
@@ -930,6 +960,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         valid_secrets.insert(
@@ -939,6 +970,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
 
@@ -979,6 +1011,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
         invalid_secrets.insert(
@@ -988,6 +1021,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 required: Some(true),
                 default: None,
                 providers: None,
+                as_path: None,
             },
         );
 

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -551,10 +551,15 @@ pub fn main() -> Result<()> {
             if let Some(p) = profile {
                 app.set_profile(p);
             }
-            let _validated = app
+            let mut validated = app
                 .check()
                 .into_diagnostic()
                 .wrap_err("Failed to check secrets")?;
+            // Persist temp files so they outlive the command
+            validated
+                .keep_temp_files()
+                .into_diagnostic()
+                .wrap_err("Failed to persist temporary files")?;
             Ok(())
         }
         // Import secrets from one provider to another

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -368,6 +368,12 @@ pub struct Secret {
     /// Example: providers = ["keyring", "env"] will try keyring first, then env.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub providers: Option<Vec<String>>,
+    /// Whether to write the secret value to a temporary file and return the path.
+    /// If true, the secret will be written to a temporary file and the field
+    /// will contain the path to that file instead of the secret value.
+    /// The temporary file will be cleaned up when the resolved secrets are dropped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub as_path: Option<bool>,
 }
 
 impl Secret {

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -296,6 +296,7 @@ impl Provider for DotEnvProvider {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
         }

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -225,6 +225,7 @@ fn test_validation_result_structure() {
         resolved: Resolved::new(HashMap::new(), "keyring".to_string(), "default".to_string()),
         missing_optional: vec!["optional_secret".to_string()],
         with_defaults: Vec::new(),
+        temp_files: Vec::new(),
     };
     assert_eq!(valid_result.missing_optional.len(), 1);
     assert_eq!(valid_result.with_defaults.len(), 0);
@@ -329,6 +330,7 @@ fn test_resolve_secret_config() {
             required: Some(true),
             default: None,
             providers: None,
+            as_path: None,
         },
     );
     default_secrets.insert(
@@ -338,6 +340,7 @@ fn test_resolve_secret_config() {
             required: Some(false),
             default: Some("sqlite:///default.db".to_string()),
             providers: None,
+            as_path: None,
         },
     );
 
@@ -349,6 +352,7 @@ fn test_resolve_secret_config() {
             required: Some(false),
             default: Some("dev-key".to_string()),
             providers: None,
+            as_path: None,
         },
     );
 
@@ -1320,6 +1324,7 @@ fn test_set_with_undefined_secret() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             profiles.insert(
@@ -1384,6 +1389,7 @@ fn test_set_with_defined_secret() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             profiles.insert(
@@ -1435,6 +1441,7 @@ fn test_set_with_readonly_provider() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             profiles.insert(
@@ -1495,6 +1502,7 @@ fn test_import_between_dotenv_files() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             secrets.insert(
@@ -1504,6 +1512,7 @@ fn test_import_between_dotenv_files() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             secrets.insert(
@@ -1513,6 +1522,7 @@ fn test_import_between_dotenv_files() {
                     required: Some(false),
                     default: Some("default_value".to_string()),
                     providers: None,
+                    as_path: None,
                 },
             );
             secrets.insert(
@@ -1522,6 +1532,7 @@ fn test_import_between_dotenv_files() {
                     required: Some(false),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
 
@@ -1624,6 +1635,7 @@ fn test_import_edge_cases() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             secrets.insert(
@@ -1633,6 +1645,7 @@ fn test_import_edge_cases() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             secrets.insert(
@@ -1642,6 +1655,7 @@ fn test_import_edge_cases() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
 
@@ -1861,6 +1875,7 @@ fn test_import_with_profiles() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             dev_secrets.insert(
@@ -1870,6 +1885,7 @@ fn test_import_with_profiles() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             profiles.insert(
@@ -1889,6 +1905,7 @@ fn test_import_with_profiles() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             prod_secrets.insert(
@@ -1898,6 +1915,7 @@ fn test_import_with_profiles() {
                     required: Some(true),
                     default: None,
                     providers: None,
+                    as_path: None,
                 },
             );
             profiles.insert(
@@ -2021,6 +2039,7 @@ fn test_run_with_missing_required_secrets() {
             required: Some(true),
             default: None,
             providers: None,
+            as_path: None,
         },
     );
 
@@ -2078,6 +2097,7 @@ fn test_get_existing_secret() {
             required: Some(true),
             default: None,
             providers: None,
+            as_path: None,
         },
     );
 
@@ -2129,6 +2149,7 @@ fn test_get_secret_with_default() {
             required: Some(false),
             default: Some("default_value".to_string()),
             providers: None,
+            as_path: None,
         },
     );
 
@@ -2179,6 +2200,7 @@ fn test_get_nonexistent_secret() {
             required: Some(true),
             default: None,
             providers: None,
+            as_path: None,
         },
     );
 
@@ -2330,6 +2352,7 @@ fn test_per_secret_provider_configuration() {
             required: Some(true),
             default: None,
             providers: Some(vec!["shared".to_string()]),
+            as_path: None,
         },
     );
 
@@ -2341,6 +2364,7 @@ fn test_per_secret_provider_configuration() {
             required: Some(true),
             default: None,
             providers: None,
+            as_path: None,
         },
     );
 
@@ -2517,6 +2541,7 @@ fn test_per_secret_provider_with_fallback_chain() {
             required: Some(true),
             default: None,
             providers: Some(vec!["primary".to_string(), "fallback".to_string()]),
+            as_path: None,
         },
     );
 
@@ -2528,6 +2553,7 @@ fn test_per_secret_provider_with_fallback_chain() {
             required: Some(true),
             default: None,
             providers: Some(vec!["fallback".to_string(), "primary".to_string()]),
+            as_path: None,
         },
     );
 
@@ -2610,6 +2636,7 @@ fn test_get_secret_with_fallback_chain() {
             required: Some(true),
             default: None,
             providers: Some(vec!["primary".to_string(), "fallback".to_string()]),
+            as_path: None,
         },
     );
 
@@ -2621,6 +2648,7 @@ fn test_get_secret_with_fallback_chain() {
             required: Some(true),
             default: None,
             providers: Some(vec!["primary".to_string(), "fallback".to_string()]),
+            as_path: None,
         },
     );
 
@@ -2703,6 +2731,7 @@ fn test_validate_with_per_secret_providers() {
             required: Some(true),
             default: None,
             providers: Some(vec!["env_provider".to_string()]),
+            as_path: None,
         },
     );
 
@@ -2714,6 +2743,7 @@ fn test_validate_with_per_secret_providers() {
             required: Some(true),
             default: None,
             providers: Some(vec!["keyring_provider".to_string()]),
+            as_path: None,
         },
     );
 
@@ -2725,6 +2755,7 @@ fn test_validate_with_per_secret_providers() {
             required: Some(false),
             default: Some("default-config".to_string()),
             providers: None,
+            as_path: None,
         },
     );
 
@@ -2817,6 +2848,7 @@ fn test_secret_config_merges_providers_from_default() {
             required: Some(true),
             default: None,
             providers: Some(vec!["shared".to_string()]),
+            as_path: None,
         },
     );
 
@@ -2830,6 +2862,7 @@ fn test_secret_config_merges_providers_from_default() {
             required: Some(true),
             default: None,
             providers: None,
+            as_path: None,
         },
     );
 
@@ -2841,6 +2874,7 @@ fn test_secret_config_merges_providers_from_default() {
             required: Some(true),
             default: None,
             providers: Some(vec!["prod".to_string()]),
+            as_path: None,
         },
     );
 
@@ -3050,4 +3084,157 @@ provider = "keyring"
         .collect();
     assert_eq!(aliases.len(), 1);
     assert_eq!(aliases[0].0, "shared");
+}
+
+#[test]
+fn test_as_path_secrets() {
+    use secrecy::ExposeSecret;
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let secret_value = "my-secret-certificate-content";
+
+    // Create a dotenv file with a secret
+    let env_file = temp_dir.path().join(".env");
+    fs::write(&env_file, format!("CERT_DATA={}", secret_value)).unwrap();
+    fs::write(
+        &env_file,
+        format!("CERT_DATA={}\nREGULAR_SECRET=not-a-path", secret_value),
+    )
+    .unwrap();
+
+    // Create config with as_path secret
+    let config_file = temp_dir.path().join("secretspec.toml");
+    let toml_content = r#"[project]
+name = "test-as-path"
+revision = "1.0"
+
+[profiles.default]
+CERT_DATA = { description = "Certificate data", as_path = true }
+REGULAR_SECRET = { description = "Regular secret", as_path = false }
+"#;
+    fs::write(&config_file, toml_content).unwrap();
+
+    // Load and validate
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", env_file.display())),
+            profile: None,
+            providers: None,
+        },
+    };
+
+    let spec = Secrets::new(config, Some(global_config), None, None);
+    let validated = spec.validate().unwrap().unwrap();
+
+    // Check that CERT_DATA contains a path
+    let cert_path_str = validated
+        .resolved
+        .secrets
+        .get("CERT_DATA")
+        .unwrap()
+        .expose_secret();
+    let cert_path = std::path::PathBuf::from(cert_path_str);
+
+    // Verify the temp file exists and contains the secret
+    assert!(cert_path.exists(), "Temporary file should exist");
+    let file_content = fs::read_to_string(&cert_path).unwrap();
+    assert_eq!(
+        file_content, secret_value,
+        "Temporary file should contain the secret value"
+    );
+
+    // Check that REGULAR_SECRET contains the actual value (not a path)
+    let regular_secret = validated
+        .resolved
+        .secrets
+        .get("REGULAR_SECRET")
+        .unwrap()
+        .expose_secret();
+    assert_eq!(regular_secret, "not-a-path");
+
+    // Check that temp_files vector is not empty
+    assert!(
+        !validated.temp_files.is_empty(),
+        "temp_files should contain the temporary file"
+    );
+
+    // Drop validated to trigger cleanup
+    drop(validated);
+
+    // Verify the temp file is cleaned up
+    assert!(
+        !cert_path.exists(),
+        "Temporary file should be cleaned up after drop"
+    );
+}
+
+#[test]
+fn test_as_path_secrets_keep_temp_files() {
+    use secrecy::ExposeSecret;
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let secret_value = "certificate-data-to-keep";
+
+    // Create a dotenv file with a secret
+    let env_file = temp_dir.path().join(".env");
+    fs::write(&env_file, format!("CERT_DATA={}", secret_value)).unwrap();
+
+    // Create config with as_path secret
+    let config_file = temp_dir.path().join("secretspec.toml");
+    let toml_content = r#"[project]
+name = "test-keep-files"
+revision = "1.0"
+
+[profiles.default]
+CERT_DATA = { description = "Certificate data", as_path = true }
+"#;
+    fs::write(&config_file, toml_content).unwrap();
+
+    // Load and validate
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", env_file.display())),
+            profile: None,
+            providers: None,
+        },
+    };
+
+    let spec = Secrets::new(config, Some(global_config), None, None);
+    let mut validated = spec.validate().unwrap().unwrap();
+
+    // Get the cert path before keeping files
+    let cert_path_str = validated
+        .resolved
+        .secrets
+        .get("CERT_DATA")
+        .unwrap()
+        .expose_secret();
+    let cert_path = std::path::PathBuf::from(cert_path_str);
+
+    // Verify the temp file exists
+    assert!(cert_path.exists(), "Temporary file should exist");
+
+    // Keep the temp files (persist them)
+    let kept_paths = validated.keep_temp_files().unwrap();
+    assert_eq!(kept_paths.len(), 1, "Should have kept one temp file");
+
+    // Drop validated
+    drop(validated);
+
+    // Verify the temp file still exists after drop (because we kept it)
+    assert!(
+        cert_path.exists(),
+        "Temporary file should still exist after keep_temp_files()"
+    );
+
+    // Verify the content
+    let file_content = fs::read_to_string(&cert_path).unwrap();
+    assert_eq!(file_content, secret_value);
+
+    // Clean up manually
+    fs::remove_file(&cert_path).unwrap();
 }


### PR DESCRIPTION
This adds support for `as_path=true` on secret definitions, which causes the secret value to be written to a temporary file instead of being returned directly. The field then contains the path to the temporary file.

```toml
[project]
name = "my-app"
revision = "1.0"

[profiles.default]
DATABASE_URL = { description = "PostgreSQL connection string", required = true, as_path = true }
```

```
$ secretspec get DATABASE_URL
/tmp/....
```

Key features:
- Secrets with as_path=true write their values to secure temporary files
- In Rust SDK: fields are generated as PathBuf or Option<PathBuf>
- In Rust SDK: temp files are automatically cleaned up on drop
- In CLI (get/check): temp files are persisted and remain after exit
- Added ValidatedSecrets::keep_temp_files() for manual control

This is useful for secrets that need to be passed as file paths to external tools (certificates, key files, service account credentials, etc).

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)