### PR TITLE
fix(test): use portable command for empty-output test

### DIFF
--- a/secretspec/src/generator.rs
+++ b/secretspec/src/generator.rs
@@ -338,8 +338,11 @@ mod tests {
 
     #[test]
     fn test_generate_command_empty_output() {
+        // `echo -n ''` is not POSIX-portable: macOS /bin/sh prints "-n"
+        // literally instead of suppressing the newline. Use `printf ''`
+        // which produces zero bytes on every platform.
         let config = GenerateConfig::Options(GenerateOptions {
-            command: Some("echo -n ''".to_string()),
+            command: Some("printf ''".to_string()),
             ..Default::default()
         });
         let result = generate("command", &config);


### PR DESCRIPTION
## Summary

- Replace `echo -n` with `printf ''` in `test_generate_command_empty_output`
- `echo -n` is non-POSIX and prints literal `-n` on macOS `/bin/sh`, causing the test to fail
- `printf ''` produces empty output on all POSIX shells

## Test plan

- [x] All 154 cargo tests pass
- [x] Verified `printf ''` produces empty output on macOS and Linux
- [x] No other `echo -n` usage in codebase