### PR TITLE
chore(derive): disable default features on secretspec dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - BWS (Bitwarden Secrets Manager) provider with async SDK integration, secret caching, and full read-write support (requires `--features bws`)
 
+### Changed
+- `secretspec-derive` now depends on `secretspec` with `default-features = false`, avoiding pulling in CLI and provider features when only the derive macro is used.
+
 ## [0.8.2] - 2026-03-19
 
 ### Changed

--- a/secretspec-derive/Cargo.toml
+++ b/secretspec-derive/Cargo.toml
@@ -15,7 +15,7 @@ quote.workspace = true
 proc-macro2.workspace = true
 toml.workspace = true
 serde.workspace = true
-secretspec = { version = "0.8.2", path = "../secretspec" }
+secretspec = { version = "0.8.2", path = "../secretspec", default-features = false }
 
 [dev-dependencies]
 trybuild.workspace = true


### PR DESCRIPTION
## Summary
- `secretspec-derive` now depends on `secretspec` with `default-features = false`, so consumers using only the derive macro don't pull in CLI and provider features transitively.
- CHANGELOG updated.

## Test plan
- [x] `cargo check -p secretspec-derive`