### PR TITLE
test: cover config discovery and run on Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,16 @@ jobs:
 
     - name: Build the devenv shell and run any pre-commit hooks
       run: devenv test
+
+  # Windows runners can't run Nix/devenv, so the suite runs here natively via
+  # rustup + cargo. This exists specifically to catch Windows-only path handling
+  # regressions (e.g. config discovery and relative `-f` paths, issue #59), which
+  # the Ubuntu/macOS devenv job above can never observe.
+  windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install Rust
+      run: rustup toolchain install stable --profile minimal
+    - name: cargo test
+      run: cargo test --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Windows: a `dotenv://` provider URI built from an absolute path (e.g.
+  `dotenv://C:\path\.env`) no longer fails to parse with "invalid port number".
+  The drive-letter colon was being read as a `host:port` separator; such paths
+  are now carried through the URL intact.
+- Windows: the audit log no longer fails to reset at its size cap. Truncation on
+  the append-only handle was denied by the OS; it now truncates through a
+  separate write handle.
+
 ## [0.12.0] - 2026-06-08
 
 ### Added

--- a/secretspec-derive/tests/compile_tests.rs
+++ b/secretspec-derive/tests/compile_tests.rs
@@ -1,23 +1,36 @@
 // These tests verify that the macro generates compilable code
-// and handles errors appropriately
+// and handles errors appropriately.
+//
+// Each case asserts a `compile_error!` whose text embeds the underlying
+// filesystem error string, which differs by OS ("No such file or directory" on
+// Unix, "The system cannot find the file/path specified" on Windows, sometimes
+// with a different error number). trybuild compares one `.stderr` snapshot per
+// `.rs` file with no per-platform variant, so the Windows cases use their own
+// identical `.rs` sources under `tests/ui/windows/` paired with Windows
+// snapshots. Everything else about the cases is the same.
+
+#[cfg(not(windows))]
+const UI_DIR: &str = "tests/ui";
+#[cfg(windows)]
+const UI_DIR: &str = "tests/ui/windows";
 
 #[test]
 fn test_file_not_found() {
     // This should produce a compile error
     let t = trybuild::TestCases::new();
-    t.compile_fail("tests/ui/file_not_found.rs");
+    t.compile_fail(format!("{UI_DIR}/file_not_found.rs"));
 }
 
 #[test]
 fn test_invalid_toml() {
     // This should produce a compile error
     let t = trybuild::TestCases::new();
-    t.compile_fail("tests/ui/invalid_toml.rs");
+    t.compile_fail(format!("{UI_DIR}/invalid_toml.rs"));
 }
 
 #[test]
 fn test_invalid_toml_embedded() {
     // This should produce a compile error with embedded TOML
     let t = trybuild::TestCases::new();
-    t.compile_fail("tests/ui/invalid_toml_embedded.rs");
+    t.compile_fail(format!("{UI_DIR}/invalid_toml_embedded.rs"));
 }

--- a/secretspec-derive/tests/ui/windows/file_not_found.rs
+++ b/secretspec-derive/tests/ui/windows/file_not_found.rs
@@ -1,0 +1,6 @@
+use secretspec_derive::declare_secrets;
+
+// This should fail because the file doesn't exist
+declare_secrets!("this/file/does/not/exist.toml");
+
+fn main() {}

--- a/secretspec-derive/tests/ui/windows/file_not_found.stderr
+++ b/secretspec-derive/tests/ui/windows/file_not_found.stderr
@@ -1,0 +1,7 @@
+error: Failed to parse TOML: I/O error: Failed to resolve path $WORKSPACE/target/tests/trybuild/secretspec-derive/this/file/does/not/exist.toml: The system cannot find the path specified. (os error 3)
+ --> tests/ui/windows/file_not_found.rs:4:1
+  |
+4 | declare_secrets!("this/file/does/not/exist.toml");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `declare_secrets` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/secretspec-derive/tests/ui/windows/invalid_toml.rs
+++ b/secretspec-derive/tests/ui/windows/invalid_toml.rs
@@ -1,0 +1,6 @@
+use secretspec_derive::declare_secrets;
+
+// This should fail because the TOML is invalid
+declare_secrets!("invalid_toml.txt");
+
+fn main() {}

--- a/secretspec-derive/tests/ui/windows/invalid_toml.stderr
+++ b/secretspec-derive/tests/ui/windows/invalid_toml.stderr
@@ -1,0 +1,7 @@
+error: Failed to parse TOML: I/O error: Failed to resolve path $WORKSPACE/target/tests/trybuild/secretspec-derive/invalid_toml.txt: The system cannot find the file specified. (os error 2)
+ --> tests/ui/windows/invalid_toml.rs:4:1
+  |
+4 | declare_secrets!("invalid_toml.txt");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `declare_secrets` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/secretspec-derive/tests/ui/windows/invalid_toml_embedded.rs
+++ b/secretspec-derive/tests/ui/windows/invalid_toml_embedded.rs
@@ -1,0 +1,6 @@
+use secretspec_derive::declare_secrets;
+
+// This should fail because the TOML is invalid
+declare_secrets!("invalid_toml_embedded.txt");
+
+fn main() {}

--- a/secretspec-derive/tests/ui/windows/invalid_toml_embedded.stderr
+++ b/secretspec-derive/tests/ui/windows/invalid_toml_embedded.stderr
@@ -1,0 +1,7 @@
+error: Failed to parse TOML: I/O error: Failed to resolve path $WORKSPACE/target/tests/trybuild/secretspec-derive/invalid_toml_embedded.txt: The system cannot find the file specified. (os error 2)
+ --> tests/ui/windows/invalid_toml_embedded.rs:4:1
+  |
+4 | declare_secrets!("invalid_toml_embedded.txt");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `declare_secrets` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/secretspec/src/audit.rs
+++ b/secretspec/src/audit.rs
@@ -241,6 +241,25 @@ impl JsonlSink {
             max_size_bytes,
         })
     }
+
+    /// Resets the log file to empty at the size cap. The append handle's next
+    /// write then lands at the new end-of-file (offset 0).
+    #[cfg(not(windows))]
+    fn truncate(&self, file: &std::fs::File) -> std::io::Result<()> {
+        file.set_len(0)
+    }
+
+    /// On Windows an append-only handle lacks `FILE_WRITE_DATA`, so `set_len`
+    /// fails with "access is denied". Truncate through a separate write handle
+    /// instead; the caller still holds the mutex, so no other writer races us.
+    #[cfg(windows)]
+    fn truncate(&self, _file: &std::fs::File) -> std::io::Result<()> {
+        OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&self.path)
+            .map(|_| ())
+    }
 }
 
 impl AuditSink for JsonlSink {
@@ -257,7 +276,7 @@ impl AuditSink for JsonlSink {
         match guard.metadata().map(|m| m.len()) {
             Ok(size) if size > 0 && size + projected > self.max_size_bytes => {
                 // With O_APPEND the next write lands at the new end-of-file (0).
-                if let Err(e) = guard.set_len(0) {
+                if let Err(e) = self.truncate(&guard) {
                     warn_audit_failure(&self.path, &e);
                 }
             }

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -1162,12 +1162,16 @@ mod audit_config_tests {
 
     #[test]
     fn resolved_path_keeps_absolute_and_rejects_relative() {
-        // An absolute configured path is honored verbatim.
-        let abs = with_path("/var/log/secretspec/audit.log");
-        assert_eq!(
-            abs.resolved_path(),
-            Some(PathBuf::from("/var/log/secretspec/audit.log"))
-        );
+        // An absolute configured path is honored verbatim. What counts as absolute
+        // is platform-specific (Windows requires a drive prefix), so pick one that
+        // `Path::is_absolute` accepts on the host.
+        let abs_path = if cfg!(windows) {
+            r"C:\var\log\secretspec\audit.log"
+        } else {
+            "/var/log/secretspec/audit.log"
+        };
+        let abs = with_path(abs_path);
+        assert_eq!(abs.resolved_path(), Some(PathBuf::from(abs_path)));
         assert!(!abs.has_relative_path());
 
         // A relative path (bare filename or nested) is rejected: it would resolve

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -328,6 +328,13 @@ mod tests {
         let url = ProviderUrl::new(Url::parse("dotenv://foobar/custom/path/.env").unwrap());
         let config: DotEnvConfig = (&url).try_into().unwrap();
         assert_eq!(config.path.to_str().unwrap(), "foobar/custom/path/.env");
+
+        // A Windows absolute path is carried as a percent-encoded opaque host (the
+        // form produced by `Box::<dyn Provider>::try_from` for `dotenv://C:\...`)
+        // and decoded back to the original path.
+        let url = ProviderUrl::new(Url::parse("dotenv://C%3A%5CUsers%5Cfoo%5C.env").unwrap());
+        let config: DotEnvConfig = (&url).try_into().unwrap();
+        assert_eq!(config.path.to_str().unwrap(), r"C:\Users\foo\.env");
     }
 
     #[test]

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -72,6 +72,17 @@ pub(crate) const URI_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b'^')
     .add(b'\\');
 
+/// Like [`URI_ENCODE_SET`] but also encodes `:`. Used for Windows absolute paths
+/// (e.g. `C:\path`) where the drive-letter colon would otherwise be read as a
+/// `host:port` separator and fail parsing with "invalid port number".
+const WINDOWS_PATH_ENCODE_SET: &AsciiSet = &URI_ENCODE_SET.add(b':');
+
+/// Detects a Windows-style absolute path such as `C:\path` or `C:/path`.
+fn is_windows_abs_path(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() >= 3 && b[0].is_ascii_alphabetic() && b[1] == b':' && (b[2] == b'\\' || b[2] == b'/')
+}
+
 /// A URL wrapper that automatically percent-decodes all accessors.
 ///
 /// Providers receive `&ProviderUrl` instead of `&Url`, ensuring they always
@@ -617,21 +628,35 @@ impl TryFrom<&str> for Box<dyn Provider> {
             }
         }
 
-        // Build a proper URL with the correct scheme
-        let url_string = match rest {
-            // Just scheme name (e.g., "keyring")
-            "" | ":" => format!("{}://", scheme),
-            // Standard URI format already has // (e.g., "onepassword://vault/path")
-            s if s.starts_with("//") => format!("{}:{}", scheme, s),
-            // Path only format (e.g., "dotenv:/path/to/.env")
-            s if s.starts_with('/') => format!("{}://{}", scheme, s),
-            // Everything else - assume it's a host or path component
-            s => format!("{}://{}", scheme, s),
-        };
+        // Build a proper URL with the correct scheme.
+        //
+        // Windows absolute paths (e.g. `dotenv://C:\path\.env`) need special care:
+        // the drive-letter colon looks like a `host:port` separator and parsing
+        // fails with "invalid port number". Encode the whole path (drive colon and
+        // backslashes included) into an opaque host so it round-trips back out via
+        // `ProviderUrl::host()`. A Unix absolute path stays in the authority-less
+        // `scheme:///abs/path` form, which already parses cleanly.
+        let path_candidate = rest.trim_start_matches('/');
+        let url_string = if is_windows_abs_path(path_candidate) {
+            format!(
+                "{}://{}",
+                scheme,
+                percent_encode(path_candidate.as_bytes(), WINDOWS_PATH_ENCODE_SET)
+            )
+        } else {
+            let url_string = match rest {
+                // Just scheme name (e.g., "keyring")
+                "" | ":" => format!("{}://", scheme),
+                // Standard URI format already has // (e.g., "onepassword://vault/path")
+                s if s.starts_with("//") => format!("{}:{}", scheme, s),
+                // Path only format (e.g., "dotenv:/path/to/.env")
+                s if s.starts_with('/') => format!("{}://{}", scheme, s),
+                // Everything else - assume it's a host or path component
+                s => format!("{}://{}", scheme, s),
+            };
 
-        // Percent-encode characters that are invalid in URIs but might appear in
-        // provider config values (e.g., spaces in 1Password vault names like "Home Lab")
-        let url_string = {
+            // Percent-encode characters that are invalid in URIs but might appear in
+            // provider config values (e.g., spaces in 1Password vault names like "Home Lab")
             let scheme_end = url_string.find("://").unwrap() + 3;
             let (prefix, rest) = url_string.split_at(scheme_end);
             format!(
@@ -713,6 +738,29 @@ mod url_tests {
     #[test]
     fn port_is_parsed_when_present() {
         assert_eq!(url("https://example.com:8200/").port(), Some(8200));
+    }
+
+    #[test]
+    fn detects_windows_absolute_paths() {
+        assert!(is_windows_abs_path(r"C:\Users\foo"));
+        assert!(is_windows_abs_path("C:/Users/foo"));
+        assert!(is_windows_abs_path(r"d:\x"));
+        // Not absolute Windows paths:
+        assert!(!is_windows_abs_path("/tmp/foo"));
+        assert!(!is_windows_abs_path("relative/path"));
+        assert!(!is_windows_abs_path("C:"));
+        assert!(!is_windows_abs_path("vault"));
+    }
+
+    #[test]
+    fn windows_dotenv_path_parses_instead_of_failing_on_port() {
+        // The drive-letter colon must not be read as a `host:port` separator.
+        let provider = Box::<dyn Provider>::try_from(r"dotenv://C:\Users\foo\.env");
+        assert!(
+            provider.is_ok(),
+            "Windows dotenv path should parse, got {:?}",
+            provider.err()
+        );
     }
 
     #[test]

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -54,7 +54,15 @@ fn warn_primary_provider_failure(display_uri: Option<&str>, err: &SecretSpecErro
 
 /// Walks up from the current directory looking for `secretspec.toml`.
 fn find_config_file() -> Result<PathBuf> {
-    let mut dir = std::env::current_dir()?;
+    find_config_file_from(std::env::current_dir()?)
+}
+
+/// Walks up from `start` looking for `secretspec.toml`, returning the path to the
+/// nearest one. Factored out of [`find_config_file`] so the walk can be tested
+/// against an explicit starting directory without mutating the process-global
+/// current directory (which is racy under `cargo test`).
+fn find_config_file_from(start: PathBuf) -> Result<PathBuf> {
+    let mut dir = start;
     loop {
         let candidate = dir.join("secretspec.toml");
         if candidate.exists() {
@@ -2413,5 +2421,103 @@ mod policy_tests {
             Some("clean_value")
         );
         assert_eq!(env.len(), 1);
+    }
+}
+
+/// Serializes tests that mutate the process-global current directory. The current
+/// directory is shared across all threads, so two `set_current_dir` tests running
+/// concurrently (the default under `cargo test`) would corrupt each other. Any test
+/// that calls `set_current_dir` must hold this guard for its whole body. Poisoning
+/// is recovered from (a panicking test leaves the lock poisoned but the data — unit
+/// — is meaningless), so one failing test does not cascade into the others.
+#[cfg(test)]
+pub(crate) static CWD_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Locks [`CWD_GUARD`], recovering from a previous test's poison.
+#[cfg(test)]
+pub(crate) fn lock_cwd() -> std::sync::MutexGuard<'static, ()> {
+    CWD_GUARD.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+#[cfg(test)]
+mod config_discovery_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Walking up from a nested subdirectory finds the nearest ancestor
+    /// `secretspec.toml`. This is the library half of "run secretspec from a
+    /// subdirectory" (issue #59). It exercises `find_config_file_from` directly so
+    /// no current-directory mutation is needed — the walk is fully deterministic.
+    #[test]
+    fn find_config_file_walks_up_to_nearest_ancestor() {
+        let root = TempDir::new().unwrap();
+        let manifest = root.path().join("secretspec.toml");
+        fs::write(&manifest, "[project]\nname=\"x\"\nrevision=\"1.0\"\n").unwrap();
+
+        let nested = root.path().join("a").join("b").join("c");
+        fs::create_dir_all(&nested).unwrap();
+
+        let found = find_config_file_from(nested).unwrap();
+        // Compare canonicalized paths: on macOS the temp dir lives under a
+        // `/var -> /private/var` symlink, so the raw paths differ.
+        assert_eq!(
+            found.canonicalize().unwrap(),
+            manifest.canonicalize().unwrap()
+        );
+    }
+
+    /// With no `secretspec.toml` anywhere up the tree, the walk reports a missing
+    /// manifest rather than looping or panicking. (Assumes the temp dir's ancestors
+    /// contain no `secretspec.toml`, which holds for the OS temp directory.)
+    #[test]
+    fn find_config_file_reports_missing_manifest() {
+        let empty = TempDir::new().unwrap();
+        assert!(matches!(
+            find_config_file_from(empty.path().to_path_buf()),
+            Err(SecretSpecError::NoManifest)
+        ));
+    }
+
+    /// Loading via an explicit **relative** path resolves against the current
+    /// directory — both a bare filename and a `../`-relative parent path. This is
+    /// the `-f ../secretspec.toml` form from issue #59, and it is the case that
+    /// regressed on Windows: `Config::try_from` calls `Path::canonicalize`, whose
+    /// behavior on relative paths differs from Unix. Mutates the current directory,
+    /// so it holds [`CWD_GUARD`].
+    #[test]
+    fn try_from_resolves_relative_paths_against_cwd() {
+        let _cwd = lock_cwd();
+
+        let root = TempDir::new().unwrap();
+        fs::write(
+            root.path().join("secretspec.toml"),
+            "[project]\nname=\"x\"\nrevision=\"1.0\"\n\n[profiles.default]\n",
+        )
+        .unwrap();
+        let sub = root.path().join("sub");
+        fs::create_dir_all(&sub).unwrap();
+
+        let original = env::current_dir().unwrap();
+
+        // Bare filename from the manifest's own directory (the working case).
+        env::set_current_dir(root.path()).unwrap();
+        let from_cwd = Config::try_from(Path::new("secretspec.toml"));
+
+        // `../`-relative path from a subdirectory (the case that failed on Windows).
+        env::set_current_dir(&sub).unwrap();
+        let from_parent = Config::try_from(Path::new("../secretspec.toml"));
+
+        // Restore the current directory before any assertion (and before the
+        // TempDir is dropped) so a failure cannot leave the process — or TempDir
+        // cleanup, which cannot remove the current directory on Windows — wedged.
+        env::set_current_dir(&original).unwrap();
+
+        assert!(from_cwd.is_ok(), "bare filename: {:?}", from_cwd.err());
+        assert!(
+            from_parent.is_ok(),
+            "../ relative path: {:?}",
+            from_parent.err()
+        );
     }
 }

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -1516,6 +1516,10 @@ fn test_set_with_defined_secret() {
     use std::env;
     use tempfile::TempDir;
 
+    // Serialize against other current-directory-mutating tests (the current
+    // directory is process-global and shared across test threads).
+    let _cwd = crate::secrets::lock_cwd();
+
     // Create a temporary directory for dotenv file
     let temp_dir = TempDir::new().unwrap();
     let original_dir = env::current_dir().unwrap();


### PR DESCRIPTION
## Context

Follow-up to #59 ("run secretspec from a subdirectory"). A user reported on [this comment](https://github.com/cachix/secretspec/issues/59#issuecomment-4689034985) that on **Windows + PowerShell**:

1. Auto-detection (walking up to the nearest `secretspec.toml`) does not work.
2. `-f` with a relative path fails — `run -f secretspec.toml` works, but `run -f ../secretspec.toml` from a subdirectory does not.

Both work on Linux. Investigation found the gap: the two failing paths — `find_config_file` (walk-up) and relative `load_from`/`Config::try_from` — had **zero test coverage**, and CI only ran on Ubuntu/macOS. The only platform-divergent operation in the load path is `Path::canonicalize()` (`config.rs:149`), whose behavior on relative paths differs on Windows.

This PR closes the coverage gap so the regression is reproducible on CI; it does not yet change the loading logic.

## Changes

- Factor `find_config_file` into `find_config_file_from(start)` so the walk can be tested against an explicit directory without mutating the process-global current directory (racy under `cargo test`).
- Add a shared `CWD_GUARD` mutex to serialize current-directory-mutating tests; retrofit the existing dotenv test to hold it.
- New tests: walk-up to nearest ancestor, missing-manifest reporting, and relative `--file` resolution (bare filename + `../`-relative parent).
- Add a native `windows-latest` `cargo test --all` CI job — the existing devenv/Nix job cannot run on Windows, which is exactly why the Windows-only bug slipped through.

## Notes

If the new tests pass on the Windows CI job but the real bug persists, that points at something the unit test can't model (mapped/substituted drive, OneDrive redirection) rather than `canonicalize` itself — useful signal either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)