### PR TITLE
test: expand coverage; fix init TOML serialization and -f flag conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+- Expanded test coverage for previously untested logic: CLI argument parsing
+  and `init` TOML generation, the config/secret validation guards
+  (`Config::validate`, `Secret::validate`, identifier checks), and the
+  `ValidationErrors` display/`has_errors` behavior.
+
 ### Fixed
 - `secretspec init` now serializes the generated `secretspec.toml` with
   `toml_edit` instead of hand-interpolating strings. This fixes several cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `secretspec init` now serializes the generated `secretspec.toml` with
+  `toml_edit` instead of hand-interpolating strings. This fixes several cases
+  that previously produced TOML that could not be parsed back: a project name,
+  secret description, or default value containing a double-quote, backslash,
+  control character (including U+007F), or newline; a secret name containing a
+  dot (e.g. `FOO.BAR`, which dotenvy accepts and which silently collapsed to a
+  nested key); and a configured `project.extends`, which was dropped entirely.
+  Output is now also deterministically ordered.
+- `secretspec init` no longer defines a conflicting `-f` short flag for
+  `--from`; `-f` is reserved for the global `--file` option. The duplicate
+  short flag made `secretspec init` panic in debug builds and was ambiguous in
+  release builds.
+
 ## [0.11.0] - 2026-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 - Expanded test coverage for previously untested logic: CLI argument parsing
   and `init` TOML generation, the config/secret validation guards
-  (`Config::validate`, `Secret::validate`, identifier checks), and the
-  `ValidationErrors` display/`has_errors` behavior.
+  (`Config::validate`, `Secret::validate`, identifier checks), the
+  `ValidationErrors` display/`has_errors` behavior, `ProviderUrl`
+  encode/decode and `ProviderInfo` display, and the no-network parsing and
+  path-building logic of the keyring, pass, and OnePassword providers
+  (`TryFrom<&ProviderUrl>`, path/item-name builders, and `uri()` round-trips).
 
 ### Fixed
 - `secretspec init` now serializes the generated `secretspec.toml` with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ValidationErrors` display/`has_errors` behavior, `ProviderUrl`
   encode/decode and `ProviderInfo` display, and the no-network parsing and
   path-building logic of the keyring, pass, and OnePassword providers
-  (`TryFrom<&ProviderUrl>`, path/item-name builders, and `uri()` round-trips).
+  (`TryFrom<&ProviderUrl>`, path/item-name builders, and `uri()` round-trips),
+  and the `Secrets` public surface (`check()` present/missing paths,
+  `run_command` child exit-code propagation, and the `InvalidProfile` error).
 
 ### Fixed
 - `secretspec init` now serializes the generated `secretspec.toml` with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
+ "toml_edit",
  "url",
  "uuid",
  "whoami",
@@ -4490,6 +4491,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5335,6 +5349,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keyring = { version = "3.6.2", features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9"
+toml_edit = "0.23"
 thiserror = "2.0"
 etcetera = "0.11"
 colored = "3.0"

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -15,7 +15,7 @@ secretspec init [OPTIONS]
 ```
 
 **Options:**
-- `-f, --from <PATH>` - Path to .env file to import from (default: `.env`)
+- `--from <PATH>` - Path to .env file to import from (default: `.env`)
 
 **Example:**
 ```bash

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -20,6 +20,7 @@ clap.workspace = true
 keyring = { workspace = true, optional = true }
 serde.workspace = true
 toml.workspace = true
+toml_edit = { workspace = true, optional = true }
 thiserror.workspace = true
 etcetera.workspace = true
 colored.workspace = true
@@ -47,7 +48,7 @@ data-encoding.workspace = true
 
 [features]
 default = ["cli", "keyring", "gcsm", "awssm", "vault", "bws"]
-cli = []
+cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -36,7 +36,9 @@ enum Commands {
     Init {
         /// Provider URL to import from (e.g., dotenv://.env, dotenv://.env.production)
         /// Currently only dotenv provider is supported.
-        #[arg(short, long, default_value = "dotenv://.env")]
+        ///
+        /// Note: no short flag here — `-f` is the global `--file` option.
+        #[arg(long, default_value = "dotenv://.env")]
         from: String,
     },
     /// Set a secret value
@@ -156,10 +158,14 @@ fn get_example_toml() -> &'static str {
 "#
 }
 
-/// Generates a TOML string from a ProjectConfig with helpful comments
+/// Generates a `secretspec.toml` document from a [`Config`] with helpful comments.
 ///
-/// This function serializes a `ProjectConfig` to TOML format while adding
-/// instructional comments to help users understand the configuration options.
+/// String values and keys are serialized through `toml_edit`, so anything that
+/// needs quoting or escaping (a description containing a double-quote, a secret
+/// name containing a dot, a control character, ...) is emitted as valid,
+/// round-trippable TOML rather than hand-interpolated. Secrets are written as
+/// inline tables and profiles/secrets are sorted for deterministic output, while
+/// instructional comments are preserved for users editing the file by hand.
 ///
 /// # Arguments
 ///
@@ -173,42 +179,69 @@ fn get_example_toml() -> &'static str {
 ///
 /// Returns an error if the configuration cannot be serialized
 fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
-    let mut output = String::new();
+    use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
 
-    // Project section
-    output.push_str("[project]\n");
-    output.push_str(&format!("name = \"{}\"\n", config.project.name));
-    output.push_str(&format!("revision = \"{}\"\n", config.project.revision));
+    let mut doc = DocumentMut::new();
 
-    // Add extends comment and field if needed
-    output.push_str("# Extend configurations from subdirectories\n");
-    output.push_str("# extends = [ \"subdir1\", \"subdir2\" ]\n");
-
-    // Profile sections
-    for (profile_name, profile_config) in &config.profiles {
-        output.push_str(&format!("\n[profiles.{}]\n", profile_name));
-
-        for (secret_name, secret_config) in &profile_config.secrets {
-            output.push_str(&format!(
-                "{} = {{ description = \"{}\"",
-                secret_name,
-                secret_config.description.as_deref().unwrap_or(""),
-            ));
-
-            // Only include required if it's explicitly set
-            if let Some(required) = secret_config.required {
-                output.push_str(&format!(", required = {}", required));
-            }
-
-            if let Some(default) = &secret_config.default {
-                output.push_str(&format!(", default = \"{}\"", default));
-            }
-
-            output.push_str(" }\n");
+    // [project]
+    let mut project = Table::new();
+    project.insert("name", toml_edit::value(config.project.name.as_str()));
+    project.insert(
+        "revision",
+        toml_edit::value(config.project.revision.as_str()),
+    );
+    if let Some(extends) = &config.project.extends {
+        let mut arr = Array::new();
+        for entry in extends {
+            arr.push(entry.as_str());
         }
+        project.insert("extends", toml_edit::value(arr));
     }
+    doc.insert("project", Item::Table(project));
 
-    Ok(output)
+    // [profiles.<name>] tables, each secret an inline table. Sorted so the output
+    // is deterministic regardless of the source HashMap ordering.
+    let mut profiles = Table::new();
+    profiles.set_implicit(true);
+
+    let mut profile_names: Vec<&String> = config.profiles.keys().collect();
+    profile_names.sort();
+
+    for (index, profile_name) in profile_names.iter().enumerate() {
+        let profile_config = &config.profiles[*profile_name];
+        let mut profile_table = Table::new();
+
+        let mut secret_names: Vec<&String> = profile_config.secrets.keys().collect();
+        secret_names.sort();
+        for secret_name in secret_names {
+            let secret_config = &profile_config.secrets[secret_name];
+            let mut inline = InlineTable::new();
+            inline.insert(
+                "description",
+                Value::from(secret_config.description.as_deref().unwrap_or("")),
+            );
+            if let Some(required) = secret_config.required {
+                inline.insert("required", Value::from(required));
+            }
+            if let Some(default) = &secret_config.default {
+                inline.insert("default", Value::from(default.as_str()));
+            }
+            profile_table.insert(secret_name, toml_edit::value(inline));
+        }
+
+        // Surface the `extends` option as a comment before the first profile,
+        // unless the project already declares an explicit `extends`.
+        if index == 0 && config.project.extends.is_none() {
+            profile_table.decor_mut().set_prefix(
+                "\n# Extend configurations from subdirectories\n# extends = [ \"subdir1\", \"subdir2\" ]\n\n",
+            );
+        }
+
+        profiles.insert(profile_name.as_str(), Item::Table(profile_table));
+    }
+    doc.insert("profiles", Item::Table(profiles));
+
+    Ok(doc.to_string())
 }
 
 /// Loads secrets using an explicit path or auto-detection.
@@ -583,6 +616,203 @@ pub fn main() -> Result<()> {
                 .into_diagnostic()
                 .wrap_err("Failed to import secrets")?;
             Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Secret;
+
+    /// Builds a Config with a single secret named `S` under the `default` profile.
+    fn config_with_secret(secret: Secret) -> Config {
+        let mut secrets = HashMap::new();
+        secrets.insert("S".to_string(), secret);
+        Config {
+            project: Project {
+                name: "myproj".to_string(),
+                revision: "1.0".to_string(),
+                extends: None,
+            },
+            profiles: HashMap::from([(
+                "default".to_string(),
+                Profile {
+                    defaults: None,
+                    secrets,
+                },
+            )]),
+            providers: None,
+        }
+    }
+
+    #[test]
+    fn generate_toml_quotes_dotted_secret_name_and_round_trips() {
+        // dotenvy accepts keys containing dots (e.g. `FOO.BAR`). A bare TOML key
+        // `FOO.BAR` would be parsed as a *dotted* (nested) key, silently losing
+        // the secret; toml_edit quotes it so the name round-trips intact.
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "FOO.BAR".to_string(),
+            Secret {
+                description: Some("dotted".to_string()),
+                ..Default::default()
+            },
+        );
+        let mut config = config_with_secret(Secret::default());
+        config.profiles.get_mut("default").unwrap().secrets = secrets;
+
+        let generated = generate_toml_with_comments(&config).unwrap();
+        assert!(
+            generated.contains("\"FOO.BAR\" = {"),
+            "key must be quoted, got: {generated}"
+        );
+        let parsed: Config = toml::from_str(&generated).expect("must round-trip");
+        assert!(parsed.profiles["default"].secrets.contains_key("FOO.BAR"));
+    }
+
+    #[test]
+    fn generate_toml_emits_and_round_trips_extends() {
+        let mut config = config_with_secret(Secret {
+            description: Some("desc".to_string()),
+            ..Default::default()
+        });
+        config.project.extends = Some(vec!["../shared".to_string()]);
+
+        let generated = generate_toml_with_comments(&config).unwrap();
+        let parsed: Config = toml::from_str(&generated).expect("must round-trip");
+        assert_eq!(
+            parsed.project.extends.as_deref(),
+            Some(["../shared".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn generate_toml_round_trips_control_character() {
+        // U+007F (DEL) must be escaped: TOML forbids it unescaped in a basic
+        // string. toml_edit handles it; a raw byte would fail to re-parse.
+        let config = config_with_secret(Secret {
+            description: Some("a\u{7f}b".to_string()),
+            ..Default::default()
+        });
+        let generated = generate_toml_with_comments(&config).unwrap();
+        let parsed: Config = toml::from_str(&generated).expect("must round-trip");
+        assert_eq!(
+            parsed.profiles["default"].secrets["S"]
+                .description
+                .as_deref(),
+            Some("a\u{7f}b")
+        );
+    }
+
+    #[test]
+    fn generate_toml_round_trips_values_with_special_chars() {
+        // Description and default contain quotes, a backslash and a newline; the
+        // project name contains a quote. Before escaping was added these produced
+        // malformed TOML that failed to parse back.
+        let config = Config {
+            project: Project {
+                name: "weird \"name\"".to_string(),
+                revision: "1.0".to_string(),
+                extends: None,
+            },
+            profiles: HashMap::from([(
+                "default".to_string(),
+                Profile {
+                    defaults: None,
+                    secrets: HashMap::from([(
+                        "DATABASE_URL".to_string(),
+                        Secret {
+                            description: Some("he said \"hi\"\nthen left\\".to_string()),
+                            default: Some("a\"b\\c".to_string()),
+                            ..Default::default()
+                        },
+                    )]),
+                },
+            )]),
+            providers: None,
+        };
+
+        let generated = generate_toml_with_comments(&config).unwrap();
+        let parsed: Config =
+            toml::from_str(&generated).expect("generated TOML must be valid and re-parseable");
+
+        assert_eq!(parsed.project.name, "weird \"name\"");
+        let secret = &parsed.profiles["default"].secrets["DATABASE_URL"];
+        assert_eq!(
+            secret.description.as_deref(),
+            Some("he said \"hi\"\nthen left\\")
+        );
+        assert_eq!(secret.default.as_deref(), Some("a\"b\\c"));
+    }
+
+    #[test]
+    fn generate_toml_none_branch_emits_empty_description_and_omits_fields() {
+        let out = generate_toml_with_comments(&config_with_secret(Secret::default())).unwrap();
+        assert!(out.contains("S = { description = \"\" }"), "got: {out}");
+        assert!(!out.contains("required = "));
+        assert!(!out.contains("default = "));
+    }
+
+    #[test]
+    fn generate_toml_some_branch_emits_required_and_default() {
+        let secret = Secret {
+            description: Some("desc".to_string()),
+            required: Some(false),
+            default: Some("v".to_string()),
+            ..Default::default()
+        };
+        let out = generate_toml_with_comments(&config_with_secret(secret)).unwrap();
+        assert!(out.contains(", required = false"), "got: {out}");
+        assert!(out.contains(", default = \"v\""), "got: {out}");
+    }
+
+    #[test]
+    fn generated_config_with_example_template_is_valid_toml() {
+        let mut out = generate_toml_with_comments(&config_with_secret(Secret {
+            description: Some("desc".to_string()),
+            ..Default::default()
+        }))
+        .unwrap();
+        out.push_str(get_example_toml());
+        // The appended example only adds commented secrets, so it must remain
+        // syntactically valid TOML.
+        toml::from_str::<Config>(&out).expect("init output template must be valid TOML");
+    }
+
+    #[test]
+    fn cli_command_definition_is_valid() {
+        use clap::CommandFactory;
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn init_defaults_from_to_dotenv() {
+        let cli = Cli::try_parse_from(["secretspec", "init"]).unwrap();
+        match cli.command {
+            Commands::Init { from } => assert_eq!(from, "dotenv://.env"),
+            _ => panic!("expected Init command"),
+        }
+    }
+
+    #[test]
+    fn run_captures_trailing_args() {
+        let cli =
+            Cli::try_parse_from(["secretspec", "run", "--", "npm", "start", "--flag"]).unwrap();
+        match cli.command {
+            Commands::Run { command, .. } => {
+                assert_eq!(command, vec!["npm", "start", "--flag"]);
+            }
+            _ => panic!("expected Run command"),
+        }
+    }
+
+    #[test]
+    fn check_parses_no_prompt_short_flag() {
+        let cli = Cli::try_parse_from(["secretspec", "check", "-n"]).unwrap();
+        match cli.command {
+            Commands::Check { no_prompt, .. } => assert!(no_prompt),
+            _ => panic!("expected Check command"),
         }
     }
 }

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -838,3 +838,162 @@ impl From<toml::de::Error> for ParseError {
         ParseError::Toml(e)
     }
 }
+
+#[cfg(test)]
+mod validation_tests {
+    use super::*;
+
+    fn secret(description: Option<&str>) -> Secret {
+        Secret {
+            description: description.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    fn config_with(name: &str, profiles: Vec<(&str, Vec<(&str, Secret)>)>) -> Config {
+        let profiles = profiles
+            .into_iter()
+            .map(|(pname, secrets)| {
+                let secrets = secrets
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect();
+                (
+                    pname.to_string(),
+                    Profile {
+                        defaults: None,
+                        secrets,
+                    },
+                )
+            })
+            .collect();
+        Config {
+            project: Project {
+                name: name.to_string(),
+                revision: "1.0".to_string(),
+                extends: None,
+            },
+            profiles,
+            providers: None,
+        }
+    }
+
+    #[test]
+    fn is_valid_identifier_accepts_and_rejects() {
+        for ok in ["ok", "_ok", "VALID_NAME9", "a"] {
+            assert!(is_valid_identifier(ok), "expected valid: {ok}");
+        }
+        for bad in ["", "1abc", "a-b", "has space", "a.b"] {
+            assert!(!is_valid_identifier(bad), "expected invalid: {bad}");
+        }
+    }
+
+    #[test]
+    fn config_validate_rejects_empty_name() {
+        let err = config_with("", vec![("default", vec![("A", secret(Some("d")))])])
+            .validate()
+            .unwrap_err();
+        assert!(matches!(err, ParseError::Validation(_)));
+        assert!(err.to_string().contains("name cannot be empty"));
+    }
+
+    #[test]
+    fn config_validate_rejects_no_profiles() {
+        let err = config_with("proj", vec![]).validate().unwrap_err();
+        assert!(err.to_string().contains("At least one profile"));
+    }
+
+    #[test]
+    fn config_validate_rejects_empty_profile() {
+        let err = config_with("proj", vec![("default", vec![])])
+            .validate()
+            .unwrap_err();
+        assert!(err.to_string().contains("at least one secret"));
+    }
+
+    #[test]
+    fn config_validate_rejects_invalid_secret_name() {
+        let err = config_with("proj", vec![("default", vec![("1BAD", secret(Some("d")))])])
+            .validate()
+            .unwrap_err();
+        assert!(err.to_string().contains("Invalid secret name"));
+    }
+
+    #[test]
+    fn config_validate_accepts_valid_config() {
+        assert!(
+            config_with(
+                "proj",
+                vec![("default", vec![("API_KEY", secret(Some("d")))])]
+            )
+            .validate()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn secret_validate_requires_nonempty_description() {
+        assert_eq!(secret(None).validate().unwrap_err(), "missing description");
+        assert_eq!(
+            secret(Some("")).validate().unwrap_err(),
+            "description cannot be empty"
+        );
+    }
+
+    #[test]
+    fn secret_validate_rejects_required_with_default() {
+        let s = Secret {
+            description: Some("d".to_string()),
+            required: Some(true),
+            default: Some("v".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            s.validate()
+                .unwrap_err()
+                .contains("Required secrets cannot have default")
+        );
+    }
+
+    #[test]
+    fn secret_validate_generate_requires_type() {
+        let s = Secret {
+            description: Some("d".to_string()),
+            generate: Some(GenerateConfig::Bool(true)),
+            ..Default::default()
+        };
+        assert!(s.validate().unwrap_err().contains("requires 'type'"));
+    }
+
+    #[test]
+    fn secret_validate_rejects_unknown_type() {
+        let s = Secret {
+            description: Some("d".to_string()),
+            secret_type: Some("banana".to_string()),
+            ..Default::default()
+        };
+        assert!(s.validate().unwrap_err().contains("unknown secret type"));
+    }
+
+    #[test]
+    fn secret_validate_command_type_requires_command() {
+        let s = Secret {
+            description: Some("d".to_string()),
+            secret_type: Some("command".to_string()),
+            generate: Some(GenerateConfig::Bool(true)),
+            ..Default::default()
+        };
+        assert!(
+            s.validate()
+                .unwrap_err()
+                .contains("requires generate = { command")
+        );
+    }
+
+    #[test]
+    fn generate_config_is_enabled() {
+        assert!(!GenerateConfig::Bool(false).is_enabled());
+        assert!(GenerateConfig::Bool(true).is_enabled());
+        assert!(GenerateConfig::Options(GenerateOptions::default()).is_enabled());
+    }
+}

--- a/secretspec/src/provider/keyring.rs
+++ b/secretspec/src/provider/keyring.rs
@@ -148,3 +148,69 @@ impl Provider for KeyringProvider {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    fn provider_url(s: &str) -> ProviderUrl {
+        ProviderUrl::new(Url::parse(s).unwrap())
+    }
+
+    #[test]
+    fn format_service_default_pattern() {
+        let provider = KeyringProvider::new(KeyringConfig::default());
+        assert_eq!(
+            provider.format_service("myproj", "prod", "API_KEY"),
+            "secretspec/myproj/prod/API_KEY"
+        );
+    }
+
+    #[test]
+    fn format_service_custom_prefix() {
+        let provider = KeyringProvider::new(KeyringConfig {
+            folder_prefix: Some("vault/{profile}/{key}".to_string()),
+        });
+        assert_eq!(
+            provider.format_service("myproj", "prod", "API_KEY"),
+            "vault/prod/API_KEY"
+        );
+    }
+
+    #[test]
+    fn try_from_sets_folder_prefix_from_host_and_path() {
+        let config =
+            KeyringConfig::try_from(&provider_url("keyring://secretspec/shared/{profile}/{key}"))
+                .unwrap();
+        assert_eq!(
+            config.folder_prefix.as_deref(),
+            Some("secretspec/shared/{profile}/{key}")
+        );
+    }
+
+    #[test]
+    fn try_from_without_host_has_no_prefix() {
+        let config = KeyringConfig::try_from(&provider_url("keyring://")).unwrap();
+        assert_eq!(config.folder_prefix, None);
+    }
+
+    #[test]
+    fn try_from_rejects_wrong_scheme() {
+        let err = KeyringConfig::try_from(&provider_url("pass://x")).unwrap_err();
+        assert!(err.to_string().contains("Invalid scheme"));
+    }
+
+    #[test]
+    fn uri_round_trips_default_and_prefix() {
+        assert_eq!(
+            KeyringProvider::new(KeyringConfig::default()).uri(),
+            "keyring"
+        );
+        let provider = KeyringProvider::new(KeyringConfig {
+            folder_prefix: Some("my vault/{key}".to_string()),
+        });
+        // The space must be percent-encoded.
+        assert_eq!(provider.uri(), "keyring://my%20vault/{key}");
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -645,3 +645,82 @@ fn provider_from_url(url: &ProviderUrl) -> Result<Box<dyn Provider>> {
         Ok(pwp.provider)
     }
 }
+
+#[cfg(test)]
+mod url_tests {
+    use super::*;
+    use std::collections::HashMap;
+    use url::Url;
+
+    fn url(s: &str) -> ProviderUrl {
+        ProviderUrl::new(Url::parse(s).unwrap())
+    }
+
+    #[test]
+    fn host_and_path_are_percent_decoded() {
+        let u = url("keyring://Home%20Lab/My%20Path");
+        assert_eq!(u.host().as_deref(), Some("Home Lab"));
+        assert_eq!(u.path(), "/My Path");
+    }
+
+    #[test]
+    fn username_and_password_are_percent_decoded() {
+        let u = url("onepassword://work%40acct:tok%20en@Vault");
+        assert_eq!(u.username(), "work@acct");
+        assert_eq!(u.password().as_deref(), Some("tok en"));
+        assert_eq!(u.host().as_deref(), Some("Vault"));
+    }
+
+    #[test]
+    fn missing_password_and_port_are_none() {
+        let u = url("keyring://host");
+        assert_eq!(u.password(), None);
+        assert_eq!(u.port(), None);
+        assert_eq!(u.username(), "");
+    }
+
+    #[test]
+    fn port_is_parsed_when_present() {
+        assert_eq!(url("https://example.com:8200/").port(), Some(8200));
+    }
+
+    #[test]
+    fn query_pairs_are_decoded() {
+        let u = url("keyring://h/p?prefix=a%20b&kv=v2");
+        let pairs: HashMap<String, String> = u
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        assert_eq!(pairs.get("prefix").map(String::as_str), Some("a b"));
+        assert_eq!(pairs.get("kv").map(String::as_str), Some("v2"));
+    }
+
+    #[test]
+    fn encode_escapes_spaces_but_keeps_plain() {
+        assert_eq!(ProviderUrl::encode("plain"), "plain");
+        assert_eq!(ProviderUrl::encode("Home Lab"), "Home%20Lab");
+    }
+
+    #[test]
+    fn provider_info_display_with_and_without_examples() {
+        let with = ProviderInfo {
+            name: "onepassword",
+            description: "OnePassword",
+            examples: &["onepassword://vault", "onepassword://work@Production"],
+        };
+        assert_eq!(
+            with.display_with_examples(),
+            "onepassword: OnePassword (e.g., onepassword://vault, onepassword://work@Production)"
+        );
+
+        let without = ProviderInfo {
+            name: "env",
+            description: "Environment variables",
+            examples: &[],
+        };
+        assert_eq!(
+            without.display_with_examples(),
+            "env: Environment variables"
+        );
+    }
+}

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -879,3 +879,100 @@ impl Default for OnePasswordProvider {
         Self::new(OnePasswordConfig::default())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    fn config(s: &str) -> OnePasswordConfig {
+        OnePasswordConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap()
+    }
+
+    #[test]
+    fn try_from_parses_account_and_vault() {
+        let c = config("onepassword://work@Production");
+        assert_eq!(c.account.as_deref(), Some("work"));
+        assert_eq!(c.default_vault.as_deref(), Some("Production"));
+        assert_eq!(c.service_account_token, None);
+    }
+
+    #[test]
+    fn try_from_parses_vault_only() {
+        let c = config("onepassword://Production");
+        assert_eq!(c.account, None);
+        assert_eq!(c.default_vault.as_deref(), Some("Production"));
+    }
+
+    #[test]
+    fn try_from_token_scheme_captures_token_from_username() {
+        let c = config("onepassword+token://ops_tok@Private");
+        assert_eq!(c.service_account_token.as_deref(), Some("ops_tok"));
+        assert_eq!(c.default_vault.as_deref(), Some("Private"));
+        assert_eq!(c.account, None);
+    }
+
+    #[test]
+    fn try_from_token_scheme_captures_token_from_password() {
+        let c = config("onepassword+token://acct:ops_tok@Private");
+        assert_eq!(c.service_account_token.as_deref(), Some("ops_tok"));
+    }
+
+    #[test]
+    fn try_from_ignores_localhost_host() {
+        let c = config("onepassword://localhost");
+        assert_eq!(c.default_vault, None);
+        assert_eq!(c.account, None);
+    }
+
+    // Note: the `"1password"` guard arm in `try_from` is effectively unreachable
+    // via ProviderUrl, because `Url::parse` rejects schemes that start with a
+    // digit (RFC 3986). It therefore cannot be exercised through a real URL.
+
+    #[test]
+    fn try_from_rejects_unknown_scheme() {
+        let err =
+            OnePasswordConfig::try_from(&ProviderUrl::new(Url::parse("keyring://vault").unwrap()))
+                .unwrap_err();
+        assert!(err.to_string().contains("Invalid scheme"));
+    }
+
+    #[test]
+    fn get_vault_name_defaults_to_private() {
+        let default = OnePasswordProvider::new(OnePasswordConfig::default());
+        assert_eq!(default.get_vault_name("any"), "Private");
+
+        let configured = OnePasswordProvider::new(config("onepassword://Production"));
+        assert_eq!(configured.get_vault_name("any"), "Production");
+    }
+
+    #[test]
+    fn format_item_name_default_and_custom() {
+        let default = OnePasswordProvider::new(OnePasswordConfig::default());
+        assert_eq!(
+            default.format_item_name("proj", "KEY", "prod"),
+            "secretspec/proj/prod/KEY"
+        );
+
+        let custom = OnePasswordProvider::new(OnePasswordConfig {
+            folder_prefix: Some("{project}-{key}".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(custom.format_item_name("proj", "KEY", "prod"), "proj-KEY");
+    }
+
+    #[test]
+    fn uri_for_account_round_trips() {
+        let provider = OnePasswordProvider::new(config("onepassword://work@Production"));
+        assert_eq!(provider.uri(), "onepassword://work@Production");
+    }
+
+    #[test]
+    fn uri_for_token_does_not_leak_secret() {
+        let provider =
+            OnePasswordProvider::new(config("onepassword+token://ops_secret_tok@Private"));
+        let uri = provider.uri();
+        assert_eq!(uri, "onepassword+token://Private");
+        assert!(!uri.contains("ops_secret_tok"));
+    }
+}

--- a/secretspec/src/provider/pass.rs
+++ b/secretspec/src/provider/pass.rs
@@ -231,3 +231,59 @@ impl Provider for PassProvider {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    fn provider_url(s: &str) -> ProviderUrl {
+        ProviderUrl::new(Url::parse(s).unwrap())
+    }
+
+    #[test]
+    fn format_entry_name_default_pattern() {
+        let provider = PassProvider::new(PassConfig::default());
+        assert_eq!(
+            provider.format_entry_name("myproj", "prod", "API_KEY"),
+            "secretspec/myproj/prod/API_KEY"
+        );
+    }
+
+    #[test]
+    fn format_entry_name_custom_prefix() {
+        let provider = PassProvider::new(PassConfig {
+            folder_prefix: Some("vault/{profile}/{key}".to_string()),
+        });
+        assert_eq!(
+            provider.format_entry_name("myproj", "prod", "API_KEY"),
+            "vault/prod/API_KEY"
+        );
+    }
+
+    #[test]
+    fn try_from_sets_folder_prefix_from_host_and_path() {
+        let config =
+            PassConfig::try_from(&provider_url("pass://secretspec/shared/{profile}/{key}"))
+                .unwrap();
+        assert_eq!(
+            config.folder_prefix.as_deref(),
+            Some("secretspec/shared/{profile}/{key}")
+        );
+    }
+
+    #[test]
+    fn try_from_rejects_wrong_scheme() {
+        let err = PassConfig::try_from(&provider_url("keyring://x")).unwrap_err();
+        assert!(err.to_string().contains("Invalid scheme"));
+    }
+
+    #[test]
+    fn uri_round_trips_default_and_prefix() {
+        assert_eq!(PassProvider::new(PassConfig::default()).uri(), "pass");
+        let provider = PassProvider::new(PassConfig {
+            folder_prefix: Some("my vault/{key}".to_string()),
+        });
+        assert_eq!(provider.uri(), "pass://my%20vault/{key}");
+    }
+}

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -4601,3 +4601,125 @@ fn test_validate_provider_override_project_alias_without_global_default() {
         "validation metadata should report the resolved override URI"
     );
 }
+
+/// Builds a Secrets backed by a dotenv provider over a temp `.env` file.
+///
+/// The caller must keep `temp_dir` alive for as long as the returned Secrets
+/// is used, since the `.env` file lives inside it.
+fn dotenv_spec(
+    env_contents: &str,
+    profiles: HashMap<String, Profile>,
+    temp_dir: &TempDir,
+) -> Secrets {
+    let env_file = temp_dir.path().join(".env");
+    fs::write(&env_file, env_contents).unwrap();
+    Secrets::new(
+        Config {
+            project: Project {
+                name: "test".to_string(),
+                revision: "1.0".to_string(),
+                extends: None,
+            },
+            profiles,
+            providers: None,
+        },
+        Some(GlobalConfig {
+            defaults: GlobalDefaults {
+                provider: Some(format!("dotenv://{}", env_file.display())),
+                profile: None,
+                providers: None,
+            },
+        }),
+        None,
+        None,
+    )
+}
+
+fn required_secret_profile(name: &str) -> HashMap<String, Profile> {
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        name.to_string(),
+        Secret {
+            description: Some("A required secret".to_string()),
+            required: Some(true),
+            ..Default::default()
+        },
+    );
+    HashMap::from([(
+        "default".to_string(),
+        Profile {
+            defaults: None,
+            secrets,
+        },
+    )])
+}
+
+#[test]
+fn test_check_returns_ok_when_required_present() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec = dotenv_spec(
+        "REQUIRED=value\n",
+        required_secret_profile("REQUIRED"),
+        &temp_dir,
+    );
+
+    let validated = spec.check(true).expect("check should succeed");
+    assert!(validated.resolved.secrets.contains_key("REQUIRED"));
+}
+
+#[test]
+fn test_check_no_prompt_errors_when_required_missing() {
+    let temp_dir = TempDir::new().unwrap();
+    // Empty .env -> the required secret is missing.
+    let spec = dotenv_spec("", required_secret_profile("REQUIRED"), &temp_dir);
+
+    assert!(
+        matches!(
+            spec.check(true),
+            Err(SecretSpecError::RequiredSecretMissing(_))
+        ),
+        "expected RequiredSecretMissing when a required secret is absent"
+    );
+}
+
+#[test]
+fn test_run_command_returns_child_exit_code() {
+    let temp_dir = TempDir::new().unwrap();
+    // An empty (but present) default profile -> ensure_secrets passes and the
+    // child's exit code is propagated verbatim.
+    let empty_default = HashMap::from([(
+        "default".to_string(),
+        Profile {
+            defaults: None,
+            secrets: HashMap::new(),
+        },
+    )]);
+    let spec = dotenv_spec("", empty_default, &temp_dir);
+
+    assert_eq!(
+        spec.run_command(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "exit 3".to_string()
+        ])
+        .unwrap(),
+        3
+    );
+    assert_eq!(spec.run_command(vec!["true".to_string()]).unwrap(), 0);
+    assert_eq!(spec.run_command(vec!["false".to_string()]).unwrap(), 1);
+}
+
+#[test]
+fn test_resolve_profile_unknown_returns_invalid_profile() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec = dotenv_spec("", required_secret_profile("REQUIRED"), &temp_dir);
+
+    let result = spec.resolve_profile(Some("nonexistent"));
+    match result {
+        Err(SecretSpecError::InvalidProfile(msg)) => {
+            assert!(msg.contains("nonexistent"));
+            assert!(msg.contains("Available profiles"));
+        }
+        other => panic!("expected InvalidProfile, got {other:?}"),
+    }
+}

--- a/secretspec/src/validation.rs
+++ b/secretspec/src/validation.rs
@@ -111,3 +111,43 @@ impl fmt::Display for ValidationErrors {
 }
 
 impl std::error::Error for ValidationErrors {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn errors(missing_required: Vec<&str>) -> ValidationErrors {
+        ValidationErrors::new(
+            missing_required.into_iter().map(String::from).collect(),
+            vec![],
+            vec![],
+            "keyring".to_string(),
+            "default".to_string(),
+        )
+    }
+
+    #[test]
+    fn has_errors_true_only_when_required_missing() {
+        assert!(errors(vec!["A", "B"]).has_errors());
+        assert!(!errors(vec![]).has_errors());
+
+        // Missing optional / defaults alone are not errors.
+        let only_optional = ValidationErrors::new(
+            vec![],
+            vec!["OPT".to_string()],
+            vec![("X".to_string(), "v".to_string())],
+            "keyring".to_string(),
+            "default".to_string(),
+        );
+        assert!(!only_optional.has_errors());
+    }
+
+    #[test]
+    fn display_lists_missing_required_or_is_empty() {
+        assert_eq!(
+            errors(vec!["A", "B"]).to_string(),
+            "Missing required secrets: A, B"
+        );
+        assert_eq!(errors(vec![]).to_string(), "");
+    }
+}


### PR DESCRIPTION
## Summary

Raises unit-test coverage across previously untested logic and fixes several real bugs in `secretspec init` found while writing the tests.

### Fixed
- **`init` now serializes `secretspec.toml` with `toml_edit`** instead of hand-interpolating strings. This fixes several inputs that previously produced unparseable or silently-wrong TOML:
  - control characters (notably **U+007F**) in a project name, description, or default value, which the manual escaper let through and the parser then rejected;
  - a **secret name containing a dot** (dotenvy accepts e.g. `FOO.BAR`), which was emitted as a bare key, parsed as a dotted/nested key, and silently collapsed to a secret named `FOO` on round-trip;
  - a configured **`project.extends`**, which was never written at all.

  Keys and values are now quoted/escaped by the library; secrets are emitted as inline tables and profiles/secrets are sorted for deterministic output. The helpful comments in the generated file are preserved.
- **`init` no longer defines a conflicting `-f` short flag for `--from`.** `-f` is reserved for the global `--file` option; the duplicate panicked in debug builds (`Cli::command().debug_assert()`) and was ambiguous in release. The CLI reference docs are updated to match.

### Tests (no production behavior change beyond the above)
- **CLI** (`cli/mod.rs`): TOML round-trips with special characters, dotted secret names, control characters, and `extends`; `init` template validity; clap argument parsing (with a `debug_assert` guard against future flag collisions).
- **Config** (`config.rs`): `Config::validate` / `Secret::validate` guards, identifier checks, `GenerateConfig::is_enabled`.
- **Validation** (`validation.rs`): `ValidationErrors` display and `has_errors`.
- **Providers** (`keyring.rs`, `pass.rs`, `onepassword.rs`, `provider/mod.rs`): no-network `TryFrom<&ProviderUrl>` parsing, path/item-name builders, `ProviderUrl` encode/decode, `ProviderInfo` display, and `uri()` round-trips (including OnePassword token redaction).
- **Secrets** (`tests.rs`): `check()` present/missing paths, `run_command` child exit-code propagation, and the `InvalidProfile` error.

## Test plan
- `cargo test --package secretspec` (227 tests pass)
- `cargo clippy --package secretspec --all-targets` (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
