### PR TITLE
fix: fall back to default profile when requested profile is undefined

### DIFF
--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -228,9 +228,19 @@ impl Secrets {
             .config
             .profiles
             .get(&profile_name)
+            .or_else(|| self.config.profiles.get("default"))
             .cloned()
             .ok_or_else(|| {
-                SecretSpecError::SecretNotFound(format!("Profile '{}' not found", profile_name))
+                SecretSpecError::SecretNotFound(format!(
+                    "Profile '{}' is not defined in secretspec.toml. Available profiles: {}",
+                    profile_name,
+                    self.config
+                        .profiles
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ))
             })?;
 
         // If not the default profile, also add secrets from default profile
@@ -474,12 +484,24 @@ impl Secrets {
                     None => continue, // Try next provider
                 }
             }
-            // Not found in any provider, return None
+            // Fall back to the default profile if the requested profile had no match
+            if profile_name != "default" {
+                for uri in uris {
+                    let provider = Box::<dyn ProviderTrait>::try_from(uri.clone())?;
+                    if let Some(value) = provider.get(project_name, secret_name, "default")? {
+                        return Ok(Some(value));
+                    }
+                }
+            }
             Ok(None)
         } else {
             // No per-secret providers, use default provider
             let backend = self.get_provider(default_provider_arg)?;
-            backend.get(project_name, secret_name, profile_name)
+            let result = backend.get(project_name, secret_name, profile_name)?;
+            if result.is_some() || profile_name == "default" {
+                return Ok(result);
+            }
+            backend.get(project_name, secret_name, "default")
         }
     }
 
@@ -1367,6 +1389,19 @@ impl Secrets {
                 provider.get_batch(&self.config.project.name, &keys, &profile_name)?;
 
             fetched_values.extend(batch_results);
+
+            if profile_name != "default" {
+                let missing: Vec<&str> = keys
+                    .iter()
+                    .filter(|k| !fetched_values.contains_key(**k))
+                    .copied()
+                    .collect();
+                if !missing.is_empty() {
+                    let fallback_results =
+                        provider.get_batch(&self.config.project.name, &missing, "default")?;
+                    fetched_values.extend(fallback_results);
+                }
+            }
         }
 
         // Process results - apply defaults, handle as_path, track missing

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -3819,3 +3819,46 @@ fn test_resolve_secret_config_merges_type_and_generate() {
     // description should come from production
     assert_eq!(resolved.description.as_deref(), Some("Prod DB password"));
 }
+
+#[test]
+fn test_undefined_profile_falls_back_to_default() {
+    let mut default_secrets = HashMap::new();
+    default_secrets.insert(
+        "API_KEY".to_string(),
+        Secret {
+            description: Some("API key".to_string()),
+            required: Some(true),
+            ..Default::default()
+        },
+    );
+
+    let mut profiles = HashMap::new();
+    profiles.insert(
+        "default".to_string(),
+        Profile {
+            defaults: None,
+            secrets: default_secrets,
+        },
+    );
+
+    let config = Config {
+        project: Project {
+            name: "test".to_string(),
+            revision: "1.0".to_string(),
+            extends: None,
+        },
+        profiles,
+    };
+
+    let spec = Secrets::new(config, None, None, None);
+    let result = spec.resolve_profile(Some("prod"));
+    assert!(
+        result.is_ok(),
+        "undefined profile should fall back to default"
+    );
+    let profile = result.unwrap();
+    assert!(
+        profile.secrets.contains_key("API_KEY"),
+        "fallback profile should contain default secrets"
+    );
+}


### PR DESCRIPTION
When a profile is requested that isn't explicitly defined in `secretspec.toml`, `resolve_profile` errors with "Profile 'X' not found" instead of falling back to `[profiles.default]`.

This means projects that only need a single set of secrets across all environments are forced to declare empty profile sections for every profile name that might be used:

```toml
[profiles.default]
API_KEY = { required = true }

# to avoid "not found" errors
[profiles.dev]
[profiles.staging]
[profiles.prod]
```

This PR changes `resolve_profile` to fall back to the `default` profile when the requested profile doesn't exist, matching the intuition that `default` applies universally, not just when no profile is specified.

Provider reads also fall back to the default profile. When a secret is not found at the requested profile's storage path (e.g., `secretspec/myapp/prod/API_KEY`), the provider retries at the default path (`secretspec/myapp/default/API_KEY`). This ensures secrets stored under default are accessible from any profile without duplication.

The error is preserved for the case where neither the requested profile nor `default` exists. The error message is also improved to list all available profiles, making it easier to fix any misconfiguration.