### PR TITLE
feat: local audit log for secret access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Audit logging for secret access, on by default. Every secret read and write,
+  from both the CLI and the Rust SDK, is appended to a local per-user log as JSON
+  Lines. Only metadata is recorded (secret names, the serving provider with any
+  embedded credentials redacted, outcome, reason, and actor including a detected
+  coding agent); secret values are never written. Each operation is recorded once:
+  `get` and `set` per secret, `check` as a single event, `run` when the child
+  process starts, and `import` per copied secret. Auditing never blocks secret
+  access; if it cannot write the log it warns on stderr and continues. The log is
+  a single file capped at 1 MiB. It is configured per machine via the `[audit]`
+  table in `~/.config/secretspec/config.toml` (not the project's
+  `secretspec.toml`), so a cloned repository cannot redirect or silence it. The
+  new `secretspec audit` command reads the log, with `--project`, `--action`,
+  `--tail`/`-n`, and `--json` filters. See
+  [Audit Logging](https://secretspec.dev/concepts/audit/) for details.
 - `--reason` CLI flag (and `SECRETSPEC_REASON` env var) records a human-readable
   reason for a session's secret access, forwarded to providers that support audit
   logging. `SECRETSPEC_REASON` is honored across the SDK/library too: it is resolved
   by `Secrets::load`/`load_from` (so `secretspec-derive`-generated code and other
   library callers can satisfy the `require_reason` policy and supply an audit reason
   without code changes), and `Secrets::with_reason(...)` sets it explicitly, taking
-  precedence. Blank or whitespace-only reasons are ignored so they cannot satisfy the
-  policy. Backed by a new `Provider::set_reason` trait method (default no-op).
+  precedence. The `secretspec-derive`-generated typed builder also gains a
+  `with_reason(...)` method, so SDK callers can satisfy `require_reason` in code
+  (not only via the env var). Blank or whitespace-only reasons are ignored so they
+  cannot satisfy the policy. Backed by a new `Provider::set_reason` trait method
+  (default no-op).
 - `[project] require_reason` policy in `secretspec.toml`, controlling when secret
   access must supply an explicit reason. Accepts `"agents"` (the default — require
   a reason only when an AI agent is detected), `true` (require it from every
@@ -31,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **Note:** the default `"agents"` means AI agents must now pass a reason out of
   the box.
 
+### Changed
+- Minimum supported Rust version raised to 1.92 (required by the
+  `detect-coding-agent` dependency). The devenv toolchain is pinned accordingly.
+
 ### Fixed
 - Proton Pass provider now works with `pass-cli` >= 2.1.0 agent sessions. Since
   2.1.0, audited item operations (`item view`, `item create`, `item delete`)
@@ -41,23 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`secretspec/<version> (https://secretspec.dev)`); each source is normalized first,
   so a blank reason falls through to the next rather than masking it. It is ignored by
   older releases and non-agent sessions.
-
-### Changed
-- Minimum supported Rust version raised to 1.92 (required by the
-  `detect-coding-agent` dependency). The devenv toolchain is pinned accordingly.
-
-### Internal
-- Expanded test coverage for previously untested logic: CLI argument parsing
-  and `init` TOML generation, the config/secret validation guards
-  (`Config::validate`, `Secret::validate`, identifier checks), the
-  `ValidationErrors` display/`has_errors` behavior, `ProviderUrl`
-  encode/decode and `ProviderInfo` display, and the no-network parsing and
-  path-building logic of the keyring, pass, and OnePassword providers
-  (`TryFrom<&ProviderUrl>`, path/item-name builders, and `uri()` round-trips),
-  and the `Secrets` public surface (`check()` present/missing paths,
-  `run_command` child exit-code propagation, and the `InvalidProfile` error).
-
-### Fixed
 - `secretspec init` now serializes the generated `secretspec.toml` with
   `toml_edit` instead of hand-interpolating strings. This fixes several cases
   that previously produced TOML that could not be parsed back: a project name,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3156,21 @@ dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3795,6 +3851,7 @@ dependencies = [
  "etcetera",
  "google-cloud-secretmanager-v1",
  "inquire",
+ "jiff",
  "keyring",
  "linkme",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ proc-macro2 = "1.0"
 trybuild = "1.0"
 insta = "1.34"
 linkme = "0.3"
+jiff = "0.2"
 secrecy = { version = "0.10.3", features = ["serde"] }
 bitwarden = { version = "2.0.0", features = ["secrets"] }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -156,6 +156,7 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
               slug: "concepts/inheritance",
             },
             { label: "Secret Generation", slug: "concepts/generation" },
+            { label: "Audit Logging", slug: "concepts/audit" },
           ],
         },
         {

--- a/docs/src/content/docs/concepts/audit.md
+++ b/docs/src/content/docs/concepts/audit.md
@@ -1,0 +1,118 @@
+---
+title: Audit Logging
+description: A local, append-only record of every secret access for after-the-fact review
+---
+
+secretspec records every secret access to a local audit log so you can review,
+after the fact, **what** secret was accessed, **when**, by **whom**, with what
+**reason**, and what the **outcome** was. Auditing is **on by default**.
+
+Secret values are never written to the log. Only metadata is recorded, and any
+credentials embedded in a provider URI are redacted.
+
+## Where the log lives
+
+By default the log is written to the per-user state directory, one entry per line
+in [JSON Lines](https://jsonlines.org/) format:
+
+| Platform | Default path |
+|----------|--------------|
+| Linux | `~/.local/state/secretspec/audit.log` |
+| macOS | `~/.local/state/secretspec/audit.log` |
+
+(secretspec follows the XDG state-directory convention on macOS too, matching
+where it keeps its config, so the path is the same as on Linux. Set `[audit]
+path` to override it.)
+
+The file is created with owner-only permissions (`0600` on Unix), inside an
+owner-only directory (`0700`). The first time
+secretspec writes to it, it prints a one-time note telling you where the log is
+and how to turn it off.
+
+## What a record looks like
+
+```json
+{
+  "v": 1,
+  "id": "386987e6-291f-4e8f-a08b-73db9d80897b",
+  "ts": "2026-06-04T17:04:00.893Z",
+  "session_id": "d59e0f0f-ed2f-456f-a2b6-be25a24b7ec7",
+  "seq": 0,
+  "action": "get",
+  "project": "my-app",
+  "profile": "production",
+  "key": "DATABASE_URL",
+  "provider": "keyring://",
+  "outcome": "found",
+  "reason": "deploy web frontend",
+  "actor": { "user": "alice", "agent": "claude-code", "is_agent": true },
+  "version": "0.11.0"
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `v` | Schema version of the record |
+| `id` | Unique id for this event |
+| `ts` | RFC 3339 UTC timestamp |
+| `session_id` | Shared by every event from one `secretspec` invocation |
+| `seq` | Monotonic sequence within that invocation |
+| `action` | The operation: `get`, `set`, `check`, `run`, or `import` |
+| `project` / `profile` | The project and profile in effect |
+| `key` | The secret name for single-secret actions (`get`/`set`); never its value |
+| `keys` | The set of secret names for bulk actions (`check`/`run`/`import`) |
+| `command` | For `run`, the executed program (argv[0] only — never its arguments, which may contain secrets) |
+| `provider` | The provider URI that served the access, with credentials redacted |
+| `outcome` | `found`, `missing`, `default`, `written`, `started` (a `run` launched its command), or `error` |
+| `error_kind` | A non-sensitive tag when `outcome` is `error` |
+| `reason` | The reason supplied via `--reason` / `SECRETSPEC_REASON` / the SDK, if any |
+| `actor` | The OS user, the detected coding agent (if any), and whether this is an agent session |
+
+This pairs naturally with the [`require_reason`](/reference/configuration/#requiring-a-reason-for-secret-access)
+policy: the policy makes callers state *why* they need a secret, and the audit
+log records that reason alongside the access.
+
+## Reading the log
+
+The log is plain JSON Lines, so any tool works (`cat`, `tail -f`, `jq`). The
+[`secretspec audit`](/reference/cli/#audit) command reads it for you with filters
+and a readable summary:
+
+```bash
+# Last 20 entries, formatted
+secretspec audit -n 20
+
+# Only `run` events for one project
+secretspec audit --project my-app --action run
+
+# Raw JSON Lines, piped to jq
+secretspec audit --json | jq 'select(.outcome == "missing")'
+```
+
+## Size cap
+
+The log is a single file capped at **1 MiB** by default. When it reaches the cap
+it is truncated and started fresh, so disk usage stays bounded without any log
+rotation to manage. This makes the log a size-bounded recent record rather than a
+complete, permanent history — it is not intended to satisfy long-term compliance
+retention on its own. Forward it to a central system if you need that.
+
+## Reliability
+
+Auditing never blocks secret access. If the log cannot be written (for example, a
+read-only filesystem), secretspec prints a `warning:` to stderr and continues —
+your `get`, `set`, and `run` still work.
+
+## Configuration
+
+Auditing is a per-machine concern, so it is configured in your **user-global
+config** (`~/.config/secretspec/config.toml`) under the top-level `[audit]` table —
+not in the project's `secretspec.toml`. This means a repository you clone cannot
+turn off or redirect your audit log. See the
+[configuration reference](/reference/configuration/#audit-logging) for all options.
+To turn it off:
+
+```toml title="~/.config/secretspec/config.toml"
+[audit]
+enabled = false
+```

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -247,6 +247,31 @@ $ secretspec import dotenv:/home/user/old-project/.env
 - Copy secrets between different profiles or projects
 - Import existing environment variables into SecretSpec management
 
+### audit
+
+Show the local [audit log](/concepts/audit/) of secret access.
+
+```bash
+secretspec audit [--project <NAME>] [--action <ACTION>] [-n <N>] [--json]
+```
+
+**Options:**
+- `--project <NAME>` - Only show entries for this project
+- `--action <ACTION>` - Only show entries for this action (`get`, `set`, `check`, `run`, `import`)
+- `-n, --tail <N>` - Show only the last N entries
+- `--json` - Output raw JSON Lines instead of the formatted summary
+
+The log location is read from your user-global config (`[audit]` in `~/.config/secretspec/config.toml`), defaulting to the per-user state directory.
+
+**Example:**
+```bash
+$ secretspec audit --action run -n 5
+2026-06-04T18:06:29Z  run    found  ./deploy.sh  API_KEY,DATABASE_URL  (my-app/production)  reason: deploy  [claude-code]
+
+# Pipe raw entries to jq
+$ secretspec audit --json | jq 'select(.outcome == "missing")'
+```
+
 ## Environment Variables
 
 | Variable | Description |

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -61,7 +61,8 @@ $ export SECRETSPEC_AGENT=1
 If your agent isn't auto-detected, set `SECRETSPEC_AGENT=1` (or use
 `require_reason = true` to require a reason from everyone).
 
-The reason is also forwarded to providers that support audit logging (e.g. the
+The reason is recorded in secretspec's own [audit log](/concepts/audit/) and is also
+forwarded to providers that support auditing (e.g. the
 [Proton Pass](/providers/protonpass/) provider records it in the agent audit log).
 
 ### [profiles.*] Section
@@ -177,6 +178,32 @@ $ secretspec config provider remove prod_vault
 ```
 
 The CLI commands operate on the user-global config only — edit `secretspec.toml` by hand to change project-level aliases.
+
+### Audit Logging
+
+secretspec records every secret access to a local [audit log](/concepts/audit/).
+Auditing is a per-machine/operator concern — where the log lives and whether it is
+on — so it is configured in the **user-global config**, not the project's
+`secretspec.toml`. A cloned repository therefore cannot redirect or silence your
+audit log. Auditing is **on by default**; configure it under the top-level
+`[audit]` table:
+
+```toml title="~/.config/secretspec/config.toml"
+[audit]
+enabled = true                                   # set false to turn auditing off
+path = "~/.local/state/secretspec/audit.log"     # default: per-user XDG state dir
+max_size_bytes = 1048576                          # default: 1 MiB
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `true` | Whether to record secret access. |
+| `path` | string | per-user state dir | Where to write the JSON Lines log. Must be absolute (a leading `~` is expanded); a relative path is rejected and auditing is disabled. |
+| `max_size_bytes` | integer | `1048576` (1 MiB) | Hard size cap. At the cap the file is truncated and restarted; no rotated backups are kept. |
+
+Secret values are never written to the log, and credentials embedded in provider
+URIs are redacted. Audit failures never block secret access. See
+[Audit Logging](/concepts/audit/) for the record format and full details.
 
 ### as_path Option
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -404,6 +404,54 @@ println!("{}", s.secrets.database_url);</code></pre>
   </div>
 </section>
 
+<!-- ============ SHOWCASE: audit & agent reason ============ -->
+<section class="landing-showcase">
+  <div class="landing-container">
+    <div class="landing-showcase-head">
+      <span class="landing-showcase-eyebrow">Audit &amp; AI agents</span>
+      <h2 class="landing-section-title">Know who read a secret — and why.</h2>
+      <p class="landing-section-lead landing-section-lead-narrow">
+        Every access is appended to a local, append-only log — values never written, URI credentials redacted. And when an AI agent is driving, SecretSpec makes it state a reason first. <a href="/concepts/audit/" class="landing-link">How auditing works →</a>
+      </p>
+    </div>
+
+    <div class="landing-fallback">
+      <div class="landing-terminal">
+        <div class="landing-terminal-header">
+          <div class="landing-terminal-dots"><span></span><span></span><span></span></div>
+          <span class="landing-terminal-title">agent session</span>
+        </div>
+        <pre is:raw class="landing-terminal-body"><code><span class="tok-com"># An AI agent runs your app — no reason given</span>
+$ secretspec run -- ./deploy.sh
+Error: accessing secrets requires a reason.
+       Provide one with --reason <span class="tok-str">"&lt;why...&gt;"</span>
+
+<span class="tok-com"># State why — required for agents by default</span>
+$ secretspec run --reason <span class="tok-str">"Deploy web frontend"</span> \
+    -- ./deploy.sh
+<span class="tok-str">✓</span> Loaded DATABASE_URL from keyring
+<span class="tok-pun">›</span> ./deploy.sh</code></pre>
+      </div>
+
+      <div class="landing-terminal">
+        <div class="landing-terminal-header">
+          <div class="landing-terminal-dots"><span></span><span></span><span></span></div>
+          <span class="landing-terminal-title">secretspec audit</span>
+        </div>
+        <pre is:raw class="landing-terminal-body"><code><span class="tok-com"># Review who accessed what, why, and the outcome</span>
+$ secretspec audit -n 1
+<span class="tok-com">2026-06-04T17:04Z</span>  <span class="tok-key">run</span>  <span class="tok-str">started</span>  ./deploy.sh
+  DATABASE_URL  (my-app/production via keyring://)
+  reason: <span class="tok-str">Deploy web frontend</span>  <span class="tok-pun">[claude-code]</span></code></pre>
+      </div>
+    </div>
+
+    <p class="landing-chain-result" style="margin-top: 1.5rem;">
+      The default <code class="inline-code">require_reason = "agents"</code> policy is checked into <code class="inline-code">secretspec.toml</code>, so every clone, CI runner, and agent is held to it — humans running interactively are unaffected. <a href="/reference/configuration/#requiring-a-reason-for-secret-access" class="landing-link">Configure the policy →</a>
+    </p>
+  </div>
+</section>
+
 <!-- ============ SHOWCASE: Rust SDK ============ -->
 <section class="landing-showcase">
   <div class="landing-container">

--- a/secretspec-derive/src/lib.rs
+++ b/secretspec-derive/src/lib.rs
@@ -1089,6 +1089,7 @@ mod secret_spec_generation {
             fn load_internal(
                 provider_str: Option<String>,
                 profile_str: Option<String>,
+                reason: Option<String>,
             ) -> Result<secretspec::ValidatedSecrets, secretspec::SecretSpecError> {
                 let mut spec = secretspec::Secrets::load()?;
                 if let Some(provider) = provider_str {
@@ -1096,6 +1097,14 @@ mod secret_spec_generation {
                 }
                 if let Some(profile) = profile_str {
                     spec.set_profile(profile);
+                }
+                // Apply an explicit builder reason on top of any SECRETSPEC_REASON
+                // already resolved by `Secrets::load`. Required to satisfy the
+                // `require_reason` policy (default "agents") from typed SDK code,
+                // which otherwise has no way to supply a reason. A blank reason is
+                // ignored by `with_reason`, leaving the env-resolved value intact.
+                if let Some(reason) = reason {
+                    spec = spec.with_reason(reason);
                 }
                 match spec.validate()? {
                     Ok(valid_secrets) => Ok(valid_secrets),
@@ -1153,7 +1162,10 @@ mod secret_spec_generation {
                         None => std::env::var("SECRETSPEC_PROFILE").ok(),
                     };
 
-                    let validation_result = load_internal(provider_str, profile_str)?;
+                    // The static `load` has no reason parameter; a reason is supplied
+                    // via the SECRETSPEC_REASON env var (honored by `Secrets::load`)
+                    // or through `SecretSpec::builder().with_reason(...)`.
+                    let validation_result = load_internal(provider_str, profile_str, None)?;
                     let provider_name = validation_result.resolved.provider.clone();
                     let profile = validation_result.resolved.profile.clone();
                     let secrets = validation_result.resolved.secrets;
@@ -1200,6 +1212,7 @@ mod builder_generation {
     /// pub struct SecretSpecBuilder {
     ///     provider: Option<Box<dyn FnOnce() -> Result<Box<dyn secretspec::Provider>, String>>>,
     ///     profile: Option<Box<dyn FnOnce() -> Result<Profile, String>>>,
+    ///     reason: Option<String>,
     /// }
     /// ```
     pub fn generate_struct() -> proc_macro2::TokenStream {
@@ -1207,6 +1220,7 @@ mod builder_generation {
             pub struct SecretSpecBuilder {
                 provider: Option<Box<dyn FnOnce() -> Result<Box<dyn secretspec::Provider>, String>>>,
                 profile: Option<Box<dyn FnOnce() -> Result<Profile, String>>>,
+                reason: Option<String>,
             }
         }
     }
@@ -1243,7 +1257,23 @@ mod builder_generation {
                     Self {
                         provider: None,
                         profile: None,
+                        reason: None,
                     }
+                }
+
+                /// Set a human-readable reason for this session's secret access.
+                ///
+                /// Required to satisfy the project's `require_reason` policy
+                /// (`[project].require_reason` in secretspec.toml, default `"agents"`)
+                /// when loading from agent contexts, and recorded in the audit log.
+                /// Mirrors the CLI `--reason` flag and `Secrets::with_reason`. A blank
+                /// reason is ignored, falling back to the `SECRETSPEC_REASON` env var.
+                pub fn with_reason<T>(mut self, reason: T) -> Self
+                where
+                    T: Into<String>,
+                {
+                    self.reason = Some(reason.into());
+                    self
                 }
 
                 pub fn with_provider<T>(mut self, provider: T) -> Self
@@ -1364,8 +1394,9 @@ mod builder_generation {
                 pub fn load(mut self) -> Result<secretspec::Resolved<SecretSpec>, secretspec::SecretSpecError> {
                     #resolve_provider_load
                     #resolve_profile_load
+                    let reason_str = self.reason.take();
 
-                    let validation_result = load_internal(provider_str, profile_str)?;
+                    let validation_result = load_internal(provider_str, profile_str, reason_str)?;
                     let provider_name = validation_result.resolved.provider.clone();
                     let profile = validation_result.resolved.profile.clone();
                     let secrets = validation_result.resolved.secrets;
@@ -1383,6 +1414,7 @@ mod builder_generation {
 
                 pub fn load_profile(mut self) -> Result<secretspec::Resolved<SecretSpecProfile>, secretspec::SecretSpecError> {
                     #resolve_provider_profile
+                    let reason_str = self.reason.take();
 
                     let (profile_str, selected_profile) = if let Some(profile_fn) = self.profile.take() {
                         let profile = profile_fn()
@@ -1399,7 +1431,7 @@ mod builder_generation {
                         (profile_str, selected_profile)
                     };
 
-                    let validation_result = load_internal(provider_str, profile_str)?;
+                    let validation_result = load_internal(provider_str, profile_str, reason_str)?;
                     let provider_name = validation_result.resolved.provider.clone();
                     let profile = validation_result.resolved.profile.clone();
                     let secrets = validation_result.resolved.secrets;

--- a/secretspec-derive/tests/integration_test.rs
+++ b/secretspec-derive/tests/integration_test.rs
@@ -264,5 +264,12 @@ mod profile_inheritance {
         let _ = SecretSpec::builder()
             .with_profile(Profile::Production)
             .with_provider("keyring://");
+
+        // The builder exposes with_reason so typed SDK callers can satisfy the
+        // require_reason policy (default "agents") without relying on the
+        // SECRETSPEC_REASON env var. (Not loading; just verifying the API exists.)
+        let _ = SecretSpec::builder()
+            .with_reason("running database migrations")
+            .with_provider("dotenv://.env");
     }
 }

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -33,6 +33,7 @@ url.workspace = true
 percent-encoding.workspace = true
 whoami = { workspace = true, optional = true }
 linkme.workspace = true
+jiff.workspace = true
 secrecy.workspace = true
 bitwarden = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -21,6 +21,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
 - **Secret Generation**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
 - **Configuration Inheritance**: Extend and override shared configurations using the `extends` feature
+- **[Audit Logging](https://secretspec.dev/concepts/audit/)**: Every secret access recorded locally (who, when, why, outcome) — on by default, secret values never logged
 - **Discovery**: `secretspec init` to discover secrets from existing `.env` files
 
 ## Quick Start

--- a/secretspec/src/audit.rs
+++ b/secretspec/src/audit.rs
@@ -1,0 +1,842 @@
+//! Append-only audit logging for secret access.
+//!
+//! Every secret operation that reaches a provider is recorded as one JSON object
+//! per line (JSON Lines). A policy-denied attempt (the `require_reason` gate) is
+//! recorded too, so a blocked access still leaves a trace. Auditing is **on by
+//! default**; it is configured via the `[audit]` table in the user-global config
+//! (see [`crate::config::AuditConfig`]) and written to a single file capped at a
+//! fixed size (1 MiB by default). At the cap the file is truncated in place and
+//! restarted with whole-line granularity, so the log is a size-bounded record,
+//! not a complete history, and never contains a partially written line.
+//!
+//! Two invariants hold throughout:
+//!
+//! - **Secret values are never logged.** Only metadata (key name, provider,
+//!   outcome, reason, actor) is recorded. Credentials embedded in provider URIs
+//!   are redacted via [`redact_uri`].
+//! - **Auditing never blocks secret access.** Every failure path (bad path,
+//!   write error, serialization error) emits a single `warning:` to stderr and
+//!   returns, so a logging problem can never break `get`/`set`/`run`.
+//!
+//! The log assumes a single writer at a time. Several secretspec processes
+//! writing the same log file concurrently may, around the size-cap rotation,
+//! interleave or lose entries, because rotation is not synchronized across
+//! processes. Operators who need strong guarantees should give each concurrent
+//! context its own `[audit] path`.
+
+use crate::config::AuditConfig;
+use crate::secrets::{detect_agent_id, running_as_agent};
+use colored::Colorize;
+use serde::Serialize;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Schema version embedded in every event; bump on incompatible field changes.
+const SCHEMA_VERSION: u32 = 1;
+
+/// The kind of secret operation being audited.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AuditAction {
+    /// Read a single secret (`secretspec get`).
+    Get,
+    /// Write a single secret (`secretspec set`).
+    Set,
+    /// Validate availability of all secrets (`secretspec check`).
+    Check,
+    /// Inject all secrets into a subprocess (`secretspec run`).
+    Run,
+    /// Copy secrets from one provider to another (`secretspec import`).
+    Import,
+}
+
+/// The result of an audited operation.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AuditOutcome {
+    /// The secret was found and returned.
+    Found,
+    /// The secret was not found in any provider and had no default.
+    Missing,
+    /// The secret was not found but a configured default was used.
+    Default,
+    /// The secret was written successfully.
+    Written,
+    /// The audited subprocess (`run`) was successfully started with the secrets
+    /// injected. Distinct from `found`, which is about a secret lookup.
+    Started,
+    /// The operation failed; see `error_kind`.
+    Error,
+}
+
+/// Who performed the operation. Captured once per process.
+#[derive(Debug, Clone, Serialize)]
+struct Actor {
+    /// Local OS username, best-effort from `USER`/`USERNAME`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<String>,
+    /// Detected coding-agent id (e.g. `claude-code`), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent: Option<&'static str>,
+    /// Whether secretspec considers this an agent session.
+    is_agent: bool,
+}
+
+impl Actor {
+    fn current() -> Self {
+        // Detect the specific coding agent once; reuse the result for `is_agent`
+        // instead of re-scanning the environment. A recognized agent always
+        // implies an agent session, so only fall back to the broader
+        // `running_as_agent()` probe (env opt-in + heuristics) when none was named.
+        // Both helpers route through a UTF-8 env snapshot so a non-UTF-8 variable
+        // cannot panic the process (env vars are arbitrary bytes on Unix).
+        let agent = detect_agent_id();
+        let is_recognized_agent = agent.is_some();
+        Actor {
+            user: std::env::var("USER")
+                .or_else(|_| std::env::var("USERNAME"))
+                .ok(),
+            agent,
+            is_agent: is_recognized_agent || running_as_agent(),
+        }
+    }
+}
+
+/// The variable, per-call context for one audit event, supplied by the call site.
+pub(crate) struct AuditContext<'a> {
+    pub project: &'a str,
+    pub profile: &'a str,
+    /// The single secret involved (`get`/`set`).
+    pub key: Option<&'a str>,
+    /// The set of secrets involved in a bulk action (`check`/`run`/`import`).
+    pub keys: &'a [String],
+    /// For `run`, the program that was executed (argv[0] only — never arguments,
+    /// which may contain secrets).
+    pub command: Option<&'a str>,
+    /// The provider URI that served (or was consulted for) the access. Redacted
+    /// before it is written.
+    pub provider_uri: Option<String>,
+    pub outcome: AuditOutcome,
+    pub error_kind: Option<&'a str>,
+    pub reason: Option<&'a str>,
+}
+
+/// One serialized audit record (one JSON Lines entry).
+#[derive(Serialize)]
+struct AuditEvent<'a> {
+    /// Schema version.
+    v: u32,
+    /// Unique event id.
+    id: String,
+    /// RFC 3339 UTC timestamp.
+    ts: String,
+    /// Identifier shared by all events from one process invocation.
+    session_id: &'a str,
+    /// Monotonic sequence within the session.
+    seq: u64,
+    action: AuditAction,
+    project: &'a str,
+    profile: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key: Option<&'a str>,
+    /// The set of secrets for a bulk action; omitted for single-key actions.
+    #[serde(skip_serializing_if = "<[String]>::is_empty")]
+    keys: &'a [String],
+    /// For `run`, the executed program (argv[0]); omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command: Option<&'a str>,
+    /// Redacted provider URI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    outcome: AuditOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_kind: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+    actor: &'a Actor,
+    /// secretspec version that produced the event.
+    version: &'static str,
+}
+
+/// A destination for audit events.
+///
+/// Implementations must be fail-open: a write error is handled internally (e.g.
+/// reported to stderr) and never propagated, so audit logging can never block
+/// secret access.
+pub(crate) trait AuditSink: Send + Sync {
+    fn write_line(&self, line: &str);
+}
+
+/// A JSON Lines sink: a single append-only file capped at a fixed size. When the
+/// next line would exceed the cap the file is truncated in place and restarted,
+/// so the log is bounded to one file with no rotation history — and, because the
+/// cap is enforced with whole-line granularity, it never contains a partially
+/// written entry.
+struct JsonlSink {
+    file: Mutex<std::fs::File>,
+    path: PathBuf,
+    /// Hard cap on the file size in bytes; a write that would cross it truncates
+    /// and restarts the file first.
+    max_size_bytes: u64,
+}
+
+/// Default log size cap (1 MiB) used when the configured `max_size_bytes` is
+/// invalid (zero), which would otherwise truncate the file on every write.
+const DEFAULT_MAX_SIZE_BYTES: u64 = 1_048_576;
+
+impl JsonlSink {
+    fn new(path: PathBuf, max_size_bytes: u64) -> std::io::Result<Self> {
+        // Require a parent directory; a bare root like "/" has none and cannot
+        // hold a log. Fail open rather than panic.
+        let Some(parent) = path.parent() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "audit log path has no parent directory",
+            ));
+        };
+        // Keep the audit directory owner-only, matching the 0o600 log file.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(parent)?;
+        }
+        #[cfg(not(unix))]
+        std::fs::create_dir_all(parent)?;
+
+        // A zero cap would truncate the file on every write; fall back to the
+        // default and warn rather than render the log useless.
+        let max_size_bytes = if max_size_bytes == 0 {
+            eprintln!(
+                "{} [audit] max_size_bytes = 0 is invalid; using the default of {} bytes",
+                "warning:".yellow(),
+                DEFAULT_MAX_SIZE_BYTES
+            );
+            DEFAULT_MAX_SIZE_BYTES
+        } else {
+            max_size_bytes
+        };
+
+        let mut open_options = OpenOptions::new();
+        open_options.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            // Audit logs may reference secret names; keep them owner-only.
+            open_options.mode(0o600);
+        }
+        // Open eagerly so an unwritable location (read-only fs, no permission on an
+        // existing dir) surfaces here — the caller then warns and disables auditing
+        // instead of silently dropping events.
+        let file = open_options.open(&path)?;
+
+        Ok(Self {
+            file: Mutex::new(file),
+            path,
+            max_size_bytes,
+        })
+    }
+}
+
+impl AuditSink for JsonlSink {
+    fn write_line(&self, line: &str) {
+        // A poisoned lock just means a previous writer panicked; the file handle is
+        // still usable for appending, so recover the guard rather than give up.
+        let mut guard = self.file.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Enforce the size cap with whole-line granularity: if appending this line
+        // would cross the cap, truncate and restart the file first so a line is
+        // never split across the boundary. A single line larger than the cap is
+        // still written intact (the cap bounds retained history, not one event).
+        let projected = line.len() as u64 + 1; // + trailing newline
+        match guard.metadata().map(|m| m.len()) {
+            Ok(size) if size > 0 && size + projected > self.max_size_bytes => {
+                // With O_APPEND the next write lands at the new end-of-file (0).
+                if let Err(e) = guard.set_len(0) {
+                    warn_audit_failure(&self.path, &e);
+                }
+            }
+            Ok(_) => {}
+            Err(e) => warn_audit_failure(&self.path, &e),
+        }
+
+        if let Err(e) = writeln!(guard, "{line}") {
+            warn_audit_failure(&self.path, &e);
+        }
+    }
+}
+
+/// Records secret access to a sink, stamping each event with shared session
+/// context (id, monotonic sequence, actor).
+pub(crate) struct AuditLogger {
+    sink: Box<dyn AuditSink>,
+    session_id: String,
+    seq: AtomicU64,
+    actor: Actor,
+}
+
+impl AuditLogger {
+    /// Builds a logger from the effective audit configuration, or `None` when
+    /// auditing is disabled or no log location can be established. Never fails:
+    /// any problem is reported to stderr and yields `None` (auditing off) rather
+    /// than blocking secret access.
+    pub(crate) fn from_config(config: &AuditConfig) -> Option<Self> {
+        if !config.enabled {
+            return None;
+        }
+
+        let Some(path) = config.resolved_path() else {
+            if config.has_relative_path() {
+                eprintln!(
+                    "{} [audit] path {} is not absolute; auditing is disabled \
+                     (use an absolute path, e.g. ~/.local/state/secretspec/audit.log)",
+                    "warning:".yellow(),
+                    config
+                        .path
+                        .as_deref()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_default()
+                        .bold()
+                );
+            } else {
+                eprintln!(
+                    "{} could not determine an audit log location; auditing is disabled \
+                     (set [audit] path in ~/.config/secretspec/config.toml)",
+                    "warning:".yellow()
+                );
+            }
+            return None;
+        };
+
+        // First-run disclosure: if the log file does not exist yet, announce where
+        // it lives and how to disable it. Auditing is on by default, so users must
+        // be told a file is being written.
+        let first_run = !path.exists();
+
+        let sink = match JsonlSink::new(path.clone(), config.max_size_bytes) {
+            Ok(sink) => sink,
+            Err(e) => {
+                warn_audit_failure(&path, &e);
+                return None;
+            }
+        };
+
+        if first_run {
+            eprintln!(
+                "{} secretspec is now recording secret access to {} \
+                 (disable with [audit] enabled = false in ~/.config/secretspec/config.toml)",
+                "note:".cyan(),
+                path.display().to_string().bold()
+            );
+        }
+
+        Some(Self {
+            sink: Box::new(sink),
+            session_id: uuid::Uuid::new_v4().to_string(),
+            seq: AtomicU64::new(0),
+            actor: Actor::current(),
+        })
+    }
+
+    /// Records one event. Fail-open: serialization errors are reported and dropped.
+    pub(crate) fn record(&self, action: AuditAction, ctx: AuditContext<'_>) {
+        let event = AuditEvent {
+            v: SCHEMA_VERSION,
+            id: uuid::Uuid::new_v4().to_string(),
+            ts: jiff::Timestamp::now().to_string(),
+            session_id: &self.session_id,
+            seq: self.seq.fetch_add(1, Ordering::Relaxed),
+            action,
+            project: ctx.project,
+            profile: ctx.profile,
+            key: ctx.key,
+            keys: ctx.keys,
+            command: ctx.command,
+            provider: ctx.provider_uri.as_deref().map(redact_uri),
+            outcome: ctx.outcome,
+            error_kind: ctx.error_kind,
+            reason: ctx.reason,
+            actor: &self.actor,
+            version: env!("CARGO_PKG_VERSION"),
+        };
+
+        match serde_json::to_string(&event) {
+            Ok(line) => self.sink.write_line(&line),
+            Err(e) => eprintln!(
+                "{} failed to serialize audit event: {e}; skipping",
+                "warning:".yellow()
+            ),
+        }
+    }
+}
+
+/// Locates the userinfo of a URI's authority: the span between the scheme
+/// separator (after `://` for a hierarchical URI, or after `scheme:` for an
+/// opaque one) and the first `@` that precedes any `/`, `?` or `#`. Returns
+/// `(userinfo_start, at)` so callers can slice `uri[userinfo_start..at]` (the
+/// userinfo) and `uri[at..]` (`@host...`). `None` when there is no userinfo.
+///
+/// Operates only on byte positions of ASCII delimiters (`:` `/` `?` `#` `@`), so
+/// it is correct for non-ASCII hosts/paths and handles the empty-host case
+/// (`vault://user:pass@`) that `url`'s component setters refuse.
+fn userinfo_span(uri: &str) -> Option<(usize, usize)> {
+    let scheme_end = uri.find(':')?;
+    let after_scheme = &uri[scheme_end + 1..];
+    let (userinfo_start, authority) = match after_scheme.strip_prefix("//") {
+        Some(rest) => (scheme_end + 3, rest),
+        None => (scheme_end + 1, after_scheme),
+    };
+    let authority_len = authority.find(['/', '?', '#']).unwrap_or(authority.len());
+    // Use the LAST `@` in the authority as the userinfo/host boundary: a host
+    // cannot contain `@`, so any earlier `@` belongs to a userinfo credential
+    // (e.g. a raw, un-percent-encoded password like `p@ss`). Anchoring to the
+    // first `@` would leave the post-`@` portion of such a credential intact.
+    let at_rel = authority[..authority_len].rfind('@')?;
+    Some((userinfo_start, userinfo_start + at_rel))
+}
+
+/// Redacts a `:password` credential from a provider URI's userinfo
+/// (`scheme://user:pass@host` becomes `scheme://user@host`), leaving the username,
+/// host, path, query and fragment intact.
+///
+/// Providers encode *non-secret* attribution in those positions — a 1Password
+/// account (`onepassword://acct@vault`), an AWS profile/region and `?prefix=`
+/// (`awssm://profile@region?prefix=...`). Stripping the whole userinfo/query (as a
+/// generic redactor would) corrupts the audit log's provider attribution, e.g.
+/// collapsing two different accounts to the same string. The audit log only ever
+/// records a provider's own already-secret-free `uri()`, so the only credential
+/// that can appear is an explicit `:password`, which this removes.
+///
+/// A bare userinfo token with no `:` (`scheme://TOKEN@host`) is preserved — it is
+/// structurally indistinguishable from an account/profile identifier, so the
+/// secret-free guarantee rests on each provider's `uri()`, not on this function.
+/// To redact a raw, possibly-credential-bearing URI for display, use
+/// [`redact_uri_strict`].
+fn redact_uri(uri: &str) -> String {
+    let Some((userinfo_start, at)) = userinfo_span(uri) else {
+        return uri.to_string();
+    };
+    let userinfo = &uri[userinfo_start..at];
+    match userinfo.find(':') {
+        // Keep the username (before `:`), drop the password, keep `@host...`.
+        Some(colon) => format!("{}{}", &uri[..userinfo_start + colon], &uri[at..]),
+        None => uri.to_string(),
+    }
+}
+
+/// Redacts a raw provider URI for human-facing diagnostics (e.g. a fallback-chain
+/// warning) by dropping the entire userinfo and any query or fragment, so a
+/// user-authored alias that embeds a credential — `vault+token:s3cr3t@host`,
+/// `vault://host?token=...` — is not echoed to the terminal. Unlike [`redact_uri`]
+/// it sacrifices attribution detail (account/profile/prefix) for safety, which is
+/// acceptable for a transient warning that also names the affected secret.
+pub(crate) fn redact_uri_strict(uri: &str) -> String {
+    let without_userinfo = match userinfo_span(uri) {
+        // Drop `userinfo@`, keeping the scheme prefix and everything from the host.
+        Some((userinfo_start, at)) => format!("{}{}", &uri[..userinfo_start], &uri[at + 1..]),
+        None => uri.to_string(),
+    };
+    let cut = without_userinfo
+        .find(['?', '#'])
+        .unwrap_or(without_userinfo.len());
+    without_userinfo[..cut].to_string()
+}
+
+/// Warns that the audit log could not be written, without aborting the operation
+/// that triggered it.
+fn warn_audit_failure(path: &Path, err: &dyn std::fmt::Display) {
+    eprintln!(
+        "{} could not write audit log {}: {err}; continuing without auditing this event",
+        "warning:".yellow(),
+        path.display().to_string().bold()
+    );
+}
+
+/// In-memory audit helpers shared by this module's tests and by `secrets.rs`
+/// tests that need to assert which audit events a `Secrets` operation emits.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use std::sync::Arc;
+
+    /// A sink that records written lines in memory for assertions.
+    #[derive(Clone, Default)]
+    pub(crate) struct CollectSink {
+        pub(crate) lines: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl AuditSink for CollectSink {
+        fn write_line(&self, line: &str) {
+            self.lines.lock().unwrap().push(line.to_string());
+        }
+    }
+
+    impl AuditLogger {
+        pub(crate) fn for_test(sink: Box<dyn AuditSink>) -> Self {
+            Self {
+                sink,
+                session_id: "test-session".to_string(),
+                seq: AtomicU64::new(0),
+                actor: Actor {
+                    user: Some("tester".to_string()),
+                    agent: None,
+                    is_agent: false,
+                },
+            }
+        }
+    }
+
+    /// Builds a logger that collects emitted JSON lines, returning both the
+    /// logger and a handle to read the lines back.
+    pub(crate) fn collecting_logger() -> (AuditLogger, Arc<Mutex<Vec<String>>>) {
+        let sink = CollectSink::default();
+        let lines = sink.lines.clone();
+        (AuditLogger::for_test(Box::new(sink)), lines)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::CollectSink;
+    use super::*;
+
+    #[test]
+    fn redact_uri_strips_password_but_keeps_attribution() {
+        // A `:password` is removed; the username is kept.
+        assert_eq!(
+            redact_uri("vault://user:pass@host:8200"),
+            "vault://user@host:8200"
+        );
+        // ...even with an empty host, which `url`'s setters refuse to touch.
+        assert_eq!(redact_uri("vault://user:pass@"), "vault://user@");
+        // Opaque `:password` is stripped too, username kept.
+        assert_eq!(
+            redact_uri("vault+token:user:pass@host"),
+            "vault+token:user@host"
+        );
+        // No userinfo / no password: returned unchanged.
+        assert_eq!(redact_uri("keyring://"), "keyring://");
+        assert_eq!(redact_uri("dotenv:.env"), "dotenv:.env");
+        // Provider attribution (1Password account, AWS profile + prefix) is
+        // preserved — these are identifiers, not secrets, and stripping them would
+        // make two distinct providers indistinguishable in the audit log.
+        assert_eq!(
+            redact_uri("onepassword://work@Production"),
+            "onepassword://work@Production"
+        );
+        assert_eq!(
+            redact_uri("onepassword://personal@Production"),
+            "onepassword://personal@Production"
+        );
+        assert_eq!(
+            redact_uri("awssm://prod@us-east-1?prefix=myapp"),
+            "awssm://prod@us-east-1?prefix=myapp"
+        );
+        // A bare userinfo token (structurally identical to an account identifier)
+        // is preserved; the audit log's secret-free guarantee rests on the
+        // provider's own `uri()`, not on this backstop.
+        assert_eq!(
+            redact_uri("vault+token:s3cr3t@host"),
+            "vault+token:s3cr3t@host"
+        );
+        // A `:password` that itself contains a literal `@` is still fully removed:
+        // the userinfo extends to the LAST `@` before the host, so no fragment of
+        // the password survives.
+        assert_eq!(redact_uri("vault://user:p@ss@host"), "vault://user@host");
+        assert_eq!(
+            redact_uri("vault+token:user:p@ss@host"),
+            "vault+token:user@host"
+        );
+    }
+
+    #[test]
+    fn redact_uri_strict_drops_userinfo_and_query() {
+        // The display redactor (used for fallback-chain warnings) strips the whole
+        // userinfo and any query/fragment, so a raw configured alias cannot leak a
+        // credential to the terminal.
+        assert_eq!(
+            redact_uri_strict("vault://user:pass@host:8200"),
+            "vault://host:8200"
+        );
+        assert_eq!(
+            redact_uri_strict("vault+token:s3cr3t@host/path"),
+            "vault+token:host/path"
+        );
+        assert_eq!(
+            redact_uri_strict("vault://host?token=SECRET"),
+            "vault://host"
+        );
+        assert_eq!(redact_uri_strict("vault://user:pass@"), "vault://");
+        // No userinfo / no query: unchanged.
+        assert_eq!(redact_uri_strict("keyring://"), "keyring://");
+        assert_eq!(redact_uri_strict("dotenv:.env"), "dotenv:.env");
+        let strict = redact_uri_strict("vault+token:s3cr3t@host?x=y#f");
+        assert_eq!(strict, "vault+token:host");
+        assert!(!strict.contains("s3cr3t"));
+        // A credential containing a literal `@` is dropped whole — no portion of
+        // it survives past the userinfo/host boundary (the last `@`).
+        let strict = redact_uri_strict("vault://user:p@ss@host");
+        assert_eq!(strict, "vault://host");
+        assert!(!strict.contains("p@ss") && !strict.contains("ss@"));
+        let strict = redact_uri_strict("vault+token:gh@p_realtoken@host");
+        assert_eq!(strict, "vault+token:host");
+        assert!(!strict.contains("realtoken"));
+    }
+
+    #[test]
+    fn records_metadata_but_never_the_value() {
+        let sink = CollectSink::default();
+        let logger = AuditLogger::for_test(Box::new(sink.clone()));
+
+        logger.record(
+            AuditAction::Get,
+            AuditContext {
+                project: "demo",
+                profile: "production",
+                key: Some("DATABASE_URL"),
+                keys: &[],
+                command: None,
+                provider_uri: Some("vault://user:s3cr3t@host/kv".to_string()),
+                outcome: AuditOutcome::Found,
+                error_kind: None,
+                reason: Some("deploy web frontend"),
+            },
+        );
+
+        let lines = sink.lines.lock().unwrap();
+        assert_eq!(lines.len(), 1);
+        let event: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+
+        assert_eq!(event["v"], SCHEMA_VERSION);
+        assert_eq!(event["action"], "get");
+        assert_eq!(event["outcome"], "found");
+        assert_eq!(event["project"], "demo");
+        assert_eq!(event["profile"], "production");
+        assert_eq!(event["key"], "DATABASE_URL");
+        assert_eq!(event["reason"], "deploy web frontend");
+        assert_eq!(event["session_id"], "test-session");
+        assert_eq!(event["seq"], 0);
+        // Provider credentials (the `:password`) are redacted; the username,
+        // host and path — provider attribution — are kept.
+        assert_eq!(event["provider"], "vault://user@host/kv");
+        // The secret value never appears anywhere in the record.
+        assert!(!lines[0].contains("s3cr3t"));
+    }
+
+    #[test]
+    fn bulk_event_records_keys_and_command() {
+        let sink = CollectSink::default();
+        let logger = AuditLogger::for_test(Box::new(sink.clone()));
+        let keys = vec!["DATABASE_URL".to_string(), "API_KEY".to_string()];
+
+        logger.record(
+            AuditAction::Run,
+            AuditContext {
+                project: "demo",
+                profile: "production",
+                key: None,
+                keys: &keys,
+                command: Some("./deploy.sh"),
+                provider_uri: None,
+                outcome: AuditOutcome::Found,
+                error_kind: None,
+                reason: None,
+            },
+        );
+
+        let lines = sink.lines.lock().unwrap();
+        let event: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+        assert_eq!(event["action"], "run");
+        assert_eq!(event["command"], "./deploy.sh");
+        assert_eq!(event["keys"][0], "DATABASE_URL");
+        assert_eq!(event["keys"][1], "API_KEY");
+        // Single-key field is omitted for bulk actions.
+        assert!(event.get("key").is_none());
+    }
+
+    #[test]
+    fn seq_increments_per_event() {
+        let sink = CollectSink::default();
+        let logger = AuditLogger::for_test(Box::new(sink.clone()));
+        for _ in 0..3 {
+            logger.record(
+                AuditAction::Set,
+                AuditContext {
+                    project: "demo",
+                    profile: "default",
+                    key: Some("K"),
+                    keys: &[],
+                    command: None,
+                    provider_uri: None,
+                    outcome: AuditOutcome::Written,
+                    error_kind: None,
+                    reason: None,
+                },
+            );
+        }
+        let lines = sink.lines.lock().unwrap();
+        let seqs: Vec<u64> = lines
+            .iter()
+            .map(|l| {
+                serde_json::from_str::<serde_json::Value>(l).unwrap()["seq"]
+                    .as_u64()
+                    .unwrap()
+            })
+            .collect();
+        assert_eq!(seqs, vec![0, 1, 2]);
+    }
+
+    /// A log file that cannot be opened (here: an unwritable parent directory)
+    /// must make `JsonlSink::new` fail, so `from_config` warns and disables
+    /// auditing — rather than returning a sink whose writes silently no-op.
+    #[cfg(unix)]
+    #[test]
+    fn jsonlsink_errors_when_log_file_cannot_be_opened() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = std::env::temp_dir().join(format!("ss_audit_ro_{}", std::process::id()));
+        let ro_dir = base.join("ro");
+        std::fs::create_dir_all(&ro_dir).unwrap();
+        // Read+execute only: creating the log file inside must fail.
+        std::fs::set_permissions(&ro_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = JsonlSink::new(ro_dir.join("audit.log"), 1_048_576);
+        let is_err = result.is_err();
+
+        // Restore permissions so cleanup can remove the directory.
+        std::fs::set_permissions(&ro_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let _ = std::fs::remove_dir_all(&base);
+
+        assert!(
+            is_err,
+            "JsonlSink::new must fail when the log file cannot be opened"
+        );
+    }
+
+    /// At the size cap the file is truncated and restarted with whole-line
+    /// granularity: a write that would cross the cap resets the file first, so the
+    /// log never grows past the cap and never retains a partial line.
+    #[test]
+    fn jsonlsink_truncates_and_restarts_at_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        // 20-byte payload + newline = 21 bytes per write; two of them (42) cross
+        // the 40-byte cap, forcing a truncate-and-restart on the second write.
+        let sink = JsonlSink::new(path.clone(), 40).unwrap();
+        let line = "X".repeat(20);
+
+        sink.write_line(&line);
+        sink.write_line(&line);
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        // Only the most recent line survives the reset, intact and newline-terminated.
+        assert_eq!(contents, format!("{line}\n"));
+        assert!(contents.len() as u64 <= 40);
+    }
+
+    /// A single line larger than the cap is still written whole, not dropped or
+    /// split: the cap bounds retained history, not one event.
+    #[test]
+    fn jsonlsink_writes_oversized_line_intact() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        let sink = JsonlSink::new(path.clone(), 16).unwrap();
+        let big = "Y".repeat(100);
+
+        sink.write_line(&big);
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, format!("{big}\n"));
+    }
+
+    /// A configured `max_size_bytes` of 0 would truncate on every write; it must
+    /// fall back to the default cap so writes accumulate normally.
+    #[test]
+    fn jsonlsink_zero_cap_falls_back_to_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        let sink = JsonlSink::new(path.clone(), 0).unwrap();
+
+        sink.write_line("first");
+        sink.write_line("second");
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        // Both lines retained -> the zero cap was replaced by the default, not honored.
+        assert_eq!(contents, "first\nsecond\n");
+    }
+
+    /// The audit log may reference secret names, so it must be created owner-only.
+    #[cfg(unix)]
+    #[test]
+    fn jsonlsink_creates_owner_only_log() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        let sink = JsonlSink::new(path.clone(), 1_048_576).unwrap();
+        sink.write_line("{}");
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    /// Auditing disabled in config yields no logger.
+    #[test]
+    fn from_config_disabled_returns_none() {
+        let cfg = AuditConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        assert!(AuditLogger::from_config(&cfg).is_none());
+    }
+
+    /// A relative configured path is rejected (it would scatter the log per-CWD),
+    /// so auditing is disabled rather than written to an unexpected location.
+    #[test]
+    fn from_config_relative_path_disables_auditing() {
+        let cfg = AuditConfig {
+            enabled: true,
+            path: Some(PathBuf::from("relative/audit.log")),
+            ..Default::default()
+        };
+        assert!(AuditLogger::from_config(&cfg).is_none());
+    }
+
+    /// Enabled with an absolute path builds a logger that creates and writes the
+    /// configured file.
+    #[test]
+    fn from_config_absolute_path_builds_and_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        let cfg = AuditConfig {
+            enabled: true,
+            path: Some(path.clone()),
+            ..Default::default()
+        };
+
+        let logger = AuditLogger::from_config(&cfg).expect("auditing should be enabled");
+        logger.record(
+            AuditAction::Get,
+            AuditContext {
+                project: "demo",
+                profile: "default",
+                key: Some("K"),
+                keys: &[],
+                command: None,
+                provider_uri: None,
+                outcome: AuditOutcome::Found,
+                error_kind: None,
+                reason: None,
+            },
+        );
+
+        assert!(path.exists());
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("\"action\":\"get\""));
+    }
+}

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -105,6 +105,21 @@ enum Commands {
         /// Provider backend to import from (secrets will be imported to the default provider)
         from_provider: String,
     },
+    /// Show the local audit log of secret access
+    Audit {
+        /// Only show entries for this project
+        #[arg(long)]
+        project: Option<String>,
+        /// Only show entries for this action (get, set, check, run, import)
+        #[arg(long)]
+        action: Option<String>,
+        /// Show only the last N entries
+        #[arg(short = 'n', long)]
+        tail: Option<usize>,
+        /// Output raw JSON Lines instead of a formatted summary
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Configuration-related subcommands.
@@ -405,13 +420,13 @@ pub fn main() -> Result<()> {
                     Some(profile_choice.to_string())
                 };
 
-                let config = GlobalConfig {
-                    defaults: GlobalDefaults {
-                        provider: Some(provider.to_string()),
-                        profile,
-                        providers: None,
-                    },
-                };
+                // Preserve any existing config (audit settings, provider aliases)
+                // rather than overwriting the whole file: re-running `config init`
+                // must not silently drop a user's `[audit]` table — which would
+                // re-enable disabled logging — or their saved provider aliases.
+                let mut config = GlobalConfig::load().into_diagnostic()?.unwrap_or_default();
+                config.defaults.provider = Some(provider.to_string());
+                config.defaults.profile = profile;
 
                 config.save().into_diagnostic()?;
                 println!(
@@ -469,6 +484,7 @@ pub fn main() -> Result<()> {
                                         profile: None,
                                         providers: None,
                                     },
+                                    audit: None,
                                 });
 
                         // Initialize providers map if needed
@@ -628,7 +644,179 @@ pub fn main() -> Result<()> {
                 .wrap_err("Failed to import secrets")?;
             Ok(())
         }
+        // Show the local audit log
+        Commands::Audit {
+            project,
+            action,
+            tail,
+            json,
+        } => show_audit_log(project, action, tail, json),
     }
+}
+
+/// Reads and prints the local audit log, applying optional filters.
+fn show_audit_log(
+    project: Option<String>,
+    action: Option<String>,
+    tail: Option<usize>,
+    json: bool,
+) -> Result<()> {
+    let audit = GlobalConfig::load()
+        .into_diagnostic()
+        .wrap_err("Failed to load global configuration")?
+        .and_then(|g| g.audit)
+        .unwrap_or_default();
+
+    let path = audit.resolved_path().ok_or_else(|| {
+        if audit.has_relative_path() {
+            miette!(
+                "[audit] path {} is not absolute; set an absolute path in ~/.config/secretspec/config.toml",
+                audit.path.as_deref().map(|p| p.display().to_string()).unwrap_or_default()
+            )
+        } else {
+            miette!("Could not determine the audit log location")
+        }
+    })?;
+
+    if !path.exists() {
+        eprintln!("No audit log found at {}", path.display());
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to read audit log at {}", path.display()))?;
+
+    for (line, value) in filter_audit_entries(&content, project.as_deref(), action.as_deref(), tail)
+    {
+        if json {
+            println!("{line}");
+        } else {
+            println!("{}", format_audit_line(&value));
+        }
+    }
+
+    Ok(())
+}
+
+/// Parses the audit log, keeps the entries matching the optional `project` and
+/// `action` filters, then retains only the last `tail` of them. Each surviving
+/// entry is returned as its raw line text (for `--json`) paired with its parsed
+/// JSON value (for formatting). A line that is not valid JSON — e.g. a torn write
+/// — is dropped, so it never reaches output. Pure (no I/O) so it can be tested.
+fn filter_audit_entries<'a>(
+    content: &'a str,
+    project: Option<&str>,
+    action: Option<&str>,
+    tail: Option<usize>,
+) -> Vec<(&'a str, serde_json::Value)> {
+    let mut entries: Vec<(&str, serde_json::Value)> = content
+        .lines()
+        .filter_map(|line| {
+            let v = serde_json::from_str::<serde_json::Value>(line).ok()?;
+            let field = |k: &str| v.get(k).and_then(|x| x.as_str());
+            if let Some(p) = project
+                && field("project") != Some(p)
+            {
+                return None;
+            }
+            // Actions serialize lowercase (`get`/`set`/...); match case-insensitively
+            // so `--action Get` is not silently dropped. (`project` stays exact: a
+            // project name is an identity, not an enum.)
+            if let Some(a) = action
+                && !field("action").is_some_and(|x| x.eq_ignore_ascii_case(a))
+            {
+                return None;
+            }
+            Some((line, v))
+        })
+        .collect();
+
+    if let Some(n) = tail
+        && entries.len() > n
+    {
+        entries.drain(0..entries.len() - n);
+    }
+
+    entries
+}
+
+/// Renders control characters in a field harmlessly so caller controlled audit
+/// content (reason, command, key, ...) cannot inject escape sequences that
+/// erase, overwrite, or forge lines in the formatted `secretspec audit` view.
+///
+/// ASCII control bytes (0x00..=0x1F) and DEL (0x7F) are replaced with a visible
+/// `\xNN` rendering; all other characters pass through unchanged so normal
+/// entries look identical.
+fn sanitize_field(s: &str) -> String {
+    if !s.chars().any(|c| c.is_control()) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_control() {
+            out.push_str(&format!("\\x{:02x}", c as u32));
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Renders one parsed JSON Lines audit entry as a readable, colored summary line.
+/// The value has already been validated as JSON by `show_audit_log`.
+fn format_audit_line(v: &serde_json::Value) -> String {
+    use colored::Colorize;
+
+    let str_field = |k: &str| v.get(k).and_then(|x| x.as_str());
+
+    let ts = sanitize_field(str_field("ts").unwrap_or(""));
+    let action = sanitize_field(str_field("action").unwrap_or("?"));
+    let outcome = sanitize_field(str_field("outcome").unwrap_or("?"));
+    let project = sanitize_field(str_field("project").unwrap_or(""));
+    let profile = sanitize_field(str_field("profile").unwrap_or(""));
+
+    let target = if let Some(key) = str_field("key") {
+        sanitize_field(key)
+    } else if let Some(arr) = v.get("keys").and_then(|x| x.as_array()) {
+        arr.iter()
+            .filter_map(|x| x.as_str())
+            .map(sanitize_field)
+            .collect::<Vec<_>>()
+            .join(",")
+    } else {
+        String::new()
+    };
+
+    let outcome_colored = match outcome.as_str() {
+        "found" | "written" | "started" => outcome.green(),
+        "missing" | "error" => outcome.red(),
+        _ => outcome.yellow(),
+    };
+
+    let mut s = format!("{}  {:<6} {}", ts.dimmed(), action.bold(), outcome_colored);
+    if let Some(cmd) = str_field("command") {
+        s += &format!("  {}", sanitize_field(cmd).bold());
+    }
+    if !target.is_empty() {
+        s += &format!("  {target}");
+    }
+    s += &format!("  ({project}/{profile}");
+    if let Some(provider) = str_field("provider") {
+        s += &format!(" via {}", sanitize_field(provider));
+    }
+    s += ")";
+    if let Some(reason) = str_field("reason") {
+        s += &format!("  reason: {}", sanitize_field(reason).italic());
+    }
+    if let Some(agent) = v
+        .get("actor")
+        .and_then(|a| a.get("agent"))
+        .and_then(|x| x.as_str())
+    {
+        s += &format!("  [{}]", sanitize_field(agent));
+    }
+    s
 }
 
 #[cfg(test)]
@@ -654,6 +842,128 @@ mod tests {
             )]),
             providers: None,
         }
+    }
+
+    #[test]
+    fn sanitize_field_neutralizes_control_characters() {
+        // A clean string passes through unchanged (and takes the early-return path).
+        assert_eq!(sanitize_field("DATABASE_URL"), "DATABASE_URL");
+        assert_eq!(sanitize_field(""), "");
+
+        // ASCII control bytes and DEL become a visible `\xNN` rendering so a
+        // caller-controlled field (reason, command, key) cannot inject an escape
+        // sequence that erases or forges lines in the formatted audit view.
+        assert_eq!(sanitize_field("a\nb"), "a\\x0ab");
+        assert_eq!(sanitize_field("a\tb"), "a\\x09b");
+        assert_eq!(sanitize_field("a\x00b"), "a\\x00b");
+        assert_eq!(sanitize_field("a\x7fb"), "a\\x7fb");
+
+        // A real ANSI clear-line sequence is defanged: the ESC byte is escaped,
+        // so the literal control character no longer reaches the terminal.
+        let injected = sanitize_field("ok\x1b[2Kforged");
+        assert_eq!(injected, "ok\\x1b[2Kforged");
+        assert!(!injected.contains('\x1b'));
+    }
+
+    /// Three audit lines for two projects/actions, used by the filter tests.
+    fn sample_log() -> String {
+        [
+            r#"{"action":"get","project":"alpha","key":"A"}"#,
+            r#"{"action":"set","project":"beta","key":"B"}"#,
+            r#"{"action":"get","project":"beta","key":"C"}"#,
+        ]
+        .join("\n")
+    }
+
+    fn keys_of(entries: &[(&str, serde_json::Value)]) -> Vec<String> {
+        entries
+            .iter()
+            .map(|(_, v)| v["key"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn filter_audit_entries_filters_by_project_and_action() {
+        let log = sample_log();
+
+        // No filters -> every entry, in order.
+        assert_eq!(
+            keys_of(&filter_audit_entries(&log, None, None, None)),
+            vec!["A", "B", "C"]
+        );
+
+        // Project is matched exactly.
+        assert_eq!(
+            keys_of(&filter_audit_entries(&log, Some("beta"), None, None)),
+            vec!["B", "C"]
+        );
+
+        // Action is matched case-insensitively, so `--action GET` still matches.
+        assert_eq!(
+            keys_of(&filter_audit_entries(&log, None, Some("GET"), None)),
+            vec!["A", "C"]
+        );
+
+        // Both filters combine.
+        assert_eq!(
+            keys_of(&filter_audit_entries(&log, Some("beta"), Some("get"), None)),
+            vec!["C"]
+        );
+    }
+
+    #[test]
+    fn filter_audit_entries_applies_tail_and_drops_invalid_lines() {
+        let log = sample_log();
+
+        // `tail` keeps only the last N (after filtering).
+        assert_eq!(
+            keys_of(&filter_audit_entries(&log, None, None, Some(2))),
+            vec!["B", "C"]
+        );
+        // A tail larger than the entry count is a no-op.
+        assert_eq!(
+            keys_of(&filter_audit_entries(&log, None, None, Some(99))),
+            vec!["A", "B", "C"]
+        );
+
+        // Non-JSON lines (e.g. a torn write) and blank lines are dropped.
+        let torn = format!("{}\nnot json\n\n", sample_log());
+        assert_eq!(
+            keys_of(&filter_audit_entries(&torn, None, None, None)),
+            vec!["A", "B", "C"]
+        );
+    }
+
+    #[test]
+    fn format_audit_line_renders_fields() {
+        // Color is disabled so assertions are on stable plain text.
+        colored::control::set_override(false);
+
+        let single: serde_json::Value = serde_json::from_str(
+            r#"{"ts":"2026-06-07T00:00:00Z","action":"get","outcome":"found",
+                "project":"demo","profile":"prod","key":"DB","provider":"dotenv://.env",
+                "reason":"deploy","actor":{"agent":"claude-code"}}"#,
+        )
+        .unwrap();
+        let line = format_audit_line(&single);
+        assert!(line.contains("get"));
+        assert!(line.contains("found"));
+        assert!(line.contains("DB"));
+        assert!(line.contains("(demo/prod via dotenv://.env)"));
+        assert!(line.contains("reason: deploy"));
+        assert!(line.contains("[claude-code]"));
+
+        // A bulk entry joins `keys[]` and shows the executed command.
+        let bulk: serde_json::Value = serde_json::from_str(
+            r#"{"ts":"t","action":"run","outcome":"started","project":"demo",
+                "profile":"prod","keys":["A","B"],"command":"./deploy.sh"}"#,
+        )
+        .unwrap();
+        let line = format_audit_line(&bulk);
+        assert!(line.contains("./deploy.sh"));
+        assert!(line.contains("A,B"));
+
+        colored::control::unset_override();
     }
 
     #[test]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -340,6 +340,120 @@ impl Default for Project {
     }
 }
 
+/// Audit logging configuration, parsed from the top-level `[audit]` table in the
+/// user-global config (`~/.config/secretspec/config.toml`).
+///
+/// Auditing is an operator/per-machine concern (where the log lives, whether it is
+/// on), so it lives in the user config rather than the project's `secretspec.toml`:
+/// a cloned repository must not be able to redirect or silence your local audit
+/// log. secretspec records every secret read/write to a local JSON Lines file so
+/// that access is reviewable after the fact. Auditing is **on by default**; set
+/// `enabled = false` to turn it off. Secret values are never written to the log.
+///
+/// ```toml
+/// [audit]
+/// enabled = false
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AuditConfig {
+    /// Whether to record secret access. Defaults to `true`.
+    pub enabled: bool,
+    /// Where to write the JSON Lines log. Must be an absolute path (a leading `~`
+    /// is expanded to the home directory); a relative path is rejected and
+    /// auditing is disabled, because it would resolve against the current working
+    /// directory and scatter the log per-CWD. When unset, defaults to the per-user
+    /// XDG state directory (`~/.local/state/secretspec/audit.log` on Linux).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    /// Hard cap on the log file size in bytes (default 1 MiB). At the cap the file
+    /// is truncated and restarted; no rotated backups are kept, so the log is a
+    /// rolling-by-reset record bounded to this size, not a complete history.
+    pub max_size_bytes: u64,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            path: None,
+            max_size_bytes: 1_048_576,
+        }
+    }
+}
+
+impl AuditConfig {
+    /// The resolved on-disk path: the configured `path` (with a leading `~`
+    /// expanded to the home directory), or the default per-user audit log
+    /// location when no `path` is set.
+    ///
+    /// Returns `None` when the location cannot be honored: either no `path` is set
+    /// and no default can be determined (no home/state directory), or the
+    /// configured `path` is **relative**. A relative path is rejected rather than
+    /// resolved against the current working directory — that would write a separate
+    /// log in every directory secretspec runs from. Use [`Self::has_relative_path`]
+    /// to distinguish the relative-path case for a precise diagnostic.
+    pub fn resolved_path(&self) -> Option<PathBuf> {
+        match self.path.clone() {
+            // Reject a relative configured path; only an absolute one is honored.
+            Some(path) => Some(expand_tilde(path)).filter(|p| p.is_absolute()),
+            None => default_audit_path(),
+        }
+    }
+
+    /// Whether a `path` is configured but is not absolute (after `~` expansion).
+    /// Such a path is rejected by [`Self::resolved_path`]; this lets callers emit a
+    /// "path is not absolute" message instead of a generic "no location" one.
+    pub fn has_relative_path(&self) -> bool {
+        self.path
+            .as_ref()
+            .is_some_and(|p| !expand_tilde(p.clone()).is_absolute())
+    }
+}
+
+/// Shared etcetera arguments identifying secretspec, so the app identity (used
+/// to derive config/state/data dirs) lives in a single place.
+fn app_strategy_args() -> etcetera::app_strategy::AppStrategyArgs {
+    etcetera::app_strategy::AppStrategyArgs {
+        top_level_domain: String::new(),
+        author: String::new(),
+        app_name: "secretspec".into(),
+    }
+}
+
+/// Default audit log location: the per-user state directory chosen by
+/// `choose_app_strategy`. That is the XDG strategy on both Linux and macOS (the
+/// CLI convention etcetera uses), so the log lives at
+/// `~/.local/state/secretspec/audit.log` on each. The `data_dir` fallback only
+/// applies on platforms whose strategy reports no distinct state dir.
+fn default_audit_path() -> Option<PathBuf> {
+    use etcetera::app_strategy::{AppStrategy, choose_app_strategy};
+    let strategy = choose_app_strategy(app_strategy_args()).ok()?;
+    let dir = strategy.state_dir().unwrap_or_else(|| strategy.data_dir());
+    Some(dir.join("audit.log"))
+}
+
+/// Expands a leading `~` (or `~/`) in a configured path to the user's home
+/// directory. A documented `path = "~/.local/state/..."` would otherwise become
+/// a literal `./~` directory. Paths without a leading `~`, or paths that cannot
+/// be resolved to a home directory, are returned unchanged.
+fn expand_tilde(path: PathBuf) -> PathBuf {
+    let Ok(rest) = path.strip_prefix("~") else {
+        return path;
+    };
+    let Some(home) = home_dir() else {
+        return path;
+    };
+    home.join(rest)
+}
+
+/// Best-effort home directory, via etcetera with an `HOME` env fallback.
+fn home_dir() -> Option<PathBuf> {
+    etcetera::home_dir()
+        .ok()
+        .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
+}
+
 /// Configuration for a specific profile (environment).
 ///
 /// A profile represents a specific environment or context (e.g., "default", "production", "staging").
@@ -643,6 +757,12 @@ pub struct GlobalConfig {
     /// Default settings
     #[serde(default)]
     pub defaults: GlobalDefaults,
+    /// Audit logging configuration (top-level `[audit]` table). Auditing is a
+    /// per-machine/operator concern, so it lives here rather than in the project's
+    /// `secretspec.toml`. `None` means "unspecified" and resolves to
+    /// [`AuditConfig::default`] (auditing on).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit: Option<AuditConfig>,
 }
 
 /// Default settings in the global configuration.
@@ -681,13 +801,9 @@ impl GlobalConfig {
     ///
     /// Returns an error if the config directory cannot be determined
     pub fn path() -> Result<PathBuf, io::Error> {
-        use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_app_strategy};
-        let strategy = choose_app_strategy(AppStrategyArgs {
-            top_level_domain: String::new(),
-            author: String::new(),
-            app_name: "secretspec".into(),
-        })
-        .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e.to_string()))?;
+        use etcetera::app_strategy::{AppStrategy, choose_app_strategy};
+        let strategy = choose_app_strategy(app_strategy_args())
+            .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e.to_string()))?;
         Ok(strategy.config_dir().join("config.toml"))
     }
 
@@ -1030,6 +1146,101 @@ mod require_reason_tests {
             toml::from_str::<Project>(&toml).unwrap().require_reason,
             Some(RequireReason::Always)
         );
+    }
+}
+
+#[cfg(test)]
+mod audit_config_tests {
+    use super::*;
+
+    fn with_path(path: &str) -> AuditConfig {
+        AuditConfig {
+            path: Some(PathBuf::from(path)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolved_path_keeps_absolute_and_rejects_relative() {
+        // An absolute configured path is honored verbatim.
+        let abs = with_path("/var/log/secretspec/audit.log");
+        assert_eq!(
+            abs.resolved_path(),
+            Some(PathBuf::from("/var/log/secretspec/audit.log"))
+        );
+        assert!(!abs.has_relative_path());
+
+        // A relative path (bare filename or nested) is rejected: it would resolve
+        // against the current working directory and scatter the log per-CWD.
+        for rel in ["audit.log", "logs/audit.log", "./audit.log"] {
+            let cfg = with_path(rel);
+            assert_eq!(
+                cfg.resolved_path(),
+                None,
+                "relative path {rel:?} must reject"
+            );
+            assert!(
+                cfg.has_relative_path(),
+                "{rel:?} should be flagged relative"
+            );
+        }
+    }
+
+    #[test]
+    fn unset_path_is_not_flagged_relative() {
+        // No configured path falls back to the per-user default and is never
+        // reported as a relative-path error.
+        let cfg = AuditConfig::default();
+        assert!(!cfg.has_relative_path());
+    }
+
+    #[test]
+    fn expand_tilde_expands_leading_tilde_only() {
+        // Paths without a leading `~` are returned unchanged...
+        assert_eq!(
+            expand_tilde(PathBuf::from("/abs/path")),
+            PathBuf::from("/abs/path")
+        );
+        assert_eq!(
+            expand_tilde(PathBuf::from("relative/path")),
+            PathBuf::from("relative/path")
+        );
+        // ...including a `~` that is not the leading component.
+        assert_eq!(
+            expand_tilde(PathBuf::from("/a/~/b")),
+            PathBuf::from("/a/~/b")
+        );
+
+        // A leading `~/...` expands against the resolved home directory.
+        if let Some(home) = home_dir() {
+            assert_eq!(
+                expand_tilde(PathBuf::from("~/.local/state/secretspec/audit.log")),
+                home.join(".local/state/secretspec/audit.log")
+            );
+        }
+    }
+
+    #[test]
+    fn audit_config_omitted_fields_default_to_on() {
+        // The security-relevant defaults: auditing on, no explicit path, 1 MiB cap.
+        // A missing field must not silently disable logging.
+        let cfg: AuditConfig = toml::from_str("").unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.path, None);
+        assert_eq!(cfg.max_size_bytes, 1_048_576);
+    }
+
+    #[test]
+    fn global_config_wires_audit_table() {
+        // A present `[audit]` table populates `GlobalConfig::audit`...
+        let g: GlobalConfig =
+            toml::from_str("[defaults]\nprovider = \"keyring\"\n\n[audit]\nenabled = false\n")
+                .unwrap();
+        assert_eq!(g.audit.map(|a| a.enabled), Some(false));
+
+        // ...and an absent one leaves it unspecified (resolving to on-by-default).
+        let g: GlobalConfig = toml::from_str("[defaults]\nprovider = \"keyring\"\n").unwrap();
+        assert!(g.audit.is_none());
     }
 }
 

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -66,6 +66,106 @@ pub enum SecretSpecError {
     ReasonRequired,
 }
 
+impl SecretSpecError {
+    /// A stable, non-sensitive token identifying the error variant, for audit logs.
+    ///
+    /// Returns only the variant name, never the error message: messages can embed
+    /// secret names, provider URIs, or backend detail that must not reach the log.
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            SecretSpecError::Io(_) => "io",
+            SecretSpecError::Toml(_) => "toml",
+            SecretSpecError::UnsupportedRevision(_) => "unsupported_revision",
+            SecretSpecError::TomlSer(_) => "toml_ser",
+            #[cfg(feature = "keyring")]
+            SecretSpecError::Keyring(_) => "keyring",
+            SecretSpecError::Dotenv(_) => "dotenv",
+            SecretSpecError::NoProviderConfigured => "no_provider_configured",
+            SecretSpecError::ProviderNotFound(_) => "provider_not_found",
+            SecretSpecError::SecretNotFound(_) => "secret_not_found",
+            SecretSpecError::RequiredSecretMissing(_) => "required_secret_missing",
+            SecretSpecError::NoManifest => "no_manifest",
+            SecretSpecError::ExtendedConfigNotFound(_) => "extended_config_not_found",
+            SecretSpecError::NoProjectName => "no_project_name",
+            SecretSpecError::ProviderOperationFailed(_) => "provider_operation_failed",
+            SecretSpecError::InquireError(_) => "inquire",
+            SecretSpecError::Json(_) => "json",
+            SecretSpecError::InvalidProfile(_) => "invalid_profile",
+            SecretSpecError::ValidationFailed(_) => "validation_failed",
+            SecretSpecError::GenerationFailed(_) => "generation_failed",
+            SecretSpecError::ReasonRequired => "reason_required",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `kind()` returns a stable token per variant and never the (possibly
+    /// secret-bearing) error message.
+    #[test]
+    fn kind_returns_stable_non_sensitive_tokens() {
+        let cases: Vec<(SecretSpecError, &str)> = vec![
+            (io::Error::other("boom").into(), "io"),
+            (
+                SecretSpecError::UnsupportedRevision("9.9".into()),
+                "unsupported_revision",
+            ),
+            (
+                SecretSpecError::NoProviderConfigured,
+                "no_provider_configured",
+            ),
+            (
+                SecretSpecError::ProviderNotFound("vault".into()),
+                "provider_not_found",
+            ),
+            (
+                SecretSpecError::SecretNotFound("X".into()),
+                "secret_not_found",
+            ),
+            (
+                SecretSpecError::RequiredSecretMissing("X".into()),
+                "required_secret_missing",
+            ),
+            (SecretSpecError::NoManifest, "no_manifest"),
+            (
+                SecretSpecError::ExtendedConfigNotFound("../x".into()),
+                "extended_config_not_found",
+            ),
+            (SecretSpecError::NoProjectName, "no_project_name"),
+            (
+                SecretSpecError::ProviderOperationFailed("nope".into()),
+                "provider_operation_failed",
+            ),
+            (
+                SecretSpecError::InvalidProfile("ghost".into()),
+                "invalid_profile",
+            ),
+            (
+                SecretSpecError::GenerationFailed("rng".into()),
+                "generation_failed",
+            ),
+            (SecretSpecError::ReasonRequired, "reason_required"),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(err.kind(), expected);
+        }
+    }
+
+    #[test]
+    fn kind_tags_wrapped_parse_errors() {
+        let json: SecretSpecError = serde_json::from_str::<serde_json::Value>("nope")
+            .unwrap_err()
+            .into();
+        assert_eq!(json.kind(), "json");
+
+        let toml: SecretSpecError = "= bad".parse::<toml::Table>().unwrap_err().into();
+        assert_eq!(toml.kind(), "toml");
+    }
+}
+
 /// A type alias for `Result<T, SecretSpecError>`
 ///
 /// This provides a convenient shorthand for functions that return

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -41,6 +41,7 @@
 //! ```
 
 // Internal modules
+mod audit;
 mod config;
 mod error;
 pub(crate) mod generator;
@@ -58,7 +59,9 @@ pub use config::Resolved;
 
 // Re-export config types for CLI usage only - these are marked #[doc(hidden)]
 #[doc(hidden)]
-pub use config::{Config, GlobalConfig, GlobalDefaults, Profile, ProfileDefaults, Project};
+pub use config::{
+    AuditConfig, Config, GlobalConfig, GlobalDefaults, Profile, ProfileDefaults, Project,
+};
 
 // Re-export Secret and generation types for secretspec-derive
 #[doc(hidden)]

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -340,6 +340,17 @@ pub trait Provider: Send + Sync {
     ///
     /// This includes any configuration like vault names, paths, etc.
     /// For example: "onepassword://VaultName" or "dotenv://.env.production"
+    ///
+    /// # Contract: the returned URI must be credential-free
+    ///
+    /// The audit log records this URI and the fallback-chain warnings print it,
+    /// so it must never contain a secret the user embedded in the source URI
+    /// (e.g. a `:password` or service-account token). Reconstruct the URI from
+    /// non-secret attribution only — account, profile, namespace, host, path —
+    /// and drop any credential, which authentication resolves from the
+    /// environment or a token field instead. This contract is enforced for every
+    /// registered scheme by `uri_never_echoes_a_userinfo_password` in
+    /// `provider::tests`.
     fn uri(&self) -> String;
 
     /// Records a human-readable reason for the secrets access happening in this

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -62,6 +62,36 @@ fn test_create_from_string_with_full_uris() {
     assert_eq!(provider.name(), "onepassword");
 }
 
+/// The audit log and the fallback-chain warnings persist a provider's `uri()`
+/// and rely on it never echoing a credential the user embedded in the source
+/// URI (see `Provider::uri`). Enforce that contract for every registered scheme:
+/// build the provider from a URI carrying a recognizable secret in the
+/// *password* position and assert the reconstructed `uri()` does not contain it.
+///
+/// The username/host/path positions hold non-secret attribution (1Password
+/// accounts, AWS profiles, Vault namespaces) and are intentionally preserved; a
+/// URL *password* is always a credential and must never resurface. A scheme that
+/// rejects this URI shape simply builds nothing, which leaks nothing.
+#[test]
+fn uri_never_echoes_a_userinfo_password() {
+    const SECRET: &str = "leaked_pw_DO_NOT_ECHO";
+
+    for reg in super::PROVIDER_REGISTRY {
+        for &scheme in reg.schemes {
+            let source = format!("{scheme}://attribution:{SECRET}@host/path");
+            // Only assert on schemes that build; a parse failure echoes nothing.
+            let Ok(provider) = Box::<dyn Provider>::try_from(source.as_str()) else {
+                continue;
+            };
+            let uri = provider.uri();
+            assert!(
+                !uri.contains(SECRET),
+                "provider scheme {scheme:?} echoed a URL password into uri(): {uri:?}"
+            );
+        }
+    }
+}
+
 #[test]
 fn test_create_from_string_with_plain_names() {
     // Test plain provider names

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1,5 +1,6 @@
 //! Core secrets management functionality
 
+use crate::audit::{AuditAction, AuditContext, AuditLogger, AuditOutcome};
 use crate::config::{Config, GlobalConfig, Profile, RequireReason, Resolved};
 use crate::error::{Result, SecretSpecError};
 use crate::provider::Provider as ProviderTrait;
@@ -15,11 +16,19 @@ use std::process::Command;
 
 /// Emits a warning when a provider in a fallback chain fails so the user
 /// can see why a particular link was skipped, without aborting the chain.
-fn warn_provider_failure(uri: &str, secret_name: &str, err: &SecretSpecError) {
+///
+/// `display_uri` must already be credential-free: pass the provider's
+/// reconstructed [`uri()`](ProviderTrait::uri) when a provider was built, or
+/// [`redact_uri_strict`] of the raw alias when construction itself failed. This
+/// function does not redact, so it never strips legitimate attribution (e.g. an
+/// `awssm://…?prefix=…`) from a provider's own `uri()`.
+///
+/// [`redact_uri_strict`]: crate::audit::redact_uri_strict
+fn warn_provider_failure(display_uri: &str, secret_name: &str, err: &SecretSpecError) {
     eprintln!(
         "{} provider {} failed for {}: {}; trying next provider in chain",
         "warning:".yellow(),
-        uri.bold(),
+        display_uri.bold(),
         secret_name.bold(),
         err
     );
@@ -28,11 +37,17 @@ fn warn_provider_failure(uri: &str, secret_name: &str, err: &SecretSpecError) {
 /// Emits a warning when the primary provider for a batch fetch fails (either
 /// during construction or during `get_batch`); affected secrets will still be
 /// retried via their per-secret fallback chain below.
-fn warn_primary_provider_failure(uri: Option<&str>, err: &SecretSpecError) {
+///
+/// Like [`warn_provider_failure`], `display_uri` must already be credential-free
+/// (a provider's reconstructed `uri()`, or [`redact_uri_strict`] of a raw alias).
+/// `None` renders as `<default>` (no per-secret provider was configured).
+///
+/// [`redact_uri_strict`]: crate::audit::redact_uri_strict
+fn warn_primary_provider_failure(display_uri: Option<&str>, err: &SecretSpecError) {
     eprintln!(
         "{} primary provider {} failed: {}; will try fallback chain for affected secrets",
         "warning:".yellow(),
-        uri.unwrap_or("<default>").bold(),
+        display_uri.unwrap_or("<default>").bold(),
         err
     );
 }
@@ -80,24 +95,64 @@ pub struct Secrets {
     /// Project policy (`[project].require_reason` in secretspec.toml) controlling
     /// when secret access requires an explicit reason.
     require_reason: RequireReason,
+    /// Audit logger, if auditing is enabled (user-global `[audit]` config). `None`
+    /// disables auditing. Built once per `Secrets` so all events share a session id.
+    audit: Option<AuditLogger>,
 }
 
 /// secretspec's own opt-in for marking the current process as an agent. Lets any
 /// harness that the `detect-coding-agent` crate does not recognize identify itself.
 const AGENT_OPT_IN_ENV: &str = "SECRETSPEC_AGENT";
 
+/// A UTF-8 snapshot of the process environment, dropping any non-UTF-8 entries.
+///
+/// `detect-coding-agent`'s `detect()`/`is_agent()` capture the environment with
+/// `std::env::vars()`, which **panics** on any non-UTF-8 variable — and env vars
+/// are arbitrary byte strings on Unix. Building the map ourselves with `vars_os`
+/// and silently skipping non-UTF-8 entries lets detection run safely: the
+/// agent-signal variables the crate looks for are always plain ASCII, so a stray
+/// non-UTF-8 var cannot abort an otherwise-fine secretspec command. Feeds the
+/// crate's `*_with_env` variants, which take the map instead of reading the
+/// environment directly.
+fn utf8_env() -> std::collections::HashMap<String, String> {
+    utf8_env_from(std::env::vars_os())
+}
+
+/// [`utf8_env`] over an explicit iterator, so the non-UTF-8 filtering can be tested
+/// without mutating the process environment (which is global and racy under `cargo
+/// test`).
+fn utf8_env_from<I>(vars: I) -> std::collections::HashMap<String, String>
+where
+    I: IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+{
+    vars.into_iter()
+        .filter_map(|(k, v)| Some((k.into_string().ok()?, v.into_string().ok()?)))
+        .collect()
+}
+
+/// The id of the detected coding agent (e.g. `"claude-code"`), or `None`.
+///
+/// Routes through [`detect_with_env`](detect_coding_agent::detect_with_env) with a
+/// [`utf8_env`] snapshot so a non-UTF-8 environment cannot panic the process.
+pub(crate) fn detect_agent_id() -> Option<&'static str> {
+    detect_coding_agent::detect_with_env(utf8_env()).map(|a| a.id)
+}
+
 /// Whether secretspec is currently running as an AI coding agent.
 ///
 /// Detection of the known agents (Claude Code, Cursor, Codex, Gemini CLI, Copilot,
 /// ...) is delegated to the [`detect-coding-agent`] crate, which maintains the
-/// per-tool signal list. `is_agent()` covers autonomous and hybrid environments
-/// (not human-driven interactive editors). `SECRETSPEC_AGENT` is an additional
-/// explicit opt-in for harnesses the crate does not yet recognize.
+/// per-tool signal list. This covers autonomous and hybrid environments (not
+/// human-driven interactive editors), mirroring the crate's own `is_agent()`.
+/// `SECRETSPEC_AGENT` is an additional explicit opt-in for harnesses the crate does
+/// not yet recognize. Detection goes through [`utf8_env`] so a non-UTF-8
+/// environment variable cannot panic the process.
 ///
 /// [`detect-coding-agent`]: https://crates.io/crates/detect-coding-agent
-fn running_as_agent() -> bool {
+pub(crate) fn running_as_agent() -> bool {
     std::env::var_os(AGENT_OPT_IN_ENV).is_some_and(|v| !v.is_empty())
-        || detect_coding_agent::is_agent()
+        || detect_coding_agent::detect_with_env(utf8_env())
+            .is_some_and(|a| a.is_agent() || a.is_hybrid())
 }
 
 /// Pure policy decision: does `mode` require a reason given whether the caller is
@@ -139,6 +194,24 @@ fn env_reason() -> Option<String> {
         .and_then(normalize_reason)
 }
 
+/// The variable, per-call fields of an audit event. Session-constant fields
+/// (project, session reason, whether auditing is enabled) are filled by
+/// [`Secrets::record`], so call sites specify only what differs and default the
+/// rest with `..Default::default()`.
+#[derive(Default)]
+struct AuditFields<'a> {
+    /// The single secret involved (`get`/`set`); `None` for bulk actions.
+    key: Option<&'a str>,
+    /// The secrets involved in a bulk action (`check`/`run`/`import`).
+    keys: &'a [String],
+    /// For `run`, the executed program (argv[0] only).
+    command: Option<&'a str>,
+    /// Redacted provider URI the access is attributed to.
+    provider_uri: Option<String>,
+    /// Stable error-variant token when the outcome is an error.
+    error_kind: Option<&'a str>,
+}
+
 impl Secrets {
     /// Creates a new `Secrets` instance with the given configurations
     ///
@@ -166,6 +239,7 @@ impl Secrets {
             profile,
             reason: None,
             require_reason: RequireReason::Never,
+            audit: None,
         }
     }
 
@@ -209,6 +283,15 @@ impl Secrets {
     pub fn load_from(path: &Path) -> Result<Self> {
         let project_config = Config::try_from(path)?;
         let global_config = GlobalConfig::load()?;
+        // Auditing is a per-machine concern configured in the user-global config
+        // (`[audit]` in ~/.config/secretspec/config.toml), not the project. It is
+        // on by default when unconfigured.
+        let audit = AuditLogger::from_config(
+            &global_config
+                .as_ref()
+                .and_then(|g| g.audit.clone())
+                .unwrap_or_default(),
+        );
         Ok(Self {
             require_reason: project_config.project.require_reason.unwrap_or_default(),
             config: project_config,
@@ -216,6 +299,7 @@ impl Secrets {
             provider: None,
             profile: None,
             reason: env_reason(),
+            audit,
         })
     }
 
@@ -322,6 +406,108 @@ impl Secrets {
         Ok(provider)
     }
 
+    /// Records one audit event with the given variable fields, if auditing is
+    /// enabled (a no-op otherwise). Session-constant fields — project, the session
+    /// reason, and whether auditing is on — are filled here so call sites specify
+    /// only what varies. Single-secret (`get`/`set`) and bulk
+    /// (`check`/`run`/`import`) events go through this one method.
+    fn record(
+        &self,
+        action: AuditAction,
+        profile: &str,
+        outcome: AuditOutcome,
+        fields: AuditFields<'_>,
+    ) {
+        if let Some(logger) = &self.audit {
+            logger.record(
+                action,
+                AuditContext {
+                    project: &self.config.project.name,
+                    profile,
+                    key: fields.key,
+                    keys: fields.keys,
+                    command: fields.command,
+                    provider_uri: fields.provider_uri,
+                    outcome,
+                    error_kind: fields.error_kind,
+                    reason: self.reason.as_deref(),
+                },
+            );
+        }
+    }
+
+    /// Audits the result of a single secret write (`set`/generate/prompt): a
+    /// `Written` event on success, an `Error` event (tagged with the error kind)
+    /// on failure. Centralizes the write-audit so every write path records the
+    /// same way and a new one cannot accidentally diverge or skip auditing.
+    fn audit_write_result(
+        &self,
+        result: &Result<()>,
+        key: &str,
+        profile: &str,
+        provider_uri: Option<String>,
+    ) {
+        let (outcome, error_kind) = match result {
+            Ok(()) => (AuditOutcome::Written, None),
+            Err(e) => (AuditOutcome::Error, Some(e.kind())),
+        };
+        self.record(
+            AuditAction::Set,
+            profile,
+            outcome,
+            AuditFields {
+                key: Some(key),
+                provider_uri,
+                error_kind,
+                ..Default::default()
+            },
+        );
+    }
+
+    /// Enforces the `require_reason` policy and, when it denies access, records the
+    /// blocked attempt as an `Error` event before returning, so a policy denial
+    /// still leaves an audit trace. `action`/`key` describe the attempted
+    /// operation. Used at every public secret-accessing entry point.
+    fn ensure_reason_for(&self, action: AuditAction, key: Option<&str>) -> Result<()> {
+        if let Err(e) = self.ensure_reason() {
+            let profile = self.resolve_profile_name(None);
+            self.record(
+                action,
+                &profile,
+                AuditOutcome::Error,
+                AuditFields {
+                    key,
+                    error_kind: Some(e.kind()),
+                    ..Default::default()
+                },
+            );
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Inserts a resolved secret into the working set, transparently materializing
+    /// an `as_path` secret to an owner-only temp file whose lifetime is tied to
+    /// `temp_files`. Shared by every resolution branch so the temp-file handling
+    /// cannot drift between them.
+    fn insert_resolved(
+        &self,
+        secrets: &mut HashMap<String, SecretString>,
+        temp_files: &mut Vec<tempfile::NamedTempFile>,
+        name: String,
+        value: SecretString,
+        as_path: bool,
+    ) -> Result<()> {
+        if as_path {
+            let (temp_file, path_str) = self.write_secret_to_temp_file(&value)?;
+            temp_files.push(temp_file);
+            secrets.insert(name, SecretString::new(path_str.into()));
+        } else {
+            secrets.insert(name, value);
+        }
+        Ok(())
+    }
+
     /// Get a reference to the project configuration (for testing)
     #[cfg(test)]
     pub(crate) fn config(&self) -> &Config {
@@ -332,6 +518,20 @@ impl Secrets {
     #[cfg(test)]
     pub(crate) fn global_config(&self) -> &Option<GlobalConfig> {
         &self.global_config
+    }
+
+    /// Attach an audit logger (for testing which events an operation emits).
+    #[cfg(test)]
+    pub(crate) fn set_audit_for_test(&mut self, logger: crate::audit::AuditLogger) {
+        self.audit = Some(logger);
+    }
+
+    /// Override the `require_reason` policy (for testing the gate without going
+    /// through `load`/`load_from`, which would build a real audit logger and write
+    /// to the user's real audit log).
+    #[cfg(test)]
+    pub(crate) fn set_require_reason(&mut self, policy: RequireReason) {
+        self.require_reason = policy;
     }
 
     /// Resolves the profile to use based on the provided value and configuration
@@ -730,7 +930,10 @@ impl Secrets {
     ///
     /// # Returns
     ///
-    /// The secret value if found in any provider, or None if not found in any
+    /// A tuple of the secret value (or `None` if not found in any provider) and
+    /// the URI of the provider to attribute the access to: on a hit, the serving
+    /// provider; on a chain miss/error, the last provider tried. The URI lets
+    /// callers (e.g. the audit log) record which provider actually answered.
     fn get_secret_from_providers(
         &self,
         project_name: &str,
@@ -738,28 +941,42 @@ impl Secrets {
         profile_name: &str,
         provider_uris: Option<&[String]>,
         default_provider_arg: Option<String>,
-    ) -> Result<Option<SecretString>> {
+    ) -> Result<(Option<SecretString>, Option<String>)> {
         // If provider URIs are specified, try them in order
         if let Some(uris) = provider_uris {
             let mut last_error: Option<SecretSpecError> = None;
             let mut any_healthy = false;
+            let mut last_uri: Option<String> = None;
             for uri in uris {
                 let provider = match self.build_provider(uri.clone()) {
                     Ok(p) => p,
                     Err(e) => {
-                        warn_provider_failure(uri, secret_name, &e);
+                        // Construction failed, so only the raw alias exists; redact it.
+                        warn_provider_failure(
+                            &crate::audit::redact_uri_strict(uri),
+                            secret_name,
+                            &e,
+                        );
                         last_error = Some(e);
                         continue;
                     }
                 };
+                // Attribute the access to the provider's own redacted `uri()`, never
+                // the raw configured alias: a per-secret alias may embed credentials
+                // (e.g. `vault+token:s3cr3t@host`) that the provider strips from
+                // `uri()` but that `redact_uri` cannot remove from an opaque URI.
+                let provider_uri = provider.uri();
+                last_uri = Some(provider_uri.clone());
                 match provider.get(project_name, secret_name, profile_name) {
-                    Ok(Some(value)) => return Ok(Some(value)),
+                    Ok(Some(value)) => return Ok((Some(value), Some(provider_uri))),
                     Ok(None) => {
                         any_healthy = true;
                         continue;
                     }
                     Err(e) => {
-                        warn_provider_failure(uri, secret_name, &e);
+                        // A provider was built, so attribute the warning to its own
+                        // credential-free `uri()` rather than the raw alias.
+                        warn_provider_failure(&provider_uri, secret_name, &e);
                         last_error = Some(e);
                         continue;
                     }
@@ -769,12 +986,15 @@ impl Secrets {
             // a healthy "not found" — otherwise the secret is genuinely missing.
             match last_error {
                 Some(e) if !any_healthy => Err(e),
-                _ => Ok(None),
+                _ => Ok((None, last_uri)),
             }
         } else {
             // No per-secret providers, use default provider
             let backend = self.get_provider(default_provider_arg)?;
-            backend.get(project_name, secret_name, profile_name)
+            let uri = backend.uri();
+            backend
+                .get(project_name, secret_name, profile_name)
+                .map(|opt| (opt, Some(uri)))
         }
     }
 
@@ -809,7 +1029,7 @@ impl Secrets {
     /// spec.set("DATABASE_URL", Some("postgres://localhost".to_string())).unwrap();
     /// ```
     pub fn set(&self, name: &str, value: Option<String>) -> Result<()> {
-        self.ensure_reason()?;
+        self.ensure_reason_for(AuditAction::Set, Some(name))?;
         // Check if the secret exists in the spec
         let profile_name = self.resolve_profile_name(None);
         self.require_profile(&profile_name)?;
@@ -825,22 +1045,46 @@ impl Secrets {
                     .collect::<Vec<_>>();
                 available_secrets.sort();
 
-                return Err(SecretSpecError::SecretNotFound(format!(
+                let err = SecretSpecError::SecretNotFound(format!(
                     "Secret '{}' is not defined in profile '{}'. Available secrets: {}",
                     name,
                     profile_name,
                     available_secrets.join(", ")
-                )));
+                ));
+                // Provider is unknown for an undefined secret, so attribute to None.
+                self.record(
+                    AuditAction::Set,
+                    &profile_name,
+                    AuditOutcome::Error,
+                    AuditFields {
+                        key: Some(name),
+                        error_kind: Some(err.kind()),
+                        ..Default::default()
+                    },
+                );
+                return Err(err);
             }
         };
 
         let backend = self.resolve_write_provider(&secret_config, None)?;
 
         if !backend.allows_set() {
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
+            let err = SecretSpecError::ProviderOperationFailed(format!(
                 "Provider '{}' is read-only and does not support setting values",
                 backend.name()
-            )));
+            ));
+            self.record(
+                AuditAction::Set,
+                &profile_name,
+                AuditOutcome::Error,
+                AuditFields {
+                    key: Some(name),
+                    provider_uri: Some(backend.uri()),
+                    error_kind: Some(err.kind()),
+                    ..Default::default()
+                },
+            );
+            return Err(err);
         }
 
         let value = if let Some(v) = value {
@@ -860,12 +1104,27 @@ impl Secrets {
         };
 
         if value.expose_secret().is_empty() {
-            return Err(SecretSpecError::ProviderOperationFailed(
+            let err = SecretSpecError::ProviderOperationFailed(
                 "Secret value cannot be empty".to_string(),
-            ));
+            );
+            self.record(
+                AuditAction::Set,
+                &profile_name,
+                AuditOutcome::Error,
+                AuditFields {
+                    key: Some(name),
+                    provider_uri: Some(backend.uri()),
+                    error_kind: Some(err.kind()),
+                    ..Default::default()
+                },
+            );
+            return Err(err);
         }
 
-        backend.set(&self.config.project.name, name, &value, &profile_name)?;
+        let result = backend.set(&self.config.project.name, name, &value, &profile_name);
+        self.audit_write_result(&result, name, &profile_name, Some(backend.uri()));
+        result?;
+
         eprintln!(
             "{} Secret '{}' saved to {} (profile: {})",
             "✓".green(),
@@ -899,23 +1158,87 @@ impl Secrets {
     /// - The secret is not defined in the specification
     /// - The secret is not found and has no default value
     pub fn get(&self, name: &str) -> Result<()> {
-        self.ensure_reason()?;
+        self.ensure_reason_for(AuditAction::Get, Some(name))?;
         let profile_name = self.resolve_profile_name(None);
-        let secret_config = self
-            .resolve_secret_config(name, None)
-            .ok_or_else(|| SecretSpecError::SecretNotFound(name.to_string()))?;
+        let secret_config = match self.resolve_secret_config(name, None) {
+            Some(config) => config,
+            None => {
+                // The secret is not defined, so no provider can be attributed.
+                // Audit the failed read for parity with `set`'s undefined path.
+                let err = SecretSpecError::SecretNotFound(name.to_string());
+                self.record(
+                    AuditAction::Get,
+                    &profile_name,
+                    AuditOutcome::Error,
+                    AuditFields {
+                        key: Some(name),
+                        error_kind: Some(err.kind()),
+                        ..Default::default()
+                    },
+                );
+                return Err(err);
+            }
+        };
         let default = secret_config.default.clone();
         let as_path = secret_config.as_path.unwrap_or(false);
 
         let provider_uris = self.resolve_read_provider_uris(&secret_config, None)?;
 
-        match self.get_secret_from_providers(
+        let result = self.get_secret_from_providers(
             &self.config.project.name,
             name,
             &profile_name,
             provider_uris.as_deref(),
             None,
-        )? {
+        );
+
+        // Audit the access at the provider boundary, before defaults are applied.
+        // The provider URI consulted is reported back so the chain miss/error
+        // attributes to the last provider tried rather than guessing.
+        match &result {
+            Ok((Some(_), uri)) => self.record(
+                AuditAction::Get,
+                &profile_name,
+                AuditOutcome::Found,
+                AuditFields {
+                    key: Some(name),
+                    provider_uri: uri.clone(),
+                    ..Default::default()
+                },
+            ),
+            Ok((None, uri)) if default.is_some() => self.record(
+                AuditAction::Get,
+                &profile_name,
+                AuditOutcome::Default,
+                AuditFields {
+                    key: Some(name),
+                    provider_uri: uri.clone(),
+                    ..Default::default()
+                },
+            ),
+            Ok((None, uri)) => self.record(
+                AuditAction::Get,
+                &profile_name,
+                AuditOutcome::Missing,
+                AuditFields {
+                    key: Some(name),
+                    provider_uri: uri.clone(),
+                    ..Default::default()
+                },
+            ),
+            Err(e) => self.record(
+                AuditAction::Get,
+                &profile_name,
+                AuditOutcome::Error,
+                AuditFields {
+                    key: Some(name),
+                    error_kind: Some(e.kind()),
+                    ..Default::default()
+                },
+            ),
+        }
+
+        match result?.0 {
             Some(value) => {
                 if as_path {
                     // Write to temp file and persist it (don't auto-delete)
@@ -987,8 +1310,10 @@ impl Secrets {
     ) -> Result<ValidatedSecrets> {
         let profile_display = self.resolve_profile_name(profile.as_deref());
 
-        // First validate to see what's missing
-        let validation_result = self.validate()?;
+        // First validate to see what's missing. Use the non-auditing variant:
+        // the caller that owns this operation (`check`, `run`) records its own
+        // audit event, so re-validating here must not emit another `Check`.
+        let validation_result = self.validate_audited(false)?;
 
         match validation_result {
             Ok(valid_secrets) => Ok(valid_secrets),
@@ -1048,12 +1373,19 @@ impl Secrets {
 
                             let backend = self
                                 .resolve_write_provider(&secret_config, provider_arg.as_deref())?;
-                            backend.set(
+                            let set_result = backend.set(
                                 &self.config.project.name,
                                 secret_name,
                                 &SecretString::new(value.into()),
                                 &profile_display,
-                            )?;
+                            );
+                            self.audit_write_result(
+                                &set_result,
+                                secret_name,
+                                &profile_display,
+                                Some(backend.uri()),
+                            );
+                            set_result?;
                             eprintln!(
                                 "{} Secret '{}' saved to {} (profile: {})",
                                 "✓".green(),
@@ -1067,7 +1399,9 @@ impl Secrets {
                     eprintln!("\nAll required secrets have been set.");
 
                     // Re-validate to get the updated results
-                    match self.validate()? {
+                    // Re-validate after prompting; still part of the same
+                    // operation, so do not emit another `Check` event.
+                    match self.validate_audited(false)? {
                         Ok(valid_secrets) => Ok(valid_secrets),
                         Err(still_errors) => Err(SecretSpecError::RequiredSecretMissing(
                             still_errors.missing_required.join(", "),
@@ -1113,7 +1447,7 @@ impl Secrets {
     /// let validated = spec.check(false).unwrap();
     /// ```
     pub fn check(&self, no_prompt: bool) -> Result<ValidatedSecrets> {
-        self.ensure_reason()?;
+        self.ensure_reason_for(AuditAction::Check, None)?;
         let profile_display = self.resolve_profile_name(None);
 
         eprintln!(
@@ -1123,6 +1457,7 @@ impl Secrets {
         );
 
         // Validate and display results
+        // The read is audited inside `validate()`, so no bulk event here.
         match self.validate()? {
             Ok(valid) => {
                 self.display_validation_success(&valid)?;
@@ -1294,98 +1629,145 @@ impl Secrets {
     /// spec.import("dotenv://.env.production").unwrap();
     /// ```
     pub fn import(&self, from_provider: &str) -> Result<()> {
-        self.ensure_reason()?;
+        self.ensure_reason_for(AuditAction::Import, None)?;
         // Resolve profile (checks env var, then global config, then defaults to "default")
         let profile_display = self.resolve_profile_name(None);
-
-        // Create the "from" provider and check availability
-        let from_provider_instance = self.build_provider(from_provider.to_string())?;
-
-        eprintln!(
-            "Importing secrets from {} (profile: {})...\n",
-            from_provider.blue(),
-            profile_display.cyan()
-        );
 
         let mut imported = 0;
         let mut already_exists = 0;
         let mut not_found = 0;
+        // Every secret the import reads from the source/target, in iteration
+        // order. An import is one bulk action over this whole set, so it is the
+        // `keys` recorded in the audit log — independent of how many were copied,
+        // so a no-op import (nothing to copy) is still recorded as a read.
+        let mut read_names: Vec<String> = Vec::new();
 
-        // Collect all secrets to import - from current profile and default profile
-        // This ensures we can import secrets defined in default profile when using other profiles
-        let profile = self.resolve_profile(Some(&profile_display))?;
+        // Run the copy in an inner closure so that any early error (provider
+        // build, profile resolution, a per-secret get/set) can be audited with
+        // the secrets read so far before the error propagates. `source_uri`
+        // is filled in once the source provider is built.
+        let mut source_uri: Option<String> = None;
+        let copy_result = (|| -> Result<()> {
+            // Create the "from" provider and check availability
+            let from_provider_instance = self.build_provider(from_provider.to_string())?;
+            source_uri = Some(from_provider_instance.uri());
 
-        // Process each secret using proper profile resolution
-        for (name, config) in profile.into_iter() {
-            let secret_config = self
-                .resolve_secret_config(&name, Some(&profile_display))
-                .expect("Secret should exist since we're iterating over it");
+            eprintln!(
+                "Importing secrets from {} (profile: {})...\n",
+                from_provider.blue(),
+                profile_display.cyan()
+            );
 
-            let to_provider = self.resolve_write_provider(&secret_config, None)?;
+            // Collect all secrets to import - from current profile and default profile
+            // This ensures we can import secrets defined in default profile when using other profiles
+            let profile = self.resolve_profile(Some(&profile_display))?;
 
-            // First check if the secret exists in the "from" provider
-            match from_provider_instance.get(&self.config.project.name, &name, &profile_display)? {
-                Some(value) => {
-                    // Secret exists in "from" provider, check if it exists in "to" provider
-                    match to_provider.get(&self.config.project.name, &name, &profile_display)? {
-                        Some(_) => {
-                            eprintln!(
-                                "{} {} - {} {} (→ {})",
-                                "○".yellow(),
-                                name,
-                                config.description.as_deref().unwrap_or("No description"),
-                                "(already exists in target)".yellow(),
-                                to_provider.name().blue()
-                            );
-                            already_exists += 1;
-                        }
-                        None => {
-                            // Secret doesn't exist in "to" provider, import it
-                            to_provider.set(
-                                &self.config.project.name,
-                                &name,
-                                &value,
-                                &profile_display,
-                            )?;
-                            eprintln!(
-                                "{} {} - {} (→ {})",
-                                "✓".green(),
-                                name,
-                                config.description.as_deref().unwrap_or("No description"),
-                                to_provider.name().blue()
-                            );
-                            imported += 1;
+            // Process each secret using proper profile resolution
+            for (name, config) in profile.into_iter() {
+                read_names.push(name.clone());
+                let secret_config = self
+                    .resolve_secret_config(&name, Some(&profile_display))
+                    .expect("Secret should exist since we're iterating over it");
+
+                let to_provider = self.resolve_write_provider(&secret_config, None)?;
+
+                // First check if the secret exists in the "from" provider
+                match from_provider_instance.get(
+                    &self.config.project.name,
+                    &name,
+                    &profile_display,
+                )? {
+                    Some(value) => {
+                        // Secret exists in "from" provider, check if it exists in "to" provider
+                        match to_provider.get(&self.config.project.name, &name, &profile_display)? {
+                            Some(_) => {
+                                eprintln!(
+                                    "{} {} - {} {} (→ {})",
+                                    "○".yellow(),
+                                    name,
+                                    config.description.as_deref().unwrap_or("No description"),
+                                    "(already exists in target)".yellow(),
+                                    to_provider.name().blue()
+                                );
+                                already_exists += 1;
+                            }
+                            None => {
+                                // Secret doesn't exist in "to" provider, import it.
+                                let set_result = to_provider.set(
+                                    &self.config.project.name,
+                                    &name,
+                                    &value,
+                                    &profile_display,
+                                );
+                                // Audit each copied secret as a write attributed to the
+                                // target provider, so import writes are recorded like
+                                // `set`/generate/prompt. The bulk Import event below only
+                                // captures the source read, not where secrets were copied.
+                                self.audit_write_result(
+                                    &set_result,
+                                    &name,
+                                    &profile_display,
+                                    Some(to_provider.uri()),
+                                );
+                                set_result?;
+                                eprintln!(
+                                    "{} {} - {} (→ {})",
+                                    "✓".green(),
+                                    name,
+                                    config.description.as_deref().unwrap_or("No description"),
+                                    to_provider.name().blue()
+                                );
+                                imported += 1;
+                            }
                         }
                     }
-                }
-                None => {
-                    // Secret doesn't exist in "from" provider
-                    // Check if it exists in the "to" provider
-                    match to_provider.get(&self.config.project.name, &name, &profile_display)? {
-                        Some(_) => {
-                            eprintln!(
-                                "{} {} - {} {} (→ {})",
-                                "○".blue(),
-                                name,
-                                config.description.as_deref().unwrap_or("No description"),
-                                "(already in target, not in source)".blue(),
-                                to_provider.name().blue()
-                            );
-                            already_exists += 1;
-                        }
-                        None => {
-                            eprintln!(
-                                "{} {} - {} {}",
-                                "✗".red(),
-                                name,
-                                config.description.as_deref().unwrap_or("No description"),
-                                "(not found in source)".red()
-                            );
-                            not_found += 1;
+                    None => {
+                        // Secret doesn't exist in "from" provider
+                        // Check if it exists in the "to" provider
+                        match to_provider.get(&self.config.project.name, &name, &profile_display)? {
+                            Some(_) => {
+                                eprintln!(
+                                    "{} {} - {} {} (→ {})",
+                                    "○".blue(),
+                                    name,
+                                    config.description.as_deref().unwrap_or("No description"),
+                                    "(already in target, not in source)".blue(),
+                                    to_provider.name().blue()
+                                );
+                                already_exists += 1;
+                            }
+                            None => {
+                                eprintln!(
+                                    "{} {} - {} {}",
+                                    "✗".red(),
+                                    name,
+                                    config.description.as_deref().unwrap_or("No description"),
+                                    "(not found in source)".red()
+                                );
+                                not_found += 1;
+                            }
                         }
                     }
                 }
             }
+            Ok(())
+        })();
+
+        if let Err(e) = copy_result {
+            // Record a failed/partial import with the secrets read before the error.
+            read_names.sort();
+            self.record(
+                AuditAction::Import,
+                &profile_display,
+                AuditOutcome::Error,
+                AuditFields {
+                    keys: &read_names,
+                    provider_uri: source_uri,
+                    error_kind: Some(e.kind()),
+                    ..Default::default()
+                },
+            );
+            return Err(e);
         }
 
         eprintln!(
@@ -1403,6 +1785,33 @@ impl Secrets {
                 from_provider,
             );
         }
+
+        // Always record the import: it read every declared secret from the
+        // source (and target), so the access is logged even when nothing was
+        // copied. Outcome reflects what the read found: `Written` when at least
+        // one secret was copied, `Found` when nothing was copied but secrets were
+        // already present (in source or target), and `Missing` when nothing was
+        // copied and nothing was found anywhere — so a "found nothing" import is
+        // not mislabeled as a successful retrieval. Per-secret copies are also
+        // recorded individually as `Set`/`Written` events above.
+        read_names.sort();
+        let outcome = if imported > 0 {
+            AuditOutcome::Written
+        } else if already_exists > 0 {
+            AuditOutcome::Found
+        } else {
+            AuditOutcome::Missing
+        };
+        self.record(
+            AuditAction::Import,
+            &profile_display,
+            outcome,
+            AuditFields {
+                keys: &read_names,
+                provider_uri: source_uri,
+                ..Default::default()
+            },
+        );
 
         Ok(())
     }
@@ -1457,7 +1866,11 @@ impl Secrets {
 
         // Store the generated value
         let backend = self.get_writable_provider_for_secret(secret_config)?;
-        backend.set(&self.config.project.name, name, &value, profile_name)?;
+        let set_result = backend.set(&self.config.project.name, name, &value, profile_name);
+        // Generating a secret writes a brand-new value to the provider; record it
+        // like any other write so the audit log captures every stored secret.
+        self.audit_write_result(&set_result, name, profile_name, Some(backend.uri()));
+        set_result?;
 
         eprintln!(
             "{} {} - generated and saved to {} (profile: {})",
@@ -1559,189 +1972,267 @@ impl Secrets {
     ///     println!("All required secrets are present!");
     /// }
     /// ```
+    ///
+    /// This is the public read/resolution entry point — used directly by the SDK
+    /// and by `secretspec-derive`-generated code — so it records exactly one
+    /// `Check` audit event per call.
     pub fn validate(&self) -> Result<std::result::Result<ValidatedSecrets, ValidationErrors>> {
-        self.ensure_reason()?;
-        let mut secrets: HashMap<String, SecretString> = HashMap::new();
-        let mut missing_required = Vec::new();
-        let mut missing_optional = Vec::new();
-        let mut with_defaults = Vec::new();
-        let mut temp_files = Vec::new();
+        self.validate_audited(true)
+    }
+
+    /// Resolves all secrets. `emit_check` controls whether this pass records a
+    /// `Check` audit event.
+    ///
+    /// Top-level reads ([`Self::validate`], `check`) pass `true`. Internal
+    /// re-validations inside [`Self::ensure_secrets`] pass `false`, so a single
+    /// user action emits one `Check` (not several), and `secretspec run` — which
+    /// resolves via `ensure_secrets` and then records its own `Run` event — is
+    /// not also recorded as a `Check`. The trade-off: a direct
+    /// `ensure_secrets` call (rare; not the path `secretspec-derive` uses) does
+    /// not emit a `Check` read event, though any writes it performs are audited.
+    fn validate_audited(
+        &self,
+        emit_check: bool,
+    ) -> Result<std::result::Result<ValidatedSecrets, ValidationErrors>> {
+        // Enforce the reason policy. For the top-level read (`emit_check`) a denial
+        // is itself audited; internal re-validations (emit_check=false) re-check the
+        // gate silently, since the reason is already present by the time they run.
+        if emit_check {
+            self.ensure_reason_for(AuditAction::Check, None)?;
+        } else {
+            self.ensure_reason()?;
+        }
 
         let profile_name = self.resolve_profile_name(None);
-        let profile = self.resolve_profile(Some(&profile_name))?;
+        // Keys for the single read-audit event. Filled inside the closure once the
+        // profile resolves; stays empty if resolution fails before that point.
+        let mut audit_keys: Vec<String> = Vec::new();
 
-        let all_secrets: Vec<(String, crate::config::Secret)> = profile.into_iter().collect();
+        // Resolve every secret inside one fallible block so that *any* error — not
+        // just the inline primary-provider failure — is captured and recorded as a
+        // single `Check` event below before it propagates. Previously only one error
+        // arm audited, so a failed alias resolution or fallback-chain error left no
+        // trace despite being an attempted read.
+        let result: Result<std::result::Result<ValidatedSecrets, ValidationErrors>> =
+            (|| -> Result<std::result::Result<ValidatedSecrets, ValidationErrors>> {
+                let mut secrets: HashMap<String, SecretString> = HashMap::new();
+                let mut missing_required = Vec::new();
+                let mut missing_optional = Vec::new();
+                let mut with_defaults = Vec::new();
+                let mut temp_files = Vec::new();
 
-        let override_uri = self.resolve_provider_override(None);
+                let profile = self.resolve_profile(Some(&profile_name))?;
+                let all_secrets: Vec<(String, crate::config::Secret)> =
+                    profile.into_iter().collect();
 
-        let mut provider_groups: HashMap<Option<String>, Vec<String>> = HashMap::new();
-        let mut secret_primary_uris: HashMap<String, Option<String>> = HashMap::new();
+                audit_keys = {
+                    let mut keys: Vec<String> =
+                        all_secrets.iter().map(|(name, _)| name.clone()).collect();
+                    keys.sort();
+                    keys
+                };
 
-        for (name, _) in &all_secrets {
-            let secret_config = self
-                .resolve_secret_config(name, Some(&profile_name))
-                .expect("Secret should exist in config since we're iterating over it");
+                let override_uri = self.resolve_provider_override(None);
 
-            let provider_uri = match (&override_uri, secret_config.providers.as_deref()) {
-                (Some(uri), _) => Some(uri.clone()),
-                (None, Some([first_alias, ..])) => self
-                    .resolve_provider_aliases(Some(std::slice::from_ref(first_alias)))?
-                    .and_then(|uris| uris.into_iter().next()),
-                _ => None,
-            };
+                let mut provider_groups: HashMap<Option<String>, Vec<String>> = HashMap::new();
+                let mut secret_primary_uris: HashMap<String, Option<String>> = HashMap::new();
 
-            secret_primary_uris.insert(name.clone(), provider_uri.clone());
-            provider_groups
-                .entry(provider_uri)
-                .or_default()
-                .push(name.clone());
-        }
+                for (name, _) in &all_secrets {
+                    let secret_config = self
+                        .resolve_secret_config(name, Some(&profile_name))
+                        .expect("Secret should exist in config since we're iterating over it");
 
-        // Batch fetch from each provider group. A failure here (e.g. an
-        // unauthenticated vault) does not abort validation: secrets that
-        // declare a fallback chain are retried per-secret below. Secrets in
-        // the failed group with no fallback to try will surface the original
-        // error instead of being silently reported as missing.
-        let mut fetched_values: HashMap<String, SecretString> = HashMap::new();
-        let mut failed_primary_uris: HashMap<Option<String>, SecretSpecError> = HashMap::new();
+                    let provider_uri = match (&override_uri, secret_config.providers.as_deref()) {
+                        (Some(uri), _) => Some(uri.clone()),
+                        (None, Some([first_alias, ..])) => self
+                            .resolve_provider_aliases(Some(std::slice::from_ref(first_alias)))?
+                            .and_then(|uris| uris.into_iter().next()),
+                        _ => None,
+                    };
 
-        for (provider_uri, secret_names) in provider_groups {
-            let provider_result = if let Some(uri) = provider_uri.clone() {
-                self.build_provider(uri)
-            } else {
-                self.get_provider(None)
-            };
-
-            let provider = match provider_result {
-                Ok(p) => p,
-                Err(e) => {
-                    warn_primary_provider_failure(provider_uri.as_deref(), &e);
-                    failed_primary_uris.insert(provider_uri, e);
-                    continue;
+                    secret_primary_uris.insert(name.clone(), provider_uri.clone());
+                    provider_groups
+                        .entry(provider_uri)
+                        .or_default()
+                        .push(name.clone());
                 }
-            };
 
-            let keys: Vec<&str> = secret_names.iter().map(|s| s.as_str()).collect();
-            match provider.get_batch(&self.config.project.name, &keys, &profile_name) {
-                Ok(batch_results) => fetched_values.extend(batch_results),
-                Err(e) => {
-                    warn_primary_provider_failure(provider_uri.as_deref(), &e);
-                    failed_primary_uris.insert(provider_uri, e);
-                }
-            }
-        }
+                // Batch fetch from each provider group. A failure here (e.g. an
+                // unauthenticated vault) does not abort validation: secrets that
+                // declare a fallback chain are retried per-secret below. Secrets in
+                // the failed group with no fallback to try will surface the original
+                // error instead of being silently reported as missing.
+                let mut fetched_values: HashMap<String, SecretString> = HashMap::new();
+                let mut failed_primary_uris: HashMap<Option<String>, SecretSpecError> =
+                    HashMap::new();
 
-        // Process results - apply defaults, handle as_path, track missing
-        for (name, _) in all_secrets {
-            let secret_config = self
-                .resolve_secret_config(&name, Some(&profile_name))
-                .expect("Secret should exist in config since we're iterating over it");
-            let required = secret_config.required.unwrap_or(true);
-            let default = secret_config.default.clone();
-            let as_path = secret_config.as_path.unwrap_or(false);
-
-            match fetched_values.remove(&name) {
-                Some(value) => {
-                    if as_path {
-                        // Write secret to temp file and store the path
-                        let (temp_file, path_str) = self.write_secret_to_temp_file(&value)?;
-                        temp_files.push(temp_file);
-                        secrets.insert(name.clone(), SecretString::new(path_str.into()));
+                for (provider_uri, secret_names) in provider_groups {
+                    let provider_result = if let Some(uri) = provider_uri.clone() {
+                        self.build_provider(uri)
                     } else {
-                        secrets.insert(name, value);
+                        self.get_provider(None)
+                    };
+
+                    let provider = match provider_result {
+                        Ok(p) => p,
+                        Err(e) => {
+                            // Construction failed: only the raw alias exists, so redact it.
+                            let shown =
+                                provider_uri.as_deref().map(crate::audit::redact_uri_strict);
+                            warn_primary_provider_failure(shown.as_deref(), &e);
+                            failed_primary_uris.insert(provider_uri, e);
+                            continue;
+                        }
+                    };
+
+                    let keys: Vec<&str> = secret_names.iter().map(|s| s.as_str()).collect();
+                    match provider.get_batch(&self.config.project.name, &keys, &profile_name) {
+                        Ok(batch_results) => fetched_values.extend(batch_results),
+                        Err(e) => {
+                            // A provider was built; attribute to its credential-free `uri()`.
+                            warn_primary_provider_failure(Some(&provider.uri()), &e);
+                            failed_primary_uris.insert(provider_uri, e);
+                        }
                     }
                 }
-                None => {
-                    let primary_uri = &secret_primary_uris[&name];
-                    let primary_failed = failed_primary_uris.contains_key(primary_uri);
 
-                    // An explicit override collapses the chain to one provider, so no fallback.
-                    let fallback_value =
-                        match (override_uri.as_ref(), secret_config.providers.as_deref()) {
-                            (None, Some(providers)) if providers.len() > 1 => {
-                                let fallback_uris =
-                                    self.resolve_provider_aliases(Some(&providers[1..]))?;
-                                self.get_secret_from_providers(
-                                    &self.config.project.name,
-                                    &name,
-                                    &profile_name,
-                                    fallback_uris.as_deref(),
-                                    None,
-                                )?
-                            }
-                            // No alternative chain to try and the primary failed: surface the
-                            // original error rather than reporting the secret as merely missing.
-                            _ if primary_failed => {
-                                return Err(failed_primary_uris
-                                    .remove(primary_uri)
-                                    .expect("primary_failed implies entry present"));
-                            }
-                            _ => None,
-                        };
+                // Process results - apply defaults, handle as_path, track missing
+                for (name, _) in all_secrets {
+                    let secret_config = self
+                        .resolve_secret_config(&name, Some(&profile_name))
+                        .expect("Secret should exist in config since we're iterating over it");
+                    let required = secret_config.required.unwrap_or(true);
+                    let default = secret_config.default.clone();
+                    let as_path = secret_config.as_path.unwrap_or(false);
 
-                    if let Some(value) = fallback_value {
-                        if as_path {
-                            let (temp_file, path_str) = self.write_secret_to_temp_file(&value)?;
-                            temp_files.push(temp_file);
-                            secrets.insert(name.clone(), SecretString::new(path_str.into()));
-                        } else {
-                            secrets.insert(name, value);
-                        }
-                    } else if let Some(generated) =
-                        self.try_generate_secret(&name, &secret_config, &profile_name)?
-                    {
-                        if as_path {
-                            let (temp_file, path_str) =
-                                self.write_secret_to_temp_file(&generated)?;
-                            temp_files.push(temp_file);
-                            secrets.insert(name.clone(), SecretString::new(path_str.into()));
-                        } else {
-                            secrets.insert(name, generated);
-                        }
-                    } else if let Some(default_value) = default {
-                        if as_path {
-                            // Write default value to temp file
-                            let (temp_file, path_str) = self.write_secret_to_temp_file(
-                                &SecretString::new(default_value.clone().into()),
+                    match fetched_values.remove(&name) {
+                        Some(value) => {
+                            self.insert_resolved(
+                                &mut secrets,
+                                &mut temp_files,
+                                name,
+                                value,
+                                as_path,
                             )?;
-                            temp_files.push(temp_file);
-                            secrets.insert(name.clone(), SecretString::new(path_str.into()));
-                        } else {
-                            secrets.insert(
-                                name.clone(),
-                                SecretString::new(default_value.clone().into()),
-                            );
                         }
-                        with_defaults.push((name, default_value));
-                    } else if required {
-                        missing_required.push(name);
-                    } else {
-                        missing_optional.push(name);
+                        None => {
+                            let primary_uri = &secret_primary_uris[&name];
+                            let primary_failed = failed_primary_uris.contains_key(primary_uri);
+
+                            // An explicit override collapses the chain to one provider, no fallback.
+                            let fallback_value =
+                                match (override_uri.as_ref(), secret_config.providers.as_deref()) {
+                                    (None, Some(providers)) if providers.len() > 1 => {
+                                        let fallback_uris =
+                                            self.resolve_provider_aliases(Some(&providers[1..]))?;
+                                        self.get_secret_from_providers(
+                                            &self.config.project.name,
+                                            &name,
+                                            &profile_name,
+                                            fallback_uris.as_deref(),
+                                            None,
+                                        )?
+                                        .0
+                                    }
+                                    // No alternative chain to try and the primary failed: surface the
+                                    // original error rather than reporting the secret as merely
+                                    // missing. The single `Check` event is recorded by the caller
+                                    // below, so this arm just propagates.
+                                    _ if primary_failed => {
+                                        let err = failed_primary_uris
+                                            .remove(primary_uri)
+                                            .expect("primary_failed implies entry present");
+                                        return Err(err);
+                                    }
+                                    _ => None,
+                                };
+
+                            if let Some(value) = fallback_value {
+                                self.insert_resolved(
+                                    &mut secrets,
+                                    &mut temp_files,
+                                    name,
+                                    value,
+                                    as_path,
+                                )?;
+                            } else if let Some(generated) =
+                                self.try_generate_secret(&name, &secret_config, &profile_name)?
+                            {
+                                self.insert_resolved(
+                                    &mut secrets,
+                                    &mut temp_files,
+                                    name,
+                                    generated,
+                                    as_path,
+                                )?;
+                            } else if let Some(default_value) = default {
+                                self.insert_resolved(
+                                    &mut secrets,
+                                    &mut temp_files,
+                                    name.clone(),
+                                    SecretString::new(default_value.clone().into()),
+                                    as_path,
+                                )?;
+                                with_defaults.push((name, default_value));
+                            } else if required {
+                                missing_required.push(name);
+                            } else {
+                                missing_optional.push(name);
+                            }
+                        }
                     }
                 }
-            }
+
+                let report_provider_uri = self.validation_report_provider_uri(
+                    override_uri.as_deref(),
+                    &secret_primary_uris,
+                )?;
+
+                if !missing_required.is_empty() {
+                    Ok(Err(ValidationErrors::new(
+                        missing_required,
+                        missing_optional,
+                        with_defaults,
+                        report_provider_uri,
+                        profile_name.to_string(),
+                    )))
+                } else {
+                    Ok(Ok(ValidatedSecrets {
+                        resolved: Resolved::new(
+                            secrets,
+                            report_provider_uri,
+                            profile_name.to_string(),
+                        ),
+                        missing_optional,
+                        with_defaults,
+                        temp_files,
+                    }))
+                }
+            })();
+
+        // Record exactly one `Check` event for the whole batch when this is a
+        // top-level read, regardless of how the resolution exited — so a failed
+        // attempt (bad alias, fallback-chain error, report-URI failure) is audited
+        // too, not only success/missing. `record` is a no-op when auditing is off.
+        if emit_check {
+            let (outcome, error_kind) = match &result {
+                Ok(Ok(_)) => (AuditOutcome::Found, None),
+                Ok(Err(_)) => (AuditOutcome::Missing, None),
+                Err(e) => (AuditOutcome::Error, Some(e.kind())),
+            };
+            self.record(
+                AuditAction::Check,
+                &profile_name,
+                outcome,
+                AuditFields {
+                    keys: &audit_keys,
+                    error_kind,
+                    ..Default::default()
+                },
+            );
         }
 
-        let report_provider_uri =
-            self.validation_report_provider_uri(override_uri.as_deref(), &secret_primary_uris)?;
-
-        // Check if there are any missing required secrets
-        if !missing_required.is_empty() {
-            Ok(Err(ValidationErrors::new(
-                missing_required,
-                missing_optional,
-                with_defaults,
-                report_provider_uri,
-                profile_name.to_string(),
-            )))
-        } else {
-            Ok(Ok(ValidatedSecrets {
-                resolved: Resolved::new(secrets, report_provider_uri, profile_name.to_string()),
-                missing_optional,
-                with_defaults,
-                temp_files,
-            }))
-        }
+        result
     }
 
     /// Runs a command with secrets injected as environment variables
@@ -1776,7 +2267,7 @@ impl Secrets {
     /// spec.run(vec!["npm".to_string(), "start".to_string()]).unwrap();
     /// ```
     pub fn run(&self, command: Vec<String>) -> Result<()> {
-        self.ensure_reason()?;
+        self.ensure_reason_for(AuditAction::Run, None)?;
         let exit_code = self.run_command(command)?;
         std::process::exit(exit_code);
     }
@@ -1797,18 +2288,74 @@ impl Secrets {
         // Ensure all secrets are available (will error out if missing).
         // `validation_result` owns the temp files for `as_path` secrets and
         // must stay alive until the child process has terminated.
-        let validation_result = self.ensure_secrets(None, None, false)?;
+        let validation_result = match self.ensure_secrets(None, None, false) {
+            Ok(v) => v,
+            Err(e) => {
+                // Record the attempt even when validation fails and the command
+                // never runs, so a failed/blocked run is still auditable.
+                self.record(
+                    AuditAction::Run,
+                    &self.resolve_profile_name(None),
+                    AuditOutcome::Error,
+                    AuditFields {
+                        command: Some(&command[0]),
+                        error_kind: Some(e.kind()),
+                        ..Default::default()
+                    },
+                );
+                return Err(e);
+            }
+        };
 
         let mut env_vars = env::vars().collect::<HashMap<_, _>>();
         for (key, secret) in &validation_result.resolved.secrets {
             env_vars.insert(key.clone(), secret.expose_secret().to_string());
         }
 
+        // Record which secrets were injected into which command (argv[0] only —
+        // arguments may contain secrets). Keys are computed before the spawn but
+        // the event is emitted after it so the outcome reflects whether the
+        // command actually started.
+        let keys: Vec<String> = if self.audit.is_some() {
+            let mut keys: Vec<String> =
+                validation_result.resolved.secrets.keys().cloned().collect();
+            keys.sort();
+            keys
+        } else {
+            Vec::new()
+        };
+
         let mut cmd = Command::new(&command[0]);
         cmd.args(&command[1..]);
         cmd.envs(&env_vars);
 
-        let status = cmd.status()?;
+        // Spawn (rather than `status`) so the Run event is recorded the moment the
+        // child starts, before the potentially long-running wait. A long-lived
+        // command (e.g. a dev server) would otherwise not be logged until it exits,
+        // and would be lost entirely if secretspec were killed first. A failure to
+        // start is recorded as an error. `Child::wait` closes stdin and inherits
+        // stdio just like `Command::status`, so behavior is otherwise unchanged.
+        let child = cmd.spawn();
+        let (outcome, error_kind) = match &child {
+            Ok(_) => (AuditOutcome::Started, None),
+            Err(_) => (AuditOutcome::Error, Some("io")),
+        };
+        // `record` is a no-op when auditing is off, so no `self.audit.is_some()`
+        // guard is needed here (the `keys` collection above is still guarded to
+        // skip the sort).
+        self.record(
+            AuditAction::Run,
+            &validation_result.resolved.profile,
+            outcome,
+            AuditFields {
+                keys: &keys,
+                command: Some(&command[0]),
+                error_kind,
+                ..Default::default()
+            },
+        );
+
+        let status = child?.wait()?;
         Ok(status.code().unwrap_or(1))
     }
 }
@@ -1838,5 +2385,33 @@ mod policy_tests {
         assert_eq!(normalize_reason(""), None);
         assert_eq!(normalize_reason("   "), None);
         assert_eq!(normalize_reason("\t\n"), None);
+    }
+
+    /// A non-UTF-8 environment variable must not crash detection: the offending
+    /// entry is dropped and the UTF-8 entries survive. This guards against the
+    /// `std::env::vars()` panic in `detect-coding-agent`, which auditing (on by
+    /// default) would otherwise trigger on every command.
+    #[cfg(unix)]
+    #[test]
+    fn utf8_env_drops_non_utf8_entries_without_panicking() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let bad_key = OsString::from_vec(vec![0x66, 0x6f, 0xff]); // "fo\xff"
+        let bad_val = OsString::from_vec(vec![0xfe, 0xfe]);
+        let vars = vec![
+            (OsString::from("CLEAN_KEY"), OsString::from("clean_value")),
+            (bad_key, OsString::from("value_for_bad_key")),
+            (OsString::from("KEY_WITH_BAD_VALUE"), bad_val),
+        ];
+
+        let env = utf8_env_from(vars);
+
+        // Only the fully-UTF-8 entry survives; the two non-UTF-8 entries are skipped.
+        assert_eq!(
+            env.get("CLEAN_KEY").map(String::as_str),
+            Some("clean_value")
+        );
+        assert_eq!(env.len(), 1);
     }
 }

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::config::{
-    Config, GlobalConfig, GlobalDefaults, ParseError, Profile, Project, Resolved, Secret,
+    Config, GlobalConfig, GlobalDefaults, ParseError, Profile, Project, RequireReason, Resolved,
+    Secret,
 };
 use crate::error::{Result, SecretSpecError};
 use crate::secrets::Secrets;
@@ -108,31 +109,39 @@ require_reason = true
     )
     .unwrap();
 
+    // Build hermetically from the parsed project config rather than via
+    // `load_from`, which would build a real audit logger and write to the user's
+    // real audit log. This still exercises that `require_reason = true` parses to
+    // the Always policy and that the gate is enforced.
+    let project_config = Config::try_from(project_path.as_path()).unwrap();
+    assert_eq!(
+        project_config.project.require_reason,
+        Some(RequireReason::Always)
+    );
+    let build = || {
+        let mut spec = Secrets::new(project_config.clone(), None, None, None);
+        spec.set_require_reason(RequireReason::Always);
+        spec
+    };
+
     // require_reason = true -> any caller (agent or not) is refused without a reason.
-    let spec = Secrets::load_from(&project_path).unwrap();
     assert!(matches!(
-        spec.validate(),
+        build().validate(),
         Err(SecretSpecError::ReasonRequired)
     ));
 
     // With an explicit reason the policy is satisfied: validation proceeds past the
     // gate. It may still fail later for environment reasons (e.g. no provider
     // configured), so assert specifically that it is no longer the reason gate.
-    let spec = Secrets::load_from(&project_path)
-        .unwrap()
-        .with_reason("running migrations");
     assert!(!matches!(
-        spec.validate(),
+        build().with_reason("running migrations").validate(),
         Err(SecretSpecError::ReasonRequired)
     ));
 
     // A blank/whitespace-only reason must NOT satisfy the policy: it carries no
     // audit value, so the gate still refuses access.
-    let spec = Secrets::load_from(&project_path)
-        .unwrap()
-        .with_reason("   ");
     assert!(matches!(
-        spec.validate(),
+        build().with_reason("   ").validate(),
         Err(SecretSpecError::ReasonRequired)
     ));
 }
@@ -154,10 +163,18 @@ require_reason = false
     )
     .unwrap();
 
+    // Hermetic build (see the sibling test) — no real audit log is touched.
+    let project_config = Config::try_from(project_path.as_path()).unwrap();
+    assert_eq!(
+        project_config.project.require_reason,
+        Some(RequireReason::Never)
+    );
+    let mut spec = Secrets::new(project_config, None, None, None);
+    spec.set_require_reason(RequireReason::Never);
+
     // require_reason = false -> the reason gate never fires, even under an agent.
     // (validate() may still fail later for environment reasons such as no provider
     // configured, so assert specifically that it is not the ReasonRequired gate.)
-    let spec = Secrets::load_from(&project_path).unwrap();
     assert!(!matches!(
         spec.validate(),
         Err(SecretSpecError::ReasonRequired)
@@ -182,6 +199,7 @@ fn test_new_with_default_overrides() {
             profile: Some("production".to_string()),
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -332,6 +350,7 @@ fn test_secretspec_new() {
             profile: Some("dev".to_string()),
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config.clone(), Some(global_config.clone()), None, None);
@@ -354,6 +373,7 @@ fn test_resolve_profile() {
             profile: Some("development".to_string()),
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(
@@ -515,6 +535,7 @@ fn test_get_provider_with_global_config() {
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(
@@ -1470,6 +1491,7 @@ fn test_set_with_undefined_secret() {
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(project_config, Some(global_config), None, None);
@@ -1536,6 +1558,7 @@ fn test_set_with_defined_secret() {
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(project_config, Some(global_config), None, None);
@@ -1589,6 +1612,7 @@ fn test_set_with_readonly_provider() {
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(project_config, Some(global_config), None, None);
@@ -1698,6 +1722,7 @@ fn test_import_between_dotenv_files() {
             profile: Some("default".to_string()),
             providers: None,
         },
+        audit: None,
     };
 
     // Create SecretSpec instance
@@ -1824,6 +1849,7 @@ fn test_import_edge_cases() {
             profile: Some("default".to_string()),
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(project_config, Some(global_config), None, None);
@@ -1904,6 +1930,7 @@ API_KEY = { description = "Dev API key", required = true }
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config.clone(), Some(global_config.clone()), None, None);
@@ -2088,6 +2115,7 @@ fn test_import_with_profiles() {
             profile: Some("development".to_string()),
             providers: None, // Use development profile
         },
+        audit: None,
     };
 
     let spec = Secrets::new(project_config, Some(global_config), None, None);
@@ -2146,6 +2174,7 @@ fn test_run_with_empty_command() {
                 profile: None,
                 providers: None,
             },
+            audit: None,
         }),
         None,
         None,
@@ -2207,6 +2236,7 @@ fn test_run_with_missing_required_secrets() {
                 profile: None,
                 providers: None,
             },
+            audit: None,
         }),
         None,
         None,
@@ -2266,6 +2296,7 @@ fn test_get_existing_secret() {
                 profile: None,
                 providers: None,
             },
+            audit: None,
         }),
         None,
         None,
@@ -2319,6 +2350,7 @@ fn test_get_secret_with_default() {
                 profile: None,
                 providers: None,
             },
+            audit: None,
         }),
         None,
         None,
@@ -2371,6 +2403,7 @@ fn test_get_nonexistent_secret() {
                 profile: None,
                 providers: None,
             },
+            audit: None,
         }),
         None,
         None,
@@ -2418,6 +2451,7 @@ fn test_import_dotenv_profile_issue_36() {
             profile: Some("development".to_string()),
             providers: None, // Using development profile as per bug report
         },
+        audit: None,
     };
 
     // Create SecretSpec instance
@@ -2541,6 +2575,7 @@ fn test_per_secret_provider_configuration() {
             profile: None,
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -2573,6 +2608,7 @@ fn test_provider_alias_resolution() {
             profile: None,
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     let spec = Secrets::new(
@@ -2637,6 +2673,7 @@ fn test_provider_alias_not_found() {
             profile: None,
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     let spec = Secrets::new(
@@ -2738,6 +2775,7 @@ fn test_per_secret_provider_with_fallback_chain() {
             profile: None,
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -2835,6 +2873,7 @@ fn test_get_secret_with_fallback_chain() {
             profile: None,
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -2917,6 +2956,7 @@ fn test_validate_falls_back_on_primary_provider_error() {
             profile: None,
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -2984,6 +3024,7 @@ fn test_validate_surfaces_error_when_all_providers_fail() {
             profile: None,
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -3082,6 +3123,7 @@ fn test_validate_with_per_secret_providers() {
             profile: None,
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -3413,6 +3455,7 @@ REGULAR_SECRET = { description = "Regular secret", as_path = false }
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -3491,6 +3534,7 @@ CERT_DATA = { description = "Certificate data", as_path = true }
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -3560,6 +3604,7 @@ CERT_DATA = { description = "Certificate data", as_path = true }
             profile: None,
             providers: None,
         },
+        audit: None,
     };
     let spec = Secrets::new(config, Some(global_config), None, None);
 
@@ -3797,6 +3842,7 @@ DB_PASSWORD = { description = "Database password", type = "password", generate =
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -3838,6 +3884,7 @@ DB_PASSWORD = { description = "Database password", type = "password", generate =
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -3881,6 +3928,7 @@ DB_PASSWORD = { description = "Database password", type = "password", generate =
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config.clone(), Some(global_config.clone()), None, None);
@@ -3937,6 +3985,7 @@ REQUEST_ID = { description = "ID", type = "uuid", generate = true }
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -4003,6 +4052,7 @@ PROD_KEY = { description = "Production key", type = "hex", generate = { bytes = 
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(
@@ -4150,6 +4200,7 @@ fn build_chain_scenario(
             profile: Some("development".to_string()),
             providers: Some(providers_map),
         },
+        audit: None,
     };
 
     (config, global_config, personal_path, team_path)
@@ -4310,6 +4361,7 @@ OPTIONAL_MISSING = { description = "optional, not set", required = false }
             profile: None,
             providers: None,
         },
+        audit: None,
     };
 
     let spec = Secrets::new(config, Some(global_config), None, None);
@@ -4358,6 +4410,7 @@ fn global_config_with_aliases(aliases: &[(&str, &str)]) -> GlobalConfig {
             profile: None,
             providers: Some(aliases_map(aliases)),
         },
+        audit: None,
     }
 }
 
@@ -4669,6 +4722,7 @@ fn dotenv_spec(
                 profile: None,
                 providers: None,
             },
+            audit: None,
         }),
         None,
         None,
@@ -4747,6 +4801,320 @@ fn test_run_command_returns_child_exit_code() {
     );
     assert_eq!(spec.run_command(vec!["true".to_string()]).unwrap(), 0);
     assert_eq!(spec.run_command(vec!["false".to_string()]).unwrap(), 1);
+}
+
+/// The audit `action`s emitted by an operation, in order.
+fn audit_actions(lines: &std::sync::Arc<std::sync::Mutex<Vec<String>>>) -> Vec<String> {
+    lines
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|l| {
+            serde_json::from_str::<serde_json::Value>(l).unwrap()["action"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn audit_check_emits_single_check_event() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut spec = dotenv_spec(
+        "REQUIRED=value\n",
+        required_secret_profile("REQUIRED"),
+        &temp_dir,
+    );
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    spec.check(true).expect("check should succeed");
+
+    // Exactly one `check` event — not the 2-3 that the repeated internal
+    // re-validations used to produce.
+    assert_eq!(audit_actions(&lines), vec!["check"]);
+}
+
+#[test]
+fn audit_run_emits_run_not_check() {
+    let temp_dir = TempDir::new().unwrap();
+    // Present required secret -> resolution succeeds and the command runs.
+    let mut spec = dotenv_spec(
+        "REQUIRED=value\n",
+        required_secret_profile("REQUIRED"),
+        &temp_dir,
+    );
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    spec.run_command(vec!["true".to_string()]).unwrap();
+
+    // `run` records itself as a single `run` event; the internal read it performs
+    // through `ensure_secrets` must not also be logged as a `check`.
+    assert_eq!(audit_actions(&lines), vec!["run"]);
+
+    // A successfully launched command is `started`, not `found`.
+    let event: serde_json::Value = serde_json::from_str(&lines.lock().unwrap()[0]).unwrap();
+    assert_eq!(event["outcome"], "started");
+}
+
+/// The full audit events emitted by an operation, parsed in order.
+fn audit_events(lines: &std::sync::Arc<std::sync::Mutex<Vec<String>>>) -> Vec<serde_json::Value> {
+    lines
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|l| serde_json::from_str::<serde_json::Value>(l).unwrap())
+        .collect()
+}
+
+/// A `default`-only profile: one optional secret carrying a fallback value, so a
+/// `get` with no stored value resolves to the default.
+fn defaulted_secret_profile(name: &str, default: &str) -> HashMap<String, Profile> {
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        name.to_string(),
+        Secret {
+            description: Some("with default".to_string()),
+            required: Some(false),
+            default: Some(default.to_string()),
+            ..Default::default()
+        },
+    );
+    HashMap::from([(
+        "default".to_string(),
+        Profile {
+            defaults: None,
+            secrets,
+        },
+    )])
+}
+
+#[test]
+fn audit_get_present_records_found_without_value() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut spec = dotenv_spec(
+        "REQUIRED=hunter2\n",
+        required_secret_profile("REQUIRED"),
+        &temp_dir,
+    );
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    spec.get("REQUIRED").unwrap();
+
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "get");
+    assert_eq!(events[0]["outcome"], "found");
+    assert_eq!(events[0]["key"], "REQUIRED");
+    assert!(events[0]["provider"].as_str().unwrap().contains("dotenv"));
+    // The retrieved value never reaches the log.
+    assert!(!lines.lock().unwrap()[0].contains("hunter2"));
+}
+
+#[test]
+fn audit_get_missing_records_missing() {
+    let temp_dir = TempDir::new().unwrap();
+    // Empty .env -> a required secret with no default is missing.
+    let mut spec = dotenv_spec("", required_secret_profile("REQUIRED"), &temp_dir);
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    assert!(matches!(
+        spec.get("REQUIRED"),
+        Err(SecretSpecError::SecretNotFound(_))
+    ));
+
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "get");
+    // A missing read is recorded as `missing` even though `get` then errors.
+    assert_eq!(events[0]["outcome"], "missing");
+    assert_eq!(events[0]["key"], "REQUIRED");
+}
+
+#[test]
+fn audit_get_default_records_default() {
+    let temp_dir = TempDir::new().unwrap();
+    // No stored value -> the configured default is served.
+    let mut spec = dotenv_spec(
+        "",
+        defaulted_secret_profile("OPTIONAL", "fallback"),
+        &temp_dir,
+    );
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    spec.get("OPTIONAL").unwrap();
+
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "get");
+    assert_eq!(events[0]["outcome"], "default");
+    assert_eq!(events[0]["key"], "OPTIONAL");
+}
+
+#[test]
+fn audit_get_undefined_records_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut spec = dotenv_spec("", required_secret_profile("REQUIRED"), &temp_dir);
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    assert!(matches!(
+        spec.get("UNDEFINED"),
+        Err(SecretSpecError::SecretNotFound(_))
+    ));
+
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "get");
+    assert_eq!(events[0]["outcome"], "error");
+    assert_eq!(events[0]["error_kind"], "secret_not_found");
+    // No provider can be attributed to an undefined secret.
+    assert!(events[0].get("provider").is_none());
+}
+
+#[test]
+fn audit_set_records_written_without_value() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut spec = dotenv_spec("", required_secret_profile("REQUIRED"), &temp_dir);
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    spec.set("REQUIRED", Some("secret_value".to_string()))
+        .unwrap();
+
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "set");
+    assert_eq!(events[0]["outcome"], "written");
+    assert_eq!(events[0]["key"], "REQUIRED");
+    assert!(events[0]["provider"].as_str().unwrap().contains("dotenv"));
+    // The stored value is never logged.
+    assert!(!lines.lock().unwrap()[0].contains("secret_value"));
+}
+
+#[test]
+fn audit_set_undefined_records_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut spec = dotenv_spec("", required_secret_profile("REQUIRED"), &temp_dir);
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    assert!(matches!(
+        spec.set("UNDEFINED", Some("v".to_string())),
+        Err(SecretSpecError::SecretNotFound(_))
+    ));
+
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "set");
+    assert_eq!(events[0]["outcome"], "error");
+    assert_eq!(events[0]["error_kind"], "secret_not_found");
+}
+
+#[test]
+fn audit_set_readonly_provider_records_error() {
+    let project_config = Config {
+        project: Project {
+            name: "test".to_string(),
+            ..Default::default()
+        },
+        profiles: required_secret_profile("REQUIRED"),
+        providers: None,
+    };
+    // `env` is read-only, so a `set` is rejected and recorded as an error.
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some("env".to_string()),
+            profile: None,
+            providers: None,
+        },
+        audit: None,
+    };
+    let mut spec = Secrets::new(project_config, Some(global_config), None, None);
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    assert!(matches!(
+        spec.set("REQUIRED", Some("v".to_string())),
+        Err(SecretSpecError::ProviderOperationFailed(_))
+    ));
+
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "set");
+    assert_eq!(events[0]["outcome"], "error");
+    assert_eq!(events[0]["error_kind"], "provider_operation_failed");
+}
+
+#[test]
+fn audit_policy_denied_still_records_blocked_attempt() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut spec = dotenv_spec(
+        "REQUIRED=value\n",
+        required_secret_profile("REQUIRED"),
+        &temp_dir,
+    );
+    // require_reason = Always with no reason supplied -> every access is denied.
+    spec.set_require_reason(RequireReason::Always);
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    assert!(matches!(
+        spec.get("REQUIRED"),
+        Err(SecretSpecError::ReasonRequired)
+    ));
+
+    // A blocked access still leaves an audit trace.
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "get");
+    assert_eq!(events[0]["outcome"], "error");
+    assert_eq!(events[0]["error_kind"], "reason_required");
+    assert_eq!(events[0]["key"], "REQUIRED");
+}
+
+#[test]
+fn audit_import_records_keys_and_per_secret_writes() {
+    let temp_dir = TempDir::new().unwrap();
+    // Target provider (the spec default) starts empty.
+    let mut spec = dotenv_spec("", required_secret_profile("REQUIRED"), &temp_dir);
+    // Source provider holds the secret to copy.
+    let source = temp_dir.path().join("source.env");
+    fs::write(&source, "REQUIRED=from_source\n").unwrap();
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    spec.import(&format!("dotenv://{}", source.display()))
+        .unwrap();
+
+    let events = audit_events(&lines);
+    let actions: Vec<&str> = events
+        .iter()
+        .map(|e| e["action"].as_str().unwrap())
+        .collect();
+    // Each copied secret is recorded as a `set`, then one bulk `import` event.
+    assert_eq!(actions, vec!["set", "import"]);
+
+    let set = &events[0];
+    assert_eq!(set["outcome"], "written");
+    assert_eq!(set["key"], "REQUIRED");
+
+    let import = &events[1];
+    assert_eq!(import["outcome"], "written");
+    assert_eq!(import["keys"][0], "REQUIRED");
+    // The copied value is never logged.
+    assert!(
+        !lines
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|l| l.contains("from_source"))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a **local audit log** so secret access can be reviewed after the fact. **On by default.**

(The secret-access reasons, `require_reason` policy, Proton Pass 2.1 fix, and `detect-coding-agent` build changes that originally shared this branch have since landed on `main` via #101; this PR is now just the audit log, rebased on top.)

### Audit logging
- Records every secret operation (`get`/`set`/`check`/`run`/`import`) to a local audit log.
- One JSON Lines record per event: timestamp, action, project, profile, secret name(s), redacted provider URI, outcome, reason, and actor (OS user + detected coding agent). Events from one invocation share a `session_id`.
- Secret values are never written; credentials embedded in provider URIs are redacted.
- Single file capped at 1 MiB (truncate-and-restart, no backups). Audit failures **fail open** — they warn on stderr and continue.
- Configured under a top-level `[audit]` table in the **user-global** config (`~/.config/secretspec/config.toml`), not the project's `secretspec.toml`, so a cloned repo cannot redirect or silence the log.
- New `secretspec audit` command to read the log with `--project`, `--action`, `--tail/-n`, and `--json` filters.

## Docs
New Audit Logging concept page, configuration + CLI reference updates, frontpage card, and README entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
