### PR TITLE
feat: add pass (password-store) provider

### DIFF
--- a/docs/src/content/docs/providers/pass.md
+++ b/docs/src/content/docs/providers/pass.md
@@ -1,0 +1,59 @@
+---
+title: Pass Provider
+description: Unix password manager integration with GPG encryption
+---
+
+The Pass provider stores secrets using the Unix password manager `pass` (password-store). Secrets are GPG-encrypted for secure local development.
+
+## Installation
+
+```bash
+# Debian/Ubuntu
+$ sudo apt-get install pass
+
+# Fedora
+$ sudo dnf install pass
+
+# Arch
+$ sudo pacman -S pass
+
+# macOS
+$ brew install pass
+```
+
+## Configuration
+
+```toml
+# secretspec.toml
+[project]
+name = "myapp"
+
+[[providers]]
+type = "pass"
+uri = "pass://"
+```
+
+## Usage
+
+```bash
+# Initialize password store (first time only)
+$ pass init <gpg-key-id>
+
+# Set a secret
+$ secretspec set DATABASE_URL
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+
+# Run with secrets
+$ secretspec run -- npm start
+```
+
+## Storage Format
+
+Secrets are stored with a hierarchical path structure:
+`secretspec/{project}/{profile}/{key}`
+
+For example, with project "myapp" and profile "default":
+```bash
+$ pass show secretspec/myapp/default/DATABASE_URL
+postgresql://localhost/mydb
+```

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -62,6 +62,7 @@ pub mod env;
 pub mod keyring;
 pub mod lastpass;
 pub mod onepassword;
+pub mod pass;
 #[macro_use]
 pub mod macros;
 

--- a/secretspec/src/provider/pass.rs
+++ b/secretspec/src/provider/pass.rs
@@ -1,0 +1,218 @@
+use super::Provider;
+use crate::{Result, SecretSpecError};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+use url::Url;
+
+/// Configuration for the pass (password-store) provider.
+///
+/// This struct holds configuration options for the pass provider.
+/// Pass stores secrets as GPG-encrypted files using the Unix password
+/// manager in a hierarchical structure: `secretspec/{project}/{profile}/{key}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PassConfig {}
+
+impl TryFrom<&Url> for PassConfig {
+    type Error = SecretSpecError;
+
+    /// Creates a PassConfig from a URL.
+    ///
+    /// The URL must have the scheme "pass" (e.g., "pass://").
+    /// Currently, no additional parameters are supported in the URL.
+    fn try_from(url: &Url) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "pass" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for pass provider",
+                url.scheme()
+            )));
+        }
+
+        Ok(Self::default())
+    }
+}
+
+impl TryFrom<Url> for PassConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: Url) -> std::result::Result<Self, Self::Error> {
+        (&url).try_into()
+    }
+}
+
+impl PassConfig {}
+
+/// Provider for managing secrets with pass (password-store).
+///
+/// The PassProvider uses the Unix password manager `pass`, which stores
+/// secrets as GPG-encrypted files in a hierarchical structure.
+///
+/// # Storage Format
+///
+/// Secrets are stored with a hierarchical path structure:
+/// `secretspec/{project}/{profile}/{key}`
+///
+/// This ensures secrets are properly namespaced by project and profile,
+/// preventing conflicts between different projects or environments.
+///
+/// # Requirements
+///
+/// - The `pass` command must be available in PATH
+/// - GPG must be configured with appropriate keys
+/// - The password store must be initialized (`pass init`)
+pub struct PassProvider {
+    #[allow(dead_code)]
+    config: PassConfig,
+}
+
+crate::register_provider! {
+    struct: PassProvider,
+    config: PassConfig,
+    name: "pass",
+    description: "Unix password manager with GPG encryption",
+    schemes: ["pass"],
+    examples: ["pass://"],
+}
+
+impl PassProvider {
+    /// Creates a new PassProvider with the given configuration.
+    pub fn new(config: PassConfig) -> Self {
+        Self { config }
+    }
+
+    /// Formats the entry name for a secret.
+    ///
+    /// Creates a hierarchical path: `secretspec/{project}/{profile}/{key}`
+    fn format_entry_name(&self, project: &str, profile: &str, key: &str) -> String {
+        format!("secretspec/{}/{}/{}", project, profile, key)
+    }
+}
+
+impl Provider for PassProvider {
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        "pass".to_string()
+    }
+
+    /// Retrieves a secret from the password store.
+    ///
+    /// # Arguments
+    ///
+    /// * `project` - The project name
+    /// * `key` - The secret key to retrieve
+    /// * `profile` - The profile name
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(SecretString))` - The secret value if found
+    /// * `Ok(None)` - If the secret doesn't exist in the password store
+    /// * `Err` - If there was an error executing `pass` or reading the output
+    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
+        let entry_name = self.format_entry_name(project, profile, key);
+
+        let output = Command::new("pass")
+            .arg("show")
+            .arg(&entry_name)
+            .output()
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to execute 'pass' command: {}. Is pass installed?",
+                    e
+                ))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // Entry doesn't exist
+            if output.status.code() == Some(1) && stderr.contains("is not in the password store") {
+                return Ok(None);
+            }
+
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "pass command failed: {}",
+                stderr
+            )));
+        }
+
+        let content = String::from_utf8(output.stdout)
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to parse pass output as UTF-8: {}",
+                    e
+                ))
+            })?
+            .trim()
+            .to_string();
+
+        Ok(Some(SecretString::new(content.into())))
+    }
+
+    /// Sets a secret value in the password store.
+    ///
+    /// # Arguments
+    ///
+    /// * `project` - The project name
+    /// * `key` - The secret key to set
+    /// * `value` - The value to store
+    /// * `profile` - The profile name
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the value was successfully written
+    /// * `Err(SecretSpecError)` - If writing the pass entry fails
+    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
+        let entry_name = self.format_entry_name(project, profile, key);
+
+        let mut child = Command::new("pass")
+            .args(["insert", "-m", "-f", &entry_name])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to execute pass command: {}",
+                    e
+                ))
+            })?;
+
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(
+                "Failed to obtain stdin for pass command".to_string(),
+            )
+        })?;
+
+        use std::io::Write;
+        stdin
+            .write_all(value.expose_secret().as_bytes())
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to write to pass stdin: {}",
+                    e
+                ))
+            })?;
+
+        // Drop stdin to close the pipe so pass process receives EOF
+        drop(stdin);
+
+        let output = child.wait_with_output().map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to wait for pass command: {}",
+                e
+            ))
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "pass command failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -82,6 +82,9 @@ fn test_create_from_string_with_plain_names() {
 
     let provider = Box::<dyn Provider>::try_from("lastpass").unwrap();
     assert_eq!(provider.name(), "lastpass");
+
+    let provider = Box::<dyn Provider>::try_from("pass").unwrap();
+    assert_eq!(provider.name(), "pass");
 }
 
 #[test]
@@ -165,6 +168,10 @@ fn test_documentation_examples() {
     // Test dotenv examples from provider list
     let provider = Box::<dyn Provider>::try_from("dotenv://path").unwrap();
     assert_eq!(provider.name(), "dotenv");
+
+    // Test pass examples
+    let provider = Box::<dyn Provider>::try_from("pass://").unwrap();
+    assert_eq!(provider.name(), "pass");
 }
 
 #[test]
@@ -239,6 +246,11 @@ mod integration_tests {
                 let provider = Box::<dyn Provider>::try_from(provider_spec.as_str())
                     .expect("Should create dotenv provider with path");
                 (provider, Some(temp_dir))
+            }
+            "pass" => {
+                let provider =
+                    Box::<dyn Provider>::try_from("pass").expect("Should create pass provider");
+                (provider, None)
             }
             _ => {
                 let provider = Box::<dyn Provider>::try_from(provider_name)
@@ -425,6 +437,27 @@ mod integration_tests {
         assert!(
             error_msg.contains("does not support reflection"),
             "Error message should indicate reflection is not supported"
+        );
+    }
+
+    #[test]
+    fn test_pass_provider_creation() {
+        // Test pass provider can be created from various URI formats
+        let provider = Box::<dyn Provider>::try_from("pass").unwrap();
+        assert_eq!(provider.name(), "pass");
+        assert_eq!(provider.uri(), "pass");
+
+        let provider = Box::<dyn Provider>::try_from("pass://").unwrap();
+        assert_eq!(provider.name(), "pass");
+        assert_eq!(provider.uri(), "pass");
+    }
+
+    #[test]
+    fn test_pass_provider_allows_set() {
+        let provider = Box::<dyn Provider>::try_from("pass").unwrap();
+        assert!(
+            provider.allows_set(),
+            "Pass provider should support write operations"
         );
     }
 }

--- a/tests/fixtures/configs/test-pass.toml
+++ b/tests/fixtures/configs/test-pass.toml
@@ -1,0 +1,8 @@
+[project]
+name = "test-pass"
+revision = "1.0"
+
+[profiles.default]
+DATABASE_URL = { description = "Database connection string", required = true }
+API_KEY = { description = "API key for external service", required = true }
+SECRET_TOKEN = { description = "Secret authentication token", required = false }


### PR DESCRIPTION
Add support for the Unix password manager `pass` (password-store) as requested in #12.

## Features

- **Read/write support**: Full provider implementation (not read-only)
- **Hierarchical storage**: One GPG-encrypted file per secret at `secretspec/{project}/{profile}/{key}`
- **Consistent with other providers**: Follows the same pattern as keyring, OnePassword, and LastPass
- **Migration support**: Enables `secretspec import dotenv://.env` to migrate from plaintext to encrypted storage
- **Project/profile namespacing**: Properly uses project and profile parameters for organization

## Implementation

- Storage path: `~/.password-store/secretspec/{project}/{profile}/{key}.gpg`
- Uses `pass show secretspec/{project}/{profile}/{key}` for reading
- Uses `pass insert -e -f secretspec/{project}/{profile}/{key}` for writing
- Empty PassConfig (no configuration needed, like KeyringConfig)
- Includes comprehensive tests following existing patterns
- Documentation matches standard provider format

## Usage Example

```bash
# Initialize pass (first time)
$ pass init <gpg-key-id>

# Import secrets from .env (uses "default" profile)
$ secretspec import dotenv://.env --provider pass --project myapp

# Secrets stored at:
# ~/.password-store/secretspec/myapp/default/DATABASE_URL.gpg
# ~/.password-store/secretspec/myapp/default/API_KEY.gpg

# Run with encrypted secrets
$ secretspec run --provider pass --project myapp -- npm start
```

## Storage Structure

```
~/.password-store/
└── secretspec/
    └── {project}/
        └── {profile}/
            ├── SECRET_1.gpg
            ├── SECRET_2.gpg
            └── SECRET_3.gpg
```

Fixes #12