### PR TITLE
OnePassword provider: Improvements for better compatibility on WSL2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- OnePassword provider: Support for `SECRETSPEC_OPCLI_PATH` environment variable to specify custom path to the OnePassword CLI
+- OnePassword provider: Automatic detection of Windows Subsystem for Linux 2 (WSL2) and use of `op.exe` on that platform
+
+### Changed
+- OnePassword provider: Use stdin instead of temporary files when creating items for WSL2 compatibility (WSL paths are invalid when passed to Windows executables)
+
 ## [0.4.0] - 2025-11-24
 
 ### Added

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -181,6 +181,28 @@ impl TryFrom<Url> for OnePasswordConfig {
 
 impl OnePasswordConfig {}
 
+/// Detects if running on Windows Subsystem for Linux 2.
+///
+/// Checks if the system is running on WSL2 by reading `/proc/sys/kernel/osrelease`
+/// and looking for the `-microsoft-standard-WSL2` suffix.
+///
+/// # Returns
+///
+/// * `true` - Running on WSL2
+/// * `false` - Not running on WSL2 or unable to determine
+#[cfg(target_os = "linux")]
+fn is_wsl2() -> bool {
+    std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .ok()
+        .map(|content| content.trim().ends_with("-microsoft-standard-WSL2"))
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_wsl2() -> bool {
+    false
+}
+
 /// Provider implementation for OnePassword password manager.
 ///
 /// This provider integrates with OnePassword CLI (`op`) to store and retrieve
@@ -236,8 +258,13 @@ impl OnePasswordProvider {
     ///
     /// * `config` - The configuration for the provider
     pub fn new(config: OnePasswordConfig) -> Self {
-        let op_command =
-            std::env::var("SECRETSPEC_OPCLI_PATH").unwrap_or_else(|_| "op".to_string());
+        let op_command = std::env::var("SECRETSPEC_OPCLI_PATH").unwrap_or_else(|_| {
+            if is_wsl2() {
+                "op.exe".to_string()
+            } else {
+                "op".to_string()
+            }
+        });
         Self { config, op_command }
     }
 
@@ -252,6 +279,7 @@ impl OnePasswordProvider {
     /// # Arguments
     ///
     /// * `args` - The command arguments to pass to `op`
+    /// * `stdin_data` - Optional data to write to stdin
     ///
     /// # Returns
     ///
@@ -263,7 +291,11 @@ impl OnePasswordProvider {
     /// - Missing OnePassword CLI installation
     /// - Authentication required
     /// - Command execution failures
-    fn execute_op_command(&self, args: &[&str]) -> Result<String> {
+    /// - Stdin write failures
+    fn execute_op_command(&self, args: &[&str], stdin_data: Option<&str>) -> Result<String> {
+        use std::io::Write;
+        use std::process::Stdio;
+
         let mut cmd = Command::new(&self.op_command);
 
         // Set service account token if provided
@@ -278,14 +310,43 @@ impl OnePasswordProvider {
 
         cmd.args(args);
 
-        let output = match cmd.output() {
-            Ok(output) => output,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Err(SecretSpecError::ProviderOperationFailed(
-                    "OnePassword CLI (op) is not installed.\n\nTo install it:\n  - macOS: brew install 1password-cli\n  - Linux: Download from https://1password.com/downloads/command-line/\n  - Windows: Download from https://1password.com/downloads/command-line/\n  - NixOS: nix-env -iA nixpkgs.onepassword\n\nAfter installation, run 'eval $(op signin)' to authenticate.".to_string(),
-                ));
+        // Configure stdio based on whether we have stdin data
+        if stdin_data.is_some() {
+            cmd.stdin(Stdio::piped());
+            cmd.stdout(Stdio::piped());
+            cmd.stderr(Stdio::piped());
+        }
+
+        let output = if let Some(data) = stdin_data {
+            // Spawn process and write to stdin
+            let mut child = match cmd.spawn() {
+                Ok(child) => child,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(SecretSpecError::ProviderOperationFailed(
+                        "OnePassword CLI (op) is not installed.\n\nTo install it:\n  - macOS: brew install 1password-cli\n  - Linux: Download from https://1password.com/downloads/command-line/\n  - Windows: Download from https://1password.com/downloads/command-line/\n  - NixOS: nix-env -iA nixpkgs.onepassword\n\nAfter installation, run 'eval $(op signin)' to authenticate.".to_string(),
+                    ));
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            // Write to stdin
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(data.as_bytes())?;
+                drop(stdin); // Close stdin
             }
-            Err(e) => return Err(e.into()),
+
+            child.wait_with_output()?
+        } else {
+            // No stdin data, use output() directly
+            match cmd.output() {
+                Ok(output) => output,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(SecretSpecError::ProviderOperationFailed(
+                        "OnePassword CLI (op) is not installed.\n\nTo install it:\n  - macOS: brew install 1password-cli\n  - Linux: Download from https://1password.com/downloads/command-line/\n  - Windows: Download from https://1password.com/downloads/command-line/\n  - NixOS: nix-env -iA nixpkgs.onepassword\n\nAfter installation, run 'eval $(op signin)' to authenticate.".to_string(),
+                    ));
+                }
+                Err(e) => return Err(e.into()),
+            }
         };
 
         if !output.status.success() {
@@ -316,7 +377,7 @@ impl OnePasswordProvider {
     /// * `Ok(false)` - User is not authenticated
     /// * `Err(_)` - Command execution failed
     fn whoami(&self) -> Result<bool> {
-        match self.execute_op_command(&["whoami"]) {
+        match self.execute_op_command(&["whoami"], None) {
             Ok(_) => Ok(true),
             Err(SecretSpecError::ProviderOperationFailed(msg))
                 if msg.contains("not currently signed in") || msg.contains("no account found") =>
@@ -497,7 +558,7 @@ impl Provider for OnePasswordProvider {
             "item", "get", &item_name, "--vault", &vault, "--format", "json",
         ];
 
-        match self.execute_op_command(&args) {
+        match self.execute_op_command(&args, None) {
             Ok(output) => {
                 let item: OnePasswordItem = serde_json::from_str(&output)?;
 
@@ -577,32 +638,15 @@ impl Provider for OnePasswordProvider {
                 &field_assignment,
             ];
 
-            self.execute_op_command(&args)?;
+            self.execute_op_command(&args, None)?;
         } else {
             // Item doesn't exist, create it
             let template = self.create_item_template(project, key, value, profile);
             let template_json = serde_json::to_string(&template)?;
 
-            // Write template to temp file
-            use std::io::Write;
-            let mut temp_file = tempfile::NamedTempFile::new()?;
-            temp_file.write_all(template_json.as_bytes())?;
-            temp_file.flush()?;
+            let args = vec!["item", "create", "--vault", &vault, "-"];
 
-            let args = vec![
-                "item",
-                "create",
-                "--vault",
-                &vault,
-                "--template",
-                temp_file.path().to_str().ok_or_else(|| {
-                    SecretSpecError::ProviderOperationFailed(
-                        "Invalid UTF-8 in temporary file path".to_string(),
-                    )
-                })?,
-            ];
-
-            self.execute_op_command(&args)?;
+            self.execute_op_command(&args, Some(&template_json))?;
         }
 
         Ok(())


### PR DESCRIPTION
I use WSL2 (Windows Subsystem for Linux v2) quite a bit, as I need to use Windows at my workplace but much prefer a Linux environment. I also use 1Password, which I have installed on my Windows machine. Unfortunately, installing `op` in my WSL2 VM is a subpar experience, because I can't take advantage of integration with the 1Password desktop app to keep me signed in because the desktop app is sitting over on the Windows side.

Fortunately, there's a straightforward solution, similar to [how 1Password suggests integrating the SSH agent with WSL2](https://developer.1password.com/docs/ssh/integrations/wsl/): WSL2 provides a mechanism to execute native Windows binaries located on your host machine **from within** the Linux VM[^1]. Using this, you can actually execute the **Windows** 1Password CLI from **inside** WSL2. That gives Linux apps access to the "Windows-side" 1Password.

There are two catches that make this incompatible with secretspec's 1Password provider, and that's what I'm fixing here:

1. This native Windows binary integration doesn't change the name of the executable, so you have to launch `op.exe` instead of `op`. If `op.exe` is on your Windows PATH, it will automatically be present on your WSL Linux VM's PATH, but it'll still have the `.exe` extension
2. When the Windows binary is running, it's running on the Windows side, so it can't trivially read files from the WSL side (there are ways, but it's best if you can avoid it entirely).

So, there are three fixes in this PR:

1. Detect WSL2 in the OnePasswordProvider using a fairly standard approach of checking the `os-release` value. Of course, this code is only needed if the target OS is Linux.
2. Support overriding the `op` command entirely via the `SECRETSPEC_OPCLI_PATH` (**very** open to naming suggestions here). Just in case you either don't want this default behavior on WSL2, or you have the `op` CLI somewhere else for some reason.
3. When setting a secret, instead of writing it to a temp file and then passing the path, write the template on to stdin. That trivially passes through to the Windows side without requiring rewriting paths.

Let me know your thoughts! I didn't see any automated tests for the 1Password provider, but I verified this locally on my WSL2 machine and it worked like a charm. I've tried to keep the impact on standard Linux users minimal, if any impact at all. They'd incur a quick file read to check the `os-release` value, and any failures result in just assuming the OS is most likely a native Linux environment.

[^1]: Technically what it's doing is launching the binary over on the Windows side and wiring up the stdin/stdout into the linux side.