### PR TITLE
perf(onepassword): cache auth and batch fetch secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- OnePassword provider: Significant performance improvement by caching authentication status
+  and using batch fetching with parallel threads. Reduces CLI calls from 2N sequential to
+  ~2 sequential + N parallel for N secrets.
+
 ## [0.6.2] - 2026-01-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "keyring",
  "linkme",
  "miette",
+ "once_cell",
  "rpassword",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ trybuild = "1.0"
 insta = "1.34"
 linkme = "0.3"
 secrecy = { version = "0.10.3", features = ["serde"] }
+once_cell = "1.21"
 google-cloud-secretmanager-v1 = "1.2"
 tokio = { version = "1", features = ["rt"] }
 secretspec-derive = { version = "0.6.2", path = "./secretspec-derive" }

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -34,6 +34,7 @@ url.workspace = true
 whoami = { workspace = true, optional = true }
 linkme.workspace = true
 secrecy.workspace = true
+once_cell.workspace = true
 google-cloud-secretmanager-v1 = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 


### PR DESCRIPTION
- Cache whoami result using OnceCell to avoid repeated auth checks
- Add get_batch() method to Provider trait for batch fetching
- Implement parallel batch fetching for OnePassword provider
- Update validate() to group secrets by provider and use batch ops

This reduces CLI calls from 2N sequential to ~2 + N parallel for N secrets.