### PR TITLE
fix(onepassword): probe auth via vault list so desktop integration works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- OnePassword provider: `OP_SESSION_*` environment variables (left over from
+  `eval $(op signin)`) are now stripped before spawning `op`. When those
+  tokens expired, `op` refused to fall back to the desktop app's biometric
+  flow and surfaced `account is not signed in`, even though desktop
+  integration was enabled. With the env vars removed, the desktop app
+  handles unlock automatically and no manual re-signin is needed. Auth
+  failure and install hints now point users at desktop integration as the
+  primary local-dev path. Fixes
+  [#80](https://github.com/cachix/secretspec/issues/80).
 - Vault / OpenBao provider: HTTPS requests now trust certificates from the
   operating system trust store (and honor `SSL_CERT_FILE` / `SSL_CERT_DIR`),
   so servers fronted by a private / internal CA work without modification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- OnePassword provider: `OP_SESSION_*` environment variables (left over from
-  `eval $(op signin)`) are now stripped before spawning `op`. When those
-  tokens expired, `op` refused to fall back to the desktop app's biometric
-  flow and surfaced `account is not signed in`, even though desktop
-  integration was enabled. With the env vars removed, the desktop app
-  handles unlock automatically and no manual re-signin is needed. Auth
+- OnePassword provider: the auth preflight now probes `op vault list` instead
+  of `op whoami`. Under the 1Password desktop app's delegated-session
+  integration, `op whoami` reports `account is not signed in` even when
+  `op item get` / `op vault list` work fine — so every secret read or write
+  failed at preflight with a misleading "not signed in" error. `op vault
+  list` exercises the actual access path and succeeds when the desktop app
+  can serve secrets. Additionally, `OP_SESSION_*` environment variables
+  (left over from `eval $(op signin)`) are now stripped before spawning
+  `op` so a stale shell session can't shadow the desktop integration. Auth
   failure and install hints now point users at desktop integration as the
   primary local-dev path. Fixes
   [#80](https://github.com/cachix/secretspec/issues/80).

--- a/docs/src/content/docs/providers/onepassword.md
+++ b/docs/src/content/docs/providers/onepassword.md
@@ -23,10 +23,11 @@ In the 1Password desktop app, open **Settings → Developer** and enable
 (Touch ID / Windows Hello / system password) — no shell session
 needed and nothing expires from under you.
 
-`secretspec` strips any `OP_SESSION_*` environment variables from
-spawned `op` processes, so a stale `eval $(op signin)` session in
-your shell won't shadow the desktop integration and produce
-`account is not signed in` errors.
+Under desktop integration, `op whoami` reports `account is not signed
+in` even when secret access works, so `secretspec` probes auth via
+`op vault list` instead. It also strips any `OP_SESSION_*` environment
+variables from spawned `op` processes, so a stale `eval $(op signin)`
+session in your shell can't shadow the desktop integration.
 
 #### Linux note
 

--- a/docs/src/content/docs/providers/onepassword.md
+++ b/docs/src/content/docs/providers/onepassword.md
@@ -9,7 +9,47 @@ The OnePassword provider integrates with OnePassword for team-based secret manag
 
 - OnePassword CLI (`op`)
 - OnePassword account
-- Signed in via `op signin`
+- Authenticated (see [Authentication](#authentication) below)
+
+## Authentication
+
+`secretspec` supports three ways to authenticate against 1Password.
+
+### Desktop app integration (recommended for local dev)
+
+In the 1Password desktop app, open **Settings → Developer** and enable
+**"Integrate with 1Password CLI"**. Once enabled, `op` calls made by
+`secretspec` are unlocked through the desktop app via biometrics
+(Touch ID / Windows Hello / system password) — no shell session
+needed and nothing expires from under you.
+
+`secretspec` strips any `OP_SESSION_*` environment variables from
+spawned `op` processes, so a stale `eval $(op signin)` session in
+your shell won't shadow the desktop integration and produce
+`account is not signed in` errors.
+
+#### Linux note
+
+On Linux, the desktop integration requires the `op` binary to be in
+the `onepassword-cli` group with the setgid bit set — the desktop
+app verifies the caller's GID over its unlock socket. On NixOS this
+is handled automatically by `programs._1password.enable = true`. A
+plain `pkgs._1password-cli` install (e.g. via `nix-env` or Home
+Manager only) does **not** carry the setgid bit and desktop
+integration will fail; use the NixOS module, or fall back to a
+service account token for headless setups.
+
+### Service account tokens (recommended for CI/CD)
+
+Set `OP_SERVICE_ACCOUNT_TOKEN` in the environment, or use the
+`onepassword+token://` URI scheme. See the [CI/CD section](#cicd-with-service-accounts)
+below.
+
+### Manual signin (legacy)
+
+Run `eval $(op signin)` to set per-shell `OP_SESSION_*` tokens. These
+expire after 30 minutes of inactivity; if they expire mid-session,
+`secretspec` falls back to desktop integration when available.
 
 ## Configuration
 

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -195,6 +195,38 @@ fn is_wsl2() -> bool {
     false
 }
 
+/// Removes any `OP_SESSION_*` env vars from a spawned `op` invocation.
+///
+/// `op` treats `OP_SESSION_<account>` as the authoritative session and will not
+/// fall back to the desktop app's biometric flow when those tokens expire,
+/// returning `"account is not signed in"` instead. Stripping them lets the
+/// desktop integration (Settings → Developer → Integrate with 1Password CLI)
+/// handle unlock automatically. See
+/// <https://github.com/cachix/secretspec/issues/80>.
+const OP_NOT_INSTALLED_HELP: &str = "OnePassword CLI (op) is not installed.\n\n\
+    To install it:\n  \
+    - macOS: brew install 1password-cli\n  \
+    - Linux: Download from https://1password.com/downloads/command-line/\n  \
+    - Windows: Download from https://1password.com/downloads/command-line/\n  \
+    - NixOS: nix-env -iA nixpkgs.onepassword\n\n\
+    Then enable desktop integration in the 1Password app under\n  \
+    Settings → Developer → \"Integrate with 1Password CLI\".";
+
+const AUTH_REQUIRED_HELP: &str = "OnePassword authentication required.\n\n\
+    Recommended: enable desktop integration in the 1Password app under\n  \
+    Settings → Developer → \"Integrate with 1Password CLI\", then unlock the app.\n\n\
+    Alternatives:\n  \
+    - Service account (CI): set OP_SERVICE_ACCOUNT_TOKEN or use the onepassword+token:// scheme\n  \
+    - Manual signin: run 'eval $(op signin)' (session expires after 30 minutes of inactivity)";
+
+fn strip_op_session_env(cmd: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("OP_SESSION_") {
+            cmd.env_remove(&key);
+        }
+    }
+}
+
 /// Provider implementation for OnePassword password manager.
 ///
 /// This provider integrates with OnePassword CLI (`op`) to store and retrieve
@@ -203,10 +235,16 @@ fn is_wsl2() -> bool {
 ///
 /// # Authentication
 ///
-/// The provider supports two authentication methods:
+/// The provider supports three authentication methods, in order of preference:
 ///
-/// 1. **Interactive Authentication**: Users run `eval $(op signin)` before using secretspec
+/// 1. **Desktop app integration** (recommended for local dev): enable
+///    Settings → Developer → "Integrate with 1Password CLI" in the desktop app.
+///    `op` calls are unlocked via biometrics with no shell session needed.
 /// 2. **Service Account Tokens**: For CI/CD, configure a token in the config
+///    or set `OP_SERVICE_ACCOUNT_TOKEN`.
+/// 3. **Manual signin** (legacy): run `eval $(op signin)`. The provider strips
+///    `OP_SESSION_*` env vars before spawning `op` so that expired session
+///    tokens fall back to desktop integration instead of erroring.
 ///
 /// # Storage Structure
 ///
@@ -219,8 +257,7 @@ fn is_wsl2() -> bool {
 /// # Example Usage
 ///
 /// ```ignore
-/// # Interactive auth
-/// eval $(op signin)
+/// # Desktop integration (recommended): enable in 1Password app, then:
 /// secretspec set MY_SECRET --provider onepassword://Development
 ///
 /// # Service account token
@@ -290,6 +327,7 @@ impl OnePasswordProvider {
         use std::process::Stdio;
 
         let mut cmd = Command::new(&self.op_command);
+        strip_op_session_env(&mut cmd);
 
         // Set service account token if provided
         if let Some(token) = &self.config.service_account_token {
@@ -316,7 +354,7 @@ impl OnePasswordProvider {
                 Ok(child) => child,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     return Err(SecretSpecError::ProviderOperationFailed(
-                        "OnePassword CLI (op) is not installed.\n\nTo install it:\n  - macOS: brew install 1password-cli\n  - Linux: Download from https://1password.com/downloads/command-line/\n  - Windows: Download from https://1password.com/downloads/command-line/\n  - NixOS: nix-env -iA nixpkgs.onepassword\n\nAfter installation, run 'eval $(op signin)' to authenticate.".to_string(),
+                        OP_NOT_INSTALLED_HELP.to_string(),
                     ));
                 }
                 Err(e) => return Err(e.into()),
@@ -335,7 +373,7 @@ impl OnePasswordProvider {
                 Ok(output) => output,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     return Err(SecretSpecError::ProviderOperationFailed(
-                        "OnePassword CLI (op) is not installed.\n\nTo install it:\n  - macOS: brew install 1password-cli\n  - Linux: Download from https://1password.com/downloads/command-line/\n  - Windows: Download from https://1password.com/downloads/command-line/\n  - NixOS: nix-env -iA nixpkgs.onepassword\n\nAfter installation, run 'eval $(op signin)' to authenticate.".to_string(),
+                        OP_NOT_INSTALLED_HELP.to_string(),
                     ));
                 }
                 Err(e) => return Err(e.into()),
@@ -347,10 +385,10 @@ impl OnePasswordProvider {
             if error_msg.contains("not currently signed in")
                 || error_msg.contains("no active session")
                 || error_msg.contains("could not find session token")
+                || error_msg.contains("account is not signed in")
             {
                 return Err(SecretSpecError::ProviderOperationFailed(
-                    "OnePassword authentication required. Please run 'eval $(op signin)' first."
-                        .to_string(),
+                    AUTH_REQUIRED_HELP.to_string(),
                 ));
             }
             return Err(SecretSpecError::ProviderOperationFailed(
@@ -548,8 +586,7 @@ impl OnePasswordProvider {
             Ok(())
         } else {
             Err(SecretSpecError::ProviderOperationFailed(
-                "OnePassword authentication required. Please run 'eval $(op signin)' first."
-                    .to_string(),
+                AUTH_REQUIRED_HELP.to_string(),
             ))
         }
     }
@@ -770,6 +807,7 @@ impl Provider for OnePasswordProvider {
 
                 thread::spawn(move || {
                     let mut cmd = Command::new(&op_cmd);
+                    strip_op_session_env(&mut cmd);
 
                     if let Some(ref t) = token {
                         cmd.env("OP_SERVICE_ACCOUNT_TOKEN", t);

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -402,16 +402,19 @@ impl OnePasswordProvider {
 
     /// Checks if the user is authenticated with OnePassword (uncached).
     ///
-    /// Uses the `op whoami` command to verify authentication status.
-    /// This is non-intrusive and doesn't require any permissions.
+    /// Uses `op vault list` rather than `op whoami` because the latter only
+    /// reports the state of an explicit `op signin` session and reports
+    /// `account is not signed in` under desktop-app delegated sessions even
+    /// when secret reads via `op item ...` work fine. `op vault list` actually
+    /// exercises the access path used for real operations.
     ///
     /// # Returns
     ///
     /// * `Ok(true)` - User is authenticated
     /// * `Ok(false)` - User is not authenticated
     /// * `Err(_)` - Command execution failed
-    fn whoami(&self) -> Result<bool> {
-        match self.execute_op_command(&["whoami"], None) {
+    fn is_authenticated(&self) -> Result<bool> {
+        match self.execute_op_command(&["vault", "list", "--format", "json"], None) {
             Ok(_) => Ok(true),
             Err(SecretSpecError::ProviderOperationFailed(msg))
                 if msg.contains("authentication required") || msg.contains("no account found") =>
@@ -582,7 +585,7 @@ impl OnePasswordProvider {
     /// Checks that the user is authenticated with OnePassword.
     /// Called by the preflight guard before any provider operations.
     pub(crate) fn check_auth(&self) -> Result<()> {
-        if self.whoami()? {
+        if self.is_authenticated()? {
             Ok(())
         } else {
             Err(SecretSpecError::ProviderOperationFailed(


### PR DESCRIPTION
## Summary

- **Primary fix**: switch the auth preflight probe from `op whoami` to `op vault list --format json`. Under the 1Password desktop app's delegated-session integration, `op whoami` reports `account is not signed in` even when `op item get` / `op vault list` work fine — so every secret operation was failing at preflight with a misleading "not signed in" error.
- **Defensive**: strip `OP_SESSION_*` env vars from spawned `op` processes, so a stale shell session from a previous `eval \$(op signin)` can't shadow the desktop integration.
- Rewrite the auth-required and install-not-found help text to recommend desktop integration first, service-account tokens for CI, and manual `op signin` last.
- Document the Linux setgid prerequisite (`onepassword-cli` group) for desktop integration.

## Why

Reported in [#80](https://github.com/cachix/secretspec/issues/80) — \`secretspec set\` fails after the 1Password session expires, even with desktop integration enabled.

Working through this with live testing against a real desktop-integrated account turned up the actual cause: `op whoami` is a query against an explicit signin session, not the delegated session managed by the desktop app. With desktop integration, `op whoami` returns `account is not signed in` permanently, while `op item get`, `op vault list`, etc. all work normally through the unlock socket. Our preflight blocked operations before they could run.

`op vault list` exercises the same access path used by real reads/writes, so a passing preflight means real operations will work too.

The `OP_SESSION_*` strip is kept as belt-and-suspenders: community reports describe stale shell sessions shadowing desktop integration, and stripping is cheap and isolated. `OP_CONNECT_HOST` / `OP_CONNECT_TOKEN` are intentionally left in place — Connect is a legitimate auth mode and silently stripping it would break users who chose it.

## Test plan

- [x] **End-to-end with real account**: built binary, ran `secretspec get` against an actual 1Password Private vault — preflight passes, real secret value returned through the desktop biometric flow.
- [x] **Fake stale `OP_SESSION_*` env**: same `secretspec get` invocation with a bogus `OP_SESSION_<account-uuid>` exported — still returns the real value (strip + preflight both run).
- [x] `cargo test -p secretspec --lib` (149 / 149).
- [x] `pre-commit run -a` (clippy + rustfmt) — clean.

Fixes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)