### PR TITLE
docs: remove underline from marquee item links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ When adding a new provider, update **every** location below — provider names a
 2. `docs/astro.config.mjs` - Add to sidebar navigation under "Providers" **and** to the providers sentence in the `starlightLlmsTxt` description block
 3. `docs/src/content/docs/concepts/providers.md` - Add a row to the "Available Providers" table
 4. `docs/src/content/docs/reference/providers.md` - Add a provider section **and** a row in the "Security Considerations" table
-5. `docs/src/pages/index.astro` - Add to the `providerIcons` array (top of file) **and** to the `secretspec config init` mini-terminal in the hero
+5. `docs/src/pages/index.astro` - Add to the `providerMetadata` array (top of file) **and** to the `secretspec config init` mini-terminal in the hero
 6. `docs/src/content/docs/quick-start.mdx` - Update the `secretspec config init` example output to include the new provider
 7. `README.md` (symlink to `secretspec/README.md`) - Add to the "Providers" bullet list **and** to the `secretspec config init` example output
 

--- a/docs/src/styles/landing.css
+++ b/docs/src/styles/landing.css
@@ -462,6 +462,7 @@
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--color-gray-700);
+  text-decoration: none;
   transition: border-color 0.15s, color 0.15s;
 }
 


### PR DESCRIPTION
Also wanted to surface this in case it's desired: now that these are links, they by default get an underline. This PR removes that.

<img width="1091" height="137" alt="image" src="https://github.com/user-attachments/assets/9997bd4e-d0c2-487b-a869-8efa68141c2f" />

<img width="1125" height="134" alt="image" src="https://github.com/user-attachments/assets/79248e1f-8cfb-4c64-a492-eaf8ff725943" />

Additionally, fixed the stale reference to `providerIcons` in `CLAUDE.md` since that was renamed to `providerMetadata` in the prior PR.