### PR TITLE
feat(config): allow [providers] alias map in secretspec.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Provider aliases can now be declared at the project level in a top-level
+  `[providers]` table of `secretspec.toml`. Aliases declared there are visible
+  to per-secret `providers = [...]` lists and to `--provider`/`SECRETSPEC_PROVIDER`,
+  and are merged with the existing user-level `[defaults.providers]` map in
+  `~/.config/secretspec/config.toml`. On name conflicts the project entry wins,
+  so a team's checked-in mapping cannot be silently shadowed by a stale local
+  config. Closes [#79](https://github.com/cachix/secretspec/issues/79) and
+  addresses the "share aliases via VCS" half of
+  [#90](https://github.com/cachix/secretspec/issues/90).
+
 ### Fixed
 - Profile-not-found errors no longer surface as the confusing
   `Secret 'Profile 'X' not found' not found`. They now use the dedicated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,8 @@ When adding a new provider, update **every** location below — provider names a
 
 ### Provider Resolution
 1. **Per-secret providers** (with fallback chain): specified in `secretspec.toml` as `providers: [alias1, alias2, ...]`
-   - Aliases resolved against `~/.config/secretspec/config.toml` providers map
+   - Aliases resolved against the project `[providers]` table in `secretspec.toml` first, then the `[defaults.providers]` table in `~/.config/secretspec/config.toml`
+   - Project-level aliases win on conflict
    - Tries each provider in order until secret is found
 2. CLI flag (`--provider`)
 3. Environment variable (`SECRETSPEC_PROVIDER`)
@@ -97,26 +98,36 @@ API_KEY = { description = "API Key", providers = ["shared"] }
 GITHUB_TOKEN = { description = "GitHub token from env", providers = ["env"] }
 ```
 
-Provider aliases are defined in `~/.config/secretspec/config.toml`:
+Provider aliases can be checked into the project in `secretspec.toml` so every team member and CI runner sees them automatically:
+```toml
+[providers]
+prod_vault = "onepassword://vault/Production"
+shared = "onepassword://vault/Shared"
+keyring = "keyring://"
+env = "env://"
+```
+
+They can also be defined per-user in `~/.config/secretspec/config.toml` (project entries win on conflict):
 ```toml
 [defaults]
 provider = "keyring"
 
-[providers]
+[defaults.providers]
 prod_vault = "onepassword://vault/Production"
 shared = "onepassword://vault/Shared"
+keyring = "keyring://"
 env = "env://"
 ```
 
-Or managed via CLI:
+Manage the user-level map via CLI (project-level aliases are hand-edited in `secretspec.toml`):
 ```bash
-# Add provider alias
+# Add provider alias to user config
 secretspec config provider add prod_vault "onepassword://vault/Production"
 
-# List all aliases
+# List user-level aliases
 secretspec config provider list
 
-# Remove alias
+# Remove a user-level alias
 secretspec config provider remove prod_vault
 ```
 

--- a/docs/src/content/docs/concepts/profiles.md
+++ b/docs/src/content/docs/concepts/profiles.md
@@ -64,6 +64,10 @@ When using profiles, inheritance works as follows:
 To reduce repetition when multiple secrets in a profile share the same settings, use the `profiles.<name>.defaults` section:
 
 ```toml
+[providers]
+prod_vault = "onepassword://vault/Production"
+keyring = "keyring://"
+
 [profiles.production.defaults]
 providers = ["prod_vault", "keyring"]
 required = true

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -83,15 +83,29 @@ SENTRY_DSN = { description = "Error tracking", providers = ["shared_vault", "key
 
 You can also set default providers for an entire profile using `profiles.<name>.defaults`. See [Profile-Level Defaults](/concepts/profiles/#profile-level-defaults) for details.
 
-Provider aliases are defined in your user configuration file (`~/.config/secretspec/config.toml`):
+Provider aliases can be defined in two places:
 
-```toml
-[defaults]
-provider = "keyring"
+- **Project-level** — a top-level `[providers]` table in `secretspec.toml`. Check this into version control so the whole team and CI runners share the same mapping.
+- **User-level** — a `[defaults.providers]` table in `~/.config/secretspec/config.toml` for personal overrides.
 
+On name conflicts the project-level alias wins, so a stale user config cannot silently shadow the team's mapping.
+
+```toml title="secretspec.toml"
 [providers]
 prod_vault = "onepassword://vault/Production"
 shared_vault = "onepassword://vault/Shared"
+keyring = "keyring://"
+env = "env://"
+```
+
+```toml title="~/.config/secretspec/config.toml"
+[defaults]
+provider = "keyring"
+
+[defaults.providers]
+prod_vault = "onepassword://vault/Production"
+shared_vault = "onepassword://vault/Shared"
+keyring = "keyring://"
 env = "env://"
 ```
 
@@ -112,7 +126,7 @@ This enables complex workflows:
 
 ### Managing Provider Aliases
 
-Use CLI commands to manage provider aliases:
+Use CLI commands to manage user-level provider aliases in `~/.config/secretspec/config.toml`:
 
 ```bash
 # Add a provider alias
@@ -124,6 +138,8 @@ $ secretspec config provider list
 # Remove an alias
 $ secretspec config provider remove prod_vault
 ```
+
+These commands operate on the user-level config only. To change project-level aliases, edit the `[providers]` table in `secretspec.toml` directly.
 
 ## Next Steps
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -161,6 +161,7 @@ Provider aliases are configured in `~/.config/secretspec/config.toml`:
 ```bash
 $ secretspec config provider add vault "onepassword://Production"
 $ secretspec config provider add team_vault "onepassword://Shared"
+$ secretspec config provider add keyring "keyring://"
 ```
 
 ```bash

--- a/docs/src/content/docs/providers/keyring.md
+++ b/docs/src/content/docs/providers/keyring.md
@@ -27,14 +27,22 @@ $ sudo pacman -S gnome-keyring
 
 ## Configuration
 
-```toml
-# secretspec.toml
-[project]
-name = "myapp"
+### URI Format
 
-[[providers]]
-type = "keyring"
-uri = "keyring://"
+```
+keyring://[folder_prefix]
+```
+
+- `folder_prefix`: Optional path prefix supporting `{project}`, `{profile}`, and `{key}` placeholders. Defaults to `secretspec/{project}/{profile}/{key}`.
+
+### Examples
+
+```bash
+# Use default keyring storage
+$ secretspec set DATABASE_URL --provider keyring
+
+# Custom folder prefix (e.g., to share secrets across projects — see below)
+$ secretspec set DATABASE_URL --provider "keyring://shared/{profile}/{key}"
 ```
 
 ## Usage
@@ -63,7 +71,7 @@ By default, secrets are stored under `secretspec/{project}/{profile}/{key}`, whi
 
 ```toml
 # ~/.config/secretspec/config.toml
-[providers]
+[defaults.providers]
 shared = "keyring://secretspec/shared/{profile}/{key}"
 ```
 

--- a/docs/src/content/docs/providers/pass.md
+++ b/docs/src/content/docs/providers/pass.md
@@ -23,14 +23,22 @@ $ brew install pass
 
 ## Configuration
 
-```toml
-# secretspec.toml
-[project]
-name = "myapp"
+### URI Format
 
-[[providers]]
-type = "pass"
-uri = "pass://"
+```
+pass://[folder_prefix]
+```
+
+- `folder_prefix`: Optional path prefix supporting `{project}`, `{profile}`, and `{key}` placeholders. Defaults to `secretspec/{project}/{profile}/{key}`.
+
+### Examples
+
+```bash
+# Use default pass storage
+$ secretspec set DATABASE_URL --provider pass
+
+# Custom folder prefix (e.g., to share secrets across projects — see below)
+$ secretspec set DATABASE_URL --provider "pass://shared/{profile}/{key}"
 ```
 
 ## Usage
@@ -64,7 +72,7 @@ By default, secrets are stored under `secretspec/{project}/{profile}/{key}`, whi
 
 ```toml
 # ~/.config/secretspec/config.toml
-[providers]
+[defaults.providers]
 shared = "pass://secretspec/shared/{profile}/{key}"
 ```
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -55,7 +55,9 @@ Profile:  development
 ```
 
 ### config provider add
-Add a provider alias to your configuration.
+Add a provider alias to your user-level configuration (`~/.config/secretspec/config.toml`).
+
+To share aliases with your team, declare them in a top-level `[providers]` table in `secretspec.toml` instead — they take precedence over user-level aliases on name conflict.
 
 ```bash
 secretspec config provider add <ALIAS> <URI>
@@ -75,7 +77,7 @@ $ secretspec config provider add shared "onepassword://vault/Shared"
 ```
 
 ### config provider list
-List all configured provider aliases.
+List all configured user-level provider aliases. Project-level aliases declared in `secretspec.toml` are not shown by this command.
 
 ```bash
 secretspec config provider list
@@ -90,7 +92,7 @@ env         → env://
 ```
 
 ### config provider remove
-Remove a provider alias from your configuration.
+Remove a provider alias from your user-level configuration. To remove a project-level alias, edit the `[providers]` table in `secretspec.toml` directly.
 
 ```bash
 secretspec config provider remove <ALIAS>

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -63,6 +63,13 @@ name = "web-api"
 revision = "1.0"
 extends = ["../shared/secretspec.toml"]  # Optional inheritance
 
+# Provider aliases used by profile provider chains
+[providers]
+prod_vault = "onepassword://vault/Production"
+shared_vault = "onepassword://vault/Shared"
+keyring = "keyring://"
+env = "env://"
+
 # Default profile - always loaded first
 [profiles.default]
 APP_NAME = { description = "Application name", required = false, default = "MyApp" }
@@ -85,30 +92,49 @@ REDIS_URL = { description = "Redis cache connection", required = true }
 
 ### Provider Aliases
 
-When using per-secret provider configuration, provider aliases must be defined in your user configuration file at `~/.config/secretspec/config.toml`:
+Provider aliases may be declared in two places:
 
-```toml
-[defaults]
-provider = "keyring"
+1. **In `secretspec.toml`** — a top-level `[providers]` table. Check this into version control so every team member and CI runner sees the same mapping out of the box.
+2. **In `~/.config/secretspec/config.toml`** — a per-user `[defaults.providers]` table for personal overrides.
 
+On conflict the project-level alias wins, so a stale local config cannot silently shadow the team's mapping.
+
+```toml title="secretspec.toml"
 [providers]
 prod_vault = "onepassword://vault/Production"
 shared_vault = "onepassword://vault/Shared"
+keyring = "keyring://"
+env = "env://"
+
+[profiles.production]
+DATABASE_URL = { description = "Production DB", providers = ["prod_vault", "keyring"] }
+```
+
+```toml title="~/.config/secretspec/config.toml"
+[defaults]
+provider = "keyring"
+
+[defaults.providers]
+prod_vault = "onepassword://vault/Production"
+shared_vault = "onepassword://vault/Shared"
+keyring = "keyring://"
 env = "env://"
 ```
 
-Manage provider aliases using CLI commands:
+Manage user-level aliases via CLI:
 
 ```bash
-# Add a provider alias
+# Add a provider alias to your user config
 $ secretspec config provider add prod_vault "onepassword://vault/Production"
 
-# List all aliases
+# List all aliases known to your user config
 $ secretspec config provider list
 
-# Remove an alias
+# Remove an alias from your user config
 $ secretspec config provider remove prod_vault
 ```
+
+The CLI commands operate on the user-global config only — edit `secretspec.toml` by hand to change project-level aliases.
 
 ### as_path Option
 

--- a/secretspec-derive/src/tests.rs
+++ b/secretspec-derive/src/tests.rs
@@ -232,6 +232,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: valid_profiles,
+            providers: None,
         };
 
         validate_rust_identifiers(&valid_config, &mut errors);
@@ -279,6 +280,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: invalid_profiles,
+            providers: None,
         };
 
         errors.clear();
@@ -359,6 +361,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: keyword_profiles,
+            providers: None,
         };
 
         validate_rust_identifiers(&keyword_config, &mut errors);
@@ -438,6 +441,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: duplicate_profiles,
+            providers: None,
         };
 
         validate_rust_identifiers(&duplicate_config, &mut errors);
@@ -492,6 +496,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: valid_profiles,
+            providers: None,
         };
 
         validate_profile_identifiers(&valid_config, &mut errors);
@@ -524,6 +529,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: invalid_profiles,
+            providers: None,
         };
 
         errors.clear();
@@ -681,6 +687,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles,
+            providers: None,
         };
 
         // API_KEY is NOT optional (required in all profiles, default doesn't make it optional)
@@ -738,6 +745,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: strict_profiles,
+            providers: None,
         };
 
         // ALWAYS_REQUIRED should not be optional
@@ -832,6 +840,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles,
+            providers: None,
         };
 
         let field_info = analyze_field_types(&config);
@@ -997,6 +1006,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: valid_profiles,
+            providers: None,
         };
 
         let result = validate_config_for_codegen(&valid_config);
@@ -1041,6 +1051,7 @@ HAS_DEFAULT = { description = "Secret with default", required = true, default = 
                 extends: None,
             },
             profiles: invalid_profiles,
+            providers: None,
         };
 
         let result = validate_config_for_codegen(&invalid_config);

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -288,6 +288,7 @@ pub fn main() -> Result<()> {
                     extends: None,
                 },
                 profiles,
+                providers: None,
             };
             let mut content = generate_toml_with_comments(&project_config).into_diagnostic()?;
 

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -50,6 +50,13 @@ pub struct Config {
     pub project: Project,
     /// Map of profile names to their configurations (e.g., "default", "production", "staging")
     pub profiles: HashMap<String, Profile>,
+    /// Project-level provider aliases that map alias names to provider URIs.
+    ///
+    /// Take precedence over aliases in the user-global config
+    /// (`~/.config/secretspec/config.toml`), so teams can check vault mappings
+    /// into version control instead of replicating them on every machine.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub providers: Option<HashMap<String, String>>,
 }
 
 impl Config {
@@ -111,6 +118,14 @@ impl Config {
                 None => {
                     self.profiles.insert(profile_name, profile_config);
                 }
+            }
+        }
+
+        // Merge provider aliases - current entries win.
+        if let Some(other_providers) = other.providers {
+            let merged = self.providers.get_or_insert_with(HashMap::new);
+            for (alias, uri) in other_providers {
+                merged.entry(alias).or_insert(uri);
             }
         }
     }
@@ -551,9 +566,9 @@ pub struct GlobalDefaults {
     pub profile: Option<String>,
     /// Named provider aliases that map alias names to provider URIs.
     /// Used by per-secret provider configuration to avoid storing sensitive
-    /// provider details in secretspec.toml. Example:
+    /// provider details in secretspec.toml. Example user config:
     /// ```toml
-    /// [providers]
+    /// [defaults.providers]
     /// shared = "onepassword://vault/Shared"
     /// local = "dotenv://.env.local"
     /// ```

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -374,62 +374,76 @@ impl Secrets {
         }
     }
 
-    /// Resolves a list of provider aliases to their URIs using the global config providers map.
-    ///
-    /// Returns a list of provider URIs in the same order. Used for fallback chain resolution.
-    ///
-    /// # Arguments
-    ///
-    /// * `provider_aliases` - Optional list of provider aliases to resolve
-    ///
-    /// # Returns
-    ///
-    /// A list of provider URIs in the same order, or None if no aliases were provided
+    /// Provider-alias maps in lookup order: project `secretspec.toml` first,
+    /// then user-global config. Project entries win on conflict so teams can
+    /// pin shareable mappings in version control while still allowing per-user
+    /// overrides via the global config.
+    fn provider_alias_sources(&self) -> impl Iterator<Item = &HashMap<String, String>> {
+        self.config.providers.iter().chain(
+            self.global_config
+                .as_ref()
+                .and_then(|gc| gc.defaults.providers.as_ref()),
+        )
+    }
+
+    /// Resolves a single provider alias to its URI, walking
+    /// [`Self::provider_alias_sources`] in order.
+    fn lookup_provider_alias(&self, alias: &str) -> Option<String> {
+        self.provider_alias_sources()
+            .find_map(|m| m.get(alias))
+            .cloned()
+    }
+
+    /// Returns the union of alias names known across all sources, sorted.
+    fn known_provider_aliases(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .provider_alias_sources()
+            .flat_map(|m| m.keys().cloned())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Resolves a list of provider aliases to their URIs, preserving order.
+    /// Used for fallback chain resolution; each alias is looked up via
+    /// [`Self::lookup_provider_alias`].
     ///
     /// # Errors
     ///
-    /// Returns an error if any alias is not found in the providers map.
+    /// Returns an error if any alias is not defined in either the project or global config.
     pub(crate) fn resolve_provider_aliases(
         &self,
         provider_aliases: Option<&[String]>,
     ) -> Result<Option<Vec<String>>> {
-        if let Some(aliases) = provider_aliases {
-            let mut uris = Vec::new();
+        let Some(aliases) = provider_aliases else {
+            return Ok(None);
+        };
 
-            for alias in aliases {
-                // If a per-secret provider alias is specified, resolve it from the global config
-                if let Some(global_config) = &self.global_config {
-                    if let Some(providers_map) = &global_config.defaults.providers {
-                        if let Some(uri) = providers_map.get(alias) {
-                            uris.push(uri.clone());
-                        } else {
-                            return Err(SecretSpecError::ProviderNotFound(format!(
-                                "Provider alias '{}' is not defined in the global config. Available aliases: {}",
-                                alias,
-                                providers_map
-                                    .keys()
-                                    .map(|s| s.as_str())
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            )));
-                        }
-                    } else {
-                        return Err(SecretSpecError::ProviderNotFound(format!(
-                            "Provider alias '{}' specified but no providers are configured in global config",
+        let mut uris = Vec::with_capacity(aliases.len());
+        for alias in aliases {
+            match self.lookup_provider_alias(alias) {
+                Some(uri) => uris.push(uri),
+                None => {
+                    let known = self.known_provider_aliases();
+                    let msg = if known.is_empty() {
+                        format!(
+                            "Provider alias '{}' is not defined. Declare it in [providers] in secretspec.toml or in the global config.",
                             alias
-                        )));
-                    }
-                } else {
-                    return Err(SecretSpecError::ProviderNotFound(format!(
-                        "Provider alias '{}' specified but no global config is loaded",
-                        alias
-                    )));
+                        )
+                    } else {
+                        format!(
+                            "Provider alias '{}' is not defined. Available aliases: {}",
+                            alias,
+                            known.join(", ")
+                        )
+                    };
+                    return Err(SecretSpecError::ProviderNotFound(msg));
                 }
             }
-
-            return Ok(Some(uris));
         }
-        Ok(None)
+        Ok(Some(uris))
     }
 
     /// Returns the explicit provider spec from caller arg, builder, or env, in
@@ -447,16 +461,10 @@ impl Secrets {
     /// Returns the explicit provider override resolved to a URI, if one is set.
     ///
     /// Resolves the explicit spec via [`Self::explicit_provider_spec`], then
-    /// expands any matching alias from the global config providers map.
+    /// expands any matching alias via [`Self::lookup_provider_alias`].
     pub(crate) fn resolve_provider_override(&self, override_arg: Option<&str>) -> Option<String> {
         let spec = self.explicit_provider_spec(override_arg.map(|s| s.to_string()))?;
-        let resolved = self
-            .global_config
-            .as_ref()
-            .and_then(|gc| gc.defaults.providers.as_ref())
-            .and_then(|m| m.get(&spec).cloned())
-            .unwrap_or(spec);
-        Some(resolved)
+        Some(self.lookup_provider_alias(&spec).unwrap_or(spec))
     }
 
     /// Resolves the write target for a secret.
@@ -537,11 +545,40 @@ impl Secrets {
                     .as_ref()
                     .and_then(|gc| gc.defaults.provider.clone())
             })
+            .map(|spec| self.lookup_provider_alias(&spec).unwrap_or(spec))
             .ok_or(SecretSpecError::NoProviderConfigured)?;
 
         let provider = Box::<dyn ProviderTrait>::try_from(provider_spec)?;
 
         Ok(provider)
+    }
+
+    /// Returns a provider URI for validation result metadata without forcing a
+    /// user-global default when every secret used an explicit or per-secret provider.
+    fn validation_report_provider_uri(
+        &self,
+        override_uri: Option<&str>,
+        secret_primary_uris: &HashMap<String, Option<String>>,
+    ) -> Result<String> {
+        if let Some(uri) = override_uri {
+            return Ok(uri.to_string());
+        }
+
+        if secret_primary_uris.values().any(Option::is_none) {
+            return self.get_provider(None).map(|provider| provider.uri());
+        }
+
+        let mut provider_uris: Vec<&String> = secret_primary_uris
+            .values()
+            .filter_map(Option::as_ref)
+            .collect();
+        provider_uris.sort();
+
+        if let Some(uri) = provider_uris.first() {
+            return Ok((*uri).clone());
+        }
+
+        self.get_provider(None).map(|provider| provider.uri())
     }
 
     /// Gets a secret from a list of providers with fallback.
@@ -1552,8 +1589,8 @@ impl Secrets {
             }
         }
 
-        // Use default provider for error reporting
-        let primary_provider = self.get_provider(None)?;
+        let report_provider_uri =
+            self.validation_report_provider_uri(override_uri.as_deref(), &secret_primary_uris)?;
 
         // Check if there are any missing required secrets
         if !missing_required.is_empty() {
@@ -1561,12 +1598,12 @@ impl Secrets {
                 missing_required,
                 missing_optional,
                 with_defaults,
-                primary_provider.uri(),
+                report_provider_uri,
                 profile_name.to_string(),
             )))
         } else {
             Ok(Ok(ValidatedSecrets {
-                resolved: Resolved::new(secrets, primary_provider.uri(), profile_name.to_string()),
+                resolved: Resolved::new(secrets, report_provider_uri, profile_name.to_string()),
                 missing_optional,
                 with_defaults,
                 temp_files,

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -39,6 +39,7 @@ fn test_new_with_project_config() {
             extends: None,
         },
         profiles: HashMap::new(),
+        providers: None,
     };
 
     let spec = Secrets::new(config, None, None, None);
@@ -100,6 +101,7 @@ fn test_new_with_default_overrides() {
             extends: None,
         },
         profiles: HashMap::new(),
+        providers: None,
     };
 
     // Create a global config with specific defaults
@@ -251,6 +253,7 @@ fn test_secretspec_new() {
             extends: None,
         },
         profiles: HashMap::new(),
+        providers: None,
     };
 
     let global_config = GlobalConfig {
@@ -291,6 +294,7 @@ fn test_resolve_profile() {
                 extends: None,
             },
             profiles: HashMap::new(),
+            providers: None,
         },
         Some(global_config),
         None,
@@ -312,6 +316,7 @@ fn test_resolve_profile() {
                 extends: None,
             },
             profiles: HashMap::new(),
+            providers: None,
         },
         None,
         None,
@@ -383,6 +388,7 @@ fn test_resolve_secret_config() {
                 extends: None,
             },
             profiles,
+            providers: None,
         },
         None,
         None,
@@ -423,6 +429,7 @@ fn test_get_provider_error_cases() {
                 extends: None,
             },
             profiles: HashMap::new(),
+            providers: None,
         },
         None,
         None,
@@ -452,6 +459,7 @@ fn test_get_provider_with_global_config() {
                 extends: None,
             },
             profiles: HashMap::new(),
+            providers: None,
         },
         Some(global_config),
         None,
@@ -1389,6 +1397,7 @@ fn test_set_with_undefined_secret() {
             );
             profiles
         },
+        providers: None,
     };
 
     let global_config = GlobalConfig {
@@ -1455,6 +1464,7 @@ fn test_set_with_defined_secret() {
             );
             profiles
         },
+        providers: None,
     };
 
     let global_config = GlobalConfig {
@@ -1508,6 +1518,7 @@ fn test_set_with_readonly_provider() {
             );
             profiles
         },
+        providers: None,
     };
 
     let global_config = GlobalConfig {
@@ -1604,6 +1615,7 @@ fn test_import_between_dotenv_files() {
             );
             profiles
         },
+        providers: None,
     };
 
     // Create source .env file
@@ -1730,6 +1742,7 @@ fn test_import_edge_cases() {
             );
             profiles
         },
+        providers: None,
     };
 
     // Create source .env file with edge case values
@@ -1994,6 +2007,7 @@ fn test_import_with_profiles() {
 
             profiles
         },
+        providers: None,
     };
 
     // Create source .env file with all secrets
@@ -2066,6 +2080,7 @@ fn test_run_with_empty_command() {
                 extends: None,
             },
             profiles: HashMap::new(),
+            providers: None,
         },
         Some(GlobalConfig {
             defaults: GlobalDefaults {
@@ -2127,6 +2142,7 @@ fn test_run_with_missing_required_secrets() {
                 extends: None,
             },
             profiles,
+            providers: None,
         },
         Some(GlobalConfig {
             defaults: GlobalDefaults {
@@ -2186,6 +2202,7 @@ fn test_get_existing_secret() {
                 extends: None,
             },
             profiles,
+            providers: None,
         },
         Some(GlobalConfig {
             defaults: GlobalDefaults {
@@ -2239,6 +2256,7 @@ fn test_get_secret_with_default() {
                 extends: None,
             },
             profiles,
+            providers: None,
         },
         Some(GlobalConfig {
             defaults: GlobalDefaults {
@@ -2291,6 +2309,7 @@ fn test_get_nonexistent_secret() {
                 extends: None,
             },
             profiles,
+            providers: None,
         },
         Some(GlobalConfig {
             defaults: GlobalDefaults {
@@ -2456,6 +2475,7 @@ fn test_per_secret_provider_configuration() {
             extends: None,
         },
         profiles,
+        providers: None,
     };
 
     // Create global config with provider aliases
@@ -2510,6 +2530,7 @@ fn test_provider_alias_resolution() {
                 extends: None,
             },
             profiles: HashMap::new(),
+            providers: None,
         },
         Some(global_config),
         None,
@@ -2574,6 +2595,7 @@ fn test_provider_alias_not_found() {
                 extends: None,
             },
             profiles: HashMap::new(),
+            providers: None,
         },
         Some(global_config),
         None,
@@ -2647,6 +2669,7 @@ fn test_per_secret_provider_with_fallback_chain() {
             extends: None,
         },
         profiles,
+        providers: None,
     };
 
     let mut providers_map = HashMap::new();
@@ -2744,6 +2767,7 @@ fn test_get_secret_with_fallback_chain() {
             extends: None,
         },
         profiles,
+        providers: None,
     };
 
     let mut providers_map = HashMap::new();
@@ -2826,6 +2850,7 @@ fn test_validate_falls_back_on_primary_provider_error() {
             extends: None,
         },
         profiles,
+        providers: None,
     };
 
     let mut providers_map = HashMap::new();
@@ -2899,6 +2924,7 @@ fn test_validate_surfaces_error_when_all_providers_fail() {
             extends: None,
         },
         profiles,
+        providers: None,
     };
 
     let mut providers_map = HashMap::new();
@@ -2991,6 +3017,7 @@ fn test_validate_with_per_secret_providers() {
             extends: None,
         },
         profiles,
+        providers: None,
     };
 
     let mut providers_map = HashMap::new();
@@ -3120,6 +3147,7 @@ fn test_secret_config_merges_providers_from_default() {
             extends: None,
         },
         profiles,
+        providers: None,
     };
 
     let spec = Secrets::new(config, None, None, None);
@@ -4004,6 +4032,7 @@ fn test_resolve_secret_config_merges_type_and_generate() {
             extends: None,
         },
         profiles,
+        providers: None,
     };
 
     let spec = Secrets::new(config, None, Some("production".to_string()), None);
@@ -4060,6 +4089,7 @@ fn build_chain_scenario(
             );
             profiles
         },
+        providers: None,
     };
 
     let mut providers_map = HashMap::new();
@@ -4257,5 +4287,317 @@ OPTIONAL_MISSING = { description = "optional, not set", required = false }
         validated.missing_optional,
         vec!["OPTIONAL_MISSING".to_string()],
         "unset optional secret must be reported in missing_optional"
+    );
+}
+
+fn aliases_map(aliases: &[(&str, &str)]) -> HashMap<String, String> {
+    aliases
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+fn config_with_project_aliases(aliases: &[(&str, &str)]) -> Config {
+    Config {
+        project: Project {
+            name: "alias-test".to_string(),
+            revision: "1.0".to_string(),
+            extends: None,
+        },
+        profiles: HashMap::new(),
+        providers: Some(aliases_map(aliases)),
+    }
+}
+
+fn global_config_with_aliases(aliases: &[(&str, &str)]) -> GlobalConfig {
+    GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: None,
+            profile: None,
+            providers: Some(aliases_map(aliases)),
+        },
+    }
+}
+
+fn config_with_project_alias_secret(
+    alias: &str,
+    uri: &str,
+    secret_providers: Option<Vec<String>>,
+) -> Config {
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "API_KEY".to_string(),
+        Secret {
+            description: Some("API key".to_string()),
+            required: Some(true),
+            providers: secret_providers,
+            ..Default::default()
+        },
+    );
+
+    let mut profiles = HashMap::new();
+    profiles.insert(
+        "default".to_string(),
+        Profile {
+            defaults: None,
+            secrets,
+        },
+    );
+
+    Config {
+        project: Project {
+            name: "alias-validation".to_string(),
+            revision: "1.0".to_string(),
+            extends: None,
+        },
+        profiles,
+        providers: Some(aliases_map(&[(alias, uri)])),
+    }
+}
+
+#[test]
+fn test_project_providers_resolve_without_global_config() {
+    let config = config_with_project_aliases(&[("op_infra", "onepassword://Infra")]);
+    let spec = Secrets::new(config, None, None, None);
+
+    let resolved = spec
+        .resolve_provider_aliases(Some(&["op_infra".to_string()]))
+        .expect("project alias should resolve")
+        .expect("resolved list should be present");
+
+    assert_eq!(resolved, vec!["onepassword://Infra".to_string()]);
+}
+
+#[test]
+fn test_project_providers_take_precedence_over_global() {
+    let config = config_with_project_aliases(&[("shared", "dotenv://.env.team")]);
+    let global = global_config_with_aliases(&[("shared", "dotenv://.env.user")]);
+    let spec = Secrets::new(config, Some(global), None, None);
+
+    let resolved = spec
+        .resolve_provider_aliases(Some(&["shared".to_string()]))
+        .expect("alias should resolve")
+        .expect("resolved list should be present");
+
+    assert_eq!(
+        resolved,
+        vec!["dotenv://.env.team".to_string()],
+        "project alias must win on conflict with global"
+    );
+}
+
+#[test]
+fn test_unknown_alias_error_lists_both_sources() {
+    let config = config_with_project_aliases(&[("project_only", "dotenv://.env.team")]);
+    let global = global_config_with_aliases(&[("global_only", "dotenv://.env.user")]);
+    let spec = Secrets::new(config, Some(global), None, None);
+
+    let err = spec
+        .resolve_provider_aliases(Some(&["does_not_exist".to_string()]))
+        .expect_err("missing alias must error");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("project_only") && msg.contains("global_only"),
+        "error should list aliases from both project and global config, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn test_extends_carries_project_providers() {
+    let temp_dir = TempDir::new().unwrap();
+    let base = temp_dir.path();
+    fs::create_dir_all(base.join("shared")).unwrap();
+    fs::create_dir_all(base.join("app")).unwrap();
+
+    fs::write(
+        base.join("shared/secretspec.toml"),
+        r#"
+[project]
+name = "shared"
+revision = "1.0"
+
+[providers]
+op_infra = "onepassword://Shared"
+op_overridden = "onepassword://OldVault"
+
+[profiles.default]
+SHARED_SECRET = { description = "Shared", required = true }
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        base.join("app/secretspec.toml"),
+        r#"
+[project]
+name = "app"
+revision = "1.0"
+extends = ["../shared"]
+
+[providers]
+op_overridden = "onepassword://NewVault"
+
+[profiles.default]
+APP_SECRET = { description = "App", required = true }
+"#,
+    )
+    .unwrap();
+
+    let config = Config::try_from(base.join("app/secretspec.toml").as_path()).unwrap();
+    let providers = config
+        .providers
+        .as_ref()
+        .expect("merged config should carry [providers]");
+
+    assert_eq!(
+        providers.get("op_infra").map(String::as_str),
+        Some("onepassword://Shared"),
+        "alias defined only in extended config should be inherited"
+    );
+    assert_eq!(
+        providers.get("op_overridden").map(String::as_str),
+        Some("onepassword://NewVault"),
+        "alias defined in both should resolve to the current (extending) config's value"
+    );
+}
+
+#[test]
+fn test_provider_override_expands_project_alias() {
+    let config = config_with_project_aliases(&[("op_infra", "onepassword://Infra")]);
+    let spec = Secrets::new(config, None, None, Some("default".to_string()));
+    // builder-style override (mirrors `--provider <alias>`)
+    let mut spec = spec;
+    spec.set_provider("op_infra");
+
+    let resolved = spec
+        .resolve_provider_override(None)
+        .expect("override should resolve to a URI");
+
+    assert_eq!(resolved, "onepassword://Infra");
+}
+
+#[test]
+fn test_global_alias_still_resolves_when_project_providers_present() {
+    // Project map defines `local`; we look up `team`, which only exists in
+    // global. Walks past the project source into the global one.
+    let config = config_with_project_aliases(&[("local", "dotenv://.env.local")]);
+    let global = global_config_with_aliases(&[("team", "onepassword://Team")]);
+    let spec = Secrets::new(config, Some(global), None, None);
+
+    let resolved = spec
+        .resolve_provider_aliases(Some(&["team".to_string()]))
+        .expect("global alias should resolve when project map exists but doesn't define it")
+        .expect("resolved list should be present");
+
+    assert_eq!(resolved, vec!["onepassword://Team".to_string()]);
+}
+
+#[test]
+fn test_fallback_chain_resolves_aliases_from_mixed_sources() {
+    // Chain mixes a project-only alias and a global-only alias; order in the
+    // chain is preserved and each is resolved from whichever source defines it.
+    let config = config_with_project_aliases(&[("project_vault", "onepassword://Team")]);
+    let global = global_config_with_aliases(&[("user_dotenv", "dotenv://.env.user")]);
+    let spec = Secrets::new(config, Some(global), None, None);
+
+    let resolved = spec
+        .resolve_provider_aliases(Some(&[
+            "project_vault".to_string(),
+            "user_dotenv".to_string(),
+        ]))
+        .expect("mixed-source chain should resolve")
+        .expect("resolved list should be present");
+
+    assert_eq!(
+        resolved,
+        vec![
+            "onepassword://Team".to_string(),
+            "dotenv://.env.user".to_string(),
+        ],
+        "chain order must be preserved across sources"
+    );
+}
+
+#[test]
+fn test_provider_override_resolves_global_alias_when_project_providers_present() {
+    // `--provider <alias>` path must consult the same source order as the
+    // per-secret chain; a global-only alias resolves even when a project
+    // providers map is set.
+    let config = config_with_project_aliases(&[("local", "dotenv://.env.local")]);
+    let global = global_config_with_aliases(&[("team", "onepassword://Team")]);
+    let mut spec = Secrets::new(config, Some(global), None, None);
+    spec.set_provider("team");
+
+    let resolved = spec
+        .resolve_provider_override(None)
+        .expect("override should resolve to a URI");
+
+    assert_eq!(resolved, "onepassword://Team");
+}
+
+#[test]
+fn test_validate_project_provider_chain_without_global_default() {
+    let temp_dir = TempDir::new().unwrap();
+    let env_file = temp_dir.path().join(".env.project");
+    fs::write(&env_file, "API_KEY=from-project\n").unwrap();
+    let uri = format!("dotenv://{}", env_file.display());
+
+    let config = config_with_project_alias_secret(
+        "project_env",
+        &uri,
+        Some(vec!["project_env".to_string()]),
+    );
+    let spec = Secrets::new(config, None, None, None);
+
+    let validated = spec
+        .validate()
+        .expect("project provider alias should not require a global provider")
+        .expect("secret should resolve from project provider alias");
+
+    assert_eq!(
+        validated
+            .resolved
+            .secrets
+            .get("API_KEY")
+            .unwrap()
+            .expose_secret(),
+        "from-project"
+    );
+    assert_eq!(
+        validated.resolved.provider, uri,
+        "validation metadata should report the resolved project provider URI"
+    );
+}
+
+#[test]
+fn test_validate_provider_override_project_alias_without_global_default() {
+    let temp_dir = TempDir::new().unwrap();
+    let env_file = temp_dir.path().join(".env.override");
+    fs::write(&env_file, "API_KEY=from-override\n").unwrap();
+    let uri = format!("dotenv://{}", env_file.display());
+
+    let config = config_with_project_alias_secret("project_env", &uri, None);
+    let mut spec = Secrets::new(config, None, None, None);
+    spec.set_provider("project_env");
+
+    let validated = spec
+        .validate()
+        .expect("override alias should not be reparsed as a provider scheme")
+        .expect("secret should resolve from explicit project alias");
+
+    assert_eq!(
+        validated
+            .resolved
+            .secrets
+            .get("API_KEY")
+            .unwrap()
+            .expose_secret(),
+        "from-override"
+    );
+    assert_eq!(
+        validated.resolved.provider, uri,
+        "validation metadata should report the resolved override URI"
     );
 }


### PR DESCRIPTION
## Summary

- Add an optional top-level `[providers]` table to `secretspec.toml` so teams can check vault-alias mappings into VCS instead of having every developer and CI runner replicate them in `~/.config/secretspec/config.toml` by hand.
- Aliases declared there feed into per-secret `providers = [...]` chains and `--provider` / `SECRETSPEC_PROVIDER`, and are merged with the user-level `[defaults.providers]` map. On name conflicts the project entry wins, and `extends = [...]` carries inherited entries through the same merge rules.
- `defaults.provider` and `defaults.profile` deliberately stay user-scoped — pinning them per-project conflates the team manifest with a per-developer preference.
- Docs corrected: every existing example showed user-level aliases as `[providers]` at the root of `~/.config/secretspec/config.toml`, but that form silently deserializes to `defaults.providers = None`. CLI-only users were unaffected because `secretspec config provider add` writes the correct nested form, but hand-edits based on the docs did nothing. All user-config examples now use `[defaults.providers]`; project-level examples (which IS top-level) stay as `[providers]`.

Closes #79; addresses the "share aliases via VCS" half of #90.

## Test plan

- [ ] `cargo test --package secretspec` — new unit tests cover project-only resolution, project-wins-on-conflict, unknown-alias error lists both sources, `extends` carries and overrides project aliases, and `--provider <alias>` expands a project alias.
- [ ] Manual: drop a `[providers]` table into a `secretspec.toml`, reference an alias from a per-secret `providers = [...]`, run `secretspec check` / `secretspec get`.
- [ ] Manual: confirm `secretspec config provider {add,list,remove}` still operates on `~/.config/secretspec/config.toml` only (docs updated to say so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)