### PR TITLE
feat: native secret references (`ref`) as provider independent coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`ref`: native secret references on secrets**: a secret can name one
+  externally managed secret by its store's own coordinates, instead of
+  SecretSpec's `{project}/{profile}/{key}` naming:
+
+  ```toml
+  [profiles.production]
+  DATABASE_URL = { description = "...", ref = { item = "db", field = "password" }, providers = ["prod_op"] }
+  ```
+
+  `item` is the store's own name for the secret (1Password item title, Vault
+  KV path, AWS secret name or ARN, `.env` key, environment variable, ...);
+  optional keys refine it where the store supports them: `field` (1Password
+  field label, Vault KV field, AWS JSON key, keyring account), `vault` and
+  `section` (1Password), and `version` (Google Secret Manager). Every provider
+  resolves refs; coordinates a store has no equivalent for are rejected with a
+  clear error rather than guessed at.
+
+  The coordinates supply naming only — *which* store resolves them follows the
+  same routing as every other secret (the secret's `providers` chain, the
+  `--provider`/`SECRETSPEC_PROVIDER` override, or the default provider). That
+  means refs compose with `providers` fallback chains, and an explicit
+  override redirects them like any secret, e.g. at a `.env` fixtures file
+  during tests. Writes are symmetric where the backend allows it:
+  `secretspec set` and `check` prompting write through the coordinates in
+  place (1Password `op item edit`, keyring, pass, dotenv, Bitwarden, Proton
+  Pass, LastPass); Vault, AWS, and GCSM refs are read-only. Secrets sharing
+  identical coordinates fetch once, and audit events record the coordinates in
+  a new `ref` field.
+- **Inline provider URIs in `providers` chains**: chain entries that are
+  already URIs (`providers = ["onepassword://Production", "keyring"]`) now
+  pass through without declaring a `[providers]` alias first.
+
+### Changed
+- **Faster multi-provider resolution**: `check`, `run`, and SDK resolution now
+  group secrets by store and fetch the groups concurrently instead of one
+  after another; within a group, `ref` secrets batch through the store's bulk
+  surface where it has one (AWS `BatchGetSecretValue`, the single Bitwarden,
+  Proton Pass, and 1Password listings) and otherwise resolve concurrently,
+  each unique coordinate fetched once. CLI authentication (1Password,
+  LastPass, Proton Pass) is probed once per account/session instead of once
+  per provider instance.
+- **Provider trait speaks one address vocabulary** (affects custom providers
+  built on the Rust library): each provider now compiles SecretSpec's
+  `{project}/{profile}/{key}` convention into its native coordinates via a
+  new required `convention_address` method, and reads resolve every address
+  through the same coordinate path a `ref` uses. The convention-only
+  `get_batch` method is replaced by `get_many`, which takes addresses and so
+  batches `ref` secrets too. A provider declares the `ref` coordinates it
+  honors with `supported_coords` and the rest are rejected for it, and
+  `allows_set` is replaced by `check_writable`, which returns the reason a
+  write is refused rather than a bare `false`.
+- **Manifest validation runs on load**: the semantic rules `secretspec.toml`
+  documents (a required secret cannot carry a `default`, `generate` needs a
+  `type`, `ref` coordinates must be non-empty and non-whitespace) are now
+  enforced whenever the config is loaded. Configs that silently violated them
+  previously will now fail with a pointed error.
+
+### Fixed
+- **onepassword**: URIs carrying an item path (e.g. the
+  `onepassword://vault/Production` form some older docs showed) previously
+  discarded the path silently and targeted a vault literally named `vault`.
+  Item paths — including pasted `op://vault/item/field` references — now fail
+  with an error spelling out the exact `ref` coordinates to write instead.
+- **`set` on a read-only `ref`** reported "Provider '<name>' is read-only and
+  does not support setting values", which is untrue of Vault, AWS, and GCSM —
+  they write the conventional layout fine and refuse only refs. The store's own
+  reason is now shown (e.g. writing one Vault field would clobber the sibling
+  fields at the same KV path).
+
 ## [0.13.0] - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   place (1Password `op item edit`, keyring, pass, dotenv, Bitwarden, Proton
   Pass, LastPass); Vault, AWS, and GCSM refs are read-only. Secrets sharing
   identical coordinates fetch once, and audit events record the coordinates in
-  a new `ref` field.
+  a new `ref` field. A `ref` also composes with `generate`: a missing
+  referenced secret is minted and written straight to its coordinates.
 - **Inline provider URIs in `providers` chains**: chain entries that are
   already URIs (`providers = ["onepassword://Production", "keyring"]`) now
   pass through without declaring a `[providers]` alias first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ The project is organized as a Rust workspace with two crates:
 The provider system uses a trait-based architecture defined in `src/provider/mod.rs`. When implementing new providers:
 
 1. Create module in `src/provider/your_provider.rs`
-2. Implement the `Provider` trait with methods: `get()`, `set()`, `allows_set()`, `name()`, `description()`
+2. Implement the `Provider` trait with methods: `get()`, `set()`, `check_writable()`, `name()`, `description()`
 3. Use the `#[provider]` macro for automatic registration
 4. Handle profile-aware storage paths (e.g., `secretspec/{project}/{profile}/{key}`)
 
@@ -101,8 +101,8 @@ GITHUB_TOKEN = { description = "GitHub token from env", providers = ["env"] }
 Provider aliases can be checked into the project in `secretspec.toml` so every team member and CI runner sees them automatically:
 ```toml
 [providers]
-prod_vault = "onepassword://vault/Production"
-shared = "onepassword://vault/Shared"
+prod_vault = "onepassword://Production"
+shared = "onepassword://Shared"
 keyring = "keyring://"
 env = "env://"
 ```
@@ -113,8 +113,8 @@ They can also be defined per-user in `~/.config/secretspec/config.toml` (project
 provider = "keyring"
 
 [defaults.providers]
-prod_vault = "onepassword://vault/Production"
-shared = "onepassword://vault/Shared"
+prod_vault = "onepassword://Production"
+shared = "onepassword://Shared"
 keyring = "keyring://"
 env = "env://"
 ```
@@ -122,7 +122,7 @@ env = "env://"
 Manage the user-level map via CLI (project-level aliases are hand-edited in `secretspec.toml`):
 ```bash
 # Add provider alias to user config
-secretspec config provider add prod_vault "onepassword://vault/Production"
+secretspec config provider add prod_vault "onepassword://Production"
 
 # List user-level aliases
 secretspec config provider list

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -156,6 +156,7 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
               slug: "concepts/inheritance",
             },
             { label: "Secret Generation", slug: "concepts/generation" },
+            { label: "Secret References", slug: "concepts/references" },
             { label: "Audit Logging", slug: "concepts/audit" },
           ],
         },

--- a/docs/src/content/docs/blog/secretspec-0-14-secret-references.md
+++ b/docs/src/content/docs/blog/secretspec-0-14-secret-references.md
@@ -1,0 +1,168 @@
+---
+title: "SecretSpec 0.14: Secret References"
+description: A secret can now point at one that already exists in a provider's store, by the store's own coordinates, instead of a name SecretSpec picks.
+date: 2026-07-09
+authors:
+  - domen
+---
+
+SecretSpec keeps a `secretspec.toml` that declares what secrets an application
+needs, and resolves the values from a provider: your system keyring, 1Password,
+Vault, a `.env` file, and so on. Until now it stored every secret under a naming
+convention it controlled, `secretspec/{project}/{profile}/{key}`, and that
+convention was the only place it looked.
+
+That works when SecretSpec created the secret. It does not when the secret
+already exists under a name something else chose: a `db` item in a 1Password
+vault, a `myapp/config` path at a Vault mount, an environment variable your
+platform already sets. To manage such a secret you had to copy its value into
+SecretSpec's convention, leaving two copies to rotate, or leave it out of
+SecretSpec entirely.
+
+[SecretSpec 0.14](https://github.com/cachix/secretspec/releases/tag/v0.14.0 "SecretSpec 0.14 release")
+introduces `ref`. A secret can name one that already exists, by the store's own
+coordinates, and SecretSpec reads and writes that secret in place:
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "Postgres DSN", ref = { item = "db", field = "password" }, providers = ["prod_op"] }
+```
+
+`DATABASE_URL` now resolves from the `password` field of the 1Password item
+`db`. SecretSpec does not prepend a project or profile, and does not create a
+name of its own.
+
+## Why not just paste the address
+
+1Password will give you an address for that field: `op://Production/db/password`.
+The obvious design is to accept that string in the config and be done. We built
+that first and removed it.
+
+A string like `op://Production/db/password` names the store and the secret at
+the same time, which ties the secret to 1Password. The same reference cannot
+then resolve from Vault in CI and 1Password on a laptop, cannot be redirected at
+a `.env` fixture for a test run without editing the manifest, and does not
+compose with a provider fallback chain, because the chain and the address
+disagree about where the secret is.
+
+SecretSpec already decides which store to use, through providers, profiles,
+fallback chains, and the `--provider` override. A `ref` names only the secret
+and leaves the store to that existing machinery.
+
+## Coordinates
+
+A `ref` is a table, not a URL. Each key names a level of structure that some
+stores have:
+
+```
+vault                which container holds the item        (1Password only)
+└── item             the store's own name for the secret   (always required)
+    └── section      a named group of fields               (1Password only)
+        └── field    one component inside the item          (structured stores)
+            └── version   which revision to read            (GCSM only)
+```
+
+Only `item` is required, because every store names its secrets somehow. `item`
+is the complete name: it replaces the whole convention path, with no project or
+profile and no folder prefix prepended. `ref = { item = "GITHUB_PAT" }` on the
+env provider reads the environment variable `GITHUB_PAT` and nothing else.
+
+The other keys refine `item` for stores that have that structure. A `.env` key
+holds a single value, so `field` on a dotenv ref is not meaningful. A Vault KV
+entry is a map, so `field` is required. When a store has no equivalent for a
+coordinate it reports an error naming that coordinate, rather than reading a
+different secret:
+
+```toml
+GITHUB_TOKEN = { description = "GitHub token", ref = { item = "GITHUB_PAT", field = "x" }, providers = ["env"] }
+```
+
+```text
+Error: Provider operation failed: the env provider does not support the `field` coordinate. Drop `field` from the ref for `GITHUB_PAT`.
+```
+
+All eleven providers resolve refs, and each rejects the coordinates it cannot
+represent. A store whose secrets have no internal parts gets that rejection from
+shared code, without any per-provider work.
+
+## References name, providers route
+
+A `ref` supplies the name only. Which provider resolves it follows the normal
+[provider resolution order](/concepts/providers/): a `--provider` override, then
+the secret's `providers` chain, then profile and global defaults. That is the
+same order every other secret uses.
+
+Because the store is not part of the reference, the same `ref` works across
+providers. Each provider in a fallback chain is asked for the same coordinates,
+and one that cannot interpret them logs a warning and the chain continues:
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "Postgres DSN", ref = { item = "db", field = "password" }, providers = ["onepassword://Production", "keyring"] }
+```
+
+Chain entries can also be inline `scheme://` URIs, as above, with no
+`[providers]` alias declared first.
+
+The `--provider` override redirects a referenced secret the same way it
+redirects a conventional one, so pointing a whole suite at a `.env` fixture needs
+no change to the manifest:
+
+```bash
+$ secretspec run --provider dotenv:.env.fixtures -- cargo test
+```
+
+## Writing through a ref
+
+Reads and writes use the same coordinates. `secretspec set` and interactive
+`check` write to the referenced secret in place wherever the store supports
+writes:
+
+```bash
+$ secretspec set DATABASE_URL
+# writes the `password` field of the 1Password item `db`, in place
+```
+
+1Password edits the field with `op item edit` and does not create items.
+Keyring, pass, dotenv, Bitwarden, Proton Pass, and LastPass write their refs as
+well. Vault, AWS Secrets Manager, and Google Secret Manager are read-only for
+refs and report that directly, rather than claiming the provider cannot write at
+all.
+
+A `ref` also composes with `generate`. If the referenced secret does not exist
+yet, SecretSpec generates the value and writes it to the coordinates, so the
+first `check` populates the item everything else already reads.
+
+## Faster resolution
+
+`check`, `run`, and the SDKs now group secrets by store and fetch the groups
+concurrently instead of one store after another. Within a group, referenced
+secrets use the store's bulk API where it has one (AWS `BatchGetSecretValue`, and
+the single Bitwarden, Proton Pass, and 1Password listings) and otherwise resolve
+concurrently, fetching each unique coordinate once. CLI authentication for
+1Password, LastPass, and Proton Pass is probed once per account or session
+instead of once per provider instance.
+
+## Upgrading
+
+```bash
+cargo install secretspec
+```
+
+Three changes to be aware of:
+
+- A `onepassword://` URI carrying an item path used to drop the path and target a
+  vault literally named `vault`. Item paths, including pasted
+  `op://vault/item/field` strings, now fail with an error that gives the `ref`
+  table to write instead. Provider URIs are store addresses only.
+- `ref` is always a table. String and URI forms are rejected, with the same
+  translation in the error.
+- Manifest validation now runs on every load. Rules that `secretspec.toml`
+  documents (a required secret cannot have a `default`, `generate` needs a
+  `type`, ref coordinates must be non-empty) are enforced on load rather than
+  ignored. A manifest that violated one of them will now fail with a clear error.
+
+See [Secret References](/concepts/references/) for the full model and the
+[configuration reference](/reference/configuration/#secret-references) for how
+each provider maps the coordinates. Questions or feedback? Join us on
+[Discord](https://discord.gg/naMgvexb6q).

--- a/docs/src/content/docs/concepts/profiles.md
+++ b/docs/src/content/docs/concepts/profiles.md
@@ -65,7 +65,7 @@ To reduce repetition when multiple secrets in a profile share the same settings,
 
 ```toml
 [providers]
-prod_vault = "onepassword://vault/Production"
+prod_vault = "onepassword://Production"
 keyring = "keyring://"
 
 [profiles.production.defaults]

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -23,12 +23,17 @@ Providers are pluggable storage backends that handle the storage and retrieval o
 
 ## Provider Selection
 
-SecretSpec determines which provider to use in this order:
+SecretSpec determines which provider to use for each secret in this order:
 
-1. **Per-secret providers**: `providers` field in `secretspec.toml` (highest priority, with fallback chain)
-2. **CLI flag**: `secretspec --provider` flag
-3. **Environment**: `SECRETSPEC_PROVIDER`
+1. **Explicit override**: the `--provider` CLI flag or the `SECRETSPEC_PROVIDER` environment variable
+2. **Per-secret providers**: `providers` field in `secretspec.toml` (with fallback chain)
+3. **Profile defaults**: `providers` under `[profiles.<name>.defaults]`
 4. **Global default**: Default provider in user config set via `secretspec config init`
+
+A secret's [`ref`](/reference/configuration/#secret-references) field never
+affects provider selection: it only changes what name is looked up in the store,
+not which store is used. The same order above picks the store for ref secrets
+and convention secrets alike.
 
 ## Configuration
 
@@ -62,7 +67,7 @@ You can use provider URIs for more specific configuration:
 
 ```bash
 # Use a specific OnePassword vault
-$ secretspec run --provider "onepassword://Personal/Development" -- npm start
+$ secretspec run --provider "onepassword://Development" -- npm start
 
 # Use a specific dotenv file
 $ secretspec run --provider "dotenv:/home/user/work/.env" -- npm test
@@ -79,6 +84,14 @@ API_KEY = { description = "API key from env", providers = ["env"] }
 SENTRY_DSN = { description = "Error tracking", providers = ["shared_vault", "keyring"] }
 ```
 
+Chain entries are provider aliases (see below) or inline provider URIs, which
+need no alias declaration:
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "Production DB", providers = ["onepassword://Production", "keyring"] }
+```
+
 ### Profile-Level Default Providers
 
 You can also set default providers for an entire profile using `profiles.<name>.defaults`. See [Profile-Level Defaults](/concepts/profiles/#profile-level-defaults) for details.
@@ -92,8 +105,8 @@ On name conflicts the project-level alias wins, so a stale user config cannot si
 
 ```toml title="secretspec.toml"
 [providers]
-prod_vault = "onepassword://vault/Production"
-shared_vault = "onepassword://vault/Shared"
+prod_vault = "onepassword://Production"
+shared_vault = "onepassword://Shared"
 keyring = "keyring://"
 env = "env://"
 ```
@@ -103,8 +116,8 @@ env = "env://"
 provider = "keyring"
 
 [defaults.providers]
-prod_vault = "onepassword://vault/Production"
-shared_vault = "onepassword://vault/Shared"
+prod_vault = "onepassword://Production"
+shared_vault = "onepassword://Shared"
 keyring = "keyring://"
 env = "env://"
 ```
@@ -130,7 +143,7 @@ Use CLI commands to manage user-level provider aliases in `~/.config/secretspec/
 
 ```bash
 # Add a provider alias
-$ secretspec config provider add prod_vault "onepassword://vault/Production"
+$ secretspec config provider add prod_vault "onepassword://Production"
 
 # List all aliases
 $ secretspec config provider list

--- a/docs/src/content/docs/concepts/references.md
+++ b/docs/src/content/docs/concepts/references.md
@@ -87,8 +87,6 @@ $ secretspec run --provider dotenv:.env.fixtures -- cargo test
 - Reads and writes are symmetric: `secretspec set` and interactive `check` write
   through the coordinates in place wherever the store supports writes. Read-only
   stores fail with a clear error.
-- A `ref` combines freely with `default`, `required`, and `as_path`, but not with
-  `generate`: a referenced secret is externally managed, not minted.
 - `ref` is always a table. String and URI forms (`ref = "op://vault/item/field"`)
   are rejected, with an error that spells out the equivalent table.
 - Secrets sharing identical coordinates and store are fetched once, and

--- a/docs/src/content/docs/concepts/references.md
+++ b/docs/src/content/docs/concepts/references.md
@@ -1,0 +1,99 @@
+---
+title: Secret References
+description: Point a secret at one already managed in a provider's store, by the store's own coordinates
+---
+
+:::note
+Secret references are available since version 0.14.
+:::
+
+By default, SecretSpec owns the naming: it stores each secret under its own
+`{project}/{profile}/{key}` convention. A **secret reference** overrides that for
+one secret, naming a secret that already exists in the store and is managed
+outside SecretSpec. SecretSpec then reads (and writes) that existing secret in
+place, instead of a convention path it controls.
+
+You declare a reference with the `ref` field, a table of provider-independent
+coordinates:
+
+```toml
+[profiles.production]
+# The 1Password item "db", its "password" field
+DATABASE_URL = { description = "Postgres DSN", ref = { item = "db", field = "password" }, providers = ["prod_vault"] }
+
+# An existing environment variable
+GITHUB_TOKEN = { description = "GitHub token", ref = { item = "GITHUB_PAT" }, providers = ["env"] }
+```
+
+## Coordinates address a secret from the outside in
+
+A `ref` is not a store-specific address like `op://vault/item/field`. It is a set
+of provider-independent coordinates, each naming a level of structure that some
+stores have:
+
+```
+vault                which container holds the item        (1Password only)
+└── item             the store's own name for the secret   (always required)
+    └── section      a named group of fields               (1Password only)
+        └── field    one component inside the item          (structured stores)
+            └── version   which revision to read            (GCSM only)
+```
+
+Only `item` is universal, because every store names its secrets somehow. `item`
+is the **complete** name, not a suffix: it replaces the entire convention path,
+so nothing is prepended.
+
+```toml
+# Reads the .env key TOTALLY_DIFFERENT_NAME, not secretspec/myapp/default/DATABASE_URL
+DATABASE_URL = { description = "DB", ref = { item = "TOTALLY_DIFFERENT_NAME" }, providers = ["dotenv"] }
+```
+
+The other coordinates exist because some stores give a secret internal structure
+(`field`, `section`), nest it inside a container (`vault`), or keep revisions
+(`version`). A store that has no equivalent for a coordinate **rejects it with an
+error naming the coordinate**, rather than silently reading the wrong secret. The
+[configuration reference](/reference/configuration/#secret-references) documents
+exactly how each provider maps the coordinates.
+
+## References name, providers route
+
+A `ref` supplies naming only. It does not pin the secret to a particular store.
+Which provider actually resolves the coordinates follows the ordinary
+[provider resolution order](/concepts/providers/): a `--provider` override, then
+the secret's `providers` chain, then the profile and global defaults.
+
+This is the difference from pasting a store URL into your config. Because the
+store is not baked into the reference, the same `ref` works across providers.
+Each provider in a fallback chain is asked for the same coordinates, and one that
+cannot interpret them warns and the chain continues:
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "Postgres DSN", ref = { item = "db", field = "password" }, providers = ["onepassword://Production", "keyring"] }
+```
+
+It also means `--provider` redirects reference secrets exactly like convention
+secrets, which makes test fixtures trivial: point every reference at a `.env`
+file without touching the manifest.
+
+```bash
+$ secretspec run --provider dotenv:.env.fixtures -- cargo test
+```
+
+## How it works
+
+- `item` is required; `field`, `vault`, `section`, and `version` are optional and
+  only accepted by stores that have that structure.
+- Reads and writes are symmetric: `secretspec set` and interactive `check` write
+  through the coordinates in place wherever the store supports writes. Read-only
+  stores fail with a clear error.
+- A `ref` combines freely with `default`, `required`, and `as_path`, but not with
+  `generate`: a referenced secret is externally managed, not minted.
+- `ref` is always a table. String and URI forms (`ref = "op://vault/item/field"`)
+  are rejected, with an error that spells out the equivalent table.
+- Secrets sharing identical coordinates and store are fetched once, and
+  [audit log](/concepts/audit/) events carry the coordinates.
+
+See the [configuration reference](/reference/configuration/#secret-references) for
+the full specification: the coordinate table, how every provider interprets each
+coordinate, and the exact rules.

--- a/docs/src/content/docs/providers/awssm.md
+++ b/docs/src/content/docs/providers/awssm.md
@@ -45,6 +45,22 @@ $ secretspec run --provider awssm://us-east-1 -- npm start
 $ secretspec set DATABASE_URL --provider awssm
 ```
 
+## Secret References
+
+By default each secret is stored under `secretspec/{project}/{profile}/{key}`. A
+secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing secret instead: `item` is the secret name (or ARN), and the optional
+`field` selects one key of a JSON secret value. Without `field`, the whole
+secret string is returned. References are **read-only** in this provider.
+
+```toml
+[profiles.production]
+# Whole secret value
+DATABASE_URL = { description = "DB", ref = { item = "prod/database-url" }, providers = ["awssm://us-east-1"] }
+# One key of a JSON secret value
+DB_PASSWORD = { description = "DB pw", ref = { item = "prod/db-credentials", field = "password" }, providers = ["awssm://us-east-1"] }
+```
+
 ## Usage
 
 ### Basic Commands

--- a/docs/src/content/docs/providers/bws.md
+++ b/docs/src/content/docs/providers/bws.md
@@ -52,6 +52,18 @@ $ secretspec check --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
 $ secretspec run --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c -- npm start
 ```
 
+## Secret References
+
+By default each secret is matched by the BWS key name equal to the secret's own
+name. A secret's [`ref`](/reference/configuration/#secret-references) field names
+a different key instead: `item` is the BWS key name (`field` is not supported).
+Reads and writes target that key in place.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "DB", ref = { item = "prod-db-connection" }, providers = ["bws://a9230ec4-5507-4870-b8b5-b3f500587e4c"] }
+```
+
 ## Usage
 
 ### Authentication

--- a/docs/src/content/docs/providers/dotenv.md
+++ b/docs/src/content/docs/providers/dotenv.md
@@ -41,6 +41,18 @@ dotenv:/absolute/path/.env
 export SECRETSPEC_PROVIDER=dotenv:.env.local
 ```
 
+## Secret References
+
+By default each secret reads the key named after it. A secret's
+[`ref`](/reference/configuration/#secret-references) field reads a key stored
+under a different name: `item` is the `.env` key (`field` is not supported).
+Reads and writes target that key in place; the secret's own name is ignored.
+
+```toml
+[profiles.default]
+DATABASE_URL = { description = "DB", ref = { item = "POSTGRES_URL" }, providers = ["dotenv://.env.shared"] }
+```
+
 ## Usage
 
 ```bash

--- a/docs/src/content/docs/providers/env.md
+++ b/docs/src/content/docs/providers/env.md
@@ -16,6 +16,20 @@ $ secretspec check --provider env:
 $ secretspec check --provider env://
 ```
 
+## Secret References
+
+By default each secret reads the environment variable named after it. A secret's
+[`ref`](/reference/configuration/#secret-references) field reads a different
+variable, which is useful when your infrastructure already exposes a value under
+another name: `item` is the variable name, case-sensitive and preserved verbatim
+(`field` is not supported). Like the rest of this provider, references are
+read-only.
+
+```toml
+[profiles.default]
+DATABASE_URL = { description = "DB", ref = { item = "POSTGRES_CONNECTION_STRING" }, providers = ["env"] }
+```
+
 ## When to Use
 
 - Running in CI/CD pipelines where secrets are injected as environment variables

--- a/docs/src/content/docs/providers/gcsm.md
+++ b/docs/src/content/docs/providers/gcsm.md
@@ -38,6 +38,20 @@ $ secretspec check --provider gcsm://my-gcp-project
 $ secretspec run --provider gcsm://my-gcp-project -- npm start
 ```
 
+## Secret References
+
+By default each secret is stored as `secretspec-{project}-{profile}-{key}`. A
+secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing secret instead: `item` is the secret id, and the optional `version`
+pins a version (defaults to latest; `field` is not supported). References are
+**read-only** in this provider.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "DB", ref = { item = "database-url" }, providers = ["gcsm://my-gcp-project"] }
+SIGNING_KEY = { description = "Key", ref = { item = "signing-key", version = "3" }, providers = ["gcsm://my-gcp-project"] }
+```
+
 ## Usage
 
 ### Basic Commands

--- a/docs/src/content/docs/providers/keyring.md
+++ b/docs/src/content/docs/providers/keyring.md
@@ -45,6 +45,21 @@ $ secretspec set DATABASE_URL --provider keyring
 $ secretspec set DATABASE_URL --provider "keyring://shared/{profile}/{key}"
 ```
 
+## Secret References
+
+By default each secret is stored under `secretspec/{project}/{profile}/{key}` with
+the current system username as the account. A secret's
+[`ref`](/reference/configuration/#secret-references) field names an exact keyring
+entry instead, useful for reading a credential another application already
+stored: `item` is the service, and the optional `field` is the account
+(defaults to the current system username). Reads and writes target that entry in
+place.
+
+```toml
+[profiles.default]
+API_TOKEN = { description = "Token", ref = { item = "com.example.app", field = "me@example.com" }, providers = ["keyring"] }
+```
+
 ## Usage
 
 ```bash

--- a/docs/src/content/docs/providers/lastpass.md
+++ b/docs/src/content/docs/providers/lastpass.md
@@ -46,6 +46,18 @@ export LPASS_DISABLE_PINENTRY=1
 echo "password" | lpass login --trust your-email@example.com
 ```
 
+## Secret References
+
+By default each secret maps to an item named `secretspec/{project}/{profile}/{key}`.
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing item instead: `item` is the full item name, including any folder
+(`field` is not supported). Reads and writes target that item in place.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "DB", ref = { item = "Shared-Infra/Production DB" }, providers = ["lastpass"] }
+```
+
 ## Usage
 
 ```bash

--- a/docs/src/content/docs/providers/onepassword.md
+++ b/docs/src/content/docs/providers/onepassword.md
@@ -57,14 +57,16 @@ expire after 30 minutes of inactivity; if they expire mid-session,
 ### URI Format
 
 ```
-onepassword://[account@]vault[/path]
-onepassword+token://[token@]vault[/path]
+onepassword://[account@]vault
+onepassword+token://[token@]vault
 ```
 
 - `account`: Optional account shorthand
 - `vault`: Target vault name (defaults to "Private")
 - `token`: Service account token
-- `path`: Reserved for future use
+
+The URI names a vault only; item paths (e.g. `onepassword://Vault/item/field`)
+are rejected. To name a specific item, use a [secret reference](#secret-references).
 
 ### Examples
 
@@ -80,6 +82,49 @@ $ secretspec set SECRET --provider "onepassword+token://ops_token123@Production"
 
 # Default vault (Private)
 $ secretspec set KEY --provider onepassword://
+```
+
+## Secret References
+
+By default, secretspec manages its own items in 1Password (Secure Notes named
+`secretspec/{project}/{profile}/{key}`). If your secrets already live in
+1Password items you manage yourself, name those items with the
+[`ref`](/reference/configuration/#secret-references) field and route the secret
+at a vault with `providers`:
+
+```toml
+# secretspec.toml
+[profiles.production]
+DATABASE_URL = { description = "Production DB", ref = { item = "Postgres", field = "connection-url" }, providers = ["onepassword://Infra"] }
+STRIPE_API_KEY = { description = "Stripe key", ref = { item = "Stripe", field = "api key" }, providers = ["onepassword://Infra"] }
+```
+
+The coordinates translate to 1Password as follows:
+
+- `item`: the item title or UUID. Spaces are fine.
+- `field`: the field label. Without `field`, the item is read like a
+  convention secret (its value or password field), and writes edit the `value`
+  field.
+- `vault`: overrides the URI's default vault for this one secret, e.g.
+  `ref = { vault = "Production", item = "infra", field = "token" }`.
+- `section`: addresses a field inside a section; requires `field`.
+
+Writes go through `op item edit`: `secretspec set` updates the referenced field
+in place, adding the field to the item if it is missing. Items are never
+created through a ref.
+
+A ref does not pin the store. Provider resolution works as usual, so a
+`providers` chain can fall back to other stores, and
+`--provider dotenv:.env.fixtures` redirects these secrets to a fixtures file
+during tests.
+
+Native reference strings from the 1Password app's **Copy Secret Reference**
+(`op://vault/item/field`) are not accepted directly; pasting one into `ref`
+produces an error that spells out the translation:
+
+```toml
+# op://Infra/Postgres/connection-url becomes:
+DATABASE_URL = { description = "Production DB", ref = { vault = "Infra", item = "Postgres", field = "connection-url" }, providers = ["onepassword://Infra"] }
 ```
 
 ## Usage

--- a/docs/src/content/docs/providers/pass.md
+++ b/docs/src/content/docs/providers/pass.md
@@ -45,6 +45,19 @@ $ secretspec set DATABASE_URL --provider "pass://shared/{profile}/{key}"
 $ secretspec set DATABASE_URL --provider "pass://?store_dir=/path/to/store"
 ```
 
+## Secret References
+
+By default each secret is stored at `secretspec/{project}/{profile}/{key}`. A
+secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing store entry instead, letting you read credentials you already keep in
+`pass`: `item` is the entry path (`field` is not supported). Reads and writes
+target that entry in place.
+
+```toml
+[profiles.default]
+GITHUB_TOKEN = { description = "GH token", ref = { item = "github/token" }, providers = ["pass"] }
+```
+
 ## Usage
 
 ```bash

--- a/docs/src/content/docs/providers/protonpass.md
+++ b/docs/src/content/docs/providers/protonpass.md
@@ -35,6 +35,18 @@ protonpass://Work
 protonpass://Work/{project}/{profile}/{key}
 ```
 
+## Secret References
+
+By default each secret maps to an item titled `{project}/{profile}/{key}`. A
+secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing item instead: `item` is the exact item title, whose note is read
+(`field` is not supported). Reads and writes target that item in place.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "DB", ref = { item = "Production Database" }, providers = ["protonpass://Work"] }
+```
+
 ## Usage
 
 ```bash

--- a/docs/src/content/docs/providers/vault.md
+++ b/docs/src/content/docs/providers/vault.md
@@ -44,6 +44,24 @@ $ secretspec check --provider vault://vault.example.com:8200/secret
 $ secretspec run --provider vault://vault.example.com:8200/secret -- npm start
 ```
 
+## Secret References
+
+By default each secret is stored at `secretspec/{project}/{profile}/{key}` under
+the mount, with a `value` field. A secret's
+[`ref`](/reference/configuration/#secret-references) field names an existing KV
+entry instead: `item` is the KV path relative to the mount, and `field` selects
+the field to read. `field` is required, since KV entries are maps. References
+are **read-only** in this provider.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "DB", ref = { item = "myapp/config", field = "db_url" }, providers = ["vault://vault.example.com:8200/secret"] }
+```
+
+The mount is not a ref coordinate: it comes from the provider URI (`secret` in
+the example above). To read one secret from a different mount, give that secret
+a `providers` entry with the mount in the URI.
+
 ## Usage
 
 ### Basic Commands

--- a/docs/src/content/docs/reference/adding-providers.md
+++ b/docs/src/content/docs/reference/adding-providers.md
@@ -5,16 +5,48 @@ description: Step-by-step guide for implementing custom provider backends
 
 ## Provider Trait
 
-All providers must implement the `Provider` trait:
+All providers must implement the `Provider` trait. Every operation names its
+secret with an `Address`: either the store's own coordinates (a secret's
+`ref`) or SecretSpec's `{project}/{profile}/{key}` naming convention, which
+your provider compiles into its native coordinates via `convention_address`:
 
 ```rust
 pub trait Provider: Send + Sync {
     fn name(&self) -> &'static str;
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<String>>;
-    fn set(&self, project: &str, key: &str, value: &str, profile: &str) -> Result<()>;
-    fn allows_set(&self) -> bool { true }  // Optional, defaults to true
+    fn uri(&self) -> String;
+
+    /// Compile SecretSpec's naming convention into the store's native
+    /// coordinates. The single owner of the provider's convention layout.
+    fn convention_address(&self, project: &str, profile: &str, key: &str)
+        -> Result<NativeAddress>;
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>>;
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()>;
+
+    /// Optional, defaults to empty. The `ref` coordinates your store can
+    /// honor beyond `item`; every other coordinate is rejected for you.
+    fn supported_coords(&self) -> &'static [&'static str] { &[] }
+
+    /// Optional, defaults to writable. Read-only providers reject every
+    /// address; providers whose refs name externally managed secrets reject
+    /// native addresses only. State the reason: it is what the user sees.
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> { Ok(()) }
+
+    /// Optional batch read. The default resolves each request's address and
+    /// fetches every unique address once, concurrently; override it when the
+    /// store has a real bulk surface (one listing, a batch API).
+    fn get_many(&self, requests: &[(&str, Address<'_>)])
+        -> Result<HashMap<String, SecretString>> { /* default */ }
 }
 ```
+
+Inside `get`/`set`, call `self.resolve_coords(addr)` to obtain the native
+coordinates for any address. It rejects any coordinate outside
+`supported_coords` (e.g. a `field` on a flat key/value store), so a `ref`
+written for another store fails loudly instead of resolving something else —
+you declare the set, you never write the check. Have `set` call
+`self.check_writable(addr)?` first, so the pre-check and the write agree on
+one refusal message.
 
 ## Implementation Steps
 
@@ -84,13 +116,27 @@ impl Provider for MyBackendProvider {
         Self::PROVIDER_NAME
     }
 
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<String>> {
-        // Implementation
+    fn uri(&self) -> String {
+        "mybackend".to_string()
+    }
+
+    fn convention_address(&self, project: &str, profile: &str, key: &str)
+        -> Result<NativeAddress> {
+        Ok(NativeAddress {
+            item: format!("secretspec/{}/{}/{}", project, profile, key),
+            ..Default::default()
+        })
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coords = self.resolve_coords(addr)?;
+        // Reject coordinates the store cannot honor, then read coords.item
         Ok(None)
     }
 
-    fn set(&self, project: &str, key: &str, value: &str, profile: &str) -> Result<()> {
-        // Implementation
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let coords = self.resolve_coords(addr)?;
+        // Write value at coords.item
         Ok(())
     }
 }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -78,14 +78,14 @@ secretspec config provider add <ALIAS> <URI>
 
 **Arguments:**
 - `<ALIAS>` - Short name for the provider (e.g., `prod_vault`, `shared`)
-- `<URI>` - Provider URI (e.g., `onepassword://vault/Production`, `env://`)
+- `<URI>` - Provider URI (e.g., `onepassword://Production`, `env://`)
 
 **Example:**
 ```bash
-$ secretspec config provider add prod_vault "onepassword://vault/Production"
+$ secretspec config provider add prod_vault "onepassword://Production"
 ✓ Provider alias 'prod_vault' saved
 
-$ secretspec config provider add shared "onepassword://vault/Shared"
+$ secretspec config provider add shared "onepassword://Shared"
 ✓ Provider alias 'shared' saved
 ```
 
@@ -99,8 +99,8 @@ secretspec config provider list
 **Example:**
 ```bash
 $ secretspec config provider list
-prod_vault  → onepassword://vault/Production
-shared      → onepassword://vault/Shared
+prod_vault  → onepassword://Production
+shared      → onepassword://Shared
 env         → env://
 ```
 
@@ -270,6 +270,16 @@ $ secretspec run --profile production -- npm run deploy
 # Verify secrets are injected
 $ secretspec run -- env | grep DATABASE_URL
 DATABASE_URL=postgresql://localhost/mydb
+```
+
+The `--provider` override applies to every secret, including those with a
+[`ref`](/reference/configuration/#secret-references) field: refs are redirected
+to the overriding provider just like convention secrets. This makes it easy to
+point refs at fixtures during tests without editing the manifest:
+
+```bash
+# Resolve every secret, refs included, from a fixtures file
+$ secretspec run --provider dotenv:.env.fixtures -- cargo test
 ```
 
 :::note[Shell Variable Expansion]

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -89,6 +89,7 @@ Each secret variable is defined as a table with the following fields:
 | `required` | boolean | No* | Whether the value must be provided (default: true) |
 | `default` | string | No** | Default value if not provided |
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
+| `ref` | table | No**** | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
 | `type` | string | No*** | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
 | `generate` | boolean or table | No*** | Enable auto-generation when secret is missing |
@@ -96,6 +97,7 @@ Each secret variable is defined as a table with the following fields:
 *If `default` is provided, `required` defaults to false
 **Only valid when `required = false`
 ***`type` is required when `generate` is enabled; `generate` and `default` cannot both be set
+****`ref` cannot be combined with `generate`; see [Secret References](#secret-references)
 
 ## Complete Example
 
@@ -108,8 +110,8 @@ extends = ["../shared/secretspec.toml"]  # Optional inheritance
 
 # Provider aliases used by profile provider chains
 [providers]
-prod_vault = "onepassword://vault/Production"
-shared_vault = "onepassword://vault/Shared"
+prod_vault = "onepassword://Production"
+shared_vault = "onepassword://Shared"
 keyring = "keyring://"
 env = "env://"
 
@@ -144,8 +146,8 @@ On conflict the project-level alias wins, so a stale local config cannot silentl
 
 ```toml title="secretspec.toml"
 [providers]
-prod_vault = "onepassword://vault/Production"
-shared_vault = "onepassword://vault/Shared"
+prod_vault = "onepassword://Production"
+shared_vault = "onepassword://Shared"
 keyring = "keyring://"
 env = "env://"
 
@@ -158,8 +160,8 @@ DATABASE_URL = { description = "Production DB", providers = ["prod_vault", "keyr
 provider = "keyring"
 
 [defaults.providers]
-prod_vault = "onepassword://vault/Production"
-shared_vault = "onepassword://vault/Shared"
+prod_vault = "onepassword://Production"
+shared_vault = "onepassword://Shared"
 keyring = "keyring://"
 env = "env://"
 ```
@@ -168,7 +170,7 @@ Manage user-level aliases via CLI:
 
 ```bash
 # Add a provider alias to your user config
-$ secretspec config provider add prod_vault "onepassword://vault/Production"
+$ secretspec config provider add prod_vault "onepassword://Production"
 
 # List all aliases known to your user config
 $ secretspec config provider list
@@ -220,6 +222,168 @@ GOOGLE_APPLICATION_CREDENTIALS = { description = "GCP service account", as_path 
 | CLI (`get`, `check`, `run`) | Files are persisted (not deleted after command exits) |
 | Rust SDK | Files cleaned up when `ValidatedSecrets` is dropped; use `keep_temp_files()` to persist |
 | Rust SDK types | `PathBuf` or `Option<PathBuf>` instead of `String` |
+
+### Secret References
+
+By default, SecretSpec names secrets in a provider's store by its own
+`{project}/{profile}/{key}` convention. The `ref` field replaces that naming for
+one secret with the store's own coordinates, so SecretSpec reads and writes a
+secret that already exists and is managed outside SecretSpec:
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "Postgres DSN", ref = { item = "db", field = "password" }, providers = ["prod_vault"] }
+INFRA_TOKEN  = { description = "Infra token", ref = { vault = "Production", item = "infra", field = "token" } }
+GITHUB_TOKEN = { description = "GitHub token", ref = { item = "GITHUB_PAT" }, providers = ["env"] }
+```
+
+`ref` is a table of provider-independent coordinates. Unknown keys are rejected
+at parse time.
+
+| Coordinate | Required | Meaning |
+|------------|----------|---------|
+| `item` | Yes | The store's complete name for the secret. Replaces the whole convention path |
+| `field` | No | A named component inside the item. Rejected by stores whose secrets hold a single value |
+| `vault` | No | The container holding the item. 1Password only; other stores take their container from the provider URI |
+| `section` | No | A named group of fields inside the item. 1Password only; requires `field` |
+| `version` | No | Which revision of the secret to read. Google Secret Manager only; defaults to the latest |
+
+#### What the coordinates mean
+
+The coordinates address one secret from the outside in. Each names a different
+level of the store's structure:
+
+```
+vault                which container holds the item        (1Password only)
+└── item             the store's own name for the secret   (always required)
+    └── section      a named group of fields               (1Password only)
+        └── field    one component inside the item         (structured stores)
+            └── version   which revision to read           (GCSM only)
+```
+
+Only `item` is universal. The others exist because some stores give a secret
+internal structure, or nest it inside a container.
+
+**`item` is the complete name, not a suffix.** It replaces the entire
+`{project}/{profile}/{key}` convention path, including any `folder_prefix` or
+format string the provider is configured with. Nothing is prepended:
+
+```toml
+# Reads the .env key TOTALLY_DIFFERENT_NAME.
+# Not secretspec/myapp/default/DATABASE_URL.
+DATABASE_URL = { description = "DB", ref = { item = "TOTALLY_DIFFERENT_NAME" }, providers = ["dotenv"] }
+```
+
+So whatever the store calls a secret's full name is what goes in `item`: a
+1Password item title, a Vault KV path (`myapp/config`), an AWS secret name or a
+complete ARN, a `pass` entry path (`email/work`), a GCSM secret id, a keyring
+service, a `.env` key, an environment variable name.
+
+**`field` addresses a component inside the item.** Stores fall into two groups:
+
+| Store | Shape of one secret | `field` |
+|-------|---------------------|---------|
+| dotenv, env, pass, LastPass, Proton Pass, Bitwarden | a single value | Rejected: there is nothing to select |
+| 1Password, Vault KV, AWS Secrets Manager, keyring | a record of named parts | Selects the part: field label, map key, JSON key, account |
+
+A coordinate a store has no equivalent for is **rejected with an error naming
+it**, never silently ignored. A ref written for 1Password fails loudly when
+routing points it at `pass`, instead of quietly reading the wrong secret.
+
+**`vault` is the only container coordinate.** Every store has some container: a
+1Password vault, a Vault mount, a GCSM project, an AWS region. For all of them
+except 1Password, the container is part of the *provider URI*, not the ref:
+
+```toml
+# The mount `kv2` comes from the URI; the ref names the path inside it.
+DB = { description = "DB", ref = { item = "myapp/config", field = "pw" }, providers = ["vault://vault.example.com:8200/kv2"] }
+
+# 1Password is the exception: `vault` on the ref overrides the URI's default vault.
+TOKEN = { description = "Token", ref = { vault = "Production", item = "infra", field = "token" }, providers = ["onepassword://Private"] }
+```
+
+To point one secret at a different mount, project, or region, give it a
+`providers` entry with that URI rather than reaching for a coordinate.
+
+#### Refs name, providers route
+
+A `ref` supplies naming only; it does not pin a store. Which provider resolves
+the coordinates follows the ordinary resolution order:
+
+1. An explicit `--provider` flag or `SECRETSPEC_PROVIDER` override
+2. The secret's `providers` fallback chain
+3. The profile's default providers (`[profiles.<name>.defaults]`)
+4. The global default provider
+
+`ref` therefore composes with `providers`: each provider in the chain is asked
+for the same coordinates, and a chain member that cannot interpret them warns
+and the chain continues. Chain entries may be aliases from the `[providers]`
+table or inline provider URIs:
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "Postgres DSN", ref = { item = "db", field = "password" }, providers = ["onepassword://Production", "keyring"] }
+```
+
+Because the store is not baked into the ref, the `--provider` override redirects
+ref secrets exactly like convention secrets. This makes fixtures trivial: point
+every ref at a `.env` file during tests without editing the manifest:
+
+```bash
+$ secretspec run --provider dotenv:.env.fixtures -- cargo test
+```
+
+#### How providers interpret the coordinates
+
+| Provider | `item` | `field` | Without `field` | Writes via ref |
+|----------|--------|---------|-----------------|----------------|
+| [OnePassword](/providers/onepassword/#secret-references) | Item title or UUID | Field label; `vault` and `section` also apply | Reads the item like a convention secret (its value or password field); writes edit the `value` field | ✅ via `op item edit` (adds a missing field, never creates items) |
+| [keyring](/providers/keyring/#secret-references) | Service | Account (defaults to the current system username) | Current user's entry | ✅ |
+| [dotenv](/providers/dotenv/#secret-references) | `.env` key | Rejected | Reads the key | ✅ |
+| [env](/providers/env/#secret-references) | Variable name | Rejected | Reads the variable | — (read-only) |
+| [pass](/providers/pass/#secret-references) | Entry path | Rejected | Reads the entry | ✅ |
+| [LastPass](/providers/lastpass/#secret-references) | Item name | Rejected | Reads the item | ✅ |
+| [Proton Pass](/providers/protonpass/#secret-references) | Item title | Rejected | Reads the note | ✅ |
+| [Vault / OpenBao](/providers/vault/#secret-references) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
+| [AWS Secrets Manager](/providers/awssm/#secret-references) | Secret name or ARN | JSON key | Whole secret string | — (read-only) |
+| [GCSM](/providers/gcsm/#secret-references) | Secret id; `version` also applies | Rejected | Reads latest or the pinned version | — (read-only) |
+| [Bitwarden (bws)](/providers/bws/#secret-references) | BWS key name | Rejected | Reads the key | ✅ |
+
+A provider rejects coordinates it has no equivalent for, with an error naming
+the coordinate (for example, `field` on the env provider).
+
+#### Writing through a ref
+
+Writes are symmetric with reads: `secretspec set` and interactive `check`
+prompting write through the coordinates in place wherever the table above says
+writes are supported. Read-only stores fail with a clear error instead.
+
+#### Combining with other fields
+
+`ref` cannot be combined with `generate`: a referenced secret is externally
+managed, not minted. It combines freely with `default`, `required`, and
+`as_path`.
+
+#### No string refs
+
+`ref` is always a table. String and URI forms (`ref = "op://vault/item/field"`,
+`ref = "env://VAR"`, query-parameter URIs, and similar) are rejected, and the
+error spells out the exact table translation. For example, a pasted 1Password
+reference `op://Production/infra/token` translates to:
+
+```toml
+INFRA_TOKEN = { description = "Infra token", ref = { vault = "Production", item = "infra", field = "token" }, providers = ["onepassword://Production"] }
+```
+
+Provider URIs stay store addresses only: `onepassword://Production` names a
+vault, and item paths on provider URIs are errors.
+
+#### Deduplication, auditing, and reporting
+
+- Secrets sharing identical coordinates and store are fetched once.
+- [Audit log](/concepts/audit/) events carry a `ref` field with the coordinates.
+- `check --explain` and `check --json` attribute ref secrets to the store URI
+  they resolved from.
 
 ### Secret Generation
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -89,7 +89,7 @@ Each secret variable is defined as a table with the following fields:
 | `required` | boolean | No* | Whether the value must be provided (default: true) |
 | `default` | string | No** | Default value if not provided |
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
-| `ref` | table | No**** | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
+| `ref` | table | No | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
 | `type` | string | No*** | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
 | `generate` | boolean or table | No*** | Enable auto-generation when secret is missing |
@@ -97,7 +97,6 @@ Each secret variable is defined as a table with the following fields:
 *If `default` is provided, `required` defaults to false
 **Only valid when `required = false`
 ***`type` is required when `generate` is enabled; `generate` and `default` cannot both be set
-****`ref` cannot be combined with `generate`; see [Secret References](#secret-references)
 
 ## Complete Example
 
@@ -298,12 +297,6 @@ the coordinate (for example, `field` on the env provider).
 Writes are symmetric with reads: `secretspec set` and interactive `check`
 prompting write through the coordinates in place wherever the table above says
 writes are supported. Read-only stores fail with a clear error instead.
-
-#### Combining with other fields
-
-`ref` cannot be combined with `generate`: a referenced secret is externally
-managed, not minted. It combines freely with `default`, `required`, and
-`as_path`.
 
 #### No string refs
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -225,10 +225,10 @@ GOOGLE_APPLICATION_CREDENTIALS = { description = "GCP service account", as_path 
 
 ### Secret References
 
-By default, SecretSpec names secrets in a provider's store by its own
-`{project}/{profile}/{key}` convention. The `ref` field replaces that naming for
-one secret with the store's own coordinates, so SecretSpec reads and writes a
-secret that already exists and is managed outside SecretSpec:
+The `ref` field names one externally managed secret by the store's own
+coordinates, instead of SecretSpec's `{project}/{profile}/{key}` convention. See
+[Secret References](/concepts/references/) for the concept, model, and examples;
+this section is the specification.
 
 ```toml
 [profiles.production]
@@ -238,7 +238,11 @@ GITHUB_TOKEN = { description = "GitHub token", ref = { item = "GITHUB_PAT" }, pr
 ```
 
 `ref` is a table of provider-independent coordinates. Unknown keys are rejected
-at parse time.
+at parse time. Only `item` is universal; it is the secret's complete name in the
+store and replaces the whole convention path, including any `folder_prefix` or
+format string the provider is configured with (nothing is prepended). A
+coordinate a store has no equivalent for is rejected with an error naming it,
+never silently ignored.
 
 | Coordinate | Required | Meaning |
 |------------|----------|---------|
@@ -248,90 +252,27 @@ at parse time.
 | `section` | No | A named group of fields inside the item. 1Password only; requires `field` |
 | `version` | No | Which revision of the secret to read. Google Secret Manager only; defaults to the latest |
 
-#### What the coordinates mean
-
-The coordinates address one secret from the outside in. Each names a different
-level of the store's structure:
-
-```
-vault                which container holds the item        (1Password only)
-└── item             the store's own name for the secret   (always required)
-    └── section      a named group of fields               (1Password only)
-        └── field    one component inside the item         (structured stores)
-            └── version   which revision to read           (GCSM only)
-```
-
-Only `item` is universal. The others exist because some stores give a secret
-internal structure, or nest it inside a container.
-
-**`item` is the complete name, not a suffix.** It replaces the entire
-`{project}/{profile}/{key}` convention path, including any `folder_prefix` or
-format string the provider is configured with. Nothing is prepended:
-
-```toml
-# Reads the .env key TOTALLY_DIFFERENT_NAME.
-# Not secretspec/myapp/default/DATABASE_URL.
-DATABASE_URL = { description = "DB", ref = { item = "TOTALLY_DIFFERENT_NAME" }, providers = ["dotenv"] }
-```
-
-So whatever the store calls a secret's full name is what goes in `item`: a
-1Password item title, a Vault KV path (`myapp/config`), an AWS secret name or a
-complete ARN, a `pass` entry path (`email/work`), a GCSM secret id, a keyring
-service, a `.env` key, an environment variable name.
-
-**`field` addresses a component inside the item.** Stores fall into two groups:
+Stores fall into two groups for `field`:
 
 | Store | Shape of one secret | `field` |
 |-------|---------------------|---------|
 | dotenv, env, pass, LastPass, Proton Pass, Bitwarden | a single value | Rejected: there is nothing to select |
 | 1Password, Vault KV, AWS Secrets Manager, keyring | a record of named parts | Selects the part: field label, map key, JSON key, account |
 
-A coordinate a store has no equivalent for is **rejected with an error naming
-it**, never silently ignored. A ref written for 1Password fails loudly when
-routing points it at `pass`, instead of quietly reading the wrong secret.
-
-**`vault` is the only container coordinate.** Every store has some container: a
-1Password vault, a Vault mount, a GCSM project, an AWS region. For all of them
-except 1Password, the container is part of the *provider URI*, not the ref:
+`vault` is the only container coordinate. For every store except 1Password the
+container is part of the provider URI, not the ref:
 
 ```toml
 # The mount `kv2` comes from the URI; the ref names the path inside it.
 DB = { description = "DB", ref = { item = "myapp/config", field = "pw" }, providers = ["vault://vault.example.com:8200/kv2"] }
 
-# 1Password is the exception: `vault` on the ref overrides the URI's default vault.
+# 1Password: `vault` on the ref overrides the URI's default vault.
 TOKEN = { description = "Token", ref = { vault = "Production", item = "infra", field = "token" }, providers = ["onepassword://Private"] }
 ```
 
-To point one secret at a different mount, project, or region, give it a
-`providers` entry with that URI rather than reaching for a coordinate.
-
-#### Refs name, providers route
-
-A `ref` supplies naming only; it does not pin a store. Which provider resolves
-the coordinates follows the ordinary resolution order:
-
-1. An explicit `--provider` flag or `SECRETSPEC_PROVIDER` override
-2. The secret's `providers` fallback chain
-3. The profile's default providers (`[profiles.<name>.defaults]`)
-4. The global default provider
-
-`ref` therefore composes with `providers`: each provider in the chain is asked
-for the same coordinates, and a chain member that cannot interpret them warns
-and the chain continues. Chain entries may be aliases from the `[providers]`
-table or inline provider URIs:
-
-```toml
-[profiles.production]
-DATABASE_URL = { description = "Postgres DSN", ref = { item = "db", field = "password" }, providers = ["onepassword://Production", "keyring"] }
-```
-
-Because the store is not baked into the ref, the `--provider` override redirects
-ref secrets exactly like convention secrets. This makes fixtures trivial: point
-every ref at a `.env` file during tests without editing the manifest:
-
-```bash
-$ secretspec run --provider dotenv:.env.fixtures -- cargo test
-```
+Which provider resolves a `ref` follows the ordinary [provider resolution
+order](/concepts/providers/); a `ref` composes with the `providers` fallback
+chain, and each provider is asked for the same coordinates.
 
 #### How providers interpret the coordinates
 

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -66,6 +66,11 @@ onepassword+token://user:op_token@SecureVault   # Service account
 **Prerequisites**: `op` CLI, authenticated with `op signin`
 **Storage**: Item name `{project}/{key}`, tags `automated`, `{project}`
 
+The URI names a vault only; item paths on the URI are rejected. To read and
+write an existing item's field in place, name it with the `ref` field
+(`SECRET = { description = "…", ref = { item = "…", field = "…" } }`); see
+[Secret References](/reference/configuration/#secret-references).
+
 ## Pass Provider
 
 **URI**: `pass://` - Uses Unix password manager with GPG encryption

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -386,7 +386,7 @@ println!("{}", s.secrets.database_url);</code></pre>
           <span class="landing-terminal-title">secretspec.toml</span>
         </div>
         <pre is:raw class="landing-terminal-body"><code><span class="tok-sec">[providers]</span>
-<span class="tok-key">team_vault</span> <span class="tok-pun">=</span> <span class="tok-str">"onepassword://vault/Shared"</span>
+<span class="tok-key">team_vault</span> <span class="tok-pun">=</span> <span class="tok-str">"onepassword://Shared"</span>
 <span class="tok-key">keyring</span>    <span class="tok-pun">=</span> <span class="tok-str">"keyring://"</span>
 <span class="tok-key">env</span>        <span class="tok-pun">=</span> <span class="tok-str">"env://"</span>
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -413,6 +413,47 @@ println!("{}", s.secrets.database_url);</code></pre>
   </div>
 </section>
 
+<!-- ============ SHOWCASE: secret references ============ -->
+<section class="landing-showcase">
+  <div class="landing-container">
+    <div class="landing-showcase-head">
+      <span class="landing-showcase-eyebrow">Secret references</span>
+      <h2 class="landing-section-title">Name it once. Point it anywhere.</h2>
+      <p class="landing-section-lead landing-section-lead-narrow">
+        Already managing a secret in 1Password, Vault, or a <code class="inline-code">.env</code> file? Point at it by the store's own coordinates with <code class="inline-code">ref</code>. No renaming, no copying it into SecretSpec's own layout. <a href="/concepts/references/" class="landing-link">How references work →</a>
+      </p>
+    </div>
+
+    <div class="landing-fallback">
+      <div class="landing-terminal">
+        <div class="landing-terminal-header">
+          <div class="landing-terminal-dots"><span></span><span></span><span></span></div>
+          <span class="landing-terminal-title">secretspec.toml</span>
+        </div>
+        <pre is:raw class="landing-terminal-body"><code><span class="tok-sec">[profiles.production]</span>
+<span class="tok-com"># Point at a secret that already lives in your store</span>
+<span class="tok-key">DATABASE_URL</span> <span class="tok-pun">= {</span>
+  <span class="tok-key">description</span> <span class="tok-pun">=</span> <span class="tok-str">"Postgres DSN"</span><span class="tok-pun">,</span>
+  <span class="tok-key">ref</span> <span class="tok-pun">= {</span> <span class="tok-key">item</span> <span class="tok-pun">=</span> <span class="tok-str">"db"</span><span class="tok-pun">,</span> <span class="tok-key">field</span> <span class="tok-pun">=</span> <span class="tok-str">"password"</span> <span class="tok-pun">}</span>
+<span class="tok-pun">}</span></code></pre>
+      </div>
+
+      <div class="landing-chain">
+        <div class="landing-chain-step">
+          <span aria-hidden="true">🧭</span>
+          <span>A <code>ref</code> names the store's own coordinates: <code>item</code> plus an optional <code>field</code></span>
+        </div>
+        <div class="landing-chain-arrow" aria-hidden="true">↓ resolves through</div>
+        <div class="landing-chain-step is-hit">
+          <span aria-hidden="true">🔀</span>
+          <span>The same coordinates work in <strong>1Password</strong>, <strong>Vault</strong>, <strong>keyring</strong>, or <strong>.env</strong></span>
+        </div>
+        <p class="landing-chain-result">Point at secrets you already have. Switch stores without editing the ref.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- ============ SHOWCASE: audit & agent reason ============ -->
 <section class="landing-showcase">
   <div class="landing-container">

--- a/secretspec-go/codegen_test.go
+++ b/secretspec-go/codegen_test.go
@@ -70,8 +70,8 @@ name = "go-codegen"
 revision = "1.0"
 
 [profiles.default]
-DATABASE_URL = { required = true }
-LOG_LEVEL = { required = false, default = "info" }
+DATABASE_URL = { description = "Database connection URL", required = true }
+LOG_LEVEL = { description = "Log verbosity", required = false, default = "info" }
 `), 0o600)
 	os.WriteFile(env, []byte("DATABASE_URL=postgres://db\n"), 0o600)
 

--- a/secretspec-hs/test/Main.hs
+++ b/secretspec-hs/test/Main.hs
@@ -122,8 +122,8 @@ runCodegen bin = do
       , "revision = \"1.0\""
       , ""
       , "[profiles.default]"
-      , "DATABASE_URL = { required = true }"
-      , "LOG_LEVEL = { required = false, default = \"info\" }"
+      , "DATABASE_URL = { description = \"DB\", required = true }"
+      , "LOG_LEVEL = { description = \"log\", required = false, default = \"info\" }"
       ]
   writeFile (dir </> ".env") "DATABASE_URL=postgres://db\n"
 

--- a/secretspec-node/test/codegen.test.js
+++ b/secretspec-node/test/codegen.test.js
@@ -44,9 +44,9 @@ name = "node-codegen"
 revision = "1.0"
 
 [profiles.default]
-DATABASE_URL = { required = true }
-LOG_LEVEL = { required = false, default = "info" }
-SENTRY_DSN = { required = false }
+DATABASE_URL = { description = "DB", required = true }
+LOG_LEVEL = { description = "log", required = false, default = "info" }
+SENTRY_DSN = { description = "sentry", required = false }
 `;
 
 test('quicktype-generated converter consumes fieldsJson()', { skip: !hasNpx() }, () => {

--- a/secretspec-rb/test/test_codegen.rb
+++ b/secretspec-rb/test/test_codegen.rb
@@ -46,8 +46,8 @@ class CodegenTest < Minitest::Test
         revision = "1.0"
 
         [profiles.default]
-        DATABASE_URL = { required = true }
-        LOG_LEVEL = { required = false, default = "info" }
+        DATABASE_URL = { description = "DB", required = true }
+        LOG_LEVEL = { description = "log", required = false, default = "info" }
       TOML
       File.write(env_path, "DATABASE_URL=postgres://db\n")
 

--- a/secretspec/src/audit.rs
+++ b/secretspec/src/audit.rs
@@ -119,6 +119,10 @@ pub(crate) struct AuditContext<'a> {
     /// The provider URI that served (or was consulted for) the access. Redacted
     /// before it is written.
     pub provider_uri: Option<String>,
+    /// Canonical rendering of the secret's native `ref` coordinates, when the
+    /// access resolved one (e.g. `item=db field=password`). Keeps per-address
+    /// granularity now that `provider` names only the store.
+    pub reference: Option<String>,
     pub outcome: AuditOutcome,
     pub error_kind: Option<&'a str>,
     pub reason: Option<&'a str>,
@@ -151,6 +155,9 @@ struct AuditEvent<'a> {
     /// Redacted provider URI.
     #[serde(skip_serializing_if = "Option::is_none")]
     provider: Option<String>,
+    /// Canonical rendering of the native `ref` coordinates, if any.
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+    reference: Option<&'a str>,
     outcome: AuditOutcome,
     #[serde(skip_serializing_if = "Option::is_none")]
     error_kind: Option<&'a str>,
@@ -377,6 +384,7 @@ impl AuditLogger {
             keys: ctx.keys,
             command: ctx.command,
             provider: ctx.provider_uri.as_deref().map(redact_uri),
+            reference: ctx.reference.as_deref(),
             outcome: ctx.outcome,
             error_kind: ctx.error_kind,
             reason: ctx.reason,
@@ -621,6 +629,7 @@ mod tests {
                 keys: &[],
                 command: None,
                 provider_uri: Some("vault://user:s3cr3t@host/kv".to_string()),
+                reference: None,
                 outcome: AuditOutcome::Found,
                 error_kind: None,
                 reason: Some("deploy web frontend"),
@@ -662,6 +671,7 @@ mod tests {
                 keys: &keys,
                 command: Some("./deploy.sh"),
                 provider_uri: None,
+                reference: None,
                 outcome: AuditOutcome::Found,
                 error_kind: None,
                 reason: None,
@@ -692,6 +702,7 @@ mod tests {
                     keys: &[],
                     command: None,
                     provider_uri: None,
+                    reference: None,
                     outcome: AuditOutcome::Written,
                     error_kind: None,
                     reason: None,
@@ -848,6 +859,7 @@ mod tests {
                 keys: &[],
                 command: None,
                 provider_uri: None,
+                reference: None,
                 outcome: AuditOutcome::Found,
                 error_kind: None,
                 reason: None,

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -171,7 +171,7 @@ enum ProviderAction {
     Add {
         /// Name of the provider alias
         name: String,
-        /// Provider URI (e.g., "keyring://", "onepassword://vault/Shared", "dotenv://.env.local")
+        /// Provider URI (e.g., "keyring://", "onepassword://Shared", "dotenv://.env.local")
         uri: String,
     },
     /// Remove a provider alias

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -613,6 +613,218 @@ pub struct GenerateOptions {
     pub bits: Option<usize>,
 }
 
+/// Native coordinates of one externally managed secret: the value of a
+/// secret's `ref` field.
+///
+/// The coordinates carry naming only; *routing* (which store to consult) stays
+/// with the ordinary provider resolution (`providers` chains, `--provider`
+/// override, defaults). Each provider translates the coordinates into its own
+/// namespace — the 1Password item title, the Vault KV path plus field, the AWS
+/// secret name plus JSON key, the `.env` key — and rejects coordinates it has
+/// no equivalent for, so the same `ref` re-resolves against whichever store
+/// routing selects.
+///
+/// The coordinates are *not* uniformly provider-independent, and this type does
+/// not pretend they are:
+///
+/// - `item` (required) and `field` are shared vocabulary every relevant store
+///   maps: a name, and an optional component within it.
+/// - `vault`, `section` (1Password), and `version` (GCSM) are coordinates only
+///   some stores have an equivalent for. Each is named for the concept, not the
+///   vendor, so another store can adopt one by adding it to its
+///   [`supported_coords`](crate::provider::Provider::supported_coords); a store
+///   that has not rejects it rather than guessing. They are deliberately *not*
+///   collapsed into one generalized coordinate: a 1Password vault (a per-secret
+///   naming axis) and a Vault mount (set-once connection topology, whose
+///   per-secret hierarchy already lives in `item`) are different concepts and
+///   should not be forced to look alike. A store whose container is genuinely
+///   connection-level (a Vault mount, a GCSM project, an AWS region) takes it
+///   from the provider URI instead.
+///
+/// Unknown TOML keys are rejected at parse time.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize)]
+pub struct NativeAddress {
+    /// The store's own name for the secret: item title (1Password, Proton
+    /// Pass, LastPass), entry path (pass), KV path (Vault), secret name/ARN
+    /// (AWS), secret id (GCSM), key name (BWS, dotenv), variable name (env),
+    /// service (keyring).
+    pub item: String,
+    /// A component within the item: field label (1Password), KV field
+    /// (Vault), JSON key (AWS), account (keyring). Providers whose secrets
+    /// have no sub-components reject it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// 1Password only: the vault holding the item, overriding the store's
+    /// default vault for this secret.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vault: Option<String>,
+    /// 1Password only: the section containing the field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    /// GCSM only: the secret version to read; defaults to the latest.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+impl NativeAddress {
+    /// Every coordinate name paired with its value, outer scope first. The
+    /// single enumeration that the renderer, the validator, and the
+    /// provider-side coordinate rejection all consume, so a new coordinate
+    /// cannot be added to one and silently missed by the others.
+    pub(crate) fn coordinates(&self) -> [(&'static str, Option<&str>); 5] {
+        [
+            ("vault", self.vault.as_deref()),
+            ("item", Some(self.item.as_str())),
+            ("section", self.section.as_deref()),
+            ("field", self.field.as_deref()),
+            ("version", self.version.as_deref()),
+        ]
+    }
+
+    /// Canonical single-line rendering for logs and audit events, outer scope
+    /// first: `vault=Production item=db field=password`. Only present
+    /// coordinates appear.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        for (name, value) in self.coordinates() {
+            if let Some(value) = value {
+                if !out.is_empty() {
+                    out.push(' ');
+                }
+                out.push_str(name);
+                out.push('=');
+                out.push_str(value);
+            }
+        }
+        out
+    }
+}
+
+/// Derived deserialization target for [`NativeAddress`]. The manual
+/// [`Deserialize`] below delegates table input here so serde's precise
+/// `deny_unknown_fields` messages ("unknown field \`filed\`, expected one of
+/// ...") survive, while string input gets a translation hint instead of the
+/// useless "invalid type" default.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativeAddressFields {
+    item: String,
+    field: Option<String>,
+    vault: Option<String>,
+    section: Option<String>,
+    version: Option<String>,
+}
+
+impl From<NativeAddressFields> for NativeAddress {
+    fn from(f: NativeAddressFields) -> Self {
+        NativeAddress {
+            item: f.item,
+            field: f.field,
+            vault: f.vault,
+            section: f.section,
+            version: f.version,
+        }
+    }
+}
+
+/// Renders the `ref = { ... }` TOML inline table used by the error hints that
+/// translate a rejected provider-URI address into the exact table to write.
+/// Shared by the string-`ref` deserialization hint below and by every provider
+/// that rejects a URI-embedded address, so the renderings cannot drift.
+pub(crate) fn ref_table_hint(
+    vault: Option<&str>,
+    item: &str,
+    section: Option<&str>,
+    field: Option<&str>,
+) -> String {
+    let coords = NativeAddress {
+        item: item.to_string(),
+        field: field.map(str::to_string),
+        vault: vault.map(str::to_string),
+        section: section.map(str::to_string),
+        version: None,
+    };
+    let rendered: Vec<String> = coords
+        .coordinates()
+        .into_iter()
+        .filter_map(|(name, value)| value.map(|v| format!("{name} = \"{v}\"")))
+        .collect();
+    format!("ref = {{ {} }}", rendered.join(", "))
+}
+
+/// The error shown when `ref` is written as a string. Earlier iterations of
+/// the feature accepted provider URIs here, so pasted `op://vault/item/field`
+/// strings are the expected mistake: translate the common shapes into the
+/// exact table to write.
+fn ref_string_hint(s: &str) -> String {
+    if let Some(rest) = s.strip_prefix("op://") {
+        let segments: Vec<&str> = rest.split('/').collect();
+        match segments[..] {
+            [vault, item, field] if !vault.is_empty() && !item.is_empty() && !field.is_empty() => {
+                return format!(
+                    "`ref` takes a table of coordinates, not a URI. Use: {}",
+                    ref_table_hint(Some(vault), item, None, Some(field))
+                );
+            }
+            [vault, item, section, field]
+                if !vault.is_empty()
+                    && !item.is_empty()
+                    && !section.is_empty()
+                    && !field.is_empty() =>
+            {
+                return format!(
+                    "`ref` takes a table of coordinates, not a URI. Use: {}",
+                    ref_table_hint(Some(vault), item, Some(section), Some(field))
+                );
+            }
+            _ => {}
+        }
+    }
+    format!(
+        "`ref` takes a table of native secret coordinates, not a string: got '{s}'. \
+         Write e.g. {}; which store resolves \
+         the coordinates comes from `providers` (or the default provider).",
+        ref_table_hint(None, "db", None, Some("password"))
+    )
+}
+
+impl<'de> Deserialize<'de> for NativeAddress {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct AddressVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for AddressVisitor {
+            type Value = NativeAddress;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(
+                    f,
+                    "a table of native secret coordinates like {{ item = \"db\", field = \"password\" }}"
+                )
+            }
+
+            fn visit_map<A>(self, map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                NativeAddressFields::deserialize(serde::de::value::MapAccessDeserializer::new(map))
+                    .map(NativeAddress::from)
+            }
+
+            fn visit_str<E>(self, s: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Err(E::custom(ref_string_hint(s)))
+            }
+        }
+
+        deserializer.deserialize_any(AddressVisitor)
+    }
+}
+
 /// Configuration for an individual secret.
 ///
 /// Defines the properties of a secret including its documentation,
@@ -636,6 +848,19 @@ pub struct Secret {
     /// Example: providers = ["keyring", "env"] will try keyring first, then env.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub providers: Option<Vec<String>>,
+    /// Native coordinates naming one externally managed secret (see
+    /// [`NativeAddress`]): `ref = { item = "db", field = "password" }`.
+    ///
+    /// The coordinates supply *naming only*, replacing SecretSpec's own
+    /// `{project}/{profile}/{key}` scheme for this secret. Which store
+    /// resolves them follows ordinary provider resolution — the secret's
+    /// `providers` chain, the `--provider` override, or the default provider —
+    /// so the same `ref` can be re-routed (e.g. at a fixtures store during
+    /// tests) without editing it, and composes with `providers`. Cannot be
+    /// combined with `generate` (a referenced secret is externally managed,
+    /// not minted). Serialized as `ref` in TOML.
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+    pub reference: Option<NativeAddress>,
     /// Whether to write the secret value to a temporary file and return the path.
     /// If true, the secret will be written to a temporary file and the field
     /// will contain the path to that file instead of the secret value.
@@ -667,6 +892,26 @@ impl Secret {
         // If required is explicitly true and default is set, that's an error
         if self.required == Some(true) && self.default.is_some() {
             return Err("Required secrets cannot have default values".into());
+        }
+
+        // A `ref` supplies naming only, so it composes with `providers`
+        // routing; `generate` stays incompatible (a referenced secret is
+        // externally managed, not minted).
+        if let Some(reference) = &self.reference {
+            if self.generate.as_ref().is_some_and(|g| g.is_enabled()) {
+                return Err("`ref` and `generate` cannot both be set".into());
+            }
+            // `coordinates()` yields `item` too, so this covers the required
+            // coordinate as well as the optional ones. Whitespace-only is a
+            // typo, not a name: no store has a secret titled "   ".
+            for (name, value) in reference.coordinates() {
+                if value.is_some_and(|v| v.trim().is_empty()) {
+                    return Err(format!(
+                        "`ref` coordinate `{}` cannot be empty or whitespace",
+                        name
+                    ));
+                }
+            }
         }
 
         // Validate generate config
@@ -780,7 +1025,7 @@ pub struct GlobalDefaults {
     /// provider details in secretspec.toml. Example user config:
     /// ```toml
     /// [defaults.providers]
-    /// shared = "onepassword://vault/Shared"
+    /// shared = "onepassword://Shared"
     /// local = "dotenv://.env.local"
     /// ```
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1395,6 +1640,196 @@ mod validation_tests {
             s.validate()
                 .unwrap_err()
                 .contains("requires generate = { command")
+        );
+    }
+
+    /// Shorthand for a native address in tests.
+    fn addr(item: &str, field: Option<&str>) -> NativeAddress {
+        NativeAddress {
+            item: item.to_string(),
+            field: field.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn secret_validate_accepts_reference() {
+        let s = Secret {
+            description: Some("Sentry DSN".to_string()),
+            reference: Some(addr("shared", Some("SENTRY_DSN"))),
+            ..Default::default()
+        };
+        assert!(s.validate().is_ok());
+    }
+
+    /// A `ref` supplies naming and `providers` supplies routing; they compose.
+    #[test]
+    fn secret_validate_accepts_ref_with_providers() {
+        let s = Secret {
+            description: Some("d".to_string()),
+            reference: Some(addr("db", Some("password"))),
+            providers: Some(vec!["keyring".to_string()]),
+            ..Default::default()
+        };
+        assert!(s.validate().is_ok());
+    }
+
+    #[test]
+    fn secret_validate_rejects_ref_with_generate() {
+        let s = Secret {
+            description: Some("d".to_string()),
+            reference: Some(addr("db", Some("password"))),
+            secret_type: Some("password".to_string()),
+            generate: Some(GenerateConfig::Bool(true)),
+            ..Default::default()
+        };
+        assert!(
+            s.validate()
+                .unwrap_err()
+                .contains("`ref` and `generate` cannot both be set")
+        );
+    }
+
+    #[test]
+    fn secret_validate_rejects_empty_ref_coordinates() {
+        let s = Secret {
+            description: Some("d".to_string()),
+            reference: Some(addr("", None)),
+            ..Default::default()
+        };
+        assert!(s.validate().unwrap_err().contains("`item` cannot be empty"));
+
+        let s = Secret {
+            description: Some("d".to_string()),
+            reference: Some(addr("db", Some(""))),
+            ..Default::default()
+        };
+        assert!(
+            s.validate()
+                .unwrap_err()
+                .contains("`field` cannot be empty")
+        );
+
+        // Whitespace-only is the same typo as empty: no store names a secret
+        // "   ", and an unrejected one resolves against the store verbatim.
+        for blank in ["   ", "\t", "\n"] {
+            let s = Secret {
+                description: Some("d".to_string()),
+                reference: Some(addr(blank, None)),
+                ..Default::default()
+            };
+            assert!(
+                s.validate().unwrap_err().contains("`item` cannot be empty"),
+                "item {blank:?} should be rejected"
+            );
+
+            let s = Secret {
+                description: Some("d".to_string()),
+                reference: Some(addr("db", Some(blank))),
+                ..Default::default()
+            };
+            assert!(
+                s.validate()
+                    .unwrap_err()
+                    .contains("`field` cannot be empty"),
+                "field {blank:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn secret_reference_round_trips_as_ref_in_toml() {
+        // The field is `reference` in Rust but `ref` in TOML, and is omitted
+        // when unset so `secretspec config`/init output stays clean.
+        let s = Secret {
+            description: Some("d".to_string()),
+            reference: Some(NativeAddress {
+                item: "db".to_string(),
+                field: Some("password".to_string()),
+                vault: Some("Production".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let toml = toml::to_string(&s).unwrap();
+        assert!(toml.contains("item = \"db\""), "{toml}");
+        let parsed = toml::from_str::<Secret>(&toml).unwrap();
+        assert_eq!(parsed.reference, s.reference);
+
+        let toml = toml::to_string(&Secret {
+            description: Some("d".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert!(!toml.contains("ref"));
+    }
+
+    /// All coordinate keys parse from the inline table form.
+    #[test]
+    fn ref_table_parses_every_coordinate() {
+        let s: Secret = toml::from_str(
+            r#"description = "d"
+ref = { vault = "Production", item = "db", section = "api", field = "password", version = "3" }"#,
+        )
+        .unwrap();
+        let reference = s.reference.unwrap();
+        assert_eq!(reference.vault.as_deref(), Some("Production"));
+        assert_eq!(reference.item, "db");
+        assert_eq!(reference.section.as_deref(), Some("api"));
+        assert_eq!(reference.field.as_deref(), Some("password"));
+        assert_eq!(reference.version.as_deref(), Some("3"));
+    }
+
+    /// A misspelled coordinate fails with serde's precise unknown-field
+    /// message rather than an opaque untagged-enum error.
+    #[test]
+    fn ref_table_rejects_unknown_keys() {
+        let err = toml::from_str::<Secret>(
+            r#"description = "d"
+ref = { item = "db", filed = "password" }"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown field `filed`"), "{err}");
+    }
+
+    /// A string `ref` (the shape earlier iterations accepted) errors with the
+    /// exact table translation for the common `op://` paste.
+    #[test]
+    fn ref_string_gets_translation_hint() {
+        let err = toml::from_str::<Secret>(
+            r#"description = "d"
+ref = "op://Production/db/password""#,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ref = { vault = \"Production\", item = \"db\", field = \"password\" }"),
+            "{msg}"
+        );
+
+        let err = toml::from_str::<Secret>(
+            r#"description = "d"
+ref = "just-a-string""#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("table of native secret coordinates"),
+            "{err}"
+        );
+    }
+
+    /// A non-string, non-table value reports the expected shape.
+    #[test]
+    fn ref_wrong_type_reports_expected_shape() {
+        let err = toml::from_str::<Secret>(
+            r#"description = "d"
+ref = 3"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("native secret coordinates"),
+            "{err}"
         );
     }
 

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -856,9 +856,9 @@ pub struct Secret {
     /// resolves them follows ordinary provider resolution — the secret's
     /// `providers` chain, the `--provider` override, or the default provider —
     /// so the same `ref` can be re-routed (e.g. at a fixtures store during
-    /// tests) without editing it, and composes with `providers`. Cannot be
-    /// combined with `generate` (a referenced secret is externally managed,
-    /// not minted). Serialized as `ref` in TOML.
+    /// tests) without editing it, and composes with `providers`. Also composes
+    /// with `generate`: a missing referenced secret is minted and written to
+    /// its coordinates. Serialized as `ref` in TOML.
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<NativeAddress>,
     /// Whether to write the secret value to a temporary file and return the path.
@@ -894,13 +894,10 @@ impl Secret {
             return Err("Required secrets cannot have default values".into());
         }
 
-        // A `ref` supplies naming only, so it composes with `providers`
-        // routing; `generate` stays incompatible (a referenced secret is
-        // externally managed, not minted).
+        // A `ref` supplies naming only: it composes with `providers` routing
+        // and with `generate` (a missing referenced secret is minted and
+        // written to its coordinates, like any other generated value).
         if let Some(reference) = &self.reference {
-            if self.generate.as_ref().is_some_and(|g| g.is_enabled()) {
-                return Err("`ref` and `generate` cannot both be set".into());
-            }
             // `coordinates()` yields `item` too, so this covers the required
             // coordinate as well as the optional ones. Whitespace-only is a
             // typo, not a name: no store has a secret titled "   ".
@@ -1675,7 +1672,9 @@ mod validation_tests {
     }
 
     #[test]
-    fn secret_validate_rejects_ref_with_generate() {
+    fn secret_validate_allows_ref_with_generate() {
+        // `ref` names where the secret lives; `generate` mints an initial
+        // value and sets it there when missing. The two compose.
         let s = Secret {
             description: Some("d".to_string()),
             reference: Some(addr("db", Some("password"))),
@@ -1683,11 +1682,7 @@ mod validation_tests {
             generate: Some(GenerateConfig::Bool(true)),
             ..Default::default()
         };
-        assert!(
-            s.validate()
-                .unwrap_err()
-                .contains("`ref` and `generate` cannot both be set")
-        );
+        assert!(s.validate().is_ok());
     }
 
     #[test]

--- a/secretspec/src/provider/awssm.rs
+++ b/secretspec/src/provider/awssm.rs
@@ -36,7 +36,7 @@
 //! secretspec check --provider awssm://production@us-east-1
 //! ```
 
-use super::{Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use aws_sdk_secretsmanager::Client;
 use secrecy::{ExposeSecret, SecretString};
@@ -83,6 +83,19 @@ impl TryFrom<&ProviderUrl> for AwssmConfig {
         let region = url.host().filter(|s| !s.is_empty());
 
         let prefix = url.query_value("prefix");
+
+        // The path reference form from earlier iterations is rejected with a
+        // pointer at the `ref` table, instead of being silently ignored and
+        // reading the conventional layout.
+        let name = url.path().trim_start_matches('/').to_string();
+        if !name.is_empty() {
+            let hint = crate::config::ref_table_hint(None, &name, None, None);
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "awssm URIs take no path: address the secret with \
+                 {hint} on the secret instead \
+                 (add field = \"<json-key>\" to extract one JSON key)"
+            )));
+        }
 
         Ok(Self {
             region,
@@ -172,81 +185,79 @@ impl AwssmProvider {
         Ok(Client::new(&sdk_config))
     }
 
-    /// Retrieves a secret value from AWS Secrets Manager.
-    async fn get_secret_async(
-        &self,
-        project: &str,
-        key: &str,
-        profile: &str,
-    ) -> Result<Option<SecretString>> {
-        let secret_name =
-            Self::format_secret_name(self.config.prefix.as_deref(), project, profile, key)?;
-        let client = self.create_client().await?;
+    /// Extracts one key from a JSON secret value.
+    fn extract_json_key(name: &str, value: &str, json_key: &str) -> Result<Option<SecretString>> {
+        let json: serde_json::Value = serde_json::from_str(value).map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "secret '{}' is not JSON, cannot extract key '{}': {}",
+                name, json_key, e
+            ))
+        })?;
+        match json.get(json_key) {
+            Some(serde_json::Value::String(s)) => Ok(Some(SecretString::new(s.clone().into()))),
+            // Non-string JSON values (numbers, bools) are rendered as-is.
+            Some(other) => Ok(Some(SecretString::new(other.to_string().into()))),
+            None => Ok(None),
+        }
+    }
 
-        match client
-            .get_secret_value()
-            .secret_id(&secret_name)
-            .send()
-            .await
-        {
-            Ok(output) => {
-                if let Some(value) = output.secret_string() {
-                    Ok(Some(SecretString::new(value.to_string().into())))
-                } else {
-                    Ok(None)
-                }
-            }
+    /// Retrieves a secret by its full name/ARN, optionally extracting one key
+    /// from a JSON secret value.
+    async fn get_coords_async(
+        &self,
+        name: &str,
+        json_key: Option<&str>,
+    ) -> Result<Option<SecretString>> {
+        let client = self.create_client().await?;
+        let output = match client.get_secret_value().secret_id(name).send().await {
+            Ok(output) => output,
             Err(err) => {
                 let service_err = err.into_service_error();
-                if service_err.is_resource_not_found_exception() {
+                return if service_err.is_resource_not_found_exception() {
                     Ok(None)
                 } else {
                     Err(SecretSpecError::ProviderOperationFailed(format!(
                         "Failed to get secret '{}': {}",
-                        secret_name, service_err
+                        name, service_err
                     )))
-                }
+                };
+            }
+        };
+
+        let Some(value) = output.secret_string() else {
+            return Ok(None);
+        };
+
+        match json_key {
+            None => Ok(Some(SecretString::new(value.to_string().into()))),
+            Some(json_key) => Self::extract_json_key(name, value, json_key),
+        }
+    }
+
+    /// Fetches every request in batches of 20 via the BatchGetSecretValue API:
+    /// each unique secret name/ARN is fetched once, then per-request `field`
+    /// coordinates extract their JSON key from the shared value.
+    async fn get_many_async(
+        &self,
+        resolved: &[(&str, crate::config::NativeAddress)],
+    ) -> Result<HashMap<String, SecretString>> {
+        let client = self.create_client().await?;
+
+        let mut unique: Vec<&str> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for (_, coords) in resolved {
+            if seen.insert(coords.item.as_str()) {
+                unique.push(coords.item.as_str());
             }
         }
-    }
 
-    /// Builds the full AWS secret names and a reverse map back to the original keys.
-    fn build_batch_request_names(
-        prefix: Option<&str>,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<(Vec<String>, HashMap<String, String>)> {
-        let mut secret_names = Vec::with_capacity(keys.len());
-        let mut name_to_key = HashMap::with_capacity(keys.len());
-        for key in keys {
-            let name = Self::format_secret_name(prefix, project, profile, key)?;
-            name_to_key.insert(name.clone(), key.to_string());
-            secret_names.push(name);
-        }
-        Ok((secret_names, name_to_key))
-    }
-
-    /// Fetches multiple secrets in batches of 20 using the BatchGetSecretValue API.
-    async fn get_batch_async(
-        &self,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
-        if keys.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let client = self.create_client().await?;
-        let (secret_names, name_to_key) =
-            Self::build_batch_request_names(self.config.prefix.as_deref(), project, keys, profile)?;
-        let mut results = HashMap::new();
-
-        for chunk in secret_names.chunks(AWS_BATCH_GET_MAX_SECRETS) {
+        // Fetched values keyed by both name and ARN, so requests addressing
+        // the secret either way find their value.
+        let mut fetched: HashMap<String, String> = HashMap::new();
+        for chunk in unique.chunks(AWS_BATCH_GET_MAX_SECRETS) {
             let mut request = client.batch_get_secret_value();
             for name in chunk {
-                request = request.secret_id_list(name.clone());
+                request = request.secret_id_list(*name);
             }
 
             let response = request.send().await.map_err(|e| {
@@ -256,12 +267,14 @@ impl AwssmProvider {
                 ))
             })?;
 
-            // Process successful values
             for secret in response.secret_values() {
-                if let (Some(name), Some(value)) = (secret.name(), secret.secret_string())
-                    && let Some(key) = name_to_key.get(name)
-                {
-                    results.insert(key.clone(), SecretString::new(value.to_string().into()));
+                if let Some(value) = secret.secret_string() {
+                    if let Some(name) = secret.name() {
+                        fetched.insert(name.to_string(), value.to_string());
+                    }
+                    if let Some(arn) = secret.arn() {
+                        fetched.insert(arn.to_string(), value.to_string());
+                    }
                 }
             }
 
@@ -280,25 +293,30 @@ impl AwssmProvider {
             }
         }
 
+        let mut results = HashMap::new();
+        for (name, coords) in resolved {
+            let Some(value) = fetched.get(coords.item.as_str()) else {
+                continue;
+            };
+            let secret = match coords.field.as_deref() {
+                None => Some(SecretString::new(value.clone().into())),
+                Some(json_key) => Self::extract_json_key(&coords.item, value, json_key)?,
+            };
+            if let Some(secret) = secret {
+                results.insert((*name).to_string(), secret);
+            }
+        }
         Ok(results)
     }
 
-    /// Creates or updates a secret in AWS Secrets Manager.
-    async fn set_secret_async(
-        &self,
-        project: &str,
-        key: &str,
-        value: &SecretString,
-        profile: &str,
-    ) -> Result<()> {
-        let secret_name =
-            Self::format_secret_name(self.config.prefix.as_deref(), project, profile, key)?;
+    /// Creates or updates a secret at its full name in AWS Secrets Manager.
+    async fn set_secret_async(&self, secret_name: &str, value: &SecretString) -> Result<()> {
         let client = self.create_client().await?;
 
         // Try to create the secret first
         let create_result = client
             .create_secret()
-            .name(&secret_name)
+            .name(secret_name)
             .secret_string(value.expose_secret())
             .send()
             .await;
@@ -311,7 +329,7 @@ impl AwssmProvider {
                     // Secret already exists, update it
                     client
                         .put_secret_value()
-                        .secret_id(&secret_name)
+                        .secret_id(secret_name)
                         .secret_string(value.expose_secret())
                         .send()
                         .await
@@ -335,6 +353,19 @@ impl AwssmProvider {
 }
 
 impl Provider for AwssmProvider {
+    /// Convention secrets are named `[{prefix}/]secretspec/{project}/{profile}/{key}`.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: Self::format_secret_name(self.config.prefix.as_deref(), project, profile, key)?,
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
@@ -359,25 +390,46 @@ impl Provider for AwssmProvider {
         }
     }
 
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        super::block_on(self.get_secret_async(project, key, profile))
+    /// An optional `field` extracts one key from a JSON secret value.
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field"]
     }
 
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        super::block_on(self.set_secret_async(project, key, value, profile))
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        // `item` is the secret name or ARN.
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.get_coords_async(&coords.item, coords.field.as_deref()))
     }
 
-    fn allows_set(&self) -> bool {
-        true
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.set_secret_async(&coords.item, value))
     }
 
-    fn get_batch(
-        &self,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
-        super::block_on(self.get_batch_async(project, keys, profile))
+    /// Native addresses are read-only: they name a secret managed outside
+    /// SecretSpec (and a JSON-key write could not happen without clobbering
+    /// the other keys).
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Convention { .. } => Ok(()),
+            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(
+                "awssm secret references are read-only and cannot be written".to_string(),
+            )),
+        }
+    }
+
+    /// Batches every request, convention or `ref`, through
+    /// BatchGetSecretValue.
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        if requests.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut resolved = Vec::with_capacity(requests.len());
+        for (name, addr) in requests {
+            resolved.push((*name, self.resolve_coords(*addr)?.into_owned()));
+        }
+        super::block_on(self.get_many_async(&resolved))
     }
 }
 
@@ -420,61 +472,119 @@ mod tests {
     }
 
     #[test]
-    fn test_build_batch_request_names() {
-        let keys: Vec<&str> = vec!["A", "B", "C"];
-        let (secret_names, name_to_key) =
-            AwssmProvider::build_batch_request_names(None, "proj", &keys, "default").unwrap();
-
-        assert_eq!(secret_names.len(), 3);
-        assert_eq!(name_to_key.len(), 3);
-        assert_eq!(secret_names[0], "secretspec/proj/default/A");
-        assert_eq!(name_to_key["secretspec/proj/default/A"], "A");
-        assert_eq!(name_to_key["secretspec/proj/default/B"], "B");
-        assert_eq!(name_to_key["secretspec/proj/default/C"], "C");
+    fn test_convention_address() {
+        let p = AwssmProvider::new(config("awssm://us-east-1"));
+        let coords = p.convention_address("proj", "default", "A").unwrap();
+        assert_eq!(coords.item, "secretspec/proj/default/A");
+        assert_eq!(coords.field, None);
     }
 
     #[test]
-    fn test_build_batch_request_names_with_prefix() {
-        let keys: Vec<&str> = vec!["A", "B"];
-        let (secret_names, name_to_key) =
-            AwssmProvider::build_batch_request_names(Some("myteam"), "proj", &keys, "default")
-                .unwrap();
-
-        assert_eq!(secret_names.len(), 2);
-        assert_eq!(secret_names[0], "myteam/secretspec/proj/default/A");
-        assert_eq!(name_to_key["myteam/secretspec/proj/default/A"], "A");
+    fn test_convention_address_with_prefix() {
+        let p = AwssmProvider::new(config("awssm://us-east-1?prefix=myteam"));
+        let coords = p.convention_address("proj", "default", "A").unwrap();
+        assert_eq!(coords.item, "myteam/secretspec/proj/default/A");
     }
 
     #[test]
-    fn test_build_batch_request_names_empty() {
-        let keys: Vec<&str> = vec![];
-        let (secret_names, name_to_key) =
-            AwssmProvider::build_batch_request_names(None, "proj", &keys, "default").unwrap();
-        assert!(secret_names.is_empty());
-        assert!(name_to_key.is_empty());
-    }
-
-    #[test]
-    fn test_build_batch_request_names_chunking() {
-        let keys: Vec<String> = (0..45).map(|i| format!("SECRET_{}", i)).collect();
-        let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
-
-        let (secret_names, name_to_key) =
-            AwssmProvider::build_batch_request_names(None, "proj", &key_refs, "default").unwrap();
-
-        assert_eq!(secret_names.len(), 45);
-        assert_eq!(name_to_key.len(), 45);
-
-        let chunks: Vec<&[String]> = secret_names.chunks(AWS_BATCH_GET_MAX_SECRETS).collect();
+    fn test_batch_chunking() {
+        let names: Vec<String> = (0..45).map(|i| format!("SECRET_{}", i)).collect();
+        let chunks: Vec<&[String]> = names.chunks(AWS_BATCH_GET_MAX_SECRETS).collect();
         assert_eq!(chunks.len(), 3); // 20 + 20 + 5
         assert_eq!(chunks[0].len(), 20);
         assert_eq!(chunks[1].len(), 20);
         assert_eq!(chunks[2].len(), 5);
+    }
 
-        // Verify reverse mapping is correct for all keys
-        for key in &key_refs {
-            let name = AwssmProvider::format_secret_name(None, "proj", "default", key).unwrap();
-            assert_eq!(name_to_key[&name], *key);
-        }
+    fn config(s: &str) -> AwssmConfig {
+        use url::Url;
+        AwssmConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap()
+    }
+
+    /// Native addresses are read-only: they name secrets managed outside
+    /// SecretSpec.
+    #[test]
+    fn native_address_is_read_only() {
+        let p = AwssmProvider::new(config("awssm://us-east-1"));
+        let addr = crate::config::NativeAddress {
+            item: "prod/db-credentials".into(),
+            field: Some("password".into()),
+            ..Default::default()
+        };
+        let refusal = p.check_writable(Address::Native(&addr)).unwrap_err();
+        assert!(refusal.to_string().contains("read-only"), "{refusal}");
+        // `set` refuses with the same reason, so the pre-check cannot drift.
+        let err = p
+            .set(
+                Address::Native(&addr),
+                &secrecy::SecretString::new("v".into()),
+            )
+            .unwrap_err();
+        assert_eq!(err.to_string(), refusal.to_string());
+    }
+
+    /// AWS secrets have no sections; the coordinate is rejected before any
+    /// network I/O.
+    #[test]
+    fn native_address_rejects_section() {
+        let p = AwssmProvider::new(config("awssm://us-east-1"));
+        let addr = crate::config::NativeAddress {
+            item: "prod/db-credentials".into(),
+            section: Some("x".into()),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`section`"), "{err}");
+    }
+
+    // The `field` coordinate extracts one key from a JSON secret value. This
+    // is the whole point of `field` on AWS, and the only ref path that carries
+    // logic (JSON parsing) rather than a live API call, so it is unit-tested
+    // directly rather than only through the network path.
+
+    #[test]
+    fn extract_json_key_returns_string_value() {
+        let value = r#"{"username": "admin", "password": "s3cret"}"#;
+        let got = AwssmProvider::extract_json_key("db", value, "password").unwrap();
+        assert_eq!(got.unwrap().expose_secret(), "s3cret");
+    }
+
+    #[test]
+    fn extract_json_key_renders_non_string_values_verbatim() {
+        // Numbers and bools are rendered as-is, not quoted like strings.
+        let value = r#"{"port": 5432, "tls": true}"#;
+        assert_eq!(
+            AwssmProvider::extract_json_key("db", value, "port")
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "5432"
+        );
+        assert_eq!(
+            AwssmProvider::extract_json_key("db", value, "tls")
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "true"
+        );
+    }
+
+    #[test]
+    fn extract_json_key_missing_key_is_none() {
+        let value = r#"{"username": "admin"}"#;
+        assert!(
+            AwssmProvider::extract_json_key("db", value, "password")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn extract_json_key_on_non_json_value_errors() {
+        let err = AwssmProvider::extract_json_key("db", "plain-string", "password").unwrap_err();
+        let msg = err.to_string();
+        // The error names both the secret and the key so the user can locate it.
+        assert!(msg.contains("is not JSON"), "{msg}");
+        assert!(msg.contains("db") && msg.contains("password"), "{msg}");
     }
 }

--- a/secretspec/src/provider/bws.rs
+++ b/secretspec/src/provider/bws.rs
@@ -36,7 +36,7 @@
 //! secretspec check --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
 //! ```
 
-use super::{Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use bitwarden::auth::login::AccessTokenLoginRequest;
 use bitwarden::secrets_manager::ClientSecretsExt;
@@ -249,18 +249,13 @@ impl BwsProvider {
         Ok(secrets.data)
     }
 
-    /// Retrieves a secret value from BWS by key name.
-    async fn get_secret_async(
-        &self,
-        _project: &str,
-        key: &str,
-        _profile: &str,
-    ) -> Result<Option<SecretString>> {
+    /// Retrieves a secret value from BWS by its resolved key name.
+    async fn get_secret_async(&self, target: &str) -> Result<Option<SecretString>> {
         let secrets = self.ensure_secrets().await?;
 
-        // BWS uses flat key names -- match directly on the key
+        // BWS uses flat key names -- match directly.
         for secret in secrets {
-            if secret.key == key {
+            if secret.key == target {
                 return Ok(Some(SecretString::new(secret.value.clone().into())));
             }
         }
@@ -268,14 +263,8 @@ impl BwsProvider {
         Ok(None)
     }
 
-    /// Creates or updates a secret in BWS.
-    async fn set_secret_async(
-        &self,
-        _project: &str,
-        key: &str,
-        value: &SecretString,
-        _profile: &str,
-    ) -> Result<()> {
+    /// Creates or updates a secret in BWS at its resolved key name.
+    async fn set_secret_async(&self, key: &str, value: &SecretString) -> Result<()> {
         let client = self.ensure_client().await?;
 
         // get_access_token_organization() is not part of the public stable API surface
@@ -340,31 +329,23 @@ impl BwsProvider {
 
         Ok(())
     }
-
-    /// Retrieves multiple secrets in a single batch using the cached secrets list.
-    async fn get_batch_async(
-        &self,
-        _project: &str,
-        keys: &[&str],
-        _profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
-        let secrets = self.ensure_secrets().await?;
-        let mut results = HashMap::new();
-
-        for secret in secrets {
-            if keys.contains(&secret.key.as_str()) {
-                results.insert(
-                    secret.key.clone(),
-                    SecretString::new(secret.value.clone().into()),
-                );
-            }
-        }
-
-        Ok(results)
-    }
 }
 
 impl Provider for BwsProvider {
+    /// Convention names map straight to the BWS key named after the secret;
+    /// the project UUID in the URI provides namespace isolation instead.
+    fn convention_address(
+        &self,
+        _project: &str,
+        _profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: key.to_string(),
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
@@ -376,25 +357,43 @@ impl Provider for BwsProvider {
         }
     }
 
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        super::block_on(self.get_secret_async(project, key, profile))
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let target = super::flat_item(self, addr)?;
+        super::block_on(self.get_secret_async(&target))
     }
 
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        super::block_on(self.set_secret_async(project, key, value, profile))
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let target = super::flat_item(self, addr)?;
+        super::block_on(self.set_secret_async(&target, value))
     }
 
-    fn allows_set(&self) -> bool {
-        true
-    }
+    /// Serves every request, convention or `ref`, from one cached listing of
+    /// the project's secrets.
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        if requests.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut targets = Vec::with_capacity(requests.len());
+        for (name, addr) in requests {
+            targets.push((*name, super::flat_item(self, *addr)?));
+        }
 
-    fn get_batch(
-        &self,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
-        super::block_on(self.get_batch_async(project, keys, profile))
+        let secrets = super::block_on(self.ensure_secrets())?;
+        let by_key: HashMap<&str, &str> = secrets
+            .iter()
+            .map(|s| (s.key.as_str(), s.value.as_str()))
+            .collect();
+
+        let mut results = HashMap::new();
+        for (name, target) in targets {
+            if let Some(value) = by_key.get(&*target) {
+                results.insert(
+                    name.to_string(),
+                    SecretString::new((*value).to_string().into()),
+                );
+            }
+        }
+        Ok(results)
     }
 }
 
@@ -464,6 +463,23 @@ mod tests {
         );
     }
 
+    /// A native address names the BWS key directly via `item`.
+    #[test]
+    fn native_address_names_the_key() {
+        let config =
+            BwsConfig::try_from(&provider_url("bws://a9230ec4-5507-4870-b8b5-b3f500587e4c"))
+                .unwrap();
+        let p = BwsProvider::new(config);
+        let addr = crate::config::NativeAddress {
+            item: "prod-db-url".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            crate::provider::flat_item(&p, Address::Native(&addr)).unwrap(),
+            "prod-db-url"
+        );
+    }
+
     #[test]
     fn test_bws_provider_metadata() {
         let config = BwsConfig {
@@ -477,7 +493,11 @@ mod tests {
             provider.uri(),
             "bws://vault.bitwarden.com@a9230ec4-5507-4870-b8b5-b3f500587e4c"
         );
-        assert!(provider.allows_set());
+        assert!(
+            provider
+                .check_writable(Address::convention("proj", "default", "KEY"))
+                .is_ok()
+        );
 
         let config = BwsConfig {
             project_id: uuid::Uuid::parse_str("a9230ec4-5507-4870-b8b5-b3f500587e4c").unwrap(),
@@ -487,7 +507,11 @@ mod tests {
 
         assert_eq!(provider.name(), "bws");
         assert_eq!(provider.uri(), "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c");
-        assert!(provider.allows_set());
+        assert!(
+            provider
+                .check_writable(Address::convention("proj", "default", "KEY"))
+                .is_ok()
+        );
     }
 
     #[test]
@@ -502,7 +526,7 @@ mod tests {
         };
         let provider = BwsProvider::new(config);
 
-        let result = provider.get("test_project", "TEST_KEY", "default");
+        let result = provider.get(Address::convention("test_project", "default", "TEST_KEY"));
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -510,5 +534,21 @@ mod tests {
             "Error should mention BWS_ACCESS_TOKEN, got: {}",
             err_msg
         );
+    }
+
+    /// BWS secrets are flat key/value pairs; a `field` coordinate is rejected.
+    #[test]
+    fn native_address_rejects_field() {
+        let config =
+            BwsConfig::try_from(&provider_url("bws://a9230ec4-5507-4870-b8b5-b3f500587e4c"))
+                .unwrap();
+        let p = BwsProvider::new(config);
+        let addr = crate::config::NativeAddress {
+            item: "prod-db-url".into(),
+            field: Some("password".into()),
+            ..Default::default()
+        };
+        let err = crate::provider::flat_item(&p, Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
     }
 }

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -1,4 +1,4 @@
-use super::{Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -164,6 +164,20 @@ impl DotEnvProvider {
 }
 
 impl Provider for DotEnvProvider {
+    /// Convention names map straight to the `.env` key named after the
+    /// secret; `.env` files have no project or profile namespacing.
+    fn convention_address(
+        &self,
+        _project: &str,
+        _profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: key.to_string(),
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
@@ -216,7 +230,8 @@ impl Provider for DotEnvProvider {
     /// Uses the dotenvy crate for parsing to ensure compatibility with
     /// standard .env file formats and proper handling of quoted values,
     /// multiline strings, and escape sequences.
-    fn get(&self, _project: &str, key: &str, _profile: &str) -> Result<Option<SecretString>> {
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let lookup = super::flat_item(self, addr)?;
         if !self.config.path.exists() {
             return Ok(None);
         }
@@ -229,7 +244,9 @@ impl Provider for DotEnvProvider {
             vars.insert(k, v);
         }
 
-        Ok(vars.get(key).map(|v| SecretString::new(v.clone().into())))
+        Ok(vars
+            .get(&*lookup)
+            .map(|v| SecretString::new(v.clone().into())))
     }
 
     /// Sets a secret value in the .env file.
@@ -254,7 +271,8 @@ impl Provider for DotEnvProvider {
     /// 1. Loads existing variables using dotenvy to preserve them
     /// 2. Updates or adds the new key-value pair
     /// 3. Serializes back with `serialize_dotenv` for proper escaping
-    fn set(&self, _project: &str, key: &str, value: &SecretString, _profile: &str) -> Result<()> {
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let target = super::flat_item(self, addr)?;
         // Load existing vars using dotenvy
         let mut vars = HashMap::new();
         if self.config.path.exists() {
@@ -265,8 +283,7 @@ impl Provider for DotEnvProvider {
             }
         }
 
-        // Update the value
-        vars.insert(key.to_string(), value.expose_secret().to_string());
+        vars.insert(target.into_owned(), value.expose_secret().to_string());
 
         let content = serialize_dotenv(&vars);
         fs::write(&self.config.path, content)?;
@@ -399,7 +416,9 @@ mod tests {
         });
         provider.with_base_dir(root.path());
 
-        let value = provider.get("hello-world", "USER", "default").unwrap();
+        let value = provider
+            .get(Address::convention("hello-world", "default", "USER"))
+            .unwrap();
         assert_eq!(value.unwrap().expose_secret(), "hello");
     }
 
@@ -497,12 +516,17 @@ mod tests {
 
         for (k, v) in cases {
             provider
-                .set("proj", k, &SecretString::new(v.into()), "default")
+                .set(
+                    Address::convention("proj", "default", k),
+                    &SecretString::new(v.into()),
+                )
                 .unwrap();
         }
 
         for (k, v) in cases {
-            let got = provider.get("proj", k, "default").unwrap();
+            let got = provider
+                .get(Address::convention("proj", "default", k))
+                .unwrap();
             assert_eq!(
                 got.map(|s| s.expose_secret().to_string()),
                 Some(v.to_string()),
@@ -526,22 +550,62 @@ mod tests {
 
         provider
             .set(
-                "proj",
-                "BAR",
+                Address::convention("proj", "default", "BAR"),
                 &SecretString::new("foobar".into()),
-                "default",
             )
             .unwrap();
 
-        let foo = provider.get("proj", "FOO", "default").unwrap();
+        let foo = provider
+            .get(Address::convention("proj", "default", "FOO"))
+            .unwrap();
         assert_eq!(
             foo.map(|s| s.expose_secret().to_string()),
             Some(r#"{"bar":"baz"}"#.to_string()),
         );
-        let bar = provider.get("proj", "BAR", "default").unwrap();
+        let bar = provider
+            .get(Address::convention("proj", "default", "BAR"))
+            .unwrap();
         assert_eq!(
             bar.map(|s| s.expose_secret().to_string()),
             Some("foobar".to_string()),
         );
+    }
+
+    /// A native address reads and writes the key its `item` names, regardless
+    /// of the secret's own name or any instance configuration.
+    #[test]
+    fn native_address_reads_and_writes_the_named_key() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(".env");
+        let provider = DotEnvProvider::new(DotEnvConfig { path: path.clone() });
+        let addr = crate::config::NativeAddress {
+            item: "PINNED_KEY".into(),
+            ..Default::default()
+        };
+
+        provider
+            .set(Address::Native(&addr), &SecretString::new("v1".into()))
+            .unwrap();
+        let got = provider.get(Address::Native(&addr)).unwrap();
+        assert_eq!(
+            got.map(|s| s.expose_secret().to_string()),
+            Some("v1".into())
+        );
+
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("PINNED_KEY="), "wrote: {contents}");
+    }
+
+    /// `.env` entries have no sub-components; a `field` coordinate is rejected.
+    #[test]
+    fn native_address_rejects_field() {
+        let provider = DotEnvProvider::new(DotEnvConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "KEY".into(),
+            field: Some("x".into()),
+            ..Default::default()
+        };
+        let err = provider.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
     }
 }

--- a/secretspec/src/provider/env.rs
+++ b/secretspec/src/provider/env.rs
@@ -1,4 +1,4 @@
-use super::{Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
@@ -24,9 +24,9 @@ impl TryFrom<&ProviderUrl> for EnvConfig {
 
     /// Creates an `EnvConfig` from a URL.
     ///
-    /// This method validates that the URL has the correct scheme ("env")
-    /// and returns an `EnvConfig` instance. The environment provider
-    /// doesn't require any additional configuration from the URL.
+    /// Validates the scheme is "env" and that the URI carries no authority:
+    /// the provider reads the variable named after each secret, and a specific
+    /// variable is addressed with `ref = { item = "VARNAME" }`, not in the URI.
     ///
     /// # Example
     ///
@@ -44,7 +44,14 @@ impl TryFrom<&ProviderUrl> for EnvConfig {
             )));
         }
 
-        Ok(Self::default())
+        if let Some(host) = url.host().filter(|h| !h.is_empty()) {
+            let hint = crate::config::ref_table_hint(None, &host, None, None);
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "env:// takes no authority: to read one specific variable, use \
+                 {hint} on the secret instead"
+            )));
+        }
+        Ok(Self {})
     }
 }
 
@@ -73,10 +80,7 @@ impl EnvConfig {}
 /// let provider = EnvProvider::new(EnvConfig::default());
 /// // Can only read values, not set them
 /// ```
-pub struct EnvProvider {
-    #[allow(dead_code)]
-    config: EnvConfig,
-}
+pub struct EnvProvider;
 
 crate::register_provider! {
     struct: EnvProvider,
@@ -92,7 +96,8 @@ impl EnvProvider {
     ///
     /// # Arguments
     ///
-    /// * `config` - The configuration for the provider (currently unused)
+    /// * `_config` - The configuration for the provider; the process
+    ///   environment is global, so there is nothing to configure.
     ///
     /// # Example
     ///
@@ -101,18 +106,32 @@ impl EnvProvider {
     /// let config = EnvConfig::default();
     /// let provider = EnvProvider::new(config);
     /// ```
-    pub fn new(config: EnvConfig) -> Self {
-        Self { config }
+    pub fn new(_config: EnvConfig) -> Self {
+        Self
     }
 }
 
 impl Provider for EnvProvider {
+    /// Convention names map straight to the environment variable named by the
+    /// secret key; project and profile don't exist in a process environment.
+    fn convention_address(
+        &self,
+        _project: &str,
+        _profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: key.to_string(),
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
 
     fn uri(&self) -> String {
-        // Env can be "env", "env:", or "env://"
+        // Env can be "env", "env:", or "env://".
         "env".to_string()
     }
 
@@ -140,11 +159,12 @@ impl Provider for EnvProvider {
     /// # use secretspec::provider::{Provider, env::{EnvProvider, EnvConfig}};
     /// # unsafe { std::env::set_var("MY_SECRET", "value123"); }
     /// let provider = EnvProvider::new(EnvConfig::default());
-    /// let value = provider.get("myproject", "MY_SECRET", "production").unwrap();
+    /// let value = provider.get(Address::convention("myproject", "production", "MY_SECRET")).unwrap();
     /// assert_eq!(value, Some("value123".to_string()));
     /// ```
-    fn get(&self, _project: &str, key: &str, _profile: &str) -> Result<Option<SecretString>> {
-        Ok(env::var(key).ok().map(|v| SecretString::new(v.into())))
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let var = super::flat_item(self, addr)?;
+        Ok(env::var(&*var).ok().map(|v| SecretString::new(v.into())))
     }
 
     /// Attempts to set a secret value (always fails).
@@ -170,27 +190,66 @@ impl Provider for EnvProvider {
     /// ```ignore
     /// # use secretspec::provider::{Provider, env::{EnvProvider, EnvConfig}};
     /// let provider = EnvProvider::new(EnvConfig::default());
-    /// let result = provider.set("myproject", "MY_SECRET", "value", "production");
+    /// let result = provider.set(Address::convention("myproject", "production", "MY_SECRET"), "value");
     /// assert!(result.is_err());
     /// ```
-    fn set(&self, _project: &str, _key: &str, _value: &SecretString, _profile: &str) -> Result<()> {
-        // Environment variables are read-only in this backend
-        // Setting environment variables at runtime doesn't persist across processes
+    fn set(&self, addr: Address<'_>, _value: &SecretString) -> Result<()> {
+        self.check_writable(addr)
+    }
+
+    /// Always read-only: setting environment variables at runtime doesn't
+    /// persist across processes. Stating the reason here lets the CLI refuse
+    /// the write before prompting for a value, with the same message `set`
+    /// would return.
+    fn check_writable(&self, _addr: Address<'_>) -> Result<()> {
         Err(crate::SecretSpecError::ProviderOperationFailed(
             "Environment variable provider is read-only. Set variables in your shell or process environment.".to_string()
         ))
     }
+}
 
-    /// Indicates whether this provider supports setting values.
-    ///
-    /// Always returns `false` for the environment provider since it's
-    /// a read-only provider. This allows the CLI and other consumers
-    /// to check capabilities before attempting operations.
-    ///
-    /// # Returns
-    ///
-    /// Always returns `false`
-    fn allows_set(&self) -> bool {
-        false
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    /// A native address reads the variable its `item` names, regardless of any
+    /// instance configuration.
+    #[test]
+    fn native_address_reads_the_named_variable() {
+        let p = EnvProvider::new(EnvConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "PATH".into(),
+            ..Default::default()
+        };
+        // PATH is set in every test environment.
+        assert!(p.get(Address::Native(&addr)).unwrap().is_some());
+    }
+
+    /// The authority form (`env://VARNAME`) from earlier iterations is
+    /// rejected with a pointer at the `ref` table, instead of being silently
+    /// ignored and reading the wrong variable.
+    #[test]
+    fn authority_is_rejected_with_ref_hint() {
+        let err = EnvConfig::try_from(&ProviderUrl::new(Url::parse("env://SOME_VAR").unwrap()))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("ref = { item = \"SOME_VAR\" }"),
+            "{err}"
+        );
+    }
+
+    /// Environment variables have no sub-components, so a `field` coordinate is
+    /// rejected instead of silently reading the wrong thing.
+    #[test]
+    fn native_address_rejects_field() {
+        let p = EnvProvider::new(EnvConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "PATH".into(),
+            field: Some("x".into()),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
     }
 }

--- a/secretspec/src/provider/gcsm.rs
+++ b/secretspec/src/provider/gcsm.rs
@@ -30,7 +30,7 @@
 //! secretspec check --provider gcsm://my-gcp-project
 //! ```
 
-use super::{Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use google_cloud_secretmanager_v1::model::{Replication, Secret, SecretPayload, replication};
@@ -115,6 +115,26 @@ impl TryFrom<&ProviderUrl> for GcsmConfig {
 
         // Validate project ID format
         validate_gcp_project_id(&project_id)?;
+
+        // The path reference form from earlier iterations is rejected with a
+        // pointer at the `ref` table, instead of being silently ignored and
+        // reading the conventional layout.
+        let path = url.path();
+        let trimmed = path.trim_start_matches('/');
+        if !trimmed.is_empty() {
+            let id = trimmed
+                .strip_prefix("secrets/")
+                .unwrap_or(trimmed)
+                .split('/')
+                .next()
+                .unwrap_or(trimmed);
+            let hint = crate::config::ref_table_hint(None, id, None, None);
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "gcsm URIs take no path: address the secret with \
+                 {hint} on the secret instead \
+                 (add version = \"<n>\" to pin a version)"
+            )));
+        }
 
         Ok(Self { project_id })
     }
@@ -220,19 +240,18 @@ impl GcsmProvider {
         })
     }
 
-    /// Retrieves a secret value from GCP Secret Manager.
-    async fn get_secret_async(
+    /// Resolves coordinates to a version resource and reads it, mapping "not
+    /// found" to `None`: `item` is the secret id, `version` the version to read
+    /// (defaulting to the latest).
+    async fn get_coords_async(
         &self,
-        project: &str,
-        key: &str,
-        profile: &str,
+        coords: &crate::config::NativeAddress,
     ) -> Result<Option<SecretString>> {
-        let secret_name = self.format_secret_name(project, profile, key)?;
+        let version = coords.version.as_deref().unwrap_or("latest");
         let secret_version_path = format!(
-            "projects/{}/secrets/{}/versions/latest",
-            self.config.project_id, secret_name
+            "projects/{}/secrets/{}/versions/{}",
+            self.config.project_id, coords.item, version
         );
-
         let client = self.create_client().await?;
 
         match client
@@ -261,7 +280,7 @@ impl GcsmProvider {
                 } else {
                     Err(SecretSpecError::ProviderOperationFailed(format!(
                         "Failed to access secret '{}': {}",
-                        secret_name, e
+                        coords.item, e
                     )))
                 }
             }
@@ -272,21 +291,14 @@ impl GcsmProvider {
     ///
     /// Always attempts to create the secret first (idempotent operation), then adds a new version.
     /// This avoids TOCTOU race conditions by not checking existence before creation.
-    async fn set_secret_async(
-        &self,
-        project: &str,
-        key: &str,
-        value: &SecretString,
-        profile: &str,
-    ) -> Result<()> {
-        let secret_name = self.format_secret_name(project, profile, key)?;
+    async fn set_secret_async(&self, secret_name: &str, value: &SecretString) -> Result<()> {
         let client = self.create_client().await?;
 
         // Always try to create the secret first (idempotent - ALREADY_EXISTS is expected for existing secrets)
         let create_result = client
             .create_secret()
             .set_parent(format!("projects/{}", self.config.project_id))
-            .set_secret_id(&secret_name)
+            .set_secret_id(secret_name)
             .set_secret(Secret::default().set_replication(
                 Replication::default().set_automatic(replication::Automatic::default()),
             ))
@@ -328,6 +340,21 @@ impl GcsmProvider {
 }
 
 impl Provider for GcsmProvider {
+    /// Convention secrets are ids of the form
+    /// `secretspec-{project}-{profile}-{key}` (GCP secret ids cannot contain
+    /// slashes), read at their latest version.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: self.format_secret_name(project, profile, key)?,
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
@@ -336,15 +363,89 @@ impl Provider for GcsmProvider {
         format!("gcsm://{}", self.config.project_id)
     }
 
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        super::block_on(self.get_secret_async(project, key, profile))
+    /// An optional `version` pins the secret version to read.
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["version"]
     }
 
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        super::block_on(self.set_secret_async(project, key, value, profile))
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.get_coords_async(&coords))
     }
 
-    fn allows_set(&self) -> bool {
-        true
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.set_secret_async(&coords.item, value))
+    }
+
+    /// Native addresses are read-only: they name an existing (often
+    /// version-pinned) secret, and writing would mean minting a new version of
+    /// someone else's secret.
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Convention { .. } => Ok(()),
+            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(
+                "gcsm secret references are read-only and cannot be written".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod reference_tests {
+    use super::*;
+    use url::Url;
+
+    /// A path that is not a `secrets/...` resource is rejected.
+    #[test]
+    fn path_is_rejected_with_ref_hint() {
+        let err = GcsmConfig::try_from(&ProviderUrl::new(
+            Url::parse("gcsm://my-project/secrets/db-url/versions/3").unwrap(),
+        ))
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("ref = { item = \"db-url\" }"),
+            "{err}"
+        );
+    }
+
+    /// Native addresses are read-only: writing would mint a new version of a
+    /// secret managed outside SecretSpec.
+    #[test]
+    fn native_address_is_read_only() {
+        let c = GcsmConfig::try_from(&ProviderUrl::new(Url::parse("gcsm://my-project").unwrap()))
+            .unwrap();
+        let p = GcsmProvider::new(c);
+        let addr = crate::config::NativeAddress {
+            item: "db-url".into(),
+            ..Default::default()
+        };
+        let refusal = p.check_writable(Address::Native(&addr)).unwrap_err();
+        assert!(refusal.to_string().contains("read-only"), "{refusal}");
+        // `set` refuses with the same reason, so the pre-check cannot drift.
+        let err = p
+            .set(
+                Address::Native(&addr),
+                &secrecy::SecretString::new("v".into()),
+            )
+            .unwrap_err();
+        assert_eq!(err.to_string(), refusal.to_string());
+    }
+
+    /// GCSM secrets have no fields; the coordinate is rejected before any
+    /// network I/O.
+    #[test]
+    fn native_address_rejects_field() {
+        let c = GcsmConfig::try_from(&ProviderUrl::new(Url::parse("gcsm://my-project").unwrap()))
+            .unwrap();
+        let p = GcsmProvider::new(c);
+        let addr = crate::config::NativeAddress {
+            item: "db-url".into(),
+            field: Some("x".into()),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
     }
 }

--- a/secretspec/src/provider/keyring.rs
+++ b/secretspec/src/provider/keyring.rs
@@ -1,4 +1,4 @@
-use super::{Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use keyring::Entry;
 use secrecy::{ExposeSecret, SecretString};
@@ -23,7 +23,9 @@ impl TryFrom<&ProviderUrl> for KeyringConfig {
     /// Creates a new KeyringConfig from a URL.
     ///
     /// The URL must have the scheme "keyring" (e.g., "keyring://" or
-    /// "keyring://secretspec/shared/{profile}/{key}").
+    /// "keyring://secretspec/shared/{profile}/{key}"). One specific
+    /// `(service, account)` entry is addressed with a secret's
+    /// `ref = { item = "<service>", field = "<account>" }`, not in the URI.
     fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
         if url.scheme() != "keyring" {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
@@ -35,8 +37,7 @@ impl TryFrom<&ProviderUrl> for KeyringConfig {
         let mut config = Self::default();
 
         if let Some(host) = url.host() {
-            let path = url.path();
-            config.folder_prefix = Some(format!("{}{}", host, path));
+            config.folder_prefix = Some(format!("{}{}", host, url.path()));
         }
 
         Ok(config)
@@ -99,9 +100,46 @@ impl KeyringProvider {
             .replace("{profile}", profile)
             .replace("{key}", key)
     }
+
+    /// Resolves the `(service, account)` an operation targets: `item` is the
+    /// service, `field` the account, defaulting to the current system
+    /// username (the account convention entries live under).
+    fn entry_target(&self, addr: Address<'_>) -> Result<(String, String)> {
+        let coords = self.resolve_coords(addr)?;
+        let account = match &coords.field {
+            Some(account) => account.clone(),
+            None => Self::current_username()?,
+        };
+        Ok((coords.item.clone(), account))
+    }
+
+    /// The current system username, the account convention entries live under.
+    fn current_username() -> Result<String> {
+        whoami::username().map_err(|e| SecretSpecError::ProviderOperationFailed(e.to_string()))
+    }
 }
 
 impl Provider for KeyringProvider {
+    /// Convention entries use the folder-prefix format string as the service
+    /// name, `secretspec/{project}/{profile}/{key}` by default; the account
+    /// (the `field` coordinate) is resolved at operation time.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: self.format_service(project, profile, key),
+            ..Default::default()
+        })
+    }
+
+    /// `field` is the keyring account within the service entry.
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field"]
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
@@ -120,10 +158,8 @@ impl Provider for KeyringProvider {
     /// by the folder_prefix format string (defaults to `secretspec/{project}/{profile}/{key}`).
     ///
     /// The current system username is used as the account identifier.
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        let service = self.format_service(project, profile, key);
-        let username = whoami::username()
-            .map_err(|e| SecretSpecError::ProviderOperationFailed(e.to_string()))?;
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let (service, username) = self.entry_target(addr)?;
         let entry = Entry::new(&service, &username)?;
         match entry.get_password() {
             Ok(password) => Ok(Some(SecretString::new(password.into()))),
@@ -139,10 +175,8 @@ impl Provider for KeyringProvider {
     ///
     /// The current system username is used as the account identifier.
     /// If a secret already exists with the same key, it will be overwritten.
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        let service = self.format_service(project, profile, key);
-        let username = whoami::username()
-            .map_err(|e| SecretSpecError::ProviderOperationFailed(e.to_string()))?;
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let (service, username) = self.entry_target(addr)?;
         let entry = Entry::new(&service, &username)?;
         entry.set_password(value.expose_secret())?;
         Ok(())
@@ -212,5 +246,47 @@ mod tests {
         });
         // The space must be percent-encoded.
         assert_eq!(provider.uri(), "keyring://my%20vault/{key}");
+    }
+
+    /// A native address maps `item` to the service and `field` to the account.
+    #[test]
+    fn native_address_maps_item_and_field_to_service_and_account() {
+        let p = KeyringProvider::new(KeyringConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "com.example.app".into(),
+            field: Some("alice".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            p.entry_target(Address::Native(&addr)).unwrap(),
+            ("com.example.app".to_string(), "alice".to_string())
+        );
+    }
+
+    /// Without a `field`, the account defaults to the current system username,
+    /// matching where convention entries are stored.
+    #[test]
+    fn native_address_account_defaults_to_current_username() {
+        let p = KeyringProvider::new(KeyringConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "com.example.app".into(),
+            ..Default::default()
+        };
+        let (service, account) = p.entry_target(Address::Native(&addr)).unwrap();
+        assert_eq!(service, "com.example.app");
+        assert_eq!(account, whoami::username().unwrap());
+    }
+
+    /// Keyring entries have no versions; the coordinate is rejected.
+    #[test]
+    fn native_address_rejects_version() {
+        let p = KeyringProvider::new(KeyringConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "com.example.app".into(),
+            version: Some("3".into()),
+            ..Default::default()
+        };
+        let err = p.entry_target(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`version`"), "{err}");
     }
 }

--- a/secretspec/src/provider/lastpass.rs
+++ b/secretspec/src/provider/lastpass.rs
@@ -1,4 +1,4 @@
-use crate::provider::{Provider, ProviderUrl};
+use crate::provider::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -236,8 +236,28 @@ impl LastPassProvider {
 }
 
 impl Provider for LastPassProvider {
+    /// Convention items live under the folder-prefix format string,
+    /// `secretspec/{project}/{profile}/{key}` by default.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: self.format_item_name(project, key, profile),
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
+    }
+
+    /// `lpass status` probes the user's singleton LastPass session, so every
+    /// instance shares one preflight probe.
+    fn auth_scope_key(&self) -> Option<String> {
+        Some(String::new())
     }
 
     fn uri(&self) -> String {
@@ -281,8 +301,8 @@ impl Provider for LastPassProvider {
     ///
     /// - Returns an error if not logged in to LastPass
     /// - Returns an error if the LastPass CLI fails
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        let item_name = self.format_item_name(project, key, profile);
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let item_name = crate::provider::flat_item(self, addr)?;
 
         match self.execute_lpass_command(&["show", "--sync=now", "--password", &item_name]) {
             Ok(output) => {
@@ -330,11 +350,11 @@ impl Provider for LastPassProvider {
     /// The method uses non-interactive mode and disables pinentry to avoid
     /// GUI prompts. The secret value is passed via stdin to avoid exposing
     /// it in the process list.
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        let item_name = self.format_item_name(project, key, profile);
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let item_name = crate::provider::flat_item(self, addr)?;
 
         // Check if item exists
-        if self.get(project, key, profile)?.is_some() {
+        if self.get(addr)?.is_some() {
             // Update existing item
             let args = vec![
                 "edit",
@@ -408,5 +428,40 @@ impl Default for LastPassProvider {
     /// This is equivalent to calling `LastPassProvider::new(LastPassConfig::default())`.
     fn default() -> Self {
         Self::new(LastPassConfig::default())
+    }
+}
+
+#[cfg(test)]
+mod reference_tests {
+    use super::*;
+
+    /// A native address names the item directly via `item`, bypassing the
+    /// folder-prefix format string.
+    #[test]
+    fn native_address_names_the_item() {
+        let p = LastPassProvider::new(LastPassConfig {
+            folder_prefix: Some("Work/{key}".to_string()),
+        });
+        let addr = crate::config::NativeAddress {
+            item: "Shared/api-token".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            crate::provider::flat_item(&p, Address::Native(&addr)).unwrap(),
+            "Shared/api-token"
+        );
+    }
+
+    /// LastPass items are read whole here; a `field` coordinate is rejected.
+    #[test]
+    fn native_address_rejects_field() {
+        let p = LastPassProvider::new(LastPassConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "api-token".into(),
+            field: Some("password".into()),
+            ..Default::default()
+        };
+        let err = crate::provider::flat_item(&p, Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
     }
 }

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -28,34 +28,38 @@
 //! ```text
 //! keyring://
 //! dotenv://.env.production
-//! onepassword://vault/items
+//! onepassword://vault
 //! lastpass://folder
 //! ```
 //!
 //! ## Example
 //!
 //! ```rust,ignore
-//! use secretspec::provider::Provider;
+//! use secretspec::provider::{Address, Provider};
 //! use std::convert::TryFrom;
 //!
 //! // Create a provider from a URI string
 //! let provider = Box::<dyn Provider>::try_from("keyring://")?;
 //!
+//! let addr = Address::convention("myproject", "production", "API_KEY");
+//!
 //! // Store a secret
-//! provider.set("myproject", "API_KEY", "secret123", "production")?;
+//! provider.set(addr, &"secret123".to_string().into())?;
 //!
 //! // Retrieve a secret
-//! if let Some(value) = provider.get("myproject", "API_KEY", "production")? {
-//!     println!("API_KEY: {}", value);
+//! if let Some(value) = provider.get(addr)? {
+//!     println!("API_KEY retrieved");
 //! }
 //! ```
 
+use crate::config::NativeAddress;
 use crate::{Result, SecretSpecError};
 use percent_encoding::{AsciiSet, CONTROLS, percent_decode_str, percent_encode};
 use secrecy::SecretString;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::sync::OnceLock;
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use url::Url;
 
 /// Characters that are invalid in URI hosts but might appear in provider config
@@ -261,6 +265,89 @@ impl ProviderInfo {
     }
 }
 
+/// How a provider operation addresses a secret.
+///
+/// Every read and write names its secret one of two ways:
+///
+/// - [`Convention`](Address::Convention): SecretSpec's own naming scheme. The
+///   provider maps `(project, profile, key)` into its namespace, by default
+///   `{provider}/{project}/{profile}/{key}` or the provider's configured
+///   format string.
+/// - [`Native`](Address::Native): explicit coordinates from a secret's `ref`
+///   field, naming one externally managed secret in the provider's own terms
+///   (item, field, ...). The provider translates the coordinates and rejects
+///   any it has no equivalent for.
+///
+/// Which stores are consulted is decided entirely by provider resolution
+/// (chains, overrides, defaults); the address only supplies the name to look
+/// up in each.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Address<'a> {
+    /// SecretSpec's `{project}/{profile}/{key}` naming convention.
+    Convention {
+        project: &'a str,
+        profile: &'a str,
+        key: &'a str,
+    },
+    /// Native coordinates of one externally managed secret (a `ref`).
+    Native(&'a NativeAddress),
+}
+
+impl<'a> Address<'a> {
+    /// Convention-scheme constructor, in the enum's own field order.
+    pub fn convention(project: &'a str, profile: &'a str, key: &'a str) -> Self {
+        Address::Convention {
+            project,
+            profile,
+            key,
+        }
+    }
+}
+
+/// Rejects native-address coordinates a provider has no equivalent for.
+///
+/// Enforced once for every address inside the default
+/// [`resolve_coords`](Provider::resolve_coords), against the provider's
+/// declared [`supported_coords`](Provider::supported_coords): a coordinate the
+/// provider does not name produces an error that names the coordinate, the ref
+/// it came from, and how to fix it, so a `ref` written for one store fails
+/// loudly when routing points it at a store that cannot honor those
+/// coordinates, instead of silently resolving something else.
+fn reject_unsupported_coords(
+    provider: &str,
+    addr: &NativeAddress,
+    supported: &[&str],
+) -> Result<()> {
+    for (name, value) in addr.coordinates() {
+        // `item` is the one coordinate every provider consumes.
+        if name == "item" || value.is_none() {
+            continue;
+        }
+        if !supported.contains(&name) {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "the {provider} provider does not support the `{name}` coordinate. \
+                 Drop `{name}` from the ref for `{item}`.",
+                item = addr.item
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Resolves an address for flat stores whose secrets have no sub-components:
+/// any address, convention or `ref`, names the entry via `item` alone, every
+/// other coordinate having been rejected by the provider's empty
+/// [`supported_coords`](Provider::supported_coords).
+pub(crate) fn flat_item<'a, P: Provider + ?Sized>(
+    provider: &P,
+    addr: Address<'a>,
+) -> Result<Cow<'a, str>> {
+    match provider.resolve_coords(addr)? {
+        Cow::Borrowed(native) => Ok(Cow::Borrowed(native.item.as_str())),
+        Cow::Owned(native) => Ok(Cow::Owned(native.item)),
+    }
+}
+
 /// Macro support types
 pub use macros::{PROVIDER_REGISTRY, ProviderRegistration};
 
@@ -299,16 +386,60 @@ pub fn providers() -> Vec<ProviderInfo> {
 ///
 /// - Providers should handle their own error cases and return appropriate `Result` types
 /// - Storage paths should follow the pattern: `{provider}/{project}/{profile}/{key}`
-/// - Providers may choose to be read-only by overriding [`allows_set`](Provider::allows_set)
+/// - Providers may choose to be read-only by overriding [`check_writable`](Provider::check_writable)
 /// - Provider names should be lowercase and descriptive
 pub trait Provider: Send + Sync {
-    /// Retrieves a secret value from the provider.
+    /// Compiles SecretSpec's `{project}/{profile}/{key}` naming convention into
+    /// this store's native coordinates: the same address space a secret's
+    /// `ref` uses.
     ///
-    /// # Arguments
+    /// This is the single owner of the provider's convention layout (format
+    /// strings, path shapes, default vaults); the operation methods resolve
+    /// every address through [`resolve_coords`](Provider::resolve_coords) and
+    /// never re-derive names. Pure naming, no I/O.
     ///
-    /// * `project` - The project namespace for the secret
-    /// * `key` - The secret key/name to retrieve
-    /// * `profile` - The profile context (e.g., "default", "production")
+    /// # Errors
+    ///
+    /// Returns an error when the convention inputs cannot form a valid name in
+    /// this store (e.g. empty components, length limits).
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress>;
+
+    /// The optional [`NativeAddress`] coordinates this store can honor, beyond
+    /// the universally consumed `item` (e.g. `["field"]`).
+    ///
+    /// Declared as data rather than checked per operation: the default
+    /// [`resolve_coords`](Provider::resolve_coords) rejects every coordinate a
+    /// provider does not name here, so a store whose secrets have no
+    /// sub-components gets the correct behavior from the empty default without
+    /// writing any validation.
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    /// Resolves any [`Address`] to this store's native coordinates: a `ref`'s
+    /// coordinates pass through as-is, a convention address is compiled via
+    /// [`convention_address`](Provider::convention_address). Coordinates
+    /// outside [`supported_coords`](Provider::supported_coords) are rejected,
+    /// so every operation that resolves an address inherits the check.
+    fn resolve_coords<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, NativeAddress>> {
+        let coords = match addr {
+            Address::Native(native) => Cow::Borrowed(native),
+            Address::Convention {
+                project,
+                profile,
+                key,
+            } => Cow::Owned(self.convention_address(project, profile, key)?),
+        };
+        reject_unsupported_coords(self.name(), &coords, self.supported_coords())?;
+        Ok(coords)
+    }
+
+    /// Retrieves the secret named by `addr`.
+    ///
+    /// See [`Address`] for the two naming schemes. A provider that cannot
+    /// interpret a [`Native`](Address::Native) coordinate (e.g. a `field` on a
+    /// store whose secrets have no sub-components) returns an error naming the
+    /// coordinate rather than guessing.
     ///
     /// # Returns
     ///
@@ -319,59 +450,62 @@ pub trait Provider: Send + Sync {
     /// # Example
     ///
     /// ```rust,ignore
-    /// match provider.get("myapp", "DATABASE_URL", "production")? {
+    /// let addr = Address::Convention { project: "myapp", profile: "production", key: "DATABASE_URL" };
+    /// match provider.get(addr)? {
     ///     Some(url) => println!("Database URL: {}", url),
     ///     None => println!("DATABASE_URL not found"),
     /// }
     /// ```
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>>;
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>>;
 
-    /// Stores a secret value in the provider.
-    ///
-    /// # Arguments
-    ///
-    /// * `project` - The project namespace for the secret
-    /// * `key` - The secret key/name to store
-    /// * `value` - The secret value to store
-    /// * `profile` - The profile context (e.g., "default", "production")
+    /// Stores a secret value at `addr`.
     ///
     /// # Returns
     ///
     /// - `Ok(())` if the secret was successfully stored
-    /// - `Err` if there was an error or the provider is read-only
+    /// - `Err` if there was an error or the address is read-only
     ///
     /// # Errors
     ///
-    /// This method should return an error if [`allows_set`](Provider::allows_set) returns `false`.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// provider.set("myapp", "API_KEY", "secret123", "production")?;
-    /// ```
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()>;
+    /// This method should return an error whenever
+    /// [`check_writable`](Provider::check_writable) does, for the same address.
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()>;
 
-    /// Returns whether this provider supports setting values.
+    /// Reports whether this provider can write to `addr`, and why not when it
+    /// cannot.
     ///
-    /// By default, providers are assumed to support writing. Read-only providers
-    /// (like environment variables) should override this to return `false`.
+    /// Callers use this to refuse a write before prompting for a value, so the
+    /// error must be the same one [`set`](Provider::set) would return: state
+    /// the policy here and have `set` call this method, rather than writing the
+    /// rule twice.
     ///
-    /// # Returns
-    ///
-    /// - `true` if the provider supports [`set`](Provider::set) operations
-    /// - `false` if the provider is read-only
+    /// By default, providers are assumed to support writing. Read-only
+    /// providers (like environment variables) reject every address; providers
+    /// that can write their own layout but not externally managed secrets
+    /// reject only [`Native`](Address::Native) addresses, and say so — a
+    /// generic "provider is read-only" would be untrue of the store as a whole.
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// if provider.allows_set() {
-    ///     provider.set("myapp", "TOKEN", "value", "default")?;
-    /// } else {
-    ///     eprintln!("Provider is read-only");
-    /// }
+    /// provider.check_writable(addr)?;
+    /// provider.set(addr, &value)?;
     /// ```
-    fn allows_set(&self) -> bool {
-        true
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        let _ = addr;
+        Ok(())
+    }
+
+    /// Identifies the shared authentication state this instance's preflight
+    /// check probes, when that state outlives the instance.
+    ///
+    /// Instances of the same provider returning equal keys share one probe
+    /// result process-wide. This matters because a secret's `providers` chain
+    /// builds a fresh provider instance per (secret, URI) pair — without a
+    /// scope key, N secrets would run N identical auth probes (each typically a
+    /// CLI round-trip). The default `None` keeps the probe per-instance.
+    fn auth_scope_key(&self) -> Option<String> {
+        None
     }
 
     /// Returns the name of this provider.
@@ -450,52 +584,98 @@ pub trait Provider: Send + Sync {
         )))
     }
 
-    /// Retrieves multiple secrets from the provider in a single batch operation.
+    /// Retrieves multiple secrets in one batch operation.
     ///
-    /// This method allows providers to optimize fetching multiple secrets at once,
-    /// which can significantly improve performance for providers with high latency
-    /// per request (like cloud-based secret managers).
+    /// Each request pairs a secret name (the key of the returned map) with the
+    /// [`Address`] to fetch it from, so a batch mixes convention secrets and
+    /// `ref` secrets freely. Secrets that don't exist are omitted from the
+    /// result.
     ///
-    /// # Arguments
+    /// # Contract
     ///
-    /// * `project` - The project namespace for the secrets
-    /// * `keys` - A slice of secret keys to retrieve
-    /// * `profile` - The profile context (e.g., "default", "production")
-    ///
-    /// # Returns
-    ///
-    /// A HashMap where keys are the secret names and values are the secret values.
-    /// Secrets that don't exist are not included in the result.
+    /// Requests naming identical addresses (several secrets sharing one `ref`)
+    /// must be fetched once and share the value.
     ///
     /// # Default Implementation
     ///
-    /// The default implementation calls `get()` for each key sequentially.
-    /// Providers should override this for better performance when possible.
-    fn get_batch(
-        &self,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
-        let mut results = HashMap::new();
-        for key in keys {
-            if let Some(value) = self.get(project, key, profile)? {
-                results.insert((*key).to_string(), value);
-            }
-        }
-        Ok(results)
+    /// The default deduplicates identical addresses and fetches each unique
+    /// address once, concurrently. Providers with a real batch surface (one
+    /// listing, a bulk API) should override this to cut round-trips further.
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        get_each(self, requests)
     }
 }
 
+/// Shared fallback used by the default [`Provider::get_many`] and by batch
+/// overrides for the part of a request set their bulk surface cannot serve:
+/// deduplicates identical addresses and fetches each unique address once,
+/// concurrently, mirroring the per-item threading batch overrides do.
+pub(crate) fn get_each<P: Provider + ?Sized>(
+    provider: &P,
+    requests: &[(&str, Address<'_>)],
+) -> Result<HashMap<String, SecretString>> {
+    let mut groups: HashMap<Address<'_>, Vec<&str>> = HashMap::new();
+    for (name, addr) in requests {
+        groups.entry(*addr).or_default().push(name);
+    }
+
+    // One address is the common case (a single secret, or several sharing a
+    // `ref`); fetching it on this thread skips the scope and the spawn.
+    let fetched: Vec<(Vec<&str>, Result<Option<SecretString>>)> = if groups.len() <= 1 {
+        groups
+            .into_iter()
+            .map(|(addr, names)| (names, provider.get(addr)))
+            .collect()
+    } else {
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = groups
+                .into_iter()
+                .map(|(addr, names)| (names, scope.spawn(move || provider.get(addr))))
+                .collect();
+            handles
+                .into_iter()
+                .map(|(names, handle)| {
+                    (
+                        names,
+                        handle.join().expect("get_many fetch thread panicked"),
+                    )
+                })
+                .collect()
+        })
+    };
+
+    let mut results = HashMap::new();
+    for (names, result) in fetched {
+        if let Some(value) = result? {
+            for name in names {
+                results.insert(name.to_string(), value.clone());
+            }
+        }
+    }
+    Ok(results)
+}
+
 impl<T: Provider> Provider for std::sync::Arc<T> {
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        (**self).get(project, key, profile)
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        (**self).convention_address(project, profile, key)
     }
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        (**self).set(project, key, value, profile)
+    fn supported_coords(&self) -> &'static [&'static str] {
+        (**self).supported_coords()
     }
-    fn allows_set(&self) -> bool {
-        (**self).allows_set()
+    fn resolve_coords<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, NativeAddress>> {
+        (**self).resolve_coords(addr)
+    }
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        (**self).get(addr)
+    }
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        (**self).set(addr, value)
+    }
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        (**self).check_writable(addr)
+    }
+    fn auth_scope_key(&self) -> Option<String> {
+        (**self).auth_scope_key()
     }
     fn name(&self) -> &'static str {
         (**self).name()
@@ -509,13 +689,8 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn reflect(&self) -> Result<HashMap<String, crate::config::Secret>> {
         (**self).reflect()
     }
-    fn get_batch(
-        &self,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
-        (**self).get_batch(project, keys, profile)
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        (**self).get_many(requests)
     }
 }
 
@@ -525,6 +700,65 @@ pub(crate) struct ProviderWithPreflight {
     pub provider: Box<dyn Provider>,
     pub preflight: Option<Box<dyn Fn() -> Result<()> + Send + Sync>>,
 }
+
+/// Process-wide deduplication of provider auth probes.
+///
+/// Caching the preflight check per provider *instance* was enough when one
+/// instance served every secret, but a secret's `providers` fallback chain
+/// builds a fresh instance per (secret, URI) pair, so N secrets would run N
+/// identical auth probes (each a CLI round-trip). Providers whose auth state is
+/// shared across instances advertise that via [`Provider::auth_scope_key`], and
+/// [`PreflightGuard`] keys their probe here instead: the first caller per key
+/// runs it, concurrent callers block on the same cell, and later callers
+/// reuse the result.
+///
+/// Failures are returned to every caller waiting on the in-flight probe but
+/// are not cached beyond that: the user may fix auth mid-process (e.g. unlock
+/// the desktop app in a long-lived SDK process), so the next check re-probes.
+pub(crate) struct AuthCheckCache<K> {
+    cells: Mutex<HashMap<K, Arc<OnceLock<std::result::Result<(), String>>>>>,
+}
+
+impl<K> Default for AuthCheckCache<K> {
+    fn default() -> Self {
+        Self {
+            cells: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl<K: std::hash::Hash + Eq + Clone> AuthCheckCache<K> {
+    pub(crate) fn check(
+        &self,
+        key: K,
+        probe: impl FnOnce() -> std::result::Result<(), String>,
+    ) -> std::result::Result<(), String> {
+        let cell = self
+            .cells
+            .lock()
+            .unwrap()
+            .entry(key.clone())
+            .or_default()
+            .clone();
+        let result = cell.get_or_init(probe).clone();
+        if result.is_err() {
+            // Drop the failed cell so a later retry re-probes, but only if it
+            // is still ours: another thread may have already replaced it.
+            let mut cells = self.cells.lock().unwrap();
+            if let Some(existing) = cells.get(&key)
+                && Arc::ptr_eq(existing, &cell)
+            {
+                cells.remove(&key);
+            }
+        }
+        result
+    }
+}
+
+/// Auth probes shared across provider instances (see
+/// [`Provider::auth_scope_key`]), keyed by provider name plus scope.
+static PREFLIGHT_AUTH_CACHE: LazyLock<AuthCheckCache<(&'static str, String)>> =
+    LazyLock::new(AuthCheckCache::default);
 
 /// Wrapper that runs a preflight check exactly once before any provider
 /// operation, caching the result for all subsequent calls.
@@ -544,13 +778,20 @@ impl PreflightGuard {
     }
 
     fn check(&self) -> Result<()> {
-        let result = self.result.get_or_init(|| {
-            if let Some(f) = &self.preflight {
-                f().map_err(|e| e.to_string())
-            } else {
-                Ok(())
-            }
-        });
+        let Some(f) = &self.preflight else {
+            return Ok(());
+        };
+        // A provider with a shared auth scope dedupes the probe process-wide
+        // in PREFLIGHT_AUTH_CACHE, so the per-instance providers that a
+        // secret's `providers` chain creates all reuse one probe.
+        if let Some(scope) = self.inner.auth_scope_key() {
+            return PREFLIGHT_AUTH_CACHE
+                .check((self.inner.name(), scope), || {
+                    f().map_err(|e| e.to_string())
+                })
+                .map_err(SecretSpecError::ProviderOperationFailed);
+        }
+        let result = self.result.get_or_init(|| f().map_err(|e| e.to_string()));
         match result {
             Ok(()) => Ok(()),
             Err(msg) => Err(SecretSpecError::ProviderOperationFailed(msg.clone())),
@@ -559,18 +800,36 @@ impl PreflightGuard {
 }
 
 impl Provider for PreflightGuard {
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        self.check()?;
-        self.inner.get(project, key, profile)
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        // Pure naming, no I/O: needs no auth preflight.
+        self.inner.convention_address(project, profile, key)
     }
 
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        self.check()?;
-        self.inner.set(project, key, value, profile)
+    fn supported_coords(&self) -> &'static [&'static str] {
+        self.inner.supported_coords()
     }
 
-    fn allows_set(&self) -> bool {
-        self.inner.allows_set()
+    fn resolve_coords<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, NativeAddress>> {
+        // Pure naming, no I/O: needs no auth preflight.
+        self.inner.resolve_coords(addr)
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        self.check()?;
+        self.inner.get(addr)
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check()?;
+        self.inner.set(addr, value)
+    }
+
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        self.inner.check_writable(addr)
+    }
+
+    fn auth_scope_key(&self) -> Option<String> {
+        self.inner.auth_scope_key()
     }
 
     fn name(&self) -> &'static str {
@@ -594,14 +853,9 @@ impl Provider for PreflightGuard {
         self.inner.reflect()
     }
 
-    fn get_batch(
-        &self,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
         self.check()?;
-        self.inner.get_batch(project, keys, profile)
+        self.inner.get_many(requests)
     }
 }
 
@@ -615,7 +869,7 @@ impl TryFrom<String> for Box<dyn Provider> {
     ///
     /// # URI Formats
     ///
-    /// - **Full URI**: `scheme://authority/path` (e.g., `onepassword://vault/Production`)
+    /// - **Full URI**: `scheme://authority/path` (e.g., `onepassword://Production`)
     ///
     /// # Special Cases
     ///
@@ -631,7 +885,7 @@ impl TryFrom<String> for Box<dyn Provider> {
     /// let provider = Box::<dyn Provider>::try_from("keyring".to_string())?;
     ///
     /// // Full URI with configuration
-    /// let provider = Box::<dyn Provider>::try_from("onepassword://vault/Production".to_string())?;
+    /// let provider = Box::<dyn Provider>::try_from("onepassword://Production".to_string())?;
     ///
     /// // Dotenv with path
     /// let provider = Box::<dyn Provider>::try_from("dotenv:.env.production".to_string())?;
@@ -658,7 +912,8 @@ impl TryFrom<&str> for Box<dyn Provider> {
         // Validate scheme first
         if scheme == "1password" {
             return Err(SecretSpecError::ProviderOperationFailed(
-                "Invalid scheme '1password'. Use 'onepassword' instead (e.g., onepassword://vault/path)".to_string()
+                "Invalid scheme '1password'. Use 'onepassword' instead (e.g., onepassword://vault)"
+                    .to_string(),
             ));
         }
 
@@ -698,7 +953,7 @@ impl TryFrom<&str> for Box<dyn Provider> {
             let url_string = match rest {
                 // Just scheme name (e.g., "keyring")
                 "" | ":" => format!("{}://", scheme),
-                // Standard URI format already has // (e.g., "onepassword://vault/path")
+                // Standard URI format already has // (e.g., "onepassword://vault")
                 s if s.starts_with("//") => format!("{}:{}", scheme, s),
                 // Path only format (e.g., "dotenv:/path/to/.env")
                 s if s.starts_with('/') => format!("{}://{}", scheme, s),
@@ -750,6 +1005,60 @@ fn provider_from_url(url: &ProviderUrl) -> Result<Box<dyn Provider>> {
         Ok(Box::new(PreflightGuard::new(pwp)))
     } else {
         Ok(pwp.provider)
+    }
+}
+
+#[cfg(test)]
+mod auth_cache_tests {
+    use super::AuthCheckCache;
+    use std::cell::Cell;
+
+    #[test]
+    fn success_probes_once_per_key() {
+        let cache = AuthCheckCache::default();
+        let probes = Cell::new(0);
+        for _ in 0..3 {
+            let result = cache.check("key", || {
+                probes.set(probes.get() + 1);
+                Ok(())
+            });
+            assert_eq!(result, Ok(()));
+        }
+        assert_eq!(probes.get(), 1);
+    }
+
+    #[test]
+    fn failure_is_not_cached() {
+        let cache = AuthCheckCache::default();
+        assert_eq!(
+            cache.check("key", || Err("not signed in".to_string())),
+            Err("not signed in".to_string())
+        );
+        // A later check re-probes and can observe recovered auth
+        // (e.g. after `op signin`).
+        assert_eq!(cache.check("key", || Ok(())), Ok(()));
+        // ...and the recovery is then cached.
+        let probes = Cell::new(0);
+        assert_eq!(
+            cache.check("key", || {
+                probes.set(probes.get() + 1);
+                Ok(())
+            }),
+            Ok(())
+        );
+        assert_eq!(probes.get(), 0);
+    }
+
+    #[test]
+    fn keys_are_independent() {
+        let cache = AuthCheckCache::default();
+        assert_eq!(cache.check("a", || Ok(())), Ok(()));
+        assert_eq!(
+            cache.check("b", || Err("nope".to_string())),
+            Err("nope".to_string())
+        );
+        // "a" stays cached despite "b" failing.
+        assert_eq!(cache.check("a", || Err("unused".to_string())), Ok(()));
     }
 }
 

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -1,4 +1,4 @@
-use crate::provider::{Provider, ProviderUrl};
+use crate::provider::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -70,6 +70,20 @@ struct OnePasswordFieldTemplate {
     value: String,
 }
 
+/// The item/field coordinates a native address resolves against 1Password,
+/// consumed by the `op read` / `op item edit` command paths. Built from a
+/// secret's `ref` table (see [`crate::config::NativeAddress`]); the vault is
+/// resolved separately (the address's `vault` key or the store's default).
+#[derive(Debug)]
+pub struct SecretReference {
+    /// The item name or UUID.
+    pub item: String,
+    /// Optional section the field lives under.
+    pub section: Option<String>,
+    /// The field label or ID to read and write.
+    pub field: String,
+}
+
 /// Configuration for the OnePassword provider.
 ///
 /// This struct contains all the necessary configuration options for
@@ -130,10 +144,10 @@ impl TryFrom<&ProviderUrl> for OnePasswordConfig {
         match scheme {
             "1password" => {
                 return Err(SecretSpecError::ProviderOperationFailed(
-                    "Invalid scheme '1password'. Use 'onepassword' instead (e.g., onepassword://vault/path)".to_string()
+                    "Invalid scheme '1password'. Use 'onepassword' instead (e.g., onepassword://vault)".to_string()
                 ));
             }
-            "onepassword" | "onepassword+token" => {}
+            "onepassword" | "onepassword+token" | "op" => {}
             _ => {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
                     "Invalid scheme '{}' for OnePassword provider",
@@ -167,6 +181,30 @@ impl TryFrom<&ProviderUrl> for OnePasswordConfig {
                 // No username, so the host is the vault
                 config.default_vault = Some(host);
             }
+        }
+
+        // Item paths (the `op://vault/item/field` form earlier iterations
+        // accepted, including via `onepassword://`) are rejected with the
+        // exact `ref` table translation, instead of being silently ignored
+        // and reading the conventional layout.
+        let path = url.path();
+        let path = path.trim_matches('/');
+        if !path.is_empty() || scheme == "op" {
+            let vault = config.default_vault.as_deref().unwrap_or("<vault>");
+            let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+            let hint = match segments.as_slice() {
+                [item, field] => {
+                    crate::config::ref_table_hint(Some(vault), item, None, Some(field))
+                }
+                [item, section, field] => {
+                    crate::config::ref_table_hint(Some(vault), item, Some(section), Some(field))
+                }
+                _ => crate::config::ref_table_hint(Some(vault), "<item>", None, Some("<field>")),
+            };
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "1Password items are addressed with a secret's `ref`, not in the provider URI: \
+                 use providers = [\"onepassword://{vault}\"] with {hint}"
+            )));
         }
 
         Ok(config)
@@ -233,6 +271,10 @@ fn strip_op_session_env(cmd: &mut Command) {
 /// secrets. It organizes secrets in a hierarchical structure within OnePassword
 /// items using a configurable format string that defaults to: `secretspec/{project}/{profile}/{key}`.
 ///
+/// A secret with native `ref` coordinates instead reads the referenced item
+/// field via `op read` and writes it via `op item edit`, ignoring the layout
+/// above. See [`SecretReference`].
+///
 /// # Authentication
 ///
 /// The provider supports three authentication methods, in order of preference:
@@ -276,7 +318,7 @@ crate::register_provider! {
     config: OnePasswordConfig,
     name: "onepassword",
     description: "OnePassword password manager",
-    schemes: ["onepassword", "onepassword+token"],
+    schemes: ["onepassword", "onepassword+token", "op"],
     examples: ["onepassword://vault", "onepassword://work@Production", "onepassword+token://vault"],
     preflight: check_auth,
 }
@@ -427,18 +469,159 @@ impl OnePasswordProvider {
 
     /// Determines the vault name to use.
     ///
-    /// # Arguments
-    ///
-    /// * `profile` - The profile name (currently unused, but kept for potential future use)
-    ///
     /// # Returns
     ///
     /// The vault name to use - always returns the configured default_vault or "Private"
-    fn get_vault_name(&self, _profile: &str) -> String {
+    fn get_vault_name(&self) -> String {
         self.config
             .default_vault
             .clone()
             .unwrap_or_else(|| "Private".to_string())
+    }
+
+    /// Renders the full `op://` reference string for `op read`.
+    ///
+    /// Names are rendered decoded (spaces and all): the reference is passed to
+    /// `op` as a single process argument, so no URL encoding is involved.
+    fn reference_uri(vault: &str, reference: &SecretReference) -> String {
+        match &reference.section {
+            Some(section) => format!(
+                "op://{}/{}/{}/{}",
+                vault, reference.item, section, reference.field
+            ),
+            None => format!("op://{}/{}/{}", vault, reference.item, reference.field),
+        }
+    }
+
+    /// Reads the pinned reference via `op read` from the given vault.
+    ///
+    /// Returns `Ok(None)` when the referenced item or field does not exist,
+    /// mirroring how the conventional layout reports unprovisioned secrets.
+    fn read_reference(
+        &self,
+        vault: &str,
+        reference: &SecretReference,
+    ) -> Result<Option<SecretString>> {
+        let reference_uri = Self::reference_uri(vault, reference);
+        match self.execute_op_command(&["read", "--no-newline", &reference_uri], None) {
+            Ok(output) => Ok(Some(SecretString::new(output.into()))),
+            Err(SecretSpecError::ProviderOperationFailed(msg))
+                if msg.contains("isn't an item") || msg.contains("doesn't have a field") =>
+            {
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Writes a value to the pinned reference via `op item edit` in the given
+    /// vault.
+    ///
+    /// The referenced item must already exist: references point at externally
+    /// managed items, so the provider never creates one. `op item edit` adds
+    /// the field to the item if it is missing.
+    fn set_reference(
+        &self,
+        vault: &str,
+        reference: &SecretReference,
+        value: &SecretString,
+    ) -> Result<()> {
+        let assignment = format!(
+            "{}={}",
+            Self::assignment_target(reference),
+            value.expose_secret()
+        );
+        let args = vec![
+            "item",
+            "edit",
+            &reference.item,
+            "--vault",
+            vault,
+            &assignment,
+        ];
+        self.execute_op_command(&args, None)?;
+        Ok(())
+    }
+
+    /// Builds the internal reference a native address's coordinates describe,
+    /// resolving the vault (the address's `vault` overrides the store's
+    /// default) and rejecting coordinate combinations 1Password cannot honor.
+    /// Without a `field`, the address names a whole item, read like a
+    /// convention secret and written through its `value` field.
+    ///
+    /// Takes coordinates already resolved (and therefore validated) by
+    /// [`Provider::resolve_coords`].
+    fn native_reference(
+        &self,
+        native: &crate::config::NativeAddress,
+    ) -> Result<(String, Option<SecretReference>)> {
+        let vault = native
+            .vault
+            .clone()
+            .unwrap_or_else(|| self.get_vault_name());
+        let reference = match &native.field {
+            Some(field) => Some(SecretReference {
+                item: native.item.clone(),
+                section: native.section.clone(),
+                field: field.clone(),
+            }),
+            None => {
+                if native.section.is_some() {
+                    return Err(SecretSpecError::ProviderOperationFailed(
+                        "onepassword references with a `section` also need a `field`".to_string(),
+                    ));
+                }
+                None
+            }
+        };
+        Ok((vault, reference))
+    }
+
+    /// Reads a whole item by title (or ID) from a vault and extracts its value:
+    /// the field labeled "value" first, then password/concealed fields. Shared
+    /// by convention reads and whole-item native addresses.
+    ///
+    /// If multiple items share the title, falls back to ID-based lookup for
+    /// the first match.
+    fn read_item(&self, vault: &str, item_name: &str) -> Result<Option<SecretString>> {
+        let args = vec![
+            "item", "get", item_name, "--vault", vault, "--format", "json",
+        ];
+
+        match self.execute_op_command(&args, None) {
+            Ok(output) => self.extract_value_from_item(&output),
+            Err(SecretSpecError::ProviderOperationFailed(msg)) if msg.contains("isn't an item") => {
+                Ok(None)
+            }
+            Err(SecretSpecError::ProviderOperationFailed(msg))
+                if msg.contains("More than one item") =>
+            {
+                // Multiple items with same title - fall back to ID-based lookup
+                if let Some(item_id) = self.find_item_id(item_name, vault)? {
+                    let args = vec![
+                        "item", "get", &item_id, "--vault", vault, "--format", "json",
+                    ];
+                    match self.execute_op_command(&args, None) {
+                        Ok(output) => self.extract_value_from_item(&output),
+                        Err(e) => Err(e),
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Builds the `[section.]field` left-hand side of an `op item edit`
+    /// assignment. Periods are structural in `op`'s assignment syntax and get
+    /// backslash-escaped so they stay part of the name.
+    fn assignment_target(reference: &SecretReference) -> String {
+        let escape = |s: &str| s.replace('.', "\\.");
+        match &reference.section {
+            Some(section) => format!("{}.{}", escape(section), escape(&reference.field)),
+            None => escape(&reference.field),
+        }
     }
 
     /// Finds an item by title in the vault and returns its ID.
@@ -583,21 +766,61 @@ impl OnePasswordProvider {
 
 impl OnePasswordProvider {
     /// Checks that the user is authenticated with OnePassword.
-    /// Called by the preflight guard before any provider operations.
+    /// Called by the preflight guard before any provider operations, which
+    /// dedupes the probe across instances via [`Provider::auth_scope_key`].
     pub(crate) fn check_auth(&self) -> Result<()> {
-        if self.is_authenticated()? {
-            Ok(())
-        } else {
-            Err(SecretSpecError::ProviderOperationFailed(
+        match self.is_authenticated() {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(SecretSpecError::ProviderOperationFailed(
                 AUTH_REQUIRED_HELP.to_string(),
-            ))
+            )),
+            Err(e) => Err(e),
         }
     }
 }
 
 impl Provider for OnePasswordProvider {
+    /// Convention items are titled by the folder-prefix format string,
+    /// `secretspec/{project}/{profile}/{key}` by default, in the store's
+    /// default vault, and read like whole-item references: the `value` field
+    /// first, then password/concealed fields.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: self.format_item_name(project, key, profile),
+            vault: Some(self.get_vault_name()),
+            ..Default::default()
+        })
+    }
+
+    /// `vault` overrides the store's default vault, `section`/`field` address a
+    /// component within the item. 1Password items are not versioned.
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field", "vault", "section"]
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
+    }
+
+    /// Auth state is per account/token (and `op` binary), not per provider
+    /// instance, so the preflight probe is shared across instances with the
+    /// same identity. Pinned secret references produce one instance per
+    /// referenced secret; without this, N references would run N identical
+    /// `op vault list` round-trips.
+    fn auth_scope_key(&self) -> Option<String> {
+        Some(format!(
+            "{:?}",
+            (
+                &self.config.account,
+                &self.config.service_account_token,
+                &self.op_command
+            )
+        ))
     }
 
     fn uri(&self) -> String {
@@ -636,55 +859,24 @@ impl Provider for OnePasswordProvider {
 
     /// Retrieves a secret from OnePassword.
     ///
-    /// Searches for an item with the title formatted according to the folder_prefix
-    /// configuration in the appropriate vault. The method looks for a field labeled "value"
-    /// first, then falls back to password or concealed fields.
-    ///
-    /// If multiple items exist with the same title, falls back to ID-based lookup
-    /// to retrieve the first matching item.
-    ///
-    /// # Arguments
-    ///
-    /// * `project` - The project name
-    /// * `key` - The secret key to retrieve
-    /// * `profile` - The profile to use for vault selection
+    /// If multiple items exist with the same title, falls back to ID-based
+    /// lookup to retrieve the first matching item.
     ///
     /// # Returns
     ///
     /// * `Ok(Some(value))` - The secret value if found
-    /// * `Ok(None)` - No secret found with the given key
+    /// * `Ok(None)` - No secret found at the address
     /// * `Err(_)` - Authentication or retrieval error
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        let vault = self.get_vault_name(profile);
-        let item_name = self.format_item_name(project, key, profile);
-
-        // Try to get the item by title
-        let args = vec![
-            "item", "get", &item_name, "--vault", &vault, "--format", "json",
-        ];
-
-        match self.execute_op_command(&args, None) {
-            Ok(output) => self.extract_value_from_item(&output),
-            Err(SecretSpecError::ProviderOperationFailed(msg)) if msg.contains("isn't an item") => {
-                Ok(None)
-            }
-            Err(SecretSpecError::ProviderOperationFailed(msg))
-                if msg.contains("More than one item") =>
-            {
-                // Multiple items with same title - fall back to ID-based lookup
-                if let Some(item_id) = self.find_item_id(&item_name, &vault)? {
-                    let args = vec![
-                        "item", "get", &item_id, "--vault", &vault, "--format", "json",
-                    ];
-                    match self.execute_op_command(&args, None) {
-                        Ok(output) => self.extract_value_from_item(&output),
-                        Err(e) => Err(e),
-                    }
-                } else {
-                    Ok(None)
-                }
-            }
-            Err(e) => Err(e),
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coords = self.resolve_coords(addr)?;
+        let (vault, reference) = self.native_reference(&coords)?;
+        match reference {
+            // A field-addressed reference goes through `op read`.
+            Some(reference) => self.read_reference(&vault, &reference),
+            // A whole-item address (every convention secret, and field-less
+            // refs) reads via the value/password field extraction of
+            // `op item get`.
+            None => self.read_item(&vault, &coords.item),
         }
     }
 
@@ -710,8 +902,29 @@ impl Provider for OnePasswordProvider {
     /// - Authentication required if not signed in
     /// - Item creation/update failures
     /// - Temporary file creation errors
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        let vault = self.get_vault_name(profile);
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let (project, profile, key) = match addr {
+            Address::Native(native) => {
+                let coords = self.resolve_coords(addr)?;
+                let (vault, reference) = self.native_reference(&coords)?;
+                // Writes through a native address go to the existing item in
+                // place (`op item edit` adds a missing field but never creates
+                // an item): a whole-item address writes its `value` field, the
+                // same field convention reads extract first.
+                let reference = reference.unwrap_or_else(|| SecretReference {
+                    item: native.item.clone(),
+                    section: None,
+                    field: "value".to_string(),
+                });
+                return self.set_reference(&vault, &reference, value);
+            }
+            Address::Convention {
+                project,
+                profile,
+                key,
+            } => (project, profile, key),
+        };
+        let vault = self.get_vault_name();
         let item_name = self.format_item_name(project, key, profile);
 
         // Check if item exists by listing items (more reliable than get which requires
@@ -745,29 +958,50 @@ impl Provider for OnePasswordProvider {
 
     /// Retrieves multiple secrets from OnePassword in a single batch operation.
     ///
-    /// This optimized implementation:
-    /// 1. Authenticates once (cached)
-    /// 2. Lists all items in the vault once to identify which secrets exist
-    /// 3. Fetches only the items that exist, using parallel threads
-    ///
-    /// This significantly improves performance compared to fetching secrets one-by-one,
-    /// especially when checking many secrets.
-    fn get_batch(
-        &self,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
-        use std::thread;
-
-        if keys.is_empty() {
+    /// Whole-item addresses (every convention secret, and field-less refs)
+    /// are served from one item listing per vault plus parallel `op item get`
+    /// calls for the titles that exist. Field-addressed refs go through
+    /// `op read` each, concurrently.
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        if requests.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let vault = self.get_vault_name(profile);
+        // Whole-item requests as (request name, item title), grouped by vault.
+        let mut whole_items: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        let mut field_refs: Vec<(&str, Address<'_>)> = Vec::new();
+        for (name, addr) in requests {
+            let coords = self.resolve_coords(*addr)?;
+            let (vault, reference) = self.native_reference(&coords)?;
+            match reference {
+                Some(_) => field_refs.push((name, *addr)),
+                None => whole_items
+                    .entry(vault)
+                    .or_default()
+                    .push((name.to_string(), coords.item.clone())),
+            }
+        }
 
+        let mut results = HashMap::new();
+        for (vault, items) in whole_items {
+            results.extend(self.get_items_batch(&vault, items)?);
+        }
+        results.extend(super::get_each(self, &field_refs)?);
+        Ok(results)
+    }
+}
+
+impl OnePasswordProvider {
+    /// Fetches the given `(request name, item title)` pairs from one vault:
+    /// lists the vault once to resolve titles to ids, then fetches the items
+    /// that exist in parallel threads and extracts their value/password field.
+    fn get_items_batch(
+        &self,
+        vault: &str,
+        items: Vec<(String, String)>,
+    ) -> Result<HashMap<String, SecretString>> {
         // List all items in the vault once
-        let args = vec!["item", "list", "--vault", &vault, "--format", "json"];
+        let args = vec!["item", "list", "--vault", vault, "--format", "json"];
         let output = self.execute_op_command(&args, None)?;
 
         #[derive(Deserialize)]
@@ -776,94 +1010,37 @@ impl Provider for OnePasswordProvider {
             title: String,
         }
 
-        let items: Vec<ListItem> = serde_json::from_str(&output).unwrap_or_default();
+        let listed: Vec<ListItem> = serde_json::from_str(&output).unwrap_or_default();
 
         // Build a map of item titles to IDs for quick lookup
-        let item_map: HashMap<String, String> = items
+        let item_map: HashMap<String, String> = listed
             .into_iter()
             .map(|item| (item.title, item.id))
             .collect();
 
-        // Find which keys exist and need to be fetched
-        let keys_to_fetch: Vec<(&str, String)> = keys
-            .iter()
-            .filter_map(|key| {
-                let item_name = self.format_item_name(project, key, profile);
-                item_map.get(&item_name).map(|id| (*key, id.clone()))
-            })
-            .collect();
-
-        // Fetch items in parallel using threads
-        let vault_clone = vault.clone();
-        let op_command = self.op_command.clone();
-        let service_token = self.config.service_account_token.clone();
-        let account = self.config.account.clone();
-
-        let handles: Vec<_> = keys_to_fetch
+        // Find which titles exist and need to be fetched
+        let to_fetch: Vec<(String, String)> = items
             .into_iter()
-            .map(|(key, item_id)| {
-                let vault = vault_clone.clone();
-                let op_cmd = op_command.clone();
-                let token = service_token.clone();
-                let acct = account.clone();
-                let key_owned = key.to_string();
-
-                thread::spawn(move || {
-                    let mut cmd = Command::new(&op_cmd);
-                    strip_op_session_env(&mut cmd);
-
-                    if let Some(ref t) = token {
-                        cmd.env("OP_SERVICE_ACCOUNT_TOKEN", t);
-                    }
-                    if let Some(ref a) = acct {
-                        cmd.arg("--account").arg(a);
-                    }
-
-                    cmd.args([
-                        "item", "get", &item_id, "--vault", &vault, "--format", "json",
-                    ]);
-
-                    match cmd.output() {
-                        Ok(output) if output.status.success() => {
-                            let stdout = String::from_utf8_lossy(&output.stdout);
-                            // Parse the item and extract value
-                            if let Ok(item) = serde_json::from_str::<OnePasswordItem>(&stdout) {
-                                // Look for "value" field first
-                                for field in &item.fields {
-                                    if field.label.as_deref() == Some("value")
-                                        && let Some(ref v) = field.value
-                                    {
-                                        return Some((
-                                            key_owned,
-                                            SecretString::new(v.clone().into()),
-                                        ));
-                                    }
-                                }
-                                // Fallback: look for password/concealed field
-                                for field in &item.fields {
-                                    if (field.field_type == "CONCEALED" || field.id == "password")
-                                        && let Some(ref v) = field.value
-                                    {
-                                        return Some((
-                                            key_owned,
-                                            SecretString::new(v.clone().into()),
-                                        ));
-                                    }
-                                }
-                            }
-                            None
-                        }
-                        _ => None,
-                    }
-                })
-            })
+            .filter_map(|(name, title)| item_map.get(&title).map(|id| (name, id.clone())))
             .collect();
 
-        // Collect results from all threads
+        // Fetch the items concurrently. Each id came from the listing above, so
+        // it is unambiguous: `read_item`'s duplicate-title fallback never fires.
+        let fetched: Vec<(String, Result<Option<SecretString>>)> = std::thread::scope(|scope| {
+            let handles: Vec<_> = to_fetch
+                .into_iter()
+                .map(|(name, item_id)| (name, scope.spawn(move || self.read_item(vault, &item_id))))
+                .collect();
+            handles
+                .into_iter()
+                .map(|(name, handle)| (name, handle.join().expect("op item get thread panicked")))
+                .collect()
+        });
+
         let mut results = HashMap::new();
-        for handle in handles {
-            if let Ok(Some((key, value))) = handle.join() {
-                results.insert(key, value);
+        for (name, result) in fetched {
+            if let Some(value) = result? {
+                results.insert(name, value);
             }
         }
 
@@ -940,10 +1117,10 @@ mod tests {
     #[test]
     fn get_vault_name_defaults_to_private() {
         let default = OnePasswordProvider::new(OnePasswordConfig::default());
-        assert_eq!(default.get_vault_name("any"), "Private");
+        assert_eq!(default.get_vault_name(), "Private");
 
         let configured = OnePasswordProvider::new(config("onepassword://Production"));
-        assert_eq!(configured.get_vault_name("any"), "Production");
+        assert_eq!(configured.get_vault_name(), "Production");
     }
 
     #[test]
@@ -974,5 +1151,152 @@ mod tests {
         let uri = provider.uri();
         assert_eq!(uri, "onepassword+token://Private");
         assert!(!uri.contains("ops_secret_tok"));
+    }
+
+    fn config_err(s: &str) -> SecretSpecError {
+        OnePasswordConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap_err()
+    }
+
+    /// Every URI shape that used to be an instance-level reference now errors
+    /// with a pointer at the `ref` table.
+    #[test]
+    fn item_paths_are_rejected_with_ref_hint() {
+        // A full reference gets the exact translation.
+        let err = config_err("op://Infra/db/password");
+        assert!(
+            err.to_string()
+                .contains("ref = { vault = \"Infra\", item = \"db\", field = \"password\" }"),
+            "{err}"
+        );
+
+        // A bare op:// with no path still points at `ref`.
+        let err = config_err("op://Infra");
+        assert!(
+            err.to_string().contains("addressed with a secret's `ref`"),
+            "{err}"
+        );
+
+        // Odd shapes (single segment, too deep) get the generic pointer.
+        let err = config_err("onepassword://vault/Production");
+        assert!(
+            err.to_string().contains("addressed with a secret's `ref`"),
+            "{err}"
+        );
+        let err = config_err("op://Infra/a/b/c/d");
+        assert!(
+            err.to_string().contains("addressed with a secret's `ref`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn assignment_target_escapes_dots() {
+        let reference = SecretReference {
+            item: "db".to_string(),
+            section: Some("api.keys".to_string()),
+            field: "connection.url".to_string(),
+        };
+        assert_eq!(
+            OnePasswordProvider::assignment_target(&reference),
+            "api\\.keys.connection\\.url"
+        );
+
+        let reference = SecretReference {
+            section: None,
+            ..reference
+        };
+        assert_eq!(
+            OnePasswordProvider::assignment_target(&reference),
+            "connection\\.url"
+        );
+    }
+
+    #[test]
+    fn pasted_reference_hint_preserves_spaces() {
+        // Spaces in vault and item names must survive into the translation
+        // hint, since users paste references straight from the 1Password app.
+        let Err(err) = Box::<dyn Provider>::try_from("op://Prod Vault/My Item/field") else {
+            panic!("op:// provider spec must be rejected");
+        };
+        assert!(
+            err.to_string().contains(
+                "ref = { vault = \"Prod Vault\", item = \"My Item\", field = \"field\" }"
+            ),
+            "{err}"
+        );
+    }
+
+    /// A native address maps its coordinates onto the internal reference: the
+    /// `vault` key overrides the store's default vault, `section` and `field`
+    /// carry through.
+    #[test]
+    fn native_address_maps_coordinates_with_vault_override() {
+        let provider = OnePasswordProvider::new(config("onepassword://Personal"));
+        let addr = crate::config::NativeAddress {
+            item: "db".into(),
+            field: Some("password".into()),
+            section: Some("api".into()),
+            vault: Some("Production".into()),
+            ..Default::default()
+        };
+        let (vault, reference) = provider.native_reference(&addr).unwrap();
+        assert_eq!(vault, "Production");
+        let reference = reference.expect("field-addressed reference");
+        assert_eq!(
+            OnePasswordProvider::reference_uri(&vault, &reference),
+            "op://Production/db/api/password"
+        );
+    }
+
+    /// Without a `vault` key, the store URI's vault applies.
+    #[test]
+    fn native_address_vault_defaults_to_store_vault() {
+        let provider = OnePasswordProvider::new(config("onepassword://Personal"));
+        let addr = crate::config::NativeAddress {
+            item: "db".into(),
+            field: Some("password".into()),
+            ..Default::default()
+        };
+        let (vault, _) = provider.native_reference(&addr).unwrap();
+        assert_eq!(vault, "Personal");
+    }
+
+    /// A whole-item address (no `field`) resolves to no internal reference:
+    /// reads go through the convention item extraction.
+    #[test]
+    fn native_address_without_field_names_the_whole_item() {
+        let provider = OnePasswordProvider::new(config("onepassword://Personal"));
+        let addr = crate::config::NativeAddress {
+            item: "My API Item".into(),
+            ..Default::default()
+        };
+        let (_, reference) = provider.native_reference(&addr).unwrap();
+        assert!(reference.is_none());
+    }
+
+    /// 1Password items are not versioned; the coordinate is rejected.
+    #[test]
+    fn native_address_rejects_version() {
+        let provider = OnePasswordProvider::new(config("onepassword://Personal"));
+        let addr = crate::config::NativeAddress {
+            item: "db".into(),
+            version: Some("3".into()),
+            ..Default::default()
+        };
+        let err = provider.resolve_coords(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`version`"), "{err}");
+    }
+
+    /// A `section` only makes sense when addressing a `field` within it.
+    #[test]
+    fn native_address_section_requires_field() {
+        let provider = OnePasswordProvider::new(config("onepassword://Personal"));
+        let addr = crate::config::NativeAddress {
+            item: "db".into(),
+            section: Some("api".into()),
+            ..Default::default()
+        };
+        let err = provider.native_reference(&addr).unwrap_err();
+        assert!(err.to_string().contains("need a `field`"), "{err}");
     }
 }

--- a/secretspec/src/provider/pass.rs
+++ b/secretspec/src/provider/pass.rs
@@ -1,4 +1,4 @@
-use super::{Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -42,12 +42,12 @@ impl TryFrom<&ProviderUrl> for PassConfig {
 
         let mut config = Self::default();
 
+        config.store_dir = url.query_value("store_dir");
+
         if let Some(host) = url.host() {
             let path = url.path();
             config.folder_prefix = Some(format!("{}{}", host, path));
         }
-
-        config.store_dir = url.query_value("store_dir");
 
         Ok(config)
     }
@@ -119,6 +119,20 @@ impl PassProvider {
 }
 
 impl Provider for PassProvider {
+    /// Convention entries live under the folder-prefix format string,
+    /// `secretspec/{project}/{profile}/{key}` by default.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: self.format_entry_name(project, profile, key),
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
@@ -156,13 +170,13 @@ impl Provider for PassProvider {
     /// * `Ok(Some(SecretString))` - The secret value if found
     /// * `Ok(None)` - If the secret doesn't exist in the password store
     /// * `Err` - If there was an error executing `pass` or reading the output
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        let entry_name = self.format_entry_name(project, profile, key);
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let entry_name = super::flat_item(self, addr)?;
 
         let output = self
             .command()
             .arg("show")
-            .arg(&entry_name)
+            .arg(&*entry_name)
             .output()
             .map_err(|e| {
                 SecretSpecError::ProviderOperationFailed(format!(
@@ -210,8 +224,8 @@ impl Provider for PassProvider {
     ///
     /// * `Ok(())` - If the value was successfully written
     /// * `Err(SecretSpecError)` - If writing the pass entry fails
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        let entry_name = self.format_entry_name(project, profile, key);
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let entry_name = super::flat_item(self, addr)?;
 
         let mut child = self
             .command()
@@ -395,5 +409,36 @@ mod tests {
                 "folder_prefix corrupted by store_dir {store_dir:?} via uri {uri:?}"
             );
         }
+    }
+
+    /// A native address names the store entry directly via `item`, bypassing
+    /// the folder-prefix format string.
+    #[test]
+    fn native_address_names_the_entry() {
+        let p = PassProvider::new(PassConfig {
+            folder_prefix: Some("vault/{profile}/{key}".to_string()),
+            store_dir: None,
+        });
+        let addr = crate::config::NativeAddress {
+            item: "email/work".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            crate::provider::flat_item(&p, Address::Native(&addr)).unwrap(),
+            "email/work"
+        );
+    }
+
+    /// Store entries have no sub-components; a `field` coordinate is rejected.
+    #[test]
+    fn native_address_rejects_field() {
+        let p = PassProvider::new(PassConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "email/work".into(),
+            field: Some("password".into()),
+            ..Default::default()
+        };
+        let err = crate::provider::flat_item(&p, Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
     }
 }

--- a/secretspec/src/provider/protonpass.rs
+++ b/secretspec/src/provider/protonpass.rs
@@ -1,4 +1,4 @@
-use crate::provider::{Provider, ProviderUrl};
+use crate::provider::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -300,6 +300,20 @@ impl ProtonPassProvider {
 }
 
 impl Provider for ProtonPassProvider {
+    /// Convention items are titled by the title template,
+    /// `{project}/{profile}/{key}` by default.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: self.format_item_title(project, profile, key),
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
@@ -316,11 +330,18 @@ impl Provider for ProtonPassProvider {
         }
     }
 
+    /// `pass-cli test` probes the CLI's login session, which every instance
+    /// using the same binary shares, so they share one preflight probe.
+    fn auth_scope_key(&self) -> Option<String> {
+        Some(self.cli_binary_path.clone())
+    }
+
     fn set_reason(&self, reason: Option<String>) {
         *self.session_reason.lock().unwrap() = reason;
     }
 
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let title = crate::provider::flat_item(self, addr)?;
         match self.run_pass_cli(
             &[
                 "item",
@@ -328,7 +349,7 @@ impl Provider for ProtonPassProvider {
                 "--vault-name",
                 self.get_vault_name(),
                 "--item-title",
-                &self.format_item_title(project, profile, key),
+                &title,
                 "--output",
                 "json",
             ],
@@ -351,8 +372,8 @@ impl Provider for ProtonPassProvider {
         }
     }
 
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        let title = self.format_item_title(project, profile, key);
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let title = crate::provider::flat_item(self, addr)?;
         let maybe_existing_item = {
             let output = self.run_pass_cli(
                 &["item", "list", self.get_vault_name(), "--output", "json"],
@@ -363,7 +384,7 @@ impl Provider for ProtonPassProvider {
             response
                 .items
                 .into_iter()
-                .find(|item| item.title() == Some(title.as_str()))
+                .find(|item| item.title() == Some(&*title))
         };
 
         if let Some(existing_item) = maybe_existing_item {
@@ -381,7 +402,7 @@ impl Provider for ProtonPassProvider {
         }
 
         let template = serde_json::to_string(&ProtonPassNoteTemplate {
-            title,
+            title: title.into_owned(),
             note: value.expose_secret().to_string(),
         })
         .map_err(|e| SecretSpecError::ProviderOperationFailed(e.to_string()))?;
@@ -402,16 +423,18 @@ impl Provider for ProtonPassProvider {
         Ok(())
     }
 
-    fn get_batch(
-        &self,
-        project: &str,
-        keys: &[&str],
-        profile: &str,
-    ) -> Result<HashMap<String, SecretString>> {
+    /// Serves every request, convention or `ref`, from one vault listing plus
+    /// parallel `item view` calls for the titles that exist.
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
         use std::thread;
 
-        if keys.is_empty() {
+        if requests.is_empty() {
             return Ok(HashMap::new());
+        }
+
+        let mut titles = Vec::with_capacity(requests.len());
+        for (name, addr) in requests {
+            titles.push((*name, crate::provider::flat_item(self, *addr)?));
         }
 
         let list_response: ProtonPassListResponse = serde_json::from_str(&self.run_pass_cli(
@@ -429,13 +452,12 @@ impl Provider for ProtonPassProvider {
             })
             .collect();
 
-        let keys_to_fetch: Vec<(&str, String, String)> = keys
+        let keys_to_fetch: Vec<(&str, String, String)> = titles
             .iter()
-            .filter_map(|key| {
-                let title = self.format_item_title(project, profile, key);
+            .filter_map(|(name, title)| {
                 item_map
-                    .get(&title)
-                    .map(|(share_id, id)| (*key, share_id.clone(), id.clone()))
+                    .get(&**title)
+                    .map(|(share_id, id)| (*name, share_id.clone(), id.clone()))
             })
             .collect();
 
@@ -586,5 +608,36 @@ mod tests {
         let provider: Arc<ProtonPassProvider> = Arc::new(ProtonPassProvider::default());
         Provider::set_reason(&provider, Some("via arc".to_string()));
         assert_eq!(provider.agent_reason(), "via arc");
+    }
+
+    /// A native address names the item title directly via `item`, bypassing
+    /// the title template.
+    #[test]
+    fn native_address_names_the_title() {
+        let p = ProtonPassProvider::new(ProtonPassConfig {
+            title_template: Some("{project}/{key}".to_string()),
+            ..Default::default()
+        });
+        let addr = crate::config::NativeAddress {
+            item: "my api token".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            crate::provider::flat_item(&p, Address::Native(&addr)).unwrap(),
+            "my api token"
+        );
+    }
+
+    /// Note items carry the whole secret; a `field` coordinate is rejected.
+    #[test]
+    fn native_address_rejects_field() {
+        let p = ProtonPassProvider::new(ProtonPassConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "my api token".into(),
+            field: Some("password".into()),
+            ..Default::default()
+        };
+        let err = crate::provider::flat_item(&p, Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
     }
 }

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use crate::provider::Provider;
+use crate::provider::{Address, Provider};
 use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -22,17 +22,29 @@ impl MockProvider {
 }
 
 impl Provider for MockProvider {
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: format!("{}/{}/{}", project, profile, key),
+            ..Default::default()
+        })
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let full_key = super::flat_item(self, addr)?;
         let storage = self.storage.lock().unwrap();
-        let full_key = format!("{}/{}/{}", project, profile, key);
         Ok(storage
-            .get(&full_key)
+            .get(&*full_key)
             .map(|v| SecretString::new(v.clone().into())))
     }
 
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        let full_key = super::flat_item(self, addr)?.into_owned();
         let mut storage = self.storage.lock().unwrap();
-        let full_key = format!("{}/{}/{}", project, profile, key);
         storage.insert(full_key, value.expose_secret().to_string());
         Ok(())
     }
@@ -44,6 +56,119 @@ impl Provider for MockProvider {
     fn uri(&self) -> String {
         "mock://".to_string()
     }
+}
+
+/// Provider that records how many times `get` runs for each resolved `item`,
+/// so the shared [`get_each`](crate::provider::get_each) contract — identical
+/// addresses fetched once, missing secrets omitted — can be asserted. Every
+/// known item returns its stored value; anything else is `None`.
+struct CountingProvider {
+    values: HashMap<String, String>,
+    gets: Arc<Mutex<HashMap<String, usize>>>,
+}
+
+impl CountingProvider {
+    fn new(values: &[(&str, &str)]) -> Self {
+        Self {
+            values: values
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            gets: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn get_count(&self, item: &str) -> usize {
+        self.gets.lock().unwrap().get(item).copied().unwrap_or(0)
+    }
+}
+
+impl Provider for CountingProvider {
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: format!("{}/{}/{}", project, profile, key),
+            ..Default::default()
+        })
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let item = super::flat_item(self, addr)?.into_owned();
+        *self.gets.lock().unwrap().entry(item.clone()).or_insert(0) += 1;
+        Ok(self
+            .values
+            .get(&item)
+            .map(|v| SecretString::new(v.clone().into())))
+    }
+
+    fn set(&self, _addr: Address<'_>, _value: &SecretString) -> Result<()> {
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "counting"
+    }
+
+    fn uri(&self) -> String {
+        "counting://".to_string()
+    }
+}
+
+/// A single distinct address (the common case: one secret, or several sharing
+/// one `ref`) is fetched once and its value shared, via the inline fast path.
+#[test]
+fn get_each_dedupes_one_address_across_names() {
+    let p = CountingProvider::new(&[("svc", "val")]);
+    let coords = crate::config::NativeAddress {
+        item: "svc".into(),
+        ..Default::default()
+    };
+    let addr = Address::Native(&coords);
+    let out = super::get_each(&p, &[("FIRST", addr), ("SECOND", addr)]).unwrap();
+
+    assert_eq!(out["FIRST"].expose_secret(), "val");
+    assert_eq!(out["SECOND"].expose_secret(), "val");
+    assert_eq!(p.get_count("svc"), 1, "one address must be fetched once");
+}
+
+/// Distinct addresses take the threaded path; each is fetched once, results map
+/// back to the right names, and a secret that does not exist is omitted rather
+/// than surfaced as an empty value.
+#[test]
+fn get_each_fetches_distinct_addresses_and_omits_missing() {
+    let p = CountingProvider::new(&[("one", "v1"), ("two", "v2")]);
+    let a1 = crate::config::NativeAddress {
+        item: "one".into(),
+        ..Default::default()
+    };
+    let a2 = crate::config::NativeAddress {
+        item: "two".into(),
+        ..Default::default()
+    };
+    let a3 = crate::config::NativeAddress {
+        item: "absent".into(),
+        ..Default::default()
+    };
+    let out = super::get_each(
+        &p,
+        &[
+            ("A", Address::Native(&a1)),
+            ("B", Address::Native(&a2)),
+            ("C", Address::Native(&a3)),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(out["A"].expose_secret(), "v1");
+    assert_eq!(out["B"].expose_secret(), "v2");
+    assert!(!out.contains_key("C"), "a missing secret is omitted");
+    assert_eq!(p.get_count("one"), 1);
+    assert_eq!(p.get_count("two"), 1);
+    assert_eq!(p.get_count("absent"), 1);
 }
 
 #[test]
@@ -217,16 +342,33 @@ fn test_edge_cases_and_normalization() {
     let provider = Box::<dyn Provider>::try_from("dotenv:/absolute/path").unwrap();
     assert_eq!(provider.name(), "dotenv");
 
-    // Test normalized URIs with localhost (line 154)
-    let provider = Box::<dyn Provider>::try_from("env://localhost").unwrap();
-    assert_eq!(provider.name(), "env");
+    // env takes no authority: a variable is addressed via `ref`, not the URI.
+    let Err(err) = Box::<dyn Provider>::try_from("env://localhost") else {
+        panic!("env authority must be rejected");
+    };
+    assert!(err.to_string().contains("ref = { item ="), "{err}");
 }
 
 #[test]
-fn test_documentation_example_line_184() {
-    // Test the exact example from line 184 of registry.rs
-    let provider = Box::<dyn Provider>::try_from("onepassword://vault/Production").unwrap();
+fn test_onepassword_uri_forms() {
+    // Vault-only form
+    let provider = Box::<dyn Provider>::try_from("onepassword://Production").unwrap();
     assert_eq!(provider.name(), "onepassword");
+
+    // op:// URIs (1Password's own reference syntax) are no longer provider
+    // addresses: the error spells out the exact `ref` table translation.
+    let Err(err) = Box::<dyn Provider>::try_from("op://Production/db/password") else {
+        panic!("op:// provider spec must be rejected");
+    };
+    assert!(
+        err.to_string()
+            .contains("ref = { vault = \"Production\", item = \"db\", field = \"password\" }"),
+        "{err}"
+    );
+
+    // Any item path on the provider URI fails loudly instead of being
+    // silently discarded.
+    assert!(Box::<dyn Provider>::try_from("onepassword://vault/Production").is_err());
 }
 
 #[test]
@@ -350,7 +492,11 @@ mod integration_tests {
         let project_name = generate_test_project_name();
 
         // Test 1: Get non-existent secret
-        let result = provider.get(&project_name, "TEST_PASSWORD", "default");
+        let result = provider.get(Address::convention(
+            &project_name,
+            "default",
+            "TEST_PASSWORD",
+        ));
         match result {
             Ok(None) => {
                 // Expected: key doesn't exist
@@ -366,10 +512,16 @@ mod integration_tests {
         // Test 2: Try to set a secret (may fail for read-only providers)
         let test_value = SecretString::new(format!("test_password_{}", provider_name).into());
 
-        if provider.allows_set() {
+        if provider
+            .check_writable(Address::convention("proj", "default", "KEY"))
+            .is_ok()
+        {
             // Provider claims to support set, so it should work
             provider
-                .set(&project_name, "TEST_PASSWORD", &test_value, "default")
+                .set(
+                    Address::convention(&project_name, "default", "TEST_PASSWORD"),
+                    &test_value,
+                )
                 .expect(&format!(
                     "[{}] Provider claims to support set but failed",
                     provider_name
@@ -377,7 +529,11 @@ mod integration_tests {
 
             // Verify we can retrieve it
             let retrieved = provider
-                .get(&project_name, "TEST_PASSWORD", "default")
+                .get(Address::convention(
+                    &project_name,
+                    "default",
+                    "TEST_PASSWORD",
+                ))
                 .expect(&format!(
                     "[{}] Should not error when getting after set",
                     provider_name
@@ -398,7 +554,10 @@ mod integration_tests {
             }
         } else {
             // Provider is read-only, verify set fails
-            match provider.set(&project_name, "TEST_PASSWORD", &test_value, "default") {
+            match provider.set(
+                Address::convention(&project_name, "default", "TEST_PASSWORD"),
+                &test_value,
+            ) {
                 Ok(_) => {
                     panic!(
                         "[{}] Read-only provider should not allow set operations",
@@ -447,11 +606,14 @@ mod integration_tests {
         for (key, value) in &test_cases {
             let secret_value = SecretString::new(value.to_string().into());
             provider
-                .set(&project_name, key, &secret_value, "default")
+                .set(
+                    Address::convention(&project_name, "default", key),
+                    &secret_value,
+                )
                 .expect("Mock provider should handle all characters");
 
             let result = provider
-                .get(&project_name, key, "default")
+                .get(Address::convention(&project_name, "default", key))
                 .expect("Should not error when getting");
 
             assert_eq!(
@@ -472,11 +634,14 @@ mod integration_tests {
         for profile in &profiles {
             let value = SecretString::new(format!("key_for_{}", profile).into());
             provider
-                .set(&project_name, test_key, &value, profile)
+                .set(
+                    Address::convention(&project_name, profile, test_key),
+                    &value,
+                )
                 .expect("Should set with profile");
 
             let result = provider
-                .get(&project_name, test_key, profile)
+                .get(Address::convention(&project_name, profile, test_key))
                 .expect("Should get with profile");
 
             assert_eq!(
@@ -490,7 +655,7 @@ mod integration_tests {
         for i in 0..profiles.len() {
             for j in 0..profiles.len() {
                 let result = provider
-                    .get(&project_name, test_key, profiles[j])
+                    .get(Address::convention(&project_name, profiles[j], test_key))
                     .expect("Should not error");
 
                 if i == j {
@@ -567,10 +732,12 @@ mod integration_tests {
     }
 
     #[test]
-    fn test_pass_provider_allows_set() {
+    fn test_pass_provider_is_writable() {
         let provider = Box::<dyn Provider>::try_from("pass").unwrap();
         assert!(
-            provider.allows_set(),
+            provider
+                .check_writable(Address::convention("proj", "default", "KEY"))
+                .is_ok(),
             "Pass provider should support write operations"
         );
     }
@@ -599,10 +766,12 @@ mod integration_tests {
     }
 
     #[test]
-    fn test_protonpass_provider_allows_set() {
+    fn test_protonpass_provider_is_writable() {
         let provider = Box::<dyn Provider>::try_from("protonpass").unwrap();
         assert!(
-            provider.allows_set(),
+            provider
+                .check_writable(Address::convention("proj", "default", "KEY"))
+                .is_ok(),
             "ProtonPass provider should support write operations"
         );
     }
@@ -628,10 +797,8 @@ mod integration_tests {
         for (key, value) in &test_secrets {
             provider
                 .set(
-                    &project_name,
-                    key,
+                    Address::convention(&project_name, profile, key),
                     &SecretString::new(value.to_string().into()),
-                    profile,
                 )
                 .unwrap();
         }
@@ -643,7 +810,11 @@ mod integration_tests {
             "BATCH_TEST_3",
             "NONEXISTENT",
         ];
-        let result = provider.get_batch(&project_name, &keys, profile).unwrap();
+        let requests: Vec<(&str, Address<'_>)> = keys
+            .iter()
+            .map(|key| (*key, Address::convention(&project_name, profile, key)))
+            .collect();
+        let result = provider.get_many(&requests).unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result["BATCH_TEST_1"].expose_secret(), "value1");

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -47,7 +47,7 @@
 //! secretspec check --provider vault://team-a@vault.example.com:8200/secret
 //! ```
 
-use super::{Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
@@ -148,15 +148,16 @@ impl TryFrom<&ProviderUrl> for VaultConfig {
                 })?,
         };
 
-        // Mount path from URL path (strip leading slash, default to "secret")
+        // Mount path from URL path (strip leading slash, default to "secret").
+        // Mount paths may contain slashes; specific KV paths are addressed with
+        // a secret's `ref`, never in the provider URI.
         let path = url.path();
-        let mount = path
-            .trim_start_matches('/')
-            .split('/')
-            .next()
-            .filter(|s| !s.is_empty())
-            .unwrap_or("secret")
-            .to_string();
+        let trimmed = path.trim_start_matches('/').trim_end_matches('/');
+        let mount = if trimmed.is_empty() {
+            "secret".to_string()
+        } else {
+            trimmed.to_string()
+        };
 
         // KV version from query parameter (default: V2)
         let kv_version = url
@@ -193,6 +194,17 @@ impl TryFrom<&ProviderUrl> for VaultConfig {
             })
             .transpose()?
             .unwrap_or_default();
+
+        // The `?field=` reference form from earlier iterations is rejected
+        // with a pointer at the `ref` table, instead of being silently ignored
+        // and reading the conventional layout.
+        if let Some(field) = url.query_value("field") {
+            let hint = crate::config::ref_table_hint(None, "<kv-path>", None, Some(&field));
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "vault URIs take no `field` query: address the KV entry with \
+                 {hint} on the secret instead"
+            )));
+        }
 
         Ok(Self {
             endpoint,
@@ -375,15 +387,15 @@ impl VaultProvider {
         }
     }
 
-    /// Retrieves a secret from Vault asynchronously.
-    async fn get_secret_async(
+    /// Reads a single field from a KV path asynchronously. SecretSpec's own layout
+    /// stores every secret under a `value` field; a reference reads an arbitrary
+    /// field at an arbitrary path.
+    async fn get_field_async(
         &self,
-        project: &str,
-        key: &str,
-        profile: &str,
+        secret_path: &str,
+        field: &str,
     ) -> Result<Option<SecretString>> {
-        let secret_path = Self::format_secret_path(project, profile, key)?;
-        let url = self.build_url(&secret_path);
+        let url = self.build_url(secret_path);
         let token = self.resolve_token()?;
         let headers = Self::build_headers(&token, &self.config.namespace)?;
 
@@ -413,11 +425,11 @@ impl VaultProvider {
                     KvVersion::V2 => body
                         .get("data")
                         .and_then(|d| d.get("data"))
-                        .and_then(|d| d.get("value"))
+                        .and_then(|d| d.get(field))
                         .and_then(|v| v.as_str()),
                     KvVersion::V1 => body
                         .get("data")
-                        .and_then(|d| d.get("value"))
+                        .and_then(|d| d.get(field))
                         .and_then(|v| v.as_str()),
                 };
 
@@ -439,16 +451,9 @@ impl VaultProvider {
         }
     }
 
-    /// Writes a secret to Vault asynchronously.
-    async fn set_secret_async(
-        &self,
-        project: &str,
-        key: &str,
-        value: &SecretString,
-        profile: &str,
-    ) -> Result<()> {
-        let secret_path = Self::format_secret_path(project, profile, key)?;
-        let url = self.build_url(&secret_path);
+    /// Writes a secret's `value` field at a KV path asynchronously.
+    async fn set_secret_async(&self, secret_path: &str, value: &SecretString) -> Result<()> {
+        let url = self.build_url(secret_path);
         let token = self.resolve_token()?;
         let headers = Self::build_headers(&token, &self.config.namespace)?;
 
@@ -494,18 +499,32 @@ impl VaultProvider {
 }
 
 impl Provider for VaultProvider {
+    /// Convention secrets each live at their own KV path,
+    /// `secretspec/{project}/{profile}/{key}`, under a `value` field.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: Self::format_secret_path(project, profile, key)?,
+            field: Some("value".to_string()),
+            ..Default::default()
+        })
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
 
     fn uri(&self) -> String {
-        let mut uri = format!(
-            "vault://{}",
-            self.config
-                .endpoint
-                .trim_start_matches("https://")
-                .trim_start_matches("http://")
-        );
+        let host = self
+            .config
+            .endpoint
+            .trim_start_matches("https://")
+            .trim_start_matches("http://");
+        let mut uri = format!("vault://{}", host);
         if self.config.mount != "secret" {
             uri.push('/');
             uri.push_str(&self.config.mount);
@@ -513,15 +532,111 @@ impl Provider for VaultProvider {
         uri
     }
 
-    fn get(&self, project: &str, key: &str, profile: &str) -> Result<Option<SecretString>> {
-        super::block_on(self.get_secret_async(project, key, profile))
+    /// `field` names the key within the KV entry's map.
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field"]
     }
 
-    fn set(&self, project: &str, key: &str, value: &SecretString, profile: &str) -> Result<()> {
-        super::block_on(self.set_secret_async(project, key, value, profile))
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coords = self.resolve_coords(addr)?;
+        // KV entries are maps; without a field there is nothing well-defined
+        // to read. Convention coordinates always carry `value`.
+        let Some(field) = &coords.field else {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "vault references need a `field`: KV entries are maps, e.g. \
+                 ref = { item = \"myapp/config\", field = \"db_password\" }"
+                    .to_string(),
+            ));
+        };
+        super::block_on(self.get_field_async(&coords.item, field))
     }
 
-    fn allows_set(&self) -> bool {
-        true
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.set_secret_async(&coords.item, value))
+    }
+
+    /// Native addresses are read-only: writing a single field would clobber
+    /// the other fields at the same KV path.
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Convention { .. } => Ok(()),
+            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(
+                "vault secret references are read-only: writing a single field would \
+                 clobber the other fields at the same KV path"
+                    .to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod reference_tests {
+    use super::*;
+    use url::Url;
+
+    fn config(s: &str) -> VaultConfig {
+        VaultConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap()
+    }
+
+    /// The `?field=` reference form from earlier iterations errors with a
+    /// pointer at the `ref` table.
+    #[test]
+    fn field_query_is_rejected_with_ref_hint() {
+        let err = VaultConfig::try_from(&ProviderUrl::new(
+            Url::parse("vault://vault.example.com:8200/secret?field=x").unwrap(),
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("field = \"x\""), "{err}");
+    }
+
+    /// KV entries are maps: a native address must say which field to read.
+    #[test]
+    fn native_address_requires_a_field() {
+        let p = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
+        let addr = crate::config::NativeAddress {
+            item: "myapp/config".into(),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("need a `field`"), "{err}");
+    }
+
+    /// Native addresses are read-only: a field-level write would clobber the
+    /// sibling fields at the KV path.
+    #[test]
+    fn native_address_is_read_only() {
+        let p = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
+        let addr = crate::config::NativeAddress {
+            item: "myapp/config".into(),
+            field: Some("db_password".into()),
+            ..Default::default()
+        };
+        let refusal = p.check_writable(Address::Native(&addr)).unwrap_err();
+        assert!(refusal.to_string().contains("read-only"), "{refusal}");
+        // `set` refuses with the same reason, so the pre-check cannot drift.
+        let err = p
+            .set(
+                Address::Native(&addr),
+                &secrecy::SecretString::new("v".into()),
+            )
+            .unwrap_err();
+        assert_eq!(err.to_string(), refusal.to_string());
+    }
+
+    /// Version pinning is not supported for Vault KV yet; the coordinate is
+    /// rejected.
+    #[test]
+    fn native_address_rejects_version() {
+        let p = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
+        let addr = crate::config::NativeAddress {
+            item: "myapp/config".into(),
+            field: Some("db_password".into()),
+            version: Some("3".into()),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`version`"), "{err}");
     }
 }

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -2056,15 +2056,21 @@ impl Secrets {
 
         let value = crate::generator::generate(secret_type, gen_config)?;
 
-        // Store the generated value. The address is convention naming in
-        // practice: validation rejects `ref` + enabled `generate`.
+        // Store the generated value at the secret's address: its `ref`
+        // coordinates when it has them, otherwise the naming convention.
         let addr =
             Self::secret_address(secret_config, &self.config.project.name, profile_name, name);
         let backend = self.get_writable_provider_for_secret(secret_config, addr)?;
         let set_result = backend.set(addr, &value);
         // Generating a secret writes a brand-new value to the provider; record it
         // like any other write so the audit log captures every stored secret.
-        self.audit_write_result(&set_result, name, profile_name, Some(backend.uri()), None);
+        self.audit_write_result(
+            &set_result,
+            name,
+            profile_name,
+            Some(backend.uri()),
+            secret_config.reference.as_ref(),
+        );
         set_result?;
 
         eprintln!(

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1,9 +1,9 @@
 //! Core secrets management functionality
 
 use crate::audit::{AuditAction, AuditContext, AuditLogger, AuditOutcome};
-use crate::config::{Config, GlobalConfig, Profile, RequireReason, Resolved};
+use crate::config::{Config, GlobalConfig, NativeAddress, Profile, RequireReason, Resolved};
 use crate::error::{Result, SecretSpecError};
-use crate::provider::Provider as ProviderTrait;
+use crate::provider::{Address, Provider as ProviderTrait};
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
 use crate::validation::{ValidatedSecrets, ValidationErrors};
@@ -37,7 +37,7 @@ fn warn_provider_failure(display_uri: &str, secret_name: &str, err: &SecretSpecE
 }
 
 /// Emits a warning when the primary provider for a batch fetch fails (either
-/// during construction or during `get_batch`); affected secrets will still be
+/// during construction or during `get_many`); affected secrets will still be
 /// retried via their per-secret fallback chain below.
 ///
 /// Like [`warn_provider_failure`], `display_uri` must already be credential-free
@@ -243,6 +243,9 @@ struct AuditFields<'a> {
     command: Option<&'a str>,
     /// Redacted provider URI the access is attributed to.
     provider_uri: Option<String>,
+    /// The secret's native `ref` coordinates, when the access resolved them;
+    /// rendered for the log by [`Secrets::record`].
+    reference: Option<&'a NativeAddress>,
     /// Stable error-variant token when the outcome is an error.
     error_kind: Option<&'a str>,
 }
@@ -318,6 +321,10 @@ impl Secrets {
     /// * `path` - Path to the `secretspec.toml` file
     pub fn load_from(path: &Path) -> Result<Self> {
         let project_config = Config::try_from(path)?;
+        // Semantic validation (required vs default, ref coordinate rules,
+        // generate consistency) runs here so every CLI and SDK entry point
+        // enforces the same rules the config documents.
+        project_config.validate()?;
         let global_config = GlobalConfig::load()?;
         // Auditing is a per-machine concern configured in the user-global config
         // (`[audit]` in ~/.config/secretspec/config.toml), not the project. It is
@@ -505,6 +512,7 @@ impl Secrets {
                     keys: fields.keys,
                     command: fields.command,
                     provider_uri: fields.provider_uri,
+                    reference: fields.reference.map(NativeAddress::render),
                     outcome,
                     error_kind: fields.error_kind,
                     reason: self.reason.as_deref(),
@@ -523,6 +531,7 @@ impl Secrets {
         key: &str,
         profile: &str,
         provider_uri: Option<String>,
+        reference: Option<&NativeAddress>,
     ) {
         let (outcome, error_kind) = match result {
             Ok(()) => (AuditOutcome::Written, None),
@@ -535,6 +544,7 @@ impl Secrets {
             AuditFields {
                 key: Some(key),
                 provider_uri,
+                reference,
                 error_kind,
                 ..Default::default()
             },
@@ -744,6 +754,10 @@ impl Secrets {
                         .clone()
                         .or_else(|| default.providers.clone())
                         .or_else(|| current_defaults.and_then(|d| d.providers.clone())),
+                    reference: current
+                        .reference
+                        .clone()
+                        .or_else(|| default.reference.clone()),
                     as_path: current.as_path.or(default.as_path),
                     secret_type: current
                         .secret_type
@@ -770,6 +784,7 @@ impl Secrets {
                         .providers
                         .clone()
                         .or_else(|| current_defaults.and_then(|d| d.providers.clone())),
+                    reference: secret.reference.clone(),
                     as_path: secret.as_path,
                     secret_type: secret.secret_type.clone(),
                     generate: secret.generate.clone(),
@@ -817,7 +832,11 @@ impl Secrets {
 
     /// Resolves a list of provider aliases to their URIs, preserving order.
     /// Used for fallback chain resolution; each alias is looked up via
-    /// [`Self::lookup_provider_alias`].
+    /// [`Self::lookup_provider_alias`]. An entry that is already a URI
+    /// (contains `://`) passes through unchanged, so a chain can point at a
+    /// store inline — `providers = ["onepassword://Production"]` — without
+    /// declaring an alias for it. A `scheme://` string is never an alias key,
+    /// so the two forms cannot collide.
     ///
     /// # Errors
     ///
@@ -832,6 +851,10 @@ impl Secrets {
 
         let mut uris = Vec::with_capacity(aliases.len());
         for alias in aliases {
+            if alias.contains("://") {
+                uris.push(alias.clone());
+                continue;
+            }
             match self.lookup_provider_alias(alias) {
                 Some(uri) => uris.push(uri),
                 None => {
@@ -877,6 +900,49 @@ impl Secrets {
         Some(self.resolve_provider_spec(spec))
     }
 
+    /// The provider [`Address`] a secret's operations resolve: its native
+    /// `ref` coordinates when it has them, otherwise SecretSpec's own naming
+    /// convention. Naming is fully orthogonal to routing: the address applies
+    /// to whichever store provider resolution selects.
+    fn secret_address<'a>(
+        secret_config: &'a crate::config::Secret,
+        project: &'a str,
+        profile: &'a str,
+        key: &'a str,
+    ) -> Address<'a> {
+        match &secret_config.reference {
+            Some(native) => Address::Native(native),
+            None => Address::Convention {
+                project,
+                profile,
+                key,
+            },
+        }
+    }
+
+    /// Fetches one provider group's secrets through the provider's batch
+    /// surface: every secret's [`Address`] (native `ref` coordinates or
+    /// convention naming) is handed to `get_many`, which dedupes identical
+    /// coordinates and batches or parallelizes as the store allows.
+    fn fetch_group(
+        provider: &dyn ProviderTrait,
+        secret_names: &[String],
+        secret_configs: &HashMap<String, crate::config::Secret>,
+        project: &str,
+        profile: &str,
+    ) -> Result<HashMap<String, SecretString>> {
+        let requests: Vec<(&str, Address<'_>)> = secret_names
+            .iter()
+            .map(|name| {
+                (
+                    name.as_str(),
+                    Self::secret_address(&secret_configs[name], project, profile, name),
+                )
+            })
+            .collect();
+        provider.get_many(&requests)
+    }
+
     /// Resolves the write target for a secret.
     ///
     /// Resolution order:
@@ -910,7 +976,8 @@ impl Secrets {
     ///
     /// If an explicit override is set, returns just that single URI (no chain fallback).
     /// Otherwise, resolves the secret's `providers` chain to URIs, or returns `None`
-    /// to indicate the default provider should be used.
+    /// to indicate the default provider should be used. A secret's `ref` never
+    /// participates: it supplies naming, not routing.
     pub(crate) fn resolve_read_provider_uris(
         &self,
         secret_config: &crate::config::Secret,
@@ -1011,9 +1078,9 @@ impl Secrets {
     ///
     /// # Arguments
     ///
-    /// * `project_name` - The project name
-    /// * `secret_name` - The secret name
-    /// * `profile_name` - The profile name
+    /// * `secret_name` - The secret name, for warning messages
+    /// * `addr` - The secret's [`Address`] (see [`Self::secret_address`]); the
+    ///   same address is asked of every provider in the chain
     /// * `provider_uris` - Optional list of provider URIs to try in order
     /// * `default_provider_arg` - Optional default provider if no URIs provided
     ///
@@ -1025,9 +1092,8 @@ impl Secrets {
     /// callers (e.g. the audit log) record which provider actually answered.
     fn get_secret_from_providers(
         &self,
-        project_name: &str,
         secret_name: &str,
-        profile_name: &str,
+        addr: Address<'_>,
         provider_uris: Option<&[String]>,
         default_provider_arg: Option<&str>,
     ) -> Result<(Option<SecretString>, Option<String>)> {
@@ -1056,7 +1122,7 @@ impl Secrets {
                 // `uri()` but that `redact_uri` cannot remove from an opaque URI.
                 let provider_uri = provider.uri();
                 last_uri = Some(provider_uri.clone());
-                match provider.get(project_name, secret_name, profile_name) {
+                match provider.get(addr) {
                     Ok(Some(value)) => return Ok((Some(value), Some(provider_uri))),
                     Ok(None) => {
                         any_healthy = true;
@@ -1081,9 +1147,7 @@ impl Secrets {
             // No per-secret providers, use default provider
             let backend = self.get_provider(default_provider_arg)?;
             let uri = backend.uri();
-            backend
-                .get(project_name, secret_name, profile_name)
-                .map(|opt| (opt, Some(uri)))
+            backend.get(addr).map(|opt| (opt, Some(uri)))
         }
     }
 
@@ -1157,11 +1221,16 @@ impl Secrets {
 
         let backend = self.resolve_write_provider(&secret_config, None)?;
 
-        if !backend.allows_set() {
-            let err = SecretSpecError::ProviderOperationFailed(format!(
-                "Provider '{}' is read-only and does not support setting values",
-                backend.name()
-            ));
+        let addr = Self::secret_address(
+            &secret_config,
+            &self.config.project.name,
+            &profile_name,
+            name,
+        );
+        // Refuse before prompting for a value. The provider states the reason:
+        // a store may be writable through the convention layout yet reject the
+        // `ref` this secret names.
+        if let Err(err) = backend.check_writable(addr) {
             self.record(
                 AuditAction::Set,
                 &profile_name,
@@ -1210,8 +1279,14 @@ impl Secrets {
             return Err(err);
         }
 
-        let result = backend.set(&self.config.project.name, name, &value, &profile_name);
-        self.audit_write_result(&result, name, &profile_name, Some(backend.uri()));
+        let result = backend.set(addr, &value);
+        self.audit_write_result(
+            &result,
+            name,
+            &profile_name,
+            Some(backend.uri()),
+            secret_config.reference.as_ref(),
+        );
         result?;
 
         eprintln!(
@@ -1274,16 +1349,23 @@ impl Secrets {
         let provider_uris = self.resolve_read_provider_uris(&secret_config, None)?;
 
         let result = self.get_secret_from_providers(
-            &self.config.project.name,
             name,
-            &profile_name,
+            Self::secret_address(
+                &secret_config,
+                &self.config.project.name,
+                &profile_name,
+                name,
+            ),
             provider_uris.as_deref(),
             None,
         );
 
         // Audit the access at the provider boundary, before defaults are applied.
         // The provider URI consulted is reported back so the chain miss/error
-        // attributes to the last provider tried rather than guessing.
+        // attributes to the last provider tried rather than guessing. The native
+        // coordinates (if any) are recorded alongside, since the provider URI
+        // names only the store.
+        let reference = secret_config.reference.as_ref();
         match &result {
             Ok((Some(_), uri)) => self.record(
                 AuditAction::Get,
@@ -1292,6 +1374,7 @@ impl Secrets {
                 AuditFields {
                     key: Some(name),
                     provider_uri: uri.clone(),
+                    reference,
                     ..Default::default()
                 },
             ),
@@ -1302,6 +1385,7 @@ impl Secrets {
                 AuditFields {
                     key: Some(name),
                     provider_uri: uri.clone(),
+                    reference,
                     ..Default::default()
                 },
             ),
@@ -1312,6 +1396,7 @@ impl Secrets {
                 AuditFields {
                     key: Some(name),
                     provider_uri: uri.clone(),
+                    reference,
                     ..Default::default()
                 },
             ),
@@ -1321,6 +1406,7 @@ impl Secrets {
                 AuditOutcome::Error,
                 AuditFields {
                     key: Some(name),
+                    reference,
                     error_kind: Some(e.kind()),
                     ..Default::default()
                 },
@@ -1464,16 +1550,20 @@ impl Secrets {
                             let backend = self
                                 .resolve_write_provider(&secret_config, provider_arg.as_deref())?;
                             let set_result = backend.set(
-                                &self.config.project.name,
-                                secret_name,
+                                Self::secret_address(
+                                    &secret_config,
+                                    &self.config.project.name,
+                                    &profile_display,
+                                    secret_name,
+                                ),
                                 &SecretString::new(value.into()),
-                                &profile_display,
                             );
                             self.audit_write_result(
                                 &set_result,
                                 secret_name,
                                 &profile_display,
                                 Some(backend.uri()),
+                                secret_config.reference.as_ref(),
                             );
                             set_result?;
                             eprintln!(
@@ -1762,15 +1852,20 @@ impl Secrets {
 
                 let to_provider = self.resolve_write_provider(&secret_config, None)?;
 
-                // First check if the secret exists in the "from" provider
-                match from_provider_instance.get(
+                // The secret's address (native `ref` coordinates or convention
+                // naming) applies to both stores: naming is orthogonal to
+                // which store holds the value.
+                let addr = Self::secret_address(
+                    &secret_config,
                     &self.config.project.name,
-                    &name,
                     &profile_display,
-                )? {
+                    &name,
+                );
+                // First check if the secret exists in the "from" provider
+                match from_provider_instance.get(addr)? {
                     Some(value) => {
                         // Secret exists in "from" provider, check if it exists in "to" provider
-                        match to_provider.get(&self.config.project.name, &name, &profile_display)? {
+                        match to_provider.get(addr)? {
                             Some(_) => {
                                 eprintln!(
                                     "{} {} - {} {} (→ {})",
@@ -1784,12 +1879,7 @@ impl Secrets {
                             }
                             None => {
                                 // Secret doesn't exist in "to" provider, import it.
-                                let set_result = to_provider.set(
-                                    &self.config.project.name,
-                                    &name,
-                                    &value,
-                                    &profile_display,
-                                );
+                                let set_result = to_provider.set(addr, &value);
                                 // Audit each copied secret as a write attributed to the
                                 // target provider, so import writes are recorded like
                                 // `set`/generate/prompt. The bulk Import event below only
@@ -1799,6 +1889,7 @@ impl Secrets {
                                     &name,
                                     &profile_display,
                                     Some(to_provider.uri()),
+                                    secret_config.reference.as_ref(),
                                 );
                                 set_result?;
                                 eprintln!(
@@ -1815,7 +1906,7 @@ impl Secrets {
                     None => {
                         // Secret doesn't exist in "from" provider
                         // Check if it exists in the "to" provider
-                        match to_provider.get(&self.config.project.name, &name, &profile_display)? {
+                        match to_provider.get(addr)? {
                             Some(_) => {
                                 eprintln!(
                                     "{} {} - {} {} (→ {})",
@@ -1910,19 +2001,18 @@ impl Secrets {
     /// Resolves a writable provider for a secret.
     ///
     /// Uses the first provider from the secret's provider list if specified,
-    /// otherwise falls back to the default provider.
+    /// otherwise falls back to the default provider. `addr` is the exact
+    /// address the caller is about to write, so writability is checked for it.
     fn get_writable_provider_for_secret(
         &self,
         secret_config: &crate::config::Secret,
+        addr: Address<'_>,
     ) -> Result<Box<dyn ProviderTrait>> {
         let backend = self.resolve_write_provider(secret_config, None)?;
 
-        if !backend.allows_set() {
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "Provider '{}' is read-only and cannot store generated secrets",
-                backend.name()
-            )));
-        }
+        // The provider states why a write is refused; wrapping it here would
+        // only nest a second "Provider operation failed" prefix.
+        backend.check_writable(addr)?;
 
         Ok(backend)
     }
@@ -1966,12 +2056,15 @@ impl Secrets {
 
         let value = crate::generator::generate(secret_type, gen_config)?;
 
-        // Store the generated value
-        let backend = self.get_writable_provider_for_secret(secret_config)?;
-        let set_result = backend.set(&self.config.project.name, name, &value, profile_name);
+        // Store the generated value. The address is convention naming in
+        // practice: validation rejects `ref` + enabled `generate`.
+        let addr =
+            Self::secret_address(secret_config, &self.config.project.name, profile_name, name);
+        let backend = self.get_writable_provider_for_secret(secret_config, addr)?;
+        let set_result = backend.set(addr, &value);
         // Generating a secret writes a brand-new value to the provider; record it
         // like any other write so the audit log captures every stored secret.
-        self.audit_write_result(&set_result, name, profile_name, Some(backend.uri()));
+        self.audit_write_result(&set_result, name, profile_name, Some(backend.uri()), None);
         set_result?;
 
         eprintln!(
@@ -2313,6 +2406,9 @@ impl Secrets {
                 for (name, _) in &all_secrets {
                     let secret_config = &secret_configs[name];
 
+                    // Groups are keyed by the resolved primary *store*; ref and
+                    // convention secrets share groups, since a `ref` supplies
+                    // naming rather than routing.
                     let provider_uri = match (&override_uri, secret_config.providers.as_deref()) {
                         (Some(uri), _) => Some(uri.clone()),
                         (None, Some([first_alias, ..])) => self
@@ -2337,6 +2433,10 @@ impl Secrets {
                 let mut failed_primary_uris: HashMap<Option<String>, SecretSpecError> =
                     HashMap::new();
 
+                // Construction is cheap and stays on this thread; only the
+                // fetches run concurrently below.
+                let mut group_fetches: Vec<(Option<String>, Vec<String>, Box<dyn ProviderTrait>)> =
+                    Vec::new();
                 for (provider_uri, secret_names) in provider_groups {
                     let provider_result = if let Some(uri) = provider_uri.clone() {
                         self.build_provider(uri)
@@ -2344,30 +2444,69 @@ impl Secrets {
                         self.get_provider(None)
                     };
 
-                    let provider = match provider_result {
-                        Ok(p) => p,
+                    match provider_result {
+                        Ok(provider) => {
+                            // Attribute primary hits to the provider's own
+                            // credential-free `uri()`, never the raw configured
+                            // alias (which may embed a token). Recorded before
+                            // the fetch so attribution survives a partial batch.
+                            group_uris.insert(provider_uri.clone(), provider.uri());
+                            group_fetches.push((provider_uri, secret_names, provider));
+                        }
                         Err(e) => {
                             // Construction failed: only the raw alias exists, so redact it.
                             let shown =
                                 provider_uri.as_deref().map(crate::audit::redact_uri_strict);
                             warn_primary_provider_failure(shown.as_deref(), &e);
                             failed_primary_uris.insert(provider_uri, e);
-                            continue;
                         }
-                    };
+                    }
+                }
 
-                    // Attribute primary hits to the provider's own credential-free
-                    // `uri()`, never the raw configured alias (which may embed a
-                    // token). Recorded before the fetch so attribution survives a
-                    // partial batch.
-                    group_uris.insert(provider_uri.clone(), provider.uri());
+                // Fetch the groups concurrently: each group is at least one
+                // provider round-trip. One thread per group mirrors the
+                // per-item threading providers already do inside `get_many`.
+                // A single group (the common case) stays on this thread.
+                let project_name = &self.config.project.name;
+                let profile_ref = profile_name.as_str();
+                let secret_configs_ref = &secret_configs;
+                let fetch_group = |(provider_uri, secret_names, provider): (
+                    Option<String>,
+                    Vec<String>,
+                    Box<dyn ProviderTrait>,
+                )| {
+                    let result = Self::fetch_group(
+                        &*provider,
+                        &secret_names,
+                        secret_configs_ref,
+                        project_name,
+                        profile_ref,
+                    );
+                    (provider_uri, result)
+                };
+                let fetch_results: Vec<(Option<String>, Result<_>)> = if group_fetches.len() <= 1 {
+                    group_fetches.into_iter().map(fetch_group).collect()
+                } else {
+                    std::thread::scope(|scope| {
+                        let handles: Vec<_> = group_fetches
+                            .into_iter()
+                            .map(|group| scope.spawn(|| fetch_group(group)))
+                            .collect();
+                        handles
+                            .into_iter()
+                            .map(|handle| handle.join().expect("group fetch thread panicked"))
+                            .collect()
+                    })
+                };
 
-                    let keys: Vec<&str> = secret_names.iter().map(|s| s.as_str()).collect();
-                    match provider.get_batch(&self.config.project.name, &keys, &profile_name) {
+                for (provider_uri, result) in fetch_results {
+                    match result {
                         Ok(batch_results) => fetched_values.extend(batch_results),
                         Err(e) => {
-                            // A provider was built; attribute to its credential-free `uri()`.
-                            warn_primary_provider_failure(Some(&provider.uri()), &e);
+                            // A provider was built; attribute to its credential-free
+                            // `uri()`, already recorded in `group_uris` above.
+                            let display_uri = group_uris.get(&provider_uri).map(String::as_str);
+                            warn_primary_provider_failure(display_uri, &e);
                             failed_primary_uris.insert(provider_uri, e);
                         }
                     }
@@ -2419,9 +2558,13 @@ impl Secrets {
                                         let fallback_uris =
                                             self.resolve_provider_aliases(Some(&providers[1..]))?;
                                         let resolved = self.get_secret_from_providers(
-                                            &self.config.project.name,
                                             &name,
-                                            &profile_name,
+                                            Self::secret_address(
+                                                secret_config,
+                                                &self.config.project.name,
+                                                &profile_name,
+                                                &name,
+                                            ),
                                             fallback_uris.as_deref(),
                                             None,
                                         )?;
@@ -2900,5 +3043,103 @@ mod report_provider_tests {
             .unwrap();
         assert_eq!(got, "vault://host");
         assert!(!got.contains("zzz"));
+    }
+}
+
+#[cfg(test)]
+mod reference_routing_tests {
+    use super::*;
+    use crate::config::Secret;
+
+    fn spec_with_provider(provider: Option<&str>) -> Secrets {
+        Secrets::new(
+            Config {
+                project: crate::config::Project {
+                    name: "ref-test".to_string(),
+                    ..Default::default()
+                },
+                profiles: HashMap::new(),
+                providers: None,
+            },
+            None,
+            provider.map(String::from),
+            None,
+        )
+    }
+
+    fn ref_secret(providers: Option<Vec<&str>>) -> Secret {
+        Secret {
+            description: Some("Sentry DSN".to_string()),
+            reference: Some(crate::config::NativeAddress {
+                item: "shared".to_string(),
+                field: Some("SENTRY_DSN".to_string()),
+                ..Default::default()
+            }),
+            providers: providers.map(|p| p.into_iter().map(String::from).collect()),
+            ..Default::default()
+        }
+    }
+
+    /// A `ref` supplies naming only: it never contributes to the read chain,
+    /// which stays whatever routing (here: nothing, so the default provider)
+    /// resolves.
+    #[test]
+    fn reference_does_not_affect_read_routing() {
+        let spec = spec_with_provider(None);
+        let uris = spec
+            .resolve_read_provider_uris(&ref_secret(None), None)
+            .unwrap();
+        assert_eq!(uris, None, "no routing configured, default store applies");
+    }
+
+    /// Uniform precedence: an explicit `--provider` override redirects ref
+    /// secrets exactly like convention secrets, e.g. at a fixtures store
+    /// during tests.
+    #[test]
+    fn override_redirects_reference() {
+        let spec = spec_with_provider(Some("keyring"));
+        let uris = spec
+            .resolve_read_provider_uris(&ref_secret(None), Some("dotenv://.env.mock"))
+            .unwrap();
+        assert_eq!(uris, Some(vec!["dotenv://.env.mock".to_string()]));
+    }
+
+    /// Routing for a ref secret follows its `providers` chain; inline
+    /// `scheme://` entries pass through without an alias declaration.
+    #[test]
+    fn reference_routes_through_providers_chain() {
+        let spec = spec_with_provider(None);
+        let uris = spec
+            .resolve_read_provider_uris(
+                &ref_secret(Some(vec!["onepassword://Production", "keyring://"])),
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            uris,
+            Some(vec![
+                "onepassword://Production".to_string(),
+                "keyring://".to_string()
+            ])
+        );
+    }
+
+    /// The write path follows the same routing: first chain entry without an
+    /// override, the override when present.
+    #[test]
+    fn write_provider_follows_routing() {
+        let spec = spec_with_provider(None);
+        let provider = spec
+            .resolve_write_provider(&ref_secret(Some(vec!["onepassword://Production"])), None)
+            .unwrap();
+        assert_eq!(provider.name(), "onepassword");
+
+        let provider = spec
+            .resolve_write_provider(
+                &ref_secret(Some(vec!["onepassword://Production"])),
+                Some("dotenv://.env.mock"),
+            )
+            .unwrap();
+        assert_eq!(provider.name(), "dotenv");
     }
 }

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -3055,10 +3055,7 @@ fn test_per_secret_provider_configuration() {
 fn test_provider_alias_resolution() {
     let mut providers_map = HashMap::new();
     providers_map.insert("dev".to_string(), "dotenv://.env.development".to_string());
-    providers_map.insert(
-        "prod".to_string(),
-        "onepassword://vault/Production".to_string(),
-    );
+    providers_map.insert("prod".to_string(), "onepassword://Production".to_string());
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
@@ -3098,7 +3095,7 @@ fn test_provider_alias_resolution() {
         .expect("Should resolve prod alias");
     assert_eq!(
         prod_uris,
-        Some(vec!["onepassword://vault/Production".to_string()])
+        Some(vec!["onepassword://Production".to_string()])
     );
 
     // Test resolving multiple aliases in order
@@ -3109,7 +3106,7 @@ fn test_provider_alias_resolution() {
         multi_uris,
         Some(vec![
             "dotenv://.env.development".to_string(),
-            "onepassword://vault/Production".to_string(),
+            "onepassword://Production".to_string(),
         ])
     );
 
@@ -3840,21 +3837,15 @@ provider = "keyring"
         config.defaults.providers = Some(HashMap::new());
     }
     if let Some(providers) = &mut config.defaults.providers {
-        providers.insert(
-            "shared".to_string(),
-            "onepassword://vault/Shared".to_string(),
-        );
-        providers.insert(
-            "prod".to_string(),
-            "onepassword://vault/Production".to_string(),
-        );
+        providers.insert("shared".to_string(), "onepassword://Shared".to_string());
+        providers.insert("prod".to_string(), "onepassword://Production".to_string());
     }
 
     // Verify providers were added
     assert_eq!(config.defaults.providers.as_ref().unwrap().len(), 2);
     assert_eq!(
         config.defaults.providers.as_ref().unwrap().get("shared"),
-        Some(&"onepassword://vault/Shared".to_string())
+        Some(&"onepassword://Shared".to_string())
     );
 
     // Simulate removing a provider alias
@@ -4545,6 +4536,7 @@ fn test_resolve_secret_config_merges_type_and_generate() {
             required: None,
             default: None,
             providers: None,
+            reference: None,
             as_path: None,
             secret_type: Some("password".to_string()),
             generate: Some(crate::config::GenerateConfig::Bool(true)),

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -4309,6 +4309,63 @@ DB_PASSWORD = { description = "Database password", type = "password", generate =
 }
 
 #[test]
+fn test_generate_writes_through_ref_coordinates() {
+    use secrecy::ExposeSecret;
+
+    // A generatable secret that also carries a `ref`: generation mints the value
+    // and writes it to the ref coordinate (the dotenv key `MY_DB_SECRET`), not to
+    // SecretSpec's `{project}/{profile}/{key}` convention path.
+    let temp_dir = TempDir::new().unwrap();
+    let env_file = temp_dir.path().join(".env");
+    fs::write(&env_file, "").unwrap();
+
+    let config_file = temp_dir.path().join("secretspec.toml");
+    let toml_content = r#"[project]
+name = "test-gen-ref"
+revision = "1.0"
+
+[profiles.default]
+DB_PASSWORD = { description = "Database password", type = "password", generate = true, ref = { item = "MY_DB_SECRET" } }
+"#;
+    fs::write(&config_file, toml_content).unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", env_file.display())),
+            profile: None,
+            providers: None,
+        },
+        audit: None,
+    };
+
+    let spec = Secrets::new(config, Some(global_config), None, None);
+    let validated = spec.validate().unwrap().unwrap();
+
+    let generated = validated
+        .resolved
+        .secrets
+        .get("DB_PASSWORD")
+        .unwrap()
+        .expose_secret()
+        .to_string();
+    assert_eq!(generated.len(), 32);
+
+    // The generated value landed at the ref key, not the convention path.
+    let env_contents = fs::read_to_string(&env_file).unwrap();
+    assert!(
+        env_contents.contains("MY_DB_SECRET="),
+        "generated value should be stored under the ref key, got: {}",
+        env_contents
+    );
+    assert!(
+        env_contents.contains(&generated),
+        "the .env file should hold the generated value, got: {}",
+        env_contents
+    );
+}
+
+#[test]
 fn test_validate_does_not_regenerate_existing_secret() {
     use secrecy::ExposeSecret;
 

--- a/tests/cli-integration.sh
+++ b/tests/cli-integration.sh
@@ -215,6 +215,64 @@ VALUE=$(secretspec get DEFAULT_SECRET)
 [ "$VALUE" = "default_value" ]
 check_success "Default value is used when secret not set"
 
+# Test 13: Native references (ref) against a dotenv store
+cat > secretspec.toml << EOF
+[project]
+name = "test-app"
+revision = "1.0"
+
+[profiles.default]
+API_KEY = { description = "Referenced secret", ref = { item = "PINNED_KEY" }, providers = ["dotenv://.env"] }
+EOF
+
+cat > .env << EOF
+PINNED_KEY="from_ref"
+EOF
+
+# The secret reads the key its ref names, not its own name
+VALUE=$(secretspec get API_KEY)
+[ "$VALUE" = "from_ref" ]
+check_success "ref reads the item it names from the routed store"
+
+# Writes go through the same coordinates
+echo "updated_ref" | secretspec set API_KEY
+VALUE=$(secretspec get API_KEY)
+[ "$VALUE" = "updated_ref" ]
+grep -q 'PINNED_KEY="updated_ref"' .env
+check_success "set writes through the ref coordinates in place"
+
+# Uniform precedence: --provider redirects ref secrets to another store
+cat > .env.mock << EOF
+PINNED_KEY="from_mock"
+EOF
+VALUE=$(secretspec get --provider dotenv://.env.mock API_KEY)
+[ "$VALUE" = "from_mock" ]
+check_success "--provider redirects a ref secret to a fixtures store"
+
+# set under an override writes to the override store, same coordinates
+echo "mock_write" | secretspec set --provider dotenv://.env.mock API_KEY
+grep -q 'PINNED_KEY="mock_write"' .env.mock
+grep -q 'PINNED_KEY="updated_ref"' .env
+check_success "set under --provider writes the ref into the override store"
+
+# A string ref is rejected with the table translation hint
+cat > secretspec.toml << EOF
+[project]
+name = "test-app"
+revision = "1.0"
+
+[profiles.default]
+API_KEY = { description = "Bad ref", ref = "op://Vault/item/field" }
+EOF
+if OUTPUT=$(secretspec get API_KEY 2>&1); then
+    false
+else
+    # The renderer may wrap the hint, so match fragments that fit one line.
+    echo "$OUTPUT" | grep -q 'takes a table of coordinates' \
+        && echo "$OUTPUT" | grep -q 'item = "item"'
+fi
+check_success "string ref errors with the table translation hint"
+
 # Cleanup
 cd ..
 rm -rf "$TEST_DIR"


### PR DESCRIPTION
Closes #64.

A secret can name one externally managed secret by its store's own coordinates, replacing SecretSpec's `{project}/{profile}/{key}` naming for that secret:

```toml
[profiles.production]
DATABASE_URL = { description = "Postgres DSN", ref = { item = "db", field = "password" }, providers = ["prod_op"] }
INFRA_TOKEN  = { description = "Infra token", ref = { vault = "Production", item = "infra", field = "token" } }
GITHUB_TOKEN = { description = "GitHub token", ref = { item = "GITHUB_PAT" }, providers = ["env"] }
```

`item` is required; `field` (1Password field label, Vault KV field, AWS JSON key, keyring account), `vault`/`section` (1Password), and `version` (GCSM) refine it where the store supports them. All 11 providers resolve refs and reject coordinates they have no equivalent for.

## Design: refs name, providers route

This PR went through a design pivot mid-review. The first iteration carried references as provider URIs (`ref = "op://vault/item/field"` plus per provider grammars like `?item=`, `?entry=`, `?field=`). That fused two independent axes, naming and routing, into one string: single secrets impersonated whole provider instances, precedence needed a special "ref beats --provider" rule, and `ref` had to be mutually exclusive with `providers`.

The final design makes `ref` a structured table of pure naming coordinates:

- **Routing is unchanged and uniform.** Which store resolves the coordinates follows the same rules as every secret: `--provider`/`SECRETSPEC_PROVIDER` override, then the secret's `providers` chain (entries may now be inline URIs, no alias needed), then defaults. So refs compose with fallback chains, and an override redirects them, e.g. `--provider dotenv:.env.fixtures` during tests.
- **Writes are symmetric.** `secretspec set` and `check` prompting write through the coordinates in place where the backend allows it (1Password, keyring, pass, dotenv, bws, Proton Pass, LastPass); Vault/AWS/GCSM refs are read only.
- **Pasted URIs translate themselves.** `ref = "op://Production/db/password"` fails with the exact table to write instead. Provider URIs stay store addresses only.
- **Internals:** the `Provider` trait now takes an `Address` (convention naming or native coordinates), which deleted the instance level reference machinery: `supports_references()`, 11 reference URI grammars, fail closed write guards, and batch fan out patches. Secrets sharing coordinates fetch once; audit events record the coordinates in a new `ref` field; manifest validation now runs on every load.

The [configuration reference](docs/src/content/docs/reference/configuration.md) documents the coordinate table and the per provider translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)