### PR TITLE
feat: add HashiCorp Vault / OpenBao provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- HashiCorp Vault / OpenBao (`vault`) provider for Vault KV v1/v2 secret storage, with support
+  for namespaces, TLS configuration, and OpenBao compatibility (requires `--features vault`)
 - AWS Secrets Manager (`awssm`) provider for AWS secret storage integration (requires `--features awssm`)
 - Support running secretspec from subdirectories: the CLI now walks up the directory tree to find the nearest `secretspec.toml`, similar to `cargo` and `git`. Also adds a `-f`/`--file` flag (and `SECRETSPEC_FILE` env var) to explicitly specify the config file path (#59)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,7 @@ dependencies = [
  "miette",
  "once_cell",
  "rand",
+ "reqwest",
  "secrecy",
  "serde",
  "serde-envfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ once_cell = "1.21"
 google-cloud-secretmanager-v1 = "1.2"
 aws-config = "1"
 aws-sdk-secretsmanager = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 secretspec-derive = { version = "0.7.2", path = "./secretspec-derive" }
 secretspec = { version = "0.7.2", path = "./secretspec" }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -84,6 +84,10 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
               label: "AWS Secrets Manager",
               slug: "providers/awssm",
             },
+            {
+              label: "Vault / OpenBao",
+              slug: "providers/vault",
+            },
           ],
         },
         {

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -17,6 +17,7 @@ Providers are pluggable storage backends that handle the storage and retrieval o
 | **lastpass** | Integration with LastPass password manager | ✓ | ✓ | ✓ |
 | **gcsm** | Google Cloud Secret Manager (requires `--features gcsm`) | ✓ | ✓ | ✓ |
 | **awssm** | AWS Secrets Manager (requires `--features awssm`) | ✓ | ✓ | ✓ |
+| **vault** | HashiCorp Vault / OpenBao (requires `--features vault`) | ✓ | ✓ | ✓ |
 
 ## Provider Selection
 

--- a/docs/src/content/docs/providers/vault.md
+++ b/docs/src/content/docs/providers/vault.md
@@ -1,0 +1,121 @@
+---
+title: Vault / OpenBao Provider
+description: HashiCorp Vault and OpenBao integration
+---
+
+The Vault provider integrates with HashiCorp Vault and OpenBao for centralized secret management using the KV (Key-Value) secrets engine. Since OpenBao is an API-compatible fork of Vault, a single provider works for both.
+
+## Prerequisites
+
+- A running Vault or OpenBao server
+- A valid authentication token (`VAULT_TOKEN` env var or `~/.vault-token` file)
+- KV secrets engine enabled (v1 or v2)
+- Build with `--features vault`
+
+## Configuration
+
+### URI Format
+
+```
+vault://[namespace@]host[:port][/mount][?kv=1&tls=false]
+openbao://[namespace@]host[:port][/mount][?kv=1&tls=false]
+```
+
+- `host[:port]`: Vault server address (falls back to `VAULT_ADDR` env var)
+- `mount`: KV engine mount path (default: `secret`)
+- `namespace@`: Optional Vault namespace (also reads `VAULT_NAMESPACE` env var)
+- `?kv=1`: Use KV v1 engine (default: v2)
+- `?tls=false`: Disable TLS (for development servers)
+
+### Examples
+
+```bash
+# Set a secret using Vault KV v2
+$ secretspec set DATABASE_URL --provider vault://vault.example.com:8200/secret
+
+# Get a secret
+$ secretspec get DATABASE_URL --provider vault://vault.example.com:8200/secret
+
+# Check secrets
+$ secretspec check --provider vault://vault.example.com:8200/secret
+
+# Run with secrets
+$ secretspec run --provider vault://vault.example.com:8200/secret -- npm start
+```
+
+## Usage
+
+### Basic Commands
+
+```bash
+# With default "secret" mount
+$ secretspec set DATABASE_URL --provider vault://vault.example.com:8200
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to vault (profile: default)
+
+# With custom mount
+$ secretspec set API_KEY --provider vault://vault.example.com:8200/custom-kv
+
+# Using OpenBao
+$ secretspec check --provider openbao://bao.internal:8200/secret
+```
+
+### KV Version 1
+
+```bash
+# Use KV v1 engine
+$ secretspec set DATABASE_URL --provider "vault://vault.example.com:8200/secret?kv=1"
+```
+
+### Vault Namespaces
+
+```bash
+# Using namespace in URI
+$ secretspec check --provider vault://team-a@vault.example.com:8200/secret
+
+# Or via environment variable
+$ export VAULT_NAMESPACE=team-a
+$ secretspec check --provider vault://vault.example.com:8200/secret
+```
+
+### Secret Naming
+
+Secrets are stored at the KV path: `secretspec/{project}/{profile}/{key}`
+
+Each secret is stored as a KV entry with a `value` field.
+
+Example for KV v2: `GET /v1/secret/data/secretspec/myapp/production/DATABASE_URL`
+
+### Development Mode
+
+For local development with Vault in dev mode:
+
+```bash
+# Start Vault in dev mode
+$ vault server -dev
+
+# Use with TLS disabled
+$ export VAULT_TOKEN=hvs.dev-root-token
+$ secretspec check --provider "vault://127.0.0.1:8200/secret?tls=false"
+```
+
+### Authentication
+
+The provider reads the Vault token from:
+
+1. `VAULT_TOKEN` environment variable
+2. `~/.vault-token` file
+
+```bash
+# Set token via environment
+$ export VAULT_TOKEN=hvs.your-token-here
+$ secretspec run --provider vault://vault.example.com:8200 -- npm start
+```
+
+### CI/CD
+
+```bash
+# Set VAULT_TOKEN from your CI secret store
+$ export VAULT_TOKEN=$CI_VAULT_TOKEN
+$ secretspec run --provider vault://vault.example.com:8200/secret -- deploy
+```

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -104,6 +104,23 @@ awssm://                      # SDK default region and credentials
 **Prerequisites**: AWS credentials configured, build with `--features awssm`
 **Storage**: Secret name `secretspec/{project}/{profile}/{key}`
 
+## Vault / OpenBao Provider
+
+**URI**: `vault://[namespace@]host[:port][/mount]` or `openbao://[namespace@]host[:port][/mount]` - Stores secrets in HashiCorp Vault or OpenBao KV engine
+
+```bash
+vault://vault.example.com:8200/secret       # KV v2 at "secret" mount
+vault://vault.example.com:8200              # Default "secret" mount
+vault://ns1@vault.example.com:8200/secret   # With namespace
+openbao://bao.internal:8200/secret          # OpenBao server
+vault://127.0.0.1:8200/secret?kv=1         # KV v1 engine
+vault://127.0.0.1:8200/secret?tls=false    # Disable TLS (dev mode)
+```
+
+**Features**: Read/write, KV v1 and v2, namespaces, OpenBao compatible
+**Prerequisites**: Vault/OpenBao server, `VAULT_TOKEN` env var or `~/.vault-token`, build with `--features vault`
+**Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
+
 ## Provider Selection
 
 ### Command Line
@@ -138,3 +155,4 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | OnePassword | ✅ End-to-end | Cloud (OnePassword) | ✅ Yes |
 | GCSM | ✅ Google-managed | Cloud (GCP) | ✅ Yes |
 | AWSSM | ✅ AWS KMS | Cloud (AWS) | ✅ Yes |
+| Vault/OpenBao | ✅ Vault encryption | Vault/OpenBao server | ✅ Yes |

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -38,6 +38,7 @@ google-cloud-secretmanager-v1 = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-secretsmanager = { workspace = true, optional = true }
 tokio.workspace = true
+reqwest = { workspace = true, optional = true }
 rand.workspace = true
 uuid.workspace = true
 data-encoding.workspace = true
@@ -48,3 +49,4 @@ cli = []
 keyring = ["dep:keyring", "dep:whoami"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
+vault = ["dep:reqwest"]

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -16,7 +16,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
 ## Features
 
 - **[Declarative Configuration](https://secretspec.dev/reference/configuration/)**: Define your secrets in `secretspec.toml` with descriptions and requirements
-- **[Multiple Provider Backends](https://secretspec.dev/concepts/providers/)**: [Keyring](https://secretspec.dev/providers/keyring), [.env](https://secretspec.dev/providers/dotenv), [OnePassword](https://secretspec.dev/providers/onepassword), [LastPass](https://secretspec.dev/providers/lastpass), and [environment variables](https://secretspec.dev/providers/env)
+- **[Multiple Provider Backends](https://secretspec.dev/concepts/providers/)**: [Keyring](https://secretspec.dev/providers/keyring), [.env](https://secretspec.dev/providers/dotenv), [OnePassword](https://secretspec.dev/providers/onepassword), [LastPass](https://secretspec.dev/providers/lastpass), [environment variables](https://secretspec.dev/providers/env), and [Vault/OpenBao](https://secretspec.dev/providers/vault)
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
 - **Secret Generation**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
@@ -124,6 +124,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[LastPass](https://secretspec.dev/providers/lastpass)** - Cloud password manager
 - **[Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)** - GCP secret management
 - **[AWS Secrets Manager](https://secretspec.dev/providers/awssm)** - AWS secret management
+- **[Vault / OpenBao](https://secretspec.dev/providers/vault)** - HashiCorp Vault and OpenBao KV engine
 
 ```bash
 $ secretspec run --provider keyring -- npm start

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -83,6 +83,8 @@ pub mod keyring;
 pub mod lastpass;
 pub mod onepassword;
 pub mod pass;
+#[cfg(feature = "vault")]
+pub mod vault;
 #[macro_use]
 pub mod macros;
 

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -252,6 +252,20 @@ mod integration_tests {
                     Box::<dyn Provider>::try_from("pass").expect("Should create pass provider");
                 (provider, None)
             }
+            #[cfg(feature = "vault")]
+            // "vault" tests KV v2 (default), "vault-kv1" tests KV v1.
+            // Set VAULT_TOKEN and run a dev server (bao server -dev).
+            // For KV v1: bao secrets enable -path=kv1 -version=1 kv
+            "vault" | "vault-kv1" => {
+                let provider_spec = if provider_name == "vault-kv1" {
+                    "vault://127.0.0.1:8200/kv1?tls=false&kv=1"
+                } else {
+                    "vault://127.0.0.1:8200?tls=false"
+                };
+                let provider = Box::<dyn Provider>::try_from(provider_spec)
+                    .expect("Should create vault provider");
+                (provider, None)
+            }
             _ => {
                 let provider = Box::<dyn Provider>::try_from(provider_name)
                     .expect(&format!("{} provider should exist", provider_name));
@@ -524,6 +538,86 @@ mod integration_tests {
         let provider = Box::<dyn Provider>::try_from("awssm://staging@eu-west-1").unwrap();
         assert_eq!(provider.name(), "awssm");
         assert_eq!(provider.uri(), "awssm://staging@eu-west-1");
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn test_vault_provider_creation() {
+        // Test Vault provider with host, port, and mount
+        let provider =
+            Box::<dyn Provider>::try_from("vault://vault.example.com:8200/secret").unwrap();
+        assert_eq!(provider.name(), "vault");
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn test_vault_provider_default_mount() {
+        // Test Vault provider without explicit mount (defaults to "secret")
+        let provider = Box::<dyn Provider>::try_from("vault://vault.example.com:8200").unwrap();
+        assert_eq!(provider.name(), "vault");
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn test_vault_provider_custom_mount() {
+        // Test Vault provider with a custom KV mount
+        let provider =
+            Box::<dyn Provider>::try_from("vault://vault.example.com:8200/custom-kv").unwrap();
+        assert_eq!(provider.name(), "vault");
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn test_vault_provider_kv_v1() {
+        // Test Vault provider with KV v1 via query parameter
+        let provider =
+            Box::<dyn Provider>::try_from("vault://vault.example.com:8200/secret?kv=1").unwrap();
+        assert_eq!(provider.name(), "vault");
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn test_vault_provider_with_namespace() {
+        // Test Vault provider with namespace in username position
+        let provider =
+            Box::<dyn Provider>::try_from("vault://ns1@vault.example.com:8200/secret").unwrap();
+        assert_eq!(provider.name(), "vault");
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn test_vault_provider_tls_false() {
+        // Test Vault provider with TLS disabled (for dev mode)
+        let provider =
+            Box::<dyn Provider>::try_from("vault://127.0.0.1:8200/secret?tls=false").unwrap();
+        assert_eq!(provider.name(), "vault");
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn test_openbao_scheme() {
+        // Test OpenBao URI scheme
+        let provider = Box::<dyn Provider>::try_from("openbao://bao.internal:8200/secret").unwrap();
+        assert_eq!(provider.name(), "vault");
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn test_vault_provider_requires_address() {
+        // Test that Vault provider requires an address when VAULT_ADDR is not set
+        let had_vault_addr = std::env::var("VAULT_ADDR").ok();
+        unsafe {
+            std::env::remove_var("VAULT_ADDR");
+        }
+
+        let result = Box::<dyn Provider>::try_from("vault://");
+        assert!(result.is_err(), "Vault provider should require an address");
+
+        if let Some(addr) = had_vault_addr {
+            unsafe {
+                std::env::set_var("VAULT_ADDR", addr);
+            }
+        }
     }
 
     #[cfg(feature = "gcsm")]

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -1,0 +1,445 @@
+//! HashiCorp Vault / OpenBao provider
+//!
+//! This provider integrates with HashiCorp Vault and OpenBao to store and retrieve
+//! secrets using the KV (Key-Value) secrets engine (v1 and v2).
+//!
+//! # Authentication
+//!
+//! Uses token-based authentication. The token is resolved from:
+//! - `VAULT_TOKEN` environment variable
+//! - Token file at `~/.vault-token`
+//!
+//! # URI Format
+//!
+//! `vault://[namespace@]host[:port][/mount][?kv=1]`
+//! `openbao://[namespace@]host[:port][/mount][?kv=1]`
+//!
+//! - `vault://vault.example.com:8200/secret` — KV v2 at "secret" mount
+//! - `vault://vault.example.com:8200` — default "secret" mount, KV v2
+//! - `vault://ns1@vault.example.com:8200/secret` — with Vault namespace
+//! - `openbao://bao.internal:8200/secret` — OpenBao server
+//! - `vault://127.0.0.1:8200/secret?kv=1` — KV v1 engine
+//! - `vault://vault.example.com:8200/secret?tls=false` — disable TLS (dev mode)
+//!
+//! When no host is provided, falls back to the `VAULT_ADDR` environment variable.
+//!
+//! # Secret Naming
+//!
+//! Secrets are stored at the path: `secretspec/{project}/{profile}/{key}`
+//! Each secret is stored as a KV entry with a `value` field.
+//!
+//! # Example
+//!
+//! ```bash
+//! # Set a secret
+//! secretspec set DATABASE_URL --provider vault://vault.example.com:8200/secret
+//!
+//! # Use with a namespace
+//! secretspec check --provider vault://team-a@vault.example.com:8200/secret
+//! ```
+
+use super::Provider;
+use crate::{Result, SecretSpecError};
+use reqwest::header::{HeaderMap, HeaderValue};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// KV secrets engine version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KvVersion {
+    /// KV version 1 (no versioning).
+    V1,
+    /// KV version 2 (versioned, default).
+    V2,
+}
+
+impl Default for KvVersion {
+    fn default() -> Self {
+        KvVersion::V2
+    }
+}
+
+/// Configuration for the Vault / OpenBao provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultConfig {
+    /// The Vault server endpoint URL (e.g., `https://vault.example.com:8200`).
+    pub endpoint: String,
+    /// The KV secrets engine mount path (default: `secret`).
+    pub mount: String,
+    /// The KV engine version (default: V2).
+    pub kv_version: KvVersion,
+    /// Optional Vault namespace.
+    pub namespace: Option<String>,
+}
+
+impl Default for VaultConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "https://127.0.0.1:8200".to_string(),
+            mount: "secret".to_string(),
+            kv_version: KvVersion::default(),
+            namespace: None,
+        }
+    }
+}
+
+impl TryFrom<&Url> for VaultConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &Url) -> std::result::Result<Self, Self::Error> {
+        let scheme = url.scheme();
+        if scheme != "vault" && scheme != "openbao" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for vault provider. Expected 'vault' or 'openbao'.",
+                scheme
+            )));
+        }
+
+        // Determine TLS setting from query parameter (default: true)
+        let use_tls = url
+            .query_pairs()
+            .find(|(k, _)| k == "tls")
+            .map(|(_, v)| v != "false" && v != "0")
+            .unwrap_or(true);
+
+        let http_scheme = if use_tls { "https" } else { "http" };
+
+        // Resolve endpoint: from URI host or VAULT_ADDR env var
+        let endpoint = match url.host_str().filter(|s| !s.is_empty()) {
+            Some(host) => {
+                if let Some(port) = url.port() {
+                    format!("{}://{}:{}", http_scheme, host, port)
+                } else {
+                    format!("{}://{}", http_scheme, host)
+                }
+            }
+            None => std::env::var("VAULT_ADDR")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    SecretSpecError::ProviderOperationFailed(
+                        "No Vault address provided. Either specify a host in the URI \
+                         (e.g., vault://vault.example.com:8200) or set the VAULT_ADDR \
+                         environment variable."
+                            .to_string(),
+                    )
+                })?,
+        };
+
+        // Mount path from URL path (strip leading slash, default to "secret")
+        let mount = url
+            .path()
+            .trim_start_matches('/')
+            .split('/')
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("secret")
+            .to_string();
+
+        // KV version from query parameter (default: V2)
+        let kv_version = url
+            .query_pairs()
+            .find(|(k, _)| k == "kv")
+            .map(|(_, v)| match v.as_ref() {
+                "1" | "v1" => KvVersion::V1,
+                _ => KvVersion::V2,
+            })
+            .unwrap_or_default();
+
+        // Namespace from URI username or VAULT_NAMESPACE env var
+        let namespace = {
+            let username = url.username();
+            if !username.is_empty() {
+                Some(username.to_string())
+            } else {
+                std::env::var("VAULT_NAMESPACE")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+            }
+        };
+
+        Ok(Self {
+            endpoint,
+            mount,
+            kv_version,
+            namespace,
+        })
+    }
+}
+
+impl TryFrom<Url> for VaultConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: Url) -> std::result::Result<Self, Self::Error> {
+        (&url).try_into()
+    }
+}
+
+/// HashiCorp Vault / OpenBao provider.
+///
+/// Stores and retrieves secrets from a Vault or OpenBao server using the
+/// KV secrets engine (v1 or v2) with token-based authentication.
+pub struct VaultProvider {
+    config: VaultConfig,
+}
+
+crate::register_provider! {
+    struct: VaultProvider,
+    config: VaultConfig,
+    name: "vault",
+    description: "HashiCorp Vault / OpenBao secret management",
+    schemes: ["vault", "openbao"],
+    examples: ["vault://vault.example.com:8200/secret", "openbao://bao.internal:8200/secret"],
+}
+
+impl VaultProvider {
+    /// Creates a new VaultProvider with the given configuration.
+    pub fn new(config: VaultConfig) -> Self {
+        Self { config }
+    }
+
+    /// Formats the secret path within the KV engine.
+    ///
+    /// Uses the pattern: `secretspec/{project}/{profile}/{key}`
+    fn format_secret_path(project: &str, profile: &str, key: &str) -> Result<String> {
+        if project.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "project cannot be empty".to_string(),
+            ));
+        }
+        if profile.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "profile cannot be empty".to_string(),
+            ));
+        }
+        if key.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "key cannot be empty".to_string(),
+            ));
+        }
+
+        Ok(format!("secretspec/{}/{}/{}", project, profile, key))
+    }
+
+    /// Resolves the Vault token from available sources.
+    ///
+    /// Resolution order:
+    /// 1. `VAULT_TOKEN` environment variable
+    /// 2. `~/.vault-token` file
+    fn resolve_token() -> Result<SecretString> {
+        // 1. VAULT_TOKEN environment variable
+        if let Ok(token) = std::env::var("VAULT_TOKEN") {
+            if !token.is_empty() {
+                return Ok(SecretString::new(token.into()));
+            }
+        }
+
+        // 2. ~/.vault-token file
+        let token_path = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(|home| std::path::PathBuf::from(home).join(".vault-token"));
+
+        if let Some(path) = token_path {
+            if let Ok(token) = std::fs::read_to_string(&path) {
+                let token = token.trim();
+                if !token.is_empty() {
+                    return Ok(SecretString::new(token.to_string().into()));
+                }
+            }
+        }
+
+        Err(SecretSpecError::ProviderOperationFailed(
+            "No Vault token found. Set the VAULT_TOKEN environment variable \
+             or create a ~/.vault-token file."
+                .to_string(),
+        ))
+    }
+
+    /// Builds the common HTTP headers for Vault API requests.
+    fn build_headers(token: &SecretString, namespace: &Option<String>) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Vault-Token",
+            HeaderValue::from_str(token.expose_secret()).map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!("Invalid token value: {}", e))
+            })?,
+        );
+        if let Some(ns) = namespace {
+            headers.insert(
+                "X-Vault-Namespace",
+                HeaderValue::from_str(ns).map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Invalid namespace value: {}",
+                        e
+                    ))
+                })?,
+            );
+        }
+        Ok(headers)
+    }
+
+    /// Builds the full Vault API URL for a secret path.
+    fn build_url(&self, secret_path: &str) -> String {
+        match self.config.kv_version {
+            KvVersion::V2 => format!(
+                "{}/v1/{}/data/{}",
+                self.config.endpoint, self.config.mount, secret_path
+            ),
+            KvVersion::V1 => format!(
+                "{}/v1/{}/{}",
+                self.config.endpoint, self.config.mount, secret_path
+            ),
+        }
+    }
+
+    /// Retrieves a secret from Vault asynchronously.
+    async fn get_secret_async(
+        &self,
+        project: &str,
+        key: &str,
+        profile: &str,
+    ) -> Result<Option<SecretString>> {
+        let secret_path = Self::format_secret_path(project, profile, key)?;
+        let url = self.build_url(&secret_path);
+        let token = Self::resolve_token()?;
+        let headers = Self::build_headers(&token, &self.config.namespace)?;
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to connect to Vault at {}: {}",
+                    self.config.endpoint, e
+                ))
+            })?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body: serde_json::Value = response.json().await.map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to parse Vault response: {}",
+                        e
+                    ))
+                })?;
+
+                let value = match self.config.kv_version {
+                    KvVersion::V2 => body
+                        .get("data")
+                        .and_then(|d| d.get("data"))
+                        .and_then(|d| d.get("value"))
+                        .and_then(|v| v.as_str()),
+                    KvVersion::V1 => body
+                        .get("data")
+                        .and_then(|d| d.get("value"))
+                        .and_then(|v| v.as_str()),
+                };
+
+                Ok(value.map(|v| SecretString::new(v.to_string().into())))
+            }
+            404 => Ok(None),
+            403 => Err(SecretSpecError::ProviderOperationFailed(
+                "Vault authentication failed (403 Forbidden). \
+                 Check your VAULT_TOKEN and ensure it has the required permissions."
+                    .to_string(),
+            )),
+            status => {
+                let body = response.text().await.unwrap_or_default();
+                Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Vault returned HTTP {}: {}",
+                    status, body
+                )))
+            }
+        }
+    }
+
+    /// Writes a secret to Vault asynchronously.
+    async fn set_secret_async(
+        &self,
+        project: &str,
+        key: &str,
+        value: &SecretString,
+        profile: &str,
+    ) -> Result<()> {
+        let secret_path = Self::format_secret_path(project, profile, key)?;
+        let url = self.build_url(&secret_path);
+        let token = Self::resolve_token()?;
+        let headers = Self::build_headers(&token, &self.config.namespace)?;
+
+        let body = match self.config.kv_version {
+            KvVersion::V2 => {
+                serde_json::json!({ "data": { "value": value.expose_secret() } })
+            }
+            KvVersion::V1 => {
+                serde_json::json!({ "value": value.expose_secret() })
+            }
+        };
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&url)
+            .headers(headers)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to connect to Vault at {}: {}",
+                    self.config.endpoint, e
+                ))
+            })?;
+
+        match response.status().as_u16() {
+            200 | 204 => Ok(()),
+            403 => Err(SecretSpecError::ProviderOperationFailed(
+                "Vault authentication failed (403 Forbidden). \
+                 Check your VAULT_TOKEN and ensure it has write permissions."
+                    .to_string(),
+            )),
+            status => {
+                let body = response.text().await.unwrap_or_default();
+                Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Vault returned HTTP {} while writing secret: {}",
+                    status, body
+                )))
+            }
+        }
+    }
+}
+
+impl Provider for VaultProvider {
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let mut uri = format!(
+            "vault://{}",
+            self.config
+                .endpoint
+                .trim_start_matches("https://")
+                .trim_start_matches("http://")
+        );
+        if self.config.mount != "secret" {
+            uri.push('/');
+            uri.push_str(&self.config.mount);
+        }
+        uri
+    }
+
+    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
+        super::block_on(self.get_secret_async(project, key, profile))
+    }
+
+    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
+        super::block_on(self.set_secret_async(project, key, value, profile))
+    }
+
+    fn allows_set(&self) -> bool {
+        true
+    }
+}


### PR DESCRIPTION
Add a `vault` provider for HashiCorp Vault and OpenBao using the KV secrets engine (v1 and v2). Feature-gated behind `--features vault` with `reqwest` (rustls) as the HTTP client.

- URI format: `vault://[namespace@]host[:port][/mount][?kv=1&tls=false]` (also `openbao://`)
- Token auth via `VAULT_TOKEN` env var or `~/.vault-token`
- `VAULT_ADDR` fallback when no host in URI, `VAULT_NAMESPACE` for namespaces
- KV v2 by default, v1 via `?kv=1`, HTTPS by default, `?tls=false` for dev servers
- Secrets stored at `secretspec/{project}/{profile}/{key}`

Closes https://github.com/cachix/secretspec/issues/8
