### PR TITLE
core: split secret resolution into a pure plan and an executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- A `ref` routed at a single store (an explicit `--provider`, a single-provider
+  chain, or the default provider) is now checked up front, before any store is
+  contacted, for coordinates that store cannot honor (e.g. a `field` ref pointed
+  at a `.env` file), failing fast with a clear message instead of at fetch time.
+  A `ref` on a multi-store fallback chain is still validated per store as the
+  chain is walked, so a coordinate a later store cannot express never blocks a
+  provider earlier in the chain that can.
+- Provider chains accept bare provider names and `scheme:path` shorthand
+  (e.g. `providers = ["keyring"]`), the same specs `--provider` accepts.
+  Previously a chain entry had to be a declared alias or a full `scheme://` URI.
+- An explicitly empty `providers = []` list now uses the default provider for
+  `get` as well, matching how `check` and `run` already treated it.
+
+### Fixed
+- Provider fallback chains (`providers = [...]`) are now tried strictly in
+  order: each link is resolved only when a read actually reaches it, and a
+  broken link (an undefined alias, an unreachable store) is skipped with a
+  warning so a working provider later in the chain still answers. `check`,
+  `run`, and `get` all walk the chain the same way.
+- `get` and `set` now record an audit event when a secret's provider routing
+  fails to resolve (for example an undefined alias), matching how `check` and
+  `run` audit every attempted read.
+- A provider chain entry that misspells `onepassword` as `1password` now gets
+  the same "use `onepassword` instead" correction that `--provider 1password`
+  gives, instead of a generic undefined-alias error.
+- `import` prints its per-secret summary in a stable, name-sorted order.
+
 ## [0.14.0] - 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously a chain entry had to be a declared alias or a full `scheme://` URI.
 - An explicitly empty `providers = []` list now uses the default provider for
   `get` as well, matching how `check` and `run` already treated it.
+- A `providers` chain whose *first* entry misspells `onepassword` as
+  `1password` now fails up front with the corrective "use `onepassword`
+  instead" message — the same hard error any other invalid primary gets —
+  instead of warning and falling through to the rest of the chain. As a
+  fallback entry it is still skipped with a warning, like any broken link.
 
 ### Fixed
 - Provider fallback chains (`providers = [...]`) are now tried strictly in

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -257,10 +257,8 @@ fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
         let profile_config = &config.profiles[*profile_name];
         let mut profile_table = Table::new();
 
-        let mut secret_names: Vec<&String> = profile_config.secrets.keys().collect();
-        secret_names.sort();
-        for secret_name in secret_names {
-            let secret_config = &profile_config.secrets[secret_name];
+        for secret_name in profile_config.sorted_secret_names() {
+            let secret_config = &profile_config.secrets[&secret_name];
             let mut inline = InlineTable::new();
             inline.insert(
                 "description",
@@ -272,7 +270,7 @@ fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
             if let Some(default) = &secret_config.default {
                 inline.insert("default", Value::from(default.as_str()));
             }
-            profile_table.insert(secret_name, toml_edit::value(inline));
+            profile_table.insert(&secret_name, toml_edit::value(inline));
         }
 
         // Surface the `extends` option as a comment before the first profile,

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -542,6 +542,14 @@ impl Profile {
     pub fn iter(&self) -> hash_map::Iter<'_, String, Secret> {
         self.secrets.iter()
     }
+
+    /// Secret names declared in this profile, sorted for deterministic
+    /// ordering (grouping, missing lists) instead of the map's hash order.
+    pub(crate) fn sorted_secret_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.secrets.keys().cloned().collect();
+        names.sort();
+        names
+    }
 }
 
 impl Default for Profile {

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -568,6 +568,16 @@ impl<'a> IntoIterator for &'a Profile {
     }
 }
 
+impl IntoIterator for Profile {
+    type Item = (String, Secret);
+    type IntoIter = hash_map::IntoIter<String, Secret>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.secrets.into_iter()
+    }
+}
+
 /// Configuration for auto-generation of a secret.
 ///
 /// Can be either a simple boolean (`generate = true`) or a table with

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -568,16 +568,6 @@ impl<'a> IntoIterator for &'a Profile {
     }
 }
 
-impl IntoIterator for Profile {
-    type Item = (String, Secret);
-    type IntoIter = hash_map::IntoIter<String, Secret>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.secrets.into_iter()
-    }
-}
-
 /// Configuration for auto-generation of a secret.
 ///
 /// Can be either a simple boolean (`generate = true`) or a table with

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -46,6 +46,7 @@ pub mod codegen;
 mod config;
 mod error;
 pub(crate) mod generator;
+mod plan;
 mod report;
 mod resolve;
 mod secrets;

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -10,111 +10,65 @@
 //! instead of re-deriving per-secret facts across `get`, `set`, and batch
 //! validation.
 //!
-//! Building a plan performs no I/O. Provider-alias resolution is a map lookup,
-//! so the only error it can raise is an undefined alias
-//! ([`SecretSpecError::ProviderNotFound`]); a plan never opens a store.
+//! Building a plan performs no I/O. Provider-spec resolution is a map lookup
+//! plus a registry check, so the only errors it can raise are a routing spec
+//! that names neither an alias nor a provider
+//! ([`SecretSpecError::ProviderNotFound`]) and the corrected `1password`
+//! misspelling; a plan never opens a store.
 
-use crate::config::{NativeAddress, Profile, Secret};
+use crate::config::{NativeAddress, Secret};
 use crate::error::Result;
 use crate::provider::Address;
 use crate::secrets::Secrets;
 use std::collections::HashMap;
 
-/// How a planned secret is named at whichever store resolves it.
-///
-/// Naming is orthogonal to routing: the same address is asked of whatever store
-/// [`Route`] selects. A secret's `ref` supplies native coordinates; otherwise
-/// SecretSpec's own `{project}/{profile}/{key}` convention applies, with the
-/// project and profile carried once on the [`ResolutionPlan`].
-#[derive(Debug)]
-pub(crate) enum PlannedAddress {
-    /// Native coordinates from the secret's `ref`.
-    Native(NativeAddress),
-    /// SecretSpec's naming convention; only the key varies per secret.
-    Convention { key: String },
-}
-
-impl PlannedAddress {
-    /// Borrow this owned address as the [`Address`] the provider trait consumes,
-    /// supplying the plan-level `project`/`profile` for a convention address.
-    pub(crate) fn as_address<'a>(&'a self, project: &'a str, profile: &'a str) -> Address<'a> {
-        match self {
-            PlannedAddress::Native(native) => Address::Native(native),
-            PlannedAddress::Convention { key } => Address::convention(project, profile, key),
-        }
-    }
-}
-
 /// Where a planned secret reads and writes.
 ///
-/// A `providers` chain is a fallback list tried in order. Only the **primary**
-/// (the first entry — always tried first, the write target, and the grouping
-/// key) is resolved to a URI up front; the rest are carried as raw specs and
-/// resolved lazily, when and only when a read actually falls through to them.
-/// That keeps the chain tried in order: an undefined alias further down never
-/// fails an operation the primary satisfies, and never fails a write at all.
+/// A `providers` chain is a fallback list tried in order. Only the primary
+/// (always tried first, the write target, and the grouping key) is resolved to
+/// a URI up front; the rest are carried as raw specs and resolved lazily, when
+/// and only when a read actually falls through to them. That keeps the chain
+/// tried in order: an undefined alias further down never fails an operation
+/// the primary satisfies, and never fails a write at all.
+///
+/// An explicit `--provider`/`SECRETSPEC_PROVIDER`/builder override collapses
+/// any chain to just that store: it becomes the primary with no fallback.
 #[derive(Debug)]
-pub(crate) enum Route {
-    /// An explicit `--provider`/`SECRETSPEC_PROVIDER`/builder override: exactly
-    /// one store, no fallback (the override collapses any per-secret chain).
-    Override(String),
-    /// The secret's `providers` chain. `primary` is the resolved first store;
-    /// `fallback` holds the remaining specs (aliases or URIs) raw, tried in
-    /// order — and resolved — only after the primary misses.
-    Chain {
-        primary: String,
-        fallback: Vec<String>,
-    },
-    /// No routing configured for this secret: the default provider applies.
-    Default,
+pub(crate) struct Route {
+    /// The store consulted first — the resolved chain head or the explicit
+    /// override — or `None` for the default provider.
+    pub primary: Option<String>,
+    /// The chain's remaining specs (aliases or URIs), raw, tried in order —
+    /// and resolved — only after the primary misses.
+    pub fallback: Vec<String>,
 }
 
 impl Route {
-    /// The store consulted first — the override, the chain's primary, or `None`
-    /// for the default provider. This is the grouping key and the write target:
-    /// secrets sharing a primary store are fetched together, and a write goes to
-    /// the primary.
+    /// The store consulted first, `None` meaning the default provider. This is
+    /// the grouping key and the write target: secrets sharing a primary store
+    /// are fetched together, and a write goes to the primary.
     pub(crate) fn primary(&self) -> Option<&str> {
-        match self {
-            Route::Override(uri) => Some(uri),
-            Route::Chain { primary, .. } => Some(primary),
-            Route::Default => None,
-        }
+        self.primary.as_deref()
     }
 
-    /// The raw fallback specs a read walks after the primary misses: a chain's
-    /// entries past the first, when there are any. `None` means the read may
-    /// consult only one store — [`Route::primary`], with `None` meaning the
-    /// default provider — so no other store could answer instead. The one
-    /// definition of "has a fallback" shared by [`Route::has_fallback`] and
-    /// the executor's fallback walk.
+    /// The raw fallback specs a read walks after the primary misses, when
+    /// there are any. `None` means the read may consult only one store —
+    /// [`Route::primary`], with `None` meaning the default provider — so no
+    /// other store could answer instead.
     pub(crate) fn fallback_specs(&self) -> Option<&[String]> {
-        match self {
-            Route::Chain { fallback, .. } if !fallback.is_empty() => Some(fallback),
-            _ => None,
-        }
-    }
-
-    /// Whether a read may consult more than one store: a chain with at least
-    /// one fallback entry.
-    pub(crate) fn has_fallback(&self) -> bool {
-        self.fallback_specs().is_some()
+        (!self.fallback.is_empty()).then_some(self.fallback.as_slice())
     }
 
     /// The ordered provider specs a read walks — the primary followed by the raw
     /// fallback — or `None` for the default provider. Each entry is resolved only
     /// when the read reaches it, so the chain is genuinely tried in order.
     pub(crate) fn specs(&self) -> Option<Vec<String>> {
-        match self {
-            Route::Override(uri) => Some(vec![uri.clone()]),
-            Route::Chain { primary, fallback } => {
-                let mut specs = Vec::with_capacity(1 + fallback.len());
-                specs.push(primary.clone());
-                specs.extend(fallback.iter().cloned());
-                Some(specs)
-            }
-            Route::Default => None,
-        }
+        self.primary.as_ref().map(|primary| {
+            let mut specs = Vec::with_capacity(1 + self.fallback.len());
+            specs.push(primary.clone());
+            specs.extend(self.fallback.iter().cloned());
+            specs
+        })
     }
 }
 
@@ -125,21 +79,25 @@ pub(crate) struct PlannedSecret {
     pub name: String,
     /// The secret's effective config after the profile field-level merge.
     pub config: Secret,
-    /// How the secret is named at whichever store resolves it.
-    pub address: PlannedAddress,
     /// The resolved read/write route.
     pub route: Route,
 }
 
 impl PlannedSecret {
-    /// The native `ref` coordinates the plan derived for this secret, if any.
-    /// Reads the planned address, not the raw config, so audit attribution
-    /// always reports the coordinates the plan actually addresses.
-    pub(crate) fn reference(&self) -> Option<&NativeAddress> {
-        match &self.address {
-            PlannedAddress::Native(native) => Some(native),
-            PlannedAddress::Convention { .. } => None,
+    /// The provider [`Address`] this secret's operations resolve: its native
+    /// `ref` coordinates when it has them, otherwise SecretSpec's own
+    /// `{project}/{profile}/{key}` naming convention. Naming is orthogonal to
+    /// routing: the same address is asked of whichever store [`Route`] selects.
+    pub(crate) fn as_address<'a>(&'a self, project: &'a str, profile: &'a str) -> Address<'a> {
+        match &self.config.reference {
+            Some(native) => Address::Native(native),
+            None => Address::convention(project, profile, &self.name),
         }
+    }
+
+    /// The native `ref` coordinates this secret addresses, if any.
+    pub(crate) fn reference(&self) -> Option<&NativeAddress> {
+        self.config.reference.as_ref()
     }
 
     /// Whether the active profile requires this secret (required by default).
@@ -156,8 +114,6 @@ impl PlannedSecret {
 /// An immutable, fully-decided plan for resolving one profile.
 #[derive(Debug)]
 pub(crate) struct ResolutionPlan {
-    /// The project name (supplies convention addressing).
-    pub project: String,
     /// The resolved profile name.
     pub profile: String,
     /// The explicit provider override in force, if any. `Some` collapses every
@@ -165,73 +121,75 @@ pub(crate) struct ResolutionPlan {
     pub override_uri: Option<String>,
     /// One entry per declared secret, sorted by name for deterministic output.
     pub secrets: Vec<PlannedSecret>,
-    /// Primary-store groups in first-seen order: each maps a store URI (`None` =
-    /// default provider) to the indices into [`ResolutionPlan::secrets`] fetched
-    /// together. A pure function of each secret's [`Route::primary`], surfaced
-    /// so the executor does not recompute it.
-    pub groups: Vec<(Option<String>, Vec<usize>)>,
+}
+
+impl ResolutionPlan {
+    /// Primary-store groups in first-seen order: each pairs a store URI
+    /// (`None` = default provider) with the planned secrets fetched together.
+    /// Derived from each secret's [`Route::primary`] on demand, so grouping
+    /// can never drift from the routes.
+    pub(crate) fn groups(&self) -> Vec<(Option<&str>, Vec<&PlannedSecret>)> {
+        let mut groups: Vec<(Option<&str>, Vec<&PlannedSecret>)> = Vec::new();
+        let mut group_index: HashMap<Option<&str>, usize> = HashMap::new();
+        for secret in &self.secrets {
+            let primary = secret.route.primary();
+            match group_index.get(&primary) {
+                Some(&idx) => groups[idx].1.push(secret),
+                None => {
+                    group_index.insert(primary, groups.len());
+                    groups.push((primary, vec![secret]));
+                }
+            }
+        }
+        groups
+    }
 }
 
 impl Secrets {
     /// Resolve a whole profile into an immutable [`ResolutionPlan`] without any
-    /// I/O: merge the profile, compute each secret's effective config, derive
-    /// its address and resolved route, and group secrets by their primary store.
+    /// I/O: merge the profile, compute each secret's effective config, and
+    /// derive its resolved route.
     ///
     /// The explicit provider override (builder or `SECRETSPEC_PROVIDER`) is
     /// picked up via [`Secrets::resolve_provider_override`]. Production code
-    /// resolves the profile itself and calls [`Secrets::build_plan_from_profile`]
-    /// directly (it needs the profile for audit attribution too, and shouldn't
-    /// merge it twice); this one-call form is for tests that don't.
+    /// resolves the profile itself and calls [`Secrets::build_plan_from_names`]
+    /// directly (it needs the sorted names for audit attribution too, and
+    /// shouldn't merge and sort twice); this one-call form is for tests that
+    /// don't.
     #[cfg(test)]
     pub(crate) fn build_plan(&self, profile: Option<&str>) -> Result<ResolutionPlan> {
         let profile_name = self.resolve_profile_name(profile);
-        let profile_config = self.resolve_profile(Some(&profile_name))?;
-        self.build_plan_from_profile(profile_name, profile_config)
+        let names = self
+            .resolve_profile(Some(&profile_name))?
+            .sorted_secret_names();
+        self.build_plan_from_names(profile_name, names)
     }
 
     /// As [`Secrets::build_plan`], but for a caller that has already resolved
-    /// the profile for another purpose (e.g. attributing an audit event before
-    /// planning can fail) and would otherwise redo that merge a second time.
-    pub(crate) fn build_plan_from_profile(
+    /// the profile and its sorted secret names for another purpose (e.g.
+    /// attributing an audit event before planning can fail) and would otherwise
+    /// redo that work a second time. Sorted names keep planning deterministic
+    /// (grouping order, missing lists) rather than inheriting the profile's
+    /// `HashMap` iteration order.
+    pub(crate) fn build_plan_from_names(
         &self,
         profile_name: String,
-        profile_config: Profile,
+        names: Vec<String>,
     ) -> Result<ResolutionPlan> {
-        // Sorted names make planning deterministic (grouping order, missing
-        // lists) rather than inheriting the profile's HashMap iteration order.
-        let names = profile_config.sorted_secret_names();
-
         let override_uri = self.resolve_provider_override(None);
 
         let mut secrets = Vec::with_capacity(names.len());
-        for name in &names {
+        for name in names {
             let config = self
-                .resolve_secret_config(name, Some(&profile_name))
+                .resolve_secret_config(&name, Some(&profile_name))
                 .expect("secret resolved from the merged profile always has a config");
-            secrets.push(self.plan_one_secret(name.clone(), config, &override_uri)?);
-        }
-
-        // Group by primary store, preserving first-seen order so grouping is
-        // deterministic and independent of hashing.
-        let mut groups: Vec<(Option<String>, Vec<usize>)> = Vec::new();
-        let mut group_index: HashMap<Option<&str>, usize> = HashMap::new();
-        for (i, secret) in secrets.iter().enumerate() {
-            let primary = secret.route.primary();
-            match group_index.get(&primary) {
-                Some(&idx) => groups[idx].1.push(i),
-                None => {
-                    group_index.insert(primary, groups.len());
-                    groups.push((primary.map(String::from), vec![i]));
-                }
-            }
+            secrets.push(self.plan_one_secret(name, config, &override_uri)?);
         }
 
         Ok(ResolutionPlan {
-            project: self.config().project.name.clone(),
             profile: profile_name,
             override_uri,
             secrets,
-            groups,
         })
     }
 
@@ -241,18 +199,17 @@ impl Secrets {
     /// [`Secrets::resolve_secret_config`], so the caller can raise its own
     /// "not found" error and audit it.
     ///
-    /// `override_arg` is the caller's explicit provider (the `--provider`
-    /// flag); like [`Secrets::build_plan`] it also picks up the builder and
-    /// `SECRETSPEC_PROVIDER` via [`Secrets::resolve_provider_override`], and
-    /// profile resolution follows the same precedence.
+    /// `profile_name` is the already-resolved profile. `override_arg` is the
+    /// caller's explicit provider (the `--provider` flag); like
+    /// [`Secrets::build_plan`] it also picks up the builder and
+    /// `SECRETSPEC_PROVIDER` via [`Secrets::resolve_provider_override`].
     pub(crate) fn plan_secret(
         &self,
         name: &str,
-        profile: Option<&str>,
+        profile_name: &str,
         override_arg: Option<&str>,
     ) -> Result<Option<PlannedSecret>> {
-        let profile_name = self.resolve_profile_name(profile);
-        let Some(config) = self.resolve_secret_config(name, Some(&profile_name)) else {
+        let Some(config) = self.resolve_secret_config(name, Some(profile_name)) else {
             return Ok(None);
         };
         let override_uri = self.resolve_provider_override(override_arg);
@@ -265,7 +222,7 @@ impl Secrets {
 
     /// Derive one [`PlannedSecret`] from its effective config and the resolved
     /// override. The single place per-secret decisions are made, shared by the
-    /// whole-profile [`Secrets::build_plan`] and the single-secret
+    /// whole-profile [`Secrets::build_plan_from_names`] and the single-secret
     /// [`Secrets::plan_secret`], so `get`, `set`, and batch validation cannot
     /// drift.
     fn plan_one_secret(
@@ -274,19 +231,10 @@ impl Secrets {
         config: Secret,
         override_uri: &Option<String>,
     ) -> Result<PlannedSecret> {
-        // A `ref` supplies naming only; convention naming otherwise. The address
-        // applies to whichever store the route selects.
-        let address = match &config.reference {
-            Some(native) => PlannedAddress::Native(native.clone()),
-            None => PlannedAddress::Convention { key: name.clone() },
-        };
-
         let route = self.route_for(&config, override_uri)?;
-
         Ok(PlannedSecret {
             name,
             config,
-            address,
             route,
         })
     }
@@ -306,14 +254,20 @@ impl Secrets {
         override_uri: &Option<String>,
     ) -> Result<Route> {
         if let Some(uri) = override_uri {
-            return Ok(Route::Override(uri.clone()));
+            return Ok(Route {
+                primary: Some(uri.clone()),
+                fallback: Vec::new(),
+            });
         }
         match config.providers.as_deref() {
-            Some([first, fallback @ ..]) => Ok(Route::Chain {
-                primary: self.resolve_one_provider(first)?,
+            Some([first, fallback @ ..]) => Ok(Route {
+                primary: Some(self.resolve_one_provider(first)?),
                 fallback: fallback.to_vec(),
             }),
-            _ => Ok(Route::Default),
+            _ => Ok(Route {
+                primary: None,
+                fallback: Vec::new(),
+            }),
         }
     }
 }
@@ -357,6 +311,14 @@ mod tests {
             .expect("secret in plan")
     }
 
+    /// The plan's groups as (primary store, secret names) for easy assertion.
+    fn group_names<'a>(plan: &'a ResolutionPlan) -> Vec<(Option<&'a str>, Vec<&'a str>)> {
+        plan.groups()
+            .into_iter()
+            .map(|(uri, group)| (uri, group.iter().map(|s| s.name.as_str()).collect()))
+            .collect()
+    }
+
     #[test]
     fn no_routing_plans_the_default_store() {
         let _env = scrub_resolution_env();
@@ -364,9 +326,9 @@ mod tests {
         let plan = plan(&spec(secrets, None, &[]));
 
         let planned = find(&plan, "DATABASE_URL");
-        assert!(matches!(planned.route, Route::Default));
         assert_eq!(planned.route.primary(), None);
-        assert_eq!(plan.groups, vec![(None, vec![0])]);
+        assert!(planned.route.fallback.is_empty());
+        assert_eq!(group_names(&plan), vec![(None, vec!["DATABASE_URL"])]);
     }
 
     #[test]
@@ -382,8 +344,11 @@ mod tests {
         let plan = plan(&spec);
 
         let planned = find(&plan, "API_KEY");
-        assert!(matches!(&planned.route, Route::Override(uri) if uri == "dotenv://.env.mock"));
         assert_eq!(planned.route.primary(), Some("dotenv://.env.mock"));
+        assert!(
+            planned.route.fallback.is_empty(),
+            "the override must collapse the chain: no fallback survives"
+        );
         assert_eq!(plan.override_uri, Some("dotenv://.env.mock".to_string()));
     }
 
@@ -397,17 +362,11 @@ mod tests {
             &[("shared", "onepassword://Shared"), ("kr", "keyring://")],
         ));
 
+        // The primary is resolved to its URI; the fallback stays as the raw
+        // alias, resolved only if the primary misses at read time.
         let planned = find(&plan, "API_KEY");
-        match &planned.route {
-            // The primary is resolved to its URI; the fallback stays as the raw
-            // alias, resolved only if the primary misses at read time.
-            Route::Chain { primary, fallback } => {
-                assert_eq!(primary, "onepassword://Shared");
-                assert_eq!(fallback, &vec!["kr".to_string()]);
-            }
-            other => panic!("expected a chain, got {other:?}"),
-        }
         assert_eq!(planned.route.primary(), Some("onepassword://Shared"));
+        assert_eq!(planned.route.fallback, vec!["kr".to_string()]);
     }
 
     #[test]
@@ -419,14 +378,9 @@ mod tests {
         let plan = plan(&spec(secrets, None, &[("kr", "keyring://")]));
 
         let planned = find(&plan, "API_KEY");
-        match &planned.route {
-            Route::Chain { primary, fallback } => {
-                assert_eq!(primary, "keyring://");
-                // The undefined alias is carried raw, not resolved (which would error).
-                assert_eq!(fallback, &vec!["ghost".to_string()]);
-            }
-            other => panic!("expected a chain, got {other:?}"),
-        }
+        assert_eq!(planned.route.primary(), Some("keyring://"));
+        // The undefined alias is carried raw, not resolved (which would error).
+        assert_eq!(planned.route.fallback, vec!["ghost".to_string()]);
     }
 
     #[test]
@@ -464,7 +418,7 @@ mod tests {
     }
 
     #[test]
-    fn a_ref_plans_a_native_address_convention_otherwise() {
+    fn a_ref_addresses_native_coordinates_convention_otherwise() {
         let _env = scrub_resolution_env();
         let mut referenced = secret(None);
         referenced.reference = Some(NativeAddress {
@@ -478,16 +432,16 @@ mod tests {
         ]);
         let plan = plan(&spec(secrets, None, &[]));
 
-        match &find(&plan, "REFERENCED").address {
-            PlannedAddress::Native(native) => {
+        match find(&plan, "REFERENCED").as_address("proj", "default") {
+            Address::Native(native) => {
                 assert_eq!(native.item, "db");
                 assert_eq!(native.field.as_deref(), Some("password"));
             }
-            PlannedAddress::Convention { .. } => panic!("a ref should plan a native address"),
+            Address::Convention { .. } => panic!("a ref should address native coordinates"),
         }
-        match &find(&plan, "PLAIN").address {
-            PlannedAddress::Convention { key } => assert_eq!(key, "PLAIN"),
-            PlannedAddress::Native(_) => panic!("no ref should plan a convention address"),
+        match find(&plan, "PLAIN").as_address("proj", "default") {
+            Address::Convention { key, .. } => assert_eq!(key, "PLAIN"),
+            Address::Native(_) => panic!("no ref should address the naming convention"),
         }
     }
 
@@ -507,11 +461,8 @@ mod tests {
 
         // A goes to the default group; B and C share the keyring group.
         assert_eq!(
-            plan.groups,
-            vec![
-                (None, vec![0]),
-                (Some("keyring://".to_string()), vec![1, 2]),
-            ]
+            group_names(&plan),
+            vec![(None, vec!["A"]), (Some("keyring://"), vec!["B", "C"])]
         );
     }
 
@@ -521,7 +472,7 @@ mod tests {
         let secrets = HashMap::from([("DECLARED".to_string(), secret(None))]);
         let spec = spec(secrets, None, &[]);
         assert!(
-            spec.plan_secret("NOPE", None, None).unwrap().is_none(),
+            spec.plan_secret("NOPE", "default", None).unwrap().is_none(),
             "an undeclared secret must not plan"
         );
     }
@@ -536,15 +487,12 @@ mod tests {
         )]);
         let spec = spec(secrets, None, &[]);
 
-        let one = spec.plan_secret("API_KEY", None, None).unwrap().unwrap();
+        let one = spec
+            .plan_secret("API_KEY", "default", None)
+            .unwrap()
+            .unwrap();
         assert_eq!(one.route.primary(), Some("onepassword://Production"));
-        match &one.route {
-            Route::Chain { primary, fallback } => {
-                assert_eq!(primary, "onepassword://Production");
-                assert_eq!(fallback, &vec!["keyring://".to_string()]);
-            }
-            other => panic!("expected a chain, got {other:?}"),
-        }
+        assert_eq!(one.route.fallback, vec!["keyring://".to_string()]);
 
         // Same route the whole-profile plan derives.
         let batch = plan(&spec);

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -1,0 +1,553 @@
+//! The resolution plan: a pure, I/O-free description of *what to do* for every
+//! secret in a profile, computed once up front and then executed.
+//!
+//! Resolution used to interleave deciding (profile merge, alias resolution,
+//! grouping, address derivation) with doing (spawning fetches, walking fallback
+//! chains, applying defaults, generating). This module isolates the deciding
+//! half: [`Secrets::build_plan`] turns the manifest plus provider-alias maps
+//! into an immutable [`ResolutionPlan`] without touching any provider, so the
+//! decisions are unit-testable on their own and the executor consumes a plan
+//! instead of re-deriving per-secret facts across `get`, `set`, and batch
+//! validation.
+//!
+//! Building a plan performs no I/O. Provider-alias resolution is a map lookup,
+//! so the only error it can raise is an undefined alias
+//! ([`SecretSpecError::ProviderNotFound`]); a plan never opens a store.
+
+use crate::config::{NativeAddress, Profile, Secret};
+use crate::error::Result;
+use crate::provider::Address;
+use crate::secrets::Secrets;
+use std::collections::HashMap;
+
+/// How a planned secret is named at whichever store resolves it.
+///
+/// Naming is orthogonal to routing: the same address is asked of whatever store
+/// [`Route`] selects. A secret's `ref` supplies native coordinates; otherwise
+/// SecretSpec's own `{project}/{profile}/{key}` convention applies, with the
+/// project and profile carried once on the [`ResolutionPlan`].
+#[derive(Debug)]
+pub(crate) enum PlannedAddress {
+    /// Native coordinates from the secret's `ref`.
+    Native(NativeAddress),
+    /// SecretSpec's naming convention; only the key varies per secret.
+    Convention { key: String },
+}
+
+impl PlannedAddress {
+    /// Borrow this owned address as the [`Address`] the provider trait consumes,
+    /// supplying the plan-level `project`/`profile` for a convention address.
+    pub(crate) fn as_address<'a>(&'a self, project: &'a str, profile: &'a str) -> Address<'a> {
+        match self {
+            PlannedAddress::Native(native) => Address::Native(native),
+            PlannedAddress::Convention { key } => Address::convention(project, profile, key),
+        }
+    }
+}
+
+/// Where a planned secret reads and writes.
+///
+/// A `providers` chain is a fallback list tried in order. Only the **primary**
+/// (the first entry — always tried first, the write target, and the grouping
+/// key) is resolved to a URI up front; the rest are carried as raw specs and
+/// resolved lazily, when and only when a read actually falls through to them.
+/// That keeps the chain tried in order: an undefined alias further down never
+/// fails an operation the primary satisfies, and never fails a write at all.
+#[derive(Debug)]
+pub(crate) enum Route {
+    /// An explicit `--provider`/`SECRETSPEC_PROVIDER`/builder override: exactly
+    /// one store, no fallback (the override collapses any per-secret chain).
+    Override(String),
+    /// The secret's `providers` chain. `primary` is the resolved first store;
+    /// `fallback` holds the remaining specs (aliases or URIs) raw, tried in
+    /// order — and resolved — only after the primary misses.
+    Chain {
+        primary: String,
+        fallback: Vec<String>,
+    },
+    /// No routing configured for this secret: the default provider applies.
+    Default,
+}
+
+impl Route {
+    /// The store consulted first — the override, the chain's primary, or `None`
+    /// for the default provider. This is the grouping key and the write target:
+    /// secrets sharing a primary store are fetched together, and a write goes to
+    /// the primary.
+    pub(crate) fn primary(&self) -> Option<&str> {
+        match self {
+            Route::Override(uri) => Some(uri),
+            Route::Chain { primary, .. } => Some(primary),
+            Route::Default => None,
+        }
+    }
+
+    /// The raw fallback specs a read walks after the primary misses: a chain's
+    /// entries past the first, when there are any. `None` means the read may
+    /// consult only one store — [`Route::primary`], with `None` meaning the
+    /// default provider — so no other store could answer instead. The one
+    /// definition of "has a fallback" shared by [`Route::has_fallback`] and
+    /// the executor's fallback walk.
+    pub(crate) fn fallback_specs(&self) -> Option<&[String]> {
+        match self {
+            Route::Chain { fallback, .. } if !fallback.is_empty() => Some(fallback),
+            _ => None,
+        }
+    }
+
+    /// Whether a read may consult more than one store: a chain with at least
+    /// one fallback entry.
+    pub(crate) fn has_fallback(&self) -> bool {
+        self.fallback_specs().is_some()
+    }
+
+    /// The ordered provider specs a read walks — the primary followed by the raw
+    /// fallback — or `None` for the default provider. Each entry is resolved only
+    /// when the read reaches it, so the chain is genuinely tried in order.
+    pub(crate) fn specs(&self) -> Option<Vec<String>> {
+        match self {
+            Route::Override(uri) => Some(vec![uri.clone()]),
+            Route::Chain { primary, fallback } => {
+                let mut specs = Vec::with_capacity(1 + fallback.len());
+                specs.push(primary.clone());
+                specs.extend(fallback.iter().cloned());
+                Some(specs)
+            }
+            Route::Default => None,
+        }
+    }
+}
+
+/// Everything decided for one declared secret, ready to execute.
+#[derive(Debug)]
+pub(crate) struct PlannedSecret {
+    /// The declared secret name (the manifest's `UPPER_SNAKE` key).
+    pub name: String,
+    /// The secret's effective config after the profile field-level merge.
+    pub config: Secret,
+    /// How the secret is named at whichever store resolves it.
+    pub address: PlannedAddress,
+    /// The resolved read/write route.
+    pub route: Route,
+}
+
+impl PlannedSecret {
+    /// The native `ref` coordinates the plan derived for this secret, if any.
+    /// Reads the planned address, not the raw config, so audit attribution
+    /// always reports the coordinates the plan actually addresses.
+    pub(crate) fn reference(&self) -> Option<&NativeAddress> {
+        match &self.address {
+            PlannedAddress::Native(native) => Some(native),
+            PlannedAddress::Convention { .. } => None,
+        }
+    }
+
+    /// Whether the active profile requires this secret (required by default).
+    pub(crate) fn required(&self) -> bool {
+        self.config.required.unwrap_or(true)
+    }
+
+    /// Whether the value is materialized to a temp file and exposed as a path.
+    pub(crate) fn as_path(&self) -> bool {
+        self.config.as_path.unwrap_or(false)
+    }
+}
+
+/// An immutable, fully-decided plan for resolving one profile.
+#[derive(Debug)]
+pub(crate) struct ResolutionPlan {
+    /// The project name (supplies convention addressing).
+    pub project: String,
+    /// The resolved profile name.
+    pub profile: String,
+    /// The explicit provider override in force, if any. `Some` collapses every
+    /// secret's route to that single store.
+    pub override_uri: Option<String>,
+    /// One entry per declared secret, sorted by name for deterministic output.
+    pub secrets: Vec<PlannedSecret>,
+    /// Primary-store groups in first-seen order: each maps a store URI (`None` =
+    /// default provider) to the indices into [`ResolutionPlan::secrets`] fetched
+    /// together. A pure function of each secret's [`Route::primary`], surfaced
+    /// so the executor does not recompute it.
+    pub groups: Vec<(Option<String>, Vec<usize>)>,
+}
+
+impl Secrets {
+    /// Resolve a whole profile into an immutable [`ResolutionPlan`] without any
+    /// I/O: merge the profile, compute each secret's effective config, derive
+    /// its address and resolved route, and group secrets by their primary store.
+    ///
+    /// The explicit provider override (builder or `SECRETSPEC_PROVIDER`) is
+    /// picked up via [`Secrets::resolve_provider_override`]. Production code
+    /// resolves the profile itself and calls [`Secrets::build_plan_from_profile`]
+    /// directly (it needs the profile for audit attribution too, and shouldn't
+    /// merge it twice); this one-call form is for tests that don't.
+    #[cfg(test)]
+    pub(crate) fn build_plan(&self, profile: Option<&str>) -> Result<ResolutionPlan> {
+        let profile_name = self.resolve_profile_name(profile);
+        let profile_config = self.resolve_profile(Some(&profile_name))?;
+        self.build_plan_from_profile(profile_name, profile_config)
+    }
+
+    /// As [`Secrets::build_plan`], but for a caller that has already resolved
+    /// the profile for another purpose (e.g. attributing an audit event before
+    /// planning can fail) and would otherwise redo that merge a second time.
+    pub(crate) fn build_plan_from_profile(
+        &self,
+        profile_name: String,
+        profile_config: Profile,
+    ) -> Result<ResolutionPlan> {
+        // Sorted names make planning deterministic (grouping order, missing
+        // lists) rather than inheriting the profile's HashMap iteration order.
+        let names = profile_config.sorted_secret_names();
+
+        let override_uri = self.resolve_provider_override(None);
+
+        let mut secrets = Vec::with_capacity(names.len());
+        for name in &names {
+            let config = self
+                .resolve_secret_config(name, Some(&profile_name))
+                .expect("secret resolved from the merged profile always has a config");
+            secrets.push(self.plan_one_secret(name.clone(), config, &override_uri)?);
+        }
+
+        // Group by primary store, preserving first-seen order so grouping is
+        // deterministic and independent of hashing.
+        let mut groups: Vec<(Option<String>, Vec<usize>)> = Vec::new();
+        let mut group_index: HashMap<Option<&str>, usize> = HashMap::new();
+        for (i, secret) in secrets.iter().enumerate() {
+            let primary = secret.route.primary();
+            match group_index.get(&primary) {
+                Some(&idx) => groups[idx].1.push(i),
+                None => {
+                    group_index.insert(primary, groups.len());
+                    groups.push((primary.map(String::from), vec![i]));
+                }
+            }
+        }
+
+        Ok(ResolutionPlan {
+            project: self.config().project.name.clone(),
+            profile: profile_name,
+            override_uri,
+            secrets,
+            groups,
+        })
+    }
+
+    /// Plan a single secret the CLI's `get`/`set` operate on, reusing the exact
+    /// per-secret decisions batch resolution makes. Returns `Ok(None)` when the
+    /// secret is not declared in the (merged) profile, mirroring
+    /// [`Secrets::resolve_secret_config`], so the caller can raise its own
+    /// "not found" error and audit it.
+    ///
+    /// `override_arg` is the caller's explicit provider (the `--provider`
+    /// flag); like [`Secrets::build_plan`] it also picks up the builder and
+    /// `SECRETSPEC_PROVIDER` via [`Secrets::resolve_provider_override`], and
+    /// profile resolution follows the same precedence.
+    pub(crate) fn plan_secret(
+        &self,
+        name: &str,
+        profile: Option<&str>,
+        override_arg: Option<&str>,
+    ) -> Result<Option<PlannedSecret>> {
+        let profile_name = self.resolve_profile_name(profile);
+        let Some(config) = self.resolve_secret_config(name, Some(&profile_name)) else {
+            return Ok(None);
+        };
+        let override_uri = self.resolve_provider_override(override_arg);
+        Ok(Some(self.plan_one_secret(
+            name.to_string(),
+            config,
+            &override_uri,
+        )?))
+    }
+
+    /// Derive one [`PlannedSecret`] from its effective config and the resolved
+    /// override. The single place per-secret decisions are made, shared by the
+    /// whole-profile [`Secrets::build_plan`] and the single-secret
+    /// [`Secrets::plan_secret`], so `get`, `set`, and batch validation cannot
+    /// drift.
+    fn plan_one_secret(
+        &self,
+        name: String,
+        config: Secret,
+        override_uri: &Option<String>,
+    ) -> Result<PlannedSecret> {
+        // A `ref` supplies naming only; convention naming otherwise. The address
+        // applies to whichever store the route selects.
+        let address = match &config.reference {
+            Some(native) => PlannedAddress::Native(native.clone()),
+            None => PlannedAddress::Convention { key: name.clone() },
+        };
+
+        let route = self.route_for(&config, override_uri)?;
+
+        Ok(PlannedSecret {
+            name,
+            config,
+            address,
+            route,
+        })
+    }
+
+    /// Resolve a secret's [`Route`] from its config and the active override.
+    ///
+    /// An explicit override collapses to a single store. Otherwise only the
+    /// primary of the `providers` chain is resolved (it is always tried first
+    /// and is the write/grouping target, so an undefined primary is a hard error
+    /// here); the fallback specs are carried raw and resolved lazily on a miss,
+    /// so the chain stays tried in order. An empty or absent chain is the default
+    /// provider. This is the one routing deriver behind the plan, `get`, `set`,
+    /// and generation.
+    pub(crate) fn route_for(
+        &self,
+        config: &Secret,
+        override_uri: &Option<String>,
+    ) -> Result<Route> {
+        if let Some(uri) = override_uri {
+            return Ok(Route::Override(uri.clone()));
+        }
+        match config.providers.as_deref() {
+            Some([first, fallback @ ..]) => Ok(Route::Chain {
+                primary: self.resolve_one_provider(first)?,
+                fallback: fallback.to_vec(),
+            }),
+            _ => Ok(Route::Default),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::SecretSpecError;
+    use crate::tests::{global_config_with_aliases, scrub_resolution_env};
+    use std::collections::HashMap;
+
+    /// Build a secret with a description and optional per-secret provider chain.
+    fn secret(providers: Option<Vec<&str>>) -> Secret {
+        Secret {
+            description: Some("a secret".to_string()),
+            providers: providers.map(|p| p.into_iter().map(String::from).collect()),
+            ..Default::default()
+        }
+    }
+
+    /// A `Secrets` over a single `default` profile holding `secrets`, with an
+    /// optional builder provider and global alias map.
+    fn spec(
+        secrets: HashMap<String, Secret>,
+        provider: Option<&str>,
+        aliases: &[(&str, &str)],
+    ) -> Secrets {
+        let config = crate::tests::resolve_test_config(secrets);
+        let global_config = (!aliases.is_empty()).then(|| global_config_with_aliases(aliases));
+        Secrets::new(config, global_config, provider.map(String::from), None)
+    }
+
+    fn plan(spec: &Secrets) -> ResolutionPlan {
+        spec.build_plan(None).unwrap()
+    }
+
+    fn find<'a>(plan: &'a ResolutionPlan, name: &str) -> &'a PlannedSecret {
+        plan.secrets
+            .iter()
+            .find(|s| s.name == name)
+            .expect("secret in plan")
+    }
+
+    #[test]
+    fn no_routing_plans_the_default_store() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([("DATABASE_URL".to_string(), secret(None))]);
+        let plan = plan(&spec(secrets, None, &[]));
+
+        let planned = find(&plan, "DATABASE_URL");
+        assert!(matches!(planned.route, Route::Default));
+        assert_eq!(planned.route.primary(), None);
+        assert_eq!(plan.groups, vec![(None, vec![0])]);
+    }
+
+    #[test]
+    fn override_collapses_the_chain_to_one_store() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([(
+            "API_KEY".to_string(),
+            secret(Some(vec!["onepassword://Production", "keyring://"])),
+        )]);
+        // An explicit override wins over the per-secret chain.
+        let mut spec = spec(secrets, None, &[]);
+        spec.set_provider("dotenv://.env.mock");
+        let plan = plan(&spec);
+
+        let planned = find(&plan, "API_KEY");
+        assert!(matches!(&planned.route, Route::Override(uri) if uri == "dotenv://.env.mock"));
+        assert_eq!(planned.route.primary(), Some("dotenv://.env.mock"));
+        assert_eq!(plan.override_uri, Some("dotenv://.env.mock".to_string()));
+    }
+
+    #[test]
+    fn providers_chain_resolves_the_primary_and_carries_the_fallback_raw() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([("API_KEY".to_string(), secret(Some(vec!["shared", "kr"])))]);
+        let plan = plan(&spec(
+            secrets,
+            None,
+            &[("shared", "onepassword://Shared"), ("kr", "keyring://")],
+        ));
+
+        let planned = find(&plan, "API_KEY");
+        match &planned.route {
+            // The primary is resolved to its URI; the fallback stays as the raw
+            // alias, resolved only if the primary misses at read time.
+            Route::Chain { primary, fallback } => {
+                assert_eq!(primary, "onepassword://Shared");
+                assert_eq!(fallback, &vec!["kr".to_string()]);
+            }
+            other => panic!("expected a chain, got {other:?}"),
+        }
+        assert_eq!(planned.route.primary(), Some("onepassword://Shared"));
+    }
+
+    #[test]
+    fn an_undefined_fallback_alias_does_not_fail_the_plan() {
+        let _env = scrub_resolution_env();
+        // The chain is tried in order: a broken link after the primary must not
+        // fail planning, since a live primary may never reach it.
+        let secrets = HashMap::from([("API_KEY".to_string(), secret(Some(vec!["kr", "ghost"])))]);
+        let plan = plan(&spec(secrets, None, &[("kr", "keyring://")]));
+
+        let planned = find(&plan, "API_KEY");
+        match &planned.route {
+            Route::Chain { primary, fallback } => {
+                assert_eq!(primary, "keyring://");
+                // The undefined alias is carried raw, not resolved (which would error).
+                assert_eq!(fallback, &vec!["ghost".to_string()]);
+            }
+            other => panic!("expected a chain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inline_uri_in_chain_passes_through_without_an_alias() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([(
+            "API_KEY".to_string(),
+            secret(Some(vec!["onepassword://Production"])),
+        )]);
+        let plan = plan(&spec(secrets, None, &[]));
+
+        let planned = find(&plan, "API_KEY");
+        assert_eq!(planned.route.primary(), Some("onepassword://Production"));
+    }
+
+    #[test]
+    fn undefined_alias_fails_the_plan() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([("API_KEY".to_string(), secret(Some(vec!["nope"])))]);
+        let spec = spec(secrets, None, &[]);
+        let err = spec.build_plan(None).unwrap_err();
+        assert!(matches!(err, SecretSpecError::ProviderNotFound(_)));
+    }
+
+    #[test]
+    fn bare_provider_name_in_chain_passes_through() {
+        let _env = scrub_resolution_env();
+        // A chain entry that names a registered provider (no alias, no `://`)
+        // is a valid spec, exactly as `--provider keyring` is: the plan carries
+        // it through for `build_provider` to construct.
+        let secrets = HashMap::from([("API_KEY".to_string(), secret(Some(vec!["keyring"])))]);
+        let plan = plan(&spec(secrets, None, &[]));
+
+        assert_eq!(find(&plan, "API_KEY").route.primary(), Some("keyring"));
+    }
+
+    #[test]
+    fn a_ref_plans_a_native_address_convention_otherwise() {
+        let _env = scrub_resolution_env();
+        let mut referenced = secret(None);
+        referenced.reference = Some(NativeAddress {
+            item: "db".to_string(),
+            field: Some("password".to_string()),
+            ..Default::default()
+        });
+        let secrets = HashMap::from([
+            ("REFERENCED".to_string(), referenced),
+            ("PLAIN".to_string(), secret(None)),
+        ]);
+        let plan = plan(&spec(secrets, None, &[]));
+
+        match &find(&plan, "REFERENCED").address {
+            PlannedAddress::Native(native) => {
+                assert_eq!(native.item, "db");
+                assert_eq!(native.field.as_deref(), Some("password"));
+            }
+            PlannedAddress::Convention { .. } => panic!("a ref should plan a native address"),
+        }
+        match &find(&plan, "PLAIN").address {
+            PlannedAddress::Convention { key } => assert_eq!(key, "PLAIN"),
+            PlannedAddress::Native(_) => panic!("no ref should plan a convention address"),
+        }
+    }
+
+    #[test]
+    fn secrets_are_sorted_and_grouped_by_primary_store() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([
+            ("B".to_string(), secret(Some(vec!["keyring://"]))),
+            ("A".to_string(), secret(None)),
+            ("C".to_string(), secret(Some(vec!["keyring://"]))),
+        ]);
+        let plan = plan(&spec(secrets, None, &[]));
+
+        // Deterministic, name-sorted ordering regardless of map hashing.
+        let names: Vec<&str> = plan.secrets.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["A", "B", "C"]);
+
+        // A goes to the default group; B and C share the keyring group.
+        assert_eq!(
+            plan.groups,
+            vec![
+                (None, vec![0]),
+                (Some("keyring://".to_string()), vec![1, 2]),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_secret_is_none_for_an_undeclared_secret() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([("DECLARED".to_string(), secret(None))]);
+        let spec = spec(secrets, None, &[]);
+        assert!(
+            spec.plan_secret("NOPE", None, None).unwrap().is_none(),
+            "an undeclared secret must not plan"
+        );
+    }
+
+    #[test]
+    fn plan_secret_matches_the_batch_plan_for_a_declared_secret() {
+        let _env = scrub_resolution_env();
+        // `get`/`set` plan one secret; the decision must match `build_plan`.
+        let secrets = HashMap::from([(
+            "API_KEY".to_string(),
+            secret(Some(vec!["onepassword://Production", "keyring://"])),
+        )]);
+        let spec = spec(secrets, None, &[]);
+
+        let one = spec.plan_secret("API_KEY", None, None).unwrap().unwrap();
+        assert_eq!(one.route.primary(), Some("onepassword://Production"));
+        match &one.route {
+            Route::Chain { primary, fallback } => {
+                assert_eq!(primary, "onepassword://Production");
+                assert_eq!(fallback, &vec!["keyring://".to_string()]);
+            }
+            other => panic!("expected a chain, got {other:?}"),
+        }
+
+        // Same route the whole-profile plan derives.
+        let batch = plan(&spec);
+        assert_eq!(one.route.primary(), find(&batch, "API_KEY").route.primary());
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -366,6 +366,46 @@ pub fn providers() -> Vec<ProviderInfo> {
         .collect()
 }
 
+/// Whether `scheme` is registered by some provider. The one place both the
+/// `TryFrom<&str>` URI parser and [`spec_names_known_provider`] check a scheme
+/// against [`PROVIDER_REGISTRY`], so the two cannot drift on what counts as
+/// known.
+fn is_registered_scheme(scheme: &str) -> bool {
+    PROVIDER_REGISTRY
+        .iter()
+        .any(|reg| reg.schemes.contains(&scheme))
+}
+
+/// The `onepassword` misspelling the `TryFrom` parser corrects with a
+/// dedicated "use `onepassword` instead" error. Shared with
+/// [`spec_names_known_provider`] so a spec using it routes to that message
+/// rather than being reported as an undefined alias.
+const ONEPASSWORD_MISSPELLING: &str = "1password";
+
+/// Splits a provider spec at the first `:` into its scheme token and the rest
+/// (empty for a bare provider name). The one definition of "the scheme",
+/// shared by the `TryFrom<&str>` URI parser and [`spec_names_known_provider`],
+/// so the two cannot disagree on how a spec is split.
+fn split_spec(spec: &str) -> (&str, &str) {
+    match spec.find(':') {
+        Some(pos) => (&spec[..pos], &spec[pos + 1..]),
+        None => (spec, ""),
+    }
+}
+
+/// Whether `spec` names a registered provider: a bare name (`keyring`), a
+/// `scheme:path` shorthand (`dotenv:.env.production`), or a full URI. Checks
+/// the leading scheme token against the registry without constructing a
+/// provider, so alias resolution can tell a valid provider spec apart from an
+/// undefined alias.
+///
+/// [`ONEPASSWORD_MISSPELLING`] also counts as naming a provider, so it passes
+/// through alias resolution to reach the parser's corrective error.
+pub(crate) fn spec_names_known_provider(spec: &str) -> bool {
+    let (scheme, _) = split_spec(spec);
+    scheme == ONEPASSWORD_MISSPELLING || is_registered_scheme(scheme)
+}
+
 /// Trait defining the interface for secret storage providers.
 ///
 /// All secret storage backends must implement this trait to integrate with SecretSpec.
@@ -900,17 +940,10 @@ impl TryFrom<&str> for Box<dyn Provider> {
 
     fn try_from(s: &str) -> Result<Self> {
         // Parse the scheme from the input string
-        let (scheme, rest) = if let Some(pos) = s.find(':') {
-            let scheme = &s[..pos];
-            let rest = &s[pos + 1..];
-            (scheme, rest)
-        } else {
-            // Just a provider name, no URI components
-            (s, "")
-        };
+        let (scheme, rest) = split_spec(s);
 
         // Validate scheme first
-        if scheme == "1password" {
+        if scheme == ONEPASSWORD_MISSPELLING {
             return Err(SecretSpecError::ProviderOperationFailed(
                 "Invalid scheme '1password'. Use 'onepassword' instead (e.g., onepassword://vault)"
                     .to_string(),
@@ -918,11 +951,7 @@ impl TryFrom<&str> for Box<dyn Provider> {
         }
 
         // Check if the scheme is registered
-        let is_valid_scheme = PROVIDER_REGISTRY
-            .iter()
-            .any(|reg| reg.schemes.contains(&scheme));
-
-        if !is_valid_scheme {
+        if !is_registered_scheme(scheme) {
             // Check if it's a known provider name to give a better error
             if PROVIDER_REGISTRY.iter().any(|reg| reg.info.name == scheme) {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -366,22 +366,6 @@ pub fn providers() -> Vec<ProviderInfo> {
         .collect()
 }
 
-/// Whether `scheme` is registered by some provider. The one place both the
-/// `TryFrom<&str>` URI parser and [`spec_names_known_provider`] check a scheme
-/// against [`PROVIDER_REGISTRY`], so the two cannot drift on what counts as
-/// known.
-fn is_registered_scheme(scheme: &str) -> bool {
-    PROVIDER_REGISTRY
-        .iter()
-        .any(|reg| reg.schemes.contains(&scheme))
-}
-
-/// The `onepassword` misspelling the `TryFrom` parser corrects with a
-/// dedicated "use `onepassword` instead" error. Shared with
-/// [`spec_names_known_provider`] so a spec using it routes to that message
-/// rather than being reported as an undefined alias.
-const ONEPASSWORD_MISSPELLING: &str = "1password";
-
 /// Splits a provider spec at the first `:` into its scheme token and the rest
 /// (empty for a bare provider name). The one definition of "the scheme",
 /// shared by the `TryFrom<&str>` URI parser and [`spec_names_known_provider`],
@@ -399,11 +383,21 @@ fn split_spec(spec: &str) -> (&str, &str) {
 /// provider, so alias resolution can tell a valid provider spec apart from an
 /// undefined alias.
 ///
-/// [`ONEPASSWORD_MISSPELLING`] also counts as naming a provider, so it passes
-/// through alias resolution to reach the parser's corrective error.
-pub(crate) fn spec_names_known_provider(spec: &str) -> bool {
+/// The common `1password` misspelling of `onepassword` errors with its
+/// corrective "use `onepassword` instead" message. Both the `TryFrom<&str>`
+/// URI parser and alias resolution gate specs through here, so the correction
+/// fires in one place no matter which path first sees the spec.
+pub(crate) fn spec_names_known_provider(spec: &str) -> Result<bool> {
     let (scheme, _) = split_spec(spec);
-    scheme == ONEPASSWORD_MISSPELLING || is_registered_scheme(scheme)
+    if scheme == "1password" {
+        return Err(SecretSpecError::ProviderOperationFailed(
+            "Invalid scheme '1password'. Use 'onepassword' instead (e.g., onepassword://vault)"
+                .to_string(),
+        ));
+    }
+    Ok(PROVIDER_REGISTRY
+        .iter()
+        .any(|reg| reg.schemes.contains(&scheme)))
 }
 
 /// Trait defining the interface for secret storage providers.
@@ -942,16 +936,10 @@ impl TryFrom<&str> for Box<dyn Provider> {
         // Parse the scheme from the input string
         let (scheme, rest) = split_spec(s);
 
-        // Validate scheme first
-        if scheme == ONEPASSWORD_MISSPELLING {
-            return Err(SecretSpecError::ProviderOperationFailed(
-                "Invalid scheme '1password'. Use 'onepassword' instead (e.g., onepassword://vault)"
-                    .to_string(),
-            ));
-        }
-
-        // Check if the scheme is registered
-        if !is_registered_scheme(scheme) {
+        // Reject the `1password` misspelling (with its corrective error) and
+        // check the scheme against the registry, through the same gate alias
+        // resolution uses.
+        if !spec_names_known_provider(s)? {
             // Check if it's a known provider name to give a better error
             if PROVIDER_REGISTRY.iter().any(|reg| reg.info.name == scheme) {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1188,7 +1188,13 @@ impl Secrets {
             }
         };
 
-        let backend = self.write_provider_for_route(&planned.route)?;
+        let backend = match self.write_provider_for_route(&planned.route) {
+            Ok(backend) => backend,
+            Err(err) => {
+                self.record_key_error(AuditAction::Set, &profile_name, name, None, None, &err);
+                return Err(err);
+            }
+        };
 
         let addr = planned.as_address(&self.config.project.name, &profile_name);
         // Refuse before prompting for a value. The provider states the reason:

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -3,7 +3,7 @@
 use crate::audit::{AuditAction, AuditContext, AuditLogger, AuditOutcome};
 use crate::config::{Config, GlobalConfig, NativeAddress, Profile, RequireReason, Resolved};
 use crate::error::{Result, SecretSpecError};
-use crate::plan::{PlannedAddress, PlannedSecret, ResolutionPlan, Route};
+use crate::plan::{PlannedSecret, ResolutionPlan, Route};
 use crate::provider::{Address, Provider as ProviderTrait};
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
@@ -553,15 +553,17 @@ impl Secrets {
     }
 
     /// Records a failed single-secret operation (`get`/`set`) as an `Error`
-    /// event attributed to `key` — and to a provider, when one was determined
-    /// before the failure. The one shape every `get`/`set` failure path
-    /// records, so the paths cannot drift on which fields a failure carries.
+    /// event attributed to `key` — and to a provider and native `ref`
+    /// coordinates, when they were determined before the failure. The one shape
+    /// every `get`/`set` failure path records, so the paths cannot drift on
+    /// which fields a failure carries.
     fn record_key_error(
         &self,
         action: AuditAction,
         profile: &str,
         key: &str,
         provider_uri: Option<String>,
+        reference: Option<&NativeAddress>,
         err: &SecretSpecError,
     ) {
         self.record(
@@ -571,6 +573,7 @@ impl Secrets {
             AuditFields {
                 key: Some(key),
                 provider_uri,
+                reference,
                 error_kind: Some(err.kind()),
                 ..Default::default()
             },
@@ -866,7 +869,9 @@ impl Secrets {
     /// shorthand like `dotenv:.env.production`) also passes through, so the
     /// chain and the resolved override accept exactly the specs `--provider`
     /// and the default provider accept; `build_provider` constructs it later.
-    /// Only a token that names neither an alias nor a provider errors.
+    /// Only a token that names neither an alias nor a provider errors — with
+    /// the corrective "use `onepassword` instead" message when it is the
+    /// common `1password` misspelling.
     ///
     /// Used both to resolve a chain's primary up front and to resolve each
     /// fallback entry lazily, in order, as a read actually reaches it.
@@ -877,7 +882,7 @@ impl Secrets {
         if let Some(uri) = self.lookup_provider_alias(spec) {
             return Ok(uri);
         }
-        if crate::provider::spec_names_known_provider(spec) {
+        if crate::provider::spec_names_known_provider(spec)? {
             return Ok(spec.to_string());
         }
         let known = self.known_provider_aliases();
@@ -931,12 +936,7 @@ impl Secrets {
     ) -> Result<HashMap<String, SecretString>> {
         let requests: Vec<(&str, Address<'_>)> = group
             .iter()
-            .map(|planned| {
-                (
-                    planned.name.as_str(),
-                    planned.address.as_address(project, profile),
-                )
-            })
+            .map(|planned| (planned.name.as_str(), planned.as_address(project, profile)))
             .collect();
         provider.get_many(&requests)
     }
@@ -1008,18 +1008,12 @@ impl Secrets {
             return Ok(crate::audit::redact_uri_strict(uri));
         }
 
-        let mut provider_uris: Vec<&str> = Vec::new();
-        for uri in primary_uris {
-            match uri {
-                // Any secret on the default provider: report that provider.
-                None => return self.get_provider(None).map(|provider| provider.uri()),
-                Some(uri) => provider_uris.push(uri),
-            }
-        }
-        provider_uris.sort_unstable();
-
-        match provider_uris.first() {
+        // Collecting into `Option` yields `None` as soon as any secret sits on
+        // the default provider, which then names the report.
+        let provider_uris: Option<Vec<&str>> = primary_uris.collect();
+        match provider_uris.and_then(|uris| uris.into_iter().min()) {
             Some(uri) => Ok(crate::audit::redact_uri_strict(uri)),
+            // A secret on the default provider, or no secrets at all.
             None => self.get_provider(None).map(|provider| provider.uri()),
         }
     }
@@ -1041,7 +1035,7 @@ impl Secrets {
     /// # Arguments
     ///
     /// * `secret_name` - The secret name, for warning messages
-    /// * `addr` - The secret's [`Address`] (see [`PlannedAddress::as_address`]);
+    /// * `addr` - The secret's [`Address`] (see [`PlannedSecret::as_address`]);
     ///   the same address is asked of every provider in the chain
     /// * `provider_specs` - Optional chain of provider specs (aliases or inline
     ///   URIs) to try in order, resolved lazily per entry
@@ -1169,13 +1163,13 @@ impl Secrets {
         // Plan the secret exactly as batch resolution would, so the write
         // target, address, and effective config are the same decisions
         // `check`/`run` make. `None` means it is not declared in this profile.
-        let planned = match self.plan_secret(name, Some(&profile_name), None) {
+        let planned = match self.plan_secret(name, &profile_name, None) {
             Ok(Some(planned)) => planned,
             // Planning failed (e.g. an undefined provider alias). Still an
             // attempted write, so audit it like the batch path audits every
             // planning failure; no provider can be attributed yet.
             Err(err) => {
-                self.record_key_error(AuditAction::Set, &profile_name, name, None, &err);
+                self.record_key_error(AuditAction::Set, &profile_name, name, None, None, &err);
                 return Err(err);
             }
             Ok(None) => {
@@ -1189,16 +1183,14 @@ impl Secrets {
                     available_secrets.join(", ")
                 ));
                 // Provider is unknown for an undefined secret, so attribute to None.
-                self.record_key_error(AuditAction::Set, &profile_name, name, None, &err);
+                self.record_key_error(AuditAction::Set, &profile_name, name, None, None, &err);
                 return Err(err);
             }
         };
 
         let backend = self.write_provider_for_route(&planned.route)?;
 
-        let addr = planned
-            .address
-            .as_address(&self.config.project.name, &profile_name);
+        let addr = planned.as_address(&self.config.project.name, &profile_name);
         // Refuse before prompting for a value. The provider states the reason:
         // a store may be writable through the convention layout yet reject the
         // `ref` this secret names.
@@ -1208,6 +1200,7 @@ impl Secrets {
                 &profile_name,
                 name,
                 Some(backend.uri()),
+                None,
                 &err,
             );
             return Err(err);
@@ -1238,6 +1231,7 @@ impl Secrets {
                 &profile_name,
                 name,
                 Some(backend.uri()),
+                None,
                 &err,
             );
             return Err(err);
@@ -1291,20 +1285,20 @@ impl Secrets {
         // Plan the secret exactly as batch resolution would, so the read route,
         // address, and effective config are the same decisions `check`/`run`
         // make. `None` means it is not declared in this profile.
-        let planned = match self.plan_secret(name, Some(&profile_name), None) {
+        let planned = match self.plan_secret(name, &profile_name, None) {
             Ok(Some(planned)) => planned,
             // Planning failed (e.g. an undefined provider alias). Still an
             // attempted read, so audit it like the batch path audits every
             // planning failure; no provider can be attributed yet.
             Err(err) => {
-                self.record_key_error(AuditAction::Get, &profile_name, name, None, &err);
+                self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
                 return Err(err);
             }
             Ok(None) => {
                 // The secret is not defined, so no provider can be attributed.
                 // Audit the failed read for parity with `set`'s undefined path.
                 let err = SecretSpecError::SecretNotFound(name.to_string());
-                self.record_key_error(AuditAction::Get, &profile_name, name, None, &err);
+                self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
                 return Err(err);
             }
         };
@@ -1317,9 +1311,7 @@ impl Secrets {
         let read_specs = planned.route.specs();
         let result = self.get_secret_from_providers(
             name,
-            planned
-                .address
-                .as_address(&self.config.project.name, &profile_name),
+            planned.as_address(&self.config.project.name, &profile_name),
             read_specs.as_deref(),
         );
 
@@ -1363,17 +1355,9 @@ impl Secrets {
                     ..Default::default()
                 },
             ),
-            Err(e) => self.record(
-                AuditAction::Get,
-                &profile_name,
-                AuditOutcome::Error,
-                AuditFields {
-                    key: Some(name),
-                    reference,
-                    error_kind: Some(e.kind()),
-                    ..Default::default()
-                },
-            ),
+            Err(e) => {
+                self.record_key_error(AuditAction::Get, &profile_name, name, None, reference, e)
+            }
         }
 
         match result?.0 {
@@ -1504,7 +1488,7 @@ impl Secrets {
                     for (i, secret_name) in missing.iter().enumerate() {
                         if let Some(planned) = self.plan_secret(
                             secret_name,
-                            Some(&profile_display),
+                            &profile_display,
                             provider_arg.as_deref(),
                         )? {
                             let prompt_msg =
@@ -1515,9 +1499,7 @@ impl Secrets {
 
                             let backend = self.write_provider_for_route(&planned.route)?;
                             let set_result = backend.set(
-                                planned
-                                    .address
-                                    .as_address(&self.config.project.name, &profile_display),
+                                planned.as_address(&self.config.project.name, &profile_display),
                                 &SecretString::new(value.into()),
                             );
                             self.audit_write_result(
@@ -1811,7 +1793,7 @@ impl Secrets {
             for name in profile.sorted_secret_names() {
                 read_names.push(name.clone());
                 let planned = self
-                    .plan_secret(&name, Some(&profile_display), None)?
+                    .plan_secret(&name, &profile_display, None)?
                     .expect("Secret should exist since we're iterating over it");
                 let description = planned.config.description.as_deref();
 
@@ -1820,9 +1802,7 @@ impl Secrets {
                 // The secret's address (native `ref` coordinates or convention
                 // naming) applies to both stores: naming is orthogonal to
                 // which store holds the value.
-                let addr = planned
-                    .address
-                    .as_address(&self.config.project.name, &profile_display);
+                let addr = planned.as_address(&self.config.project.name, &profile_display);
                 // First check if the secret exists in the "from" provider
                 match from_provider_instance.get(addr)? {
                     Some(value) => {
@@ -1898,8 +1878,8 @@ impl Secrets {
         })();
 
         if let Err(e) = copy_result {
-            // Record a failed/partial import with the secrets read before the error.
-            read_names.sort();
+            // Record a failed/partial import with the secrets read before the
+            // error (already in sorted order, from the import loop).
             self.record(
                 AuditAction::Import,
                 &profile_display,
@@ -1938,7 +1918,6 @@ impl Secrets {
         // copied and nothing was found anywhere — so a "found nothing" import is
         // not mislabeled as a successful retrieval. Per-secret copies are also
         // recorded individually as `Set`/`Written` events above.
-        read_names.sort();
         let outcome = if imported > 0 {
             AuditOutcome::Written
         } else if already_exists > 0 {
@@ -2001,9 +1980,7 @@ impl Secrets {
 
         // Store the generated value at the plan's address, through the plan's
         // write route: the same decisions every other write path executes.
-        let addr = planned
-            .address
-            .as_address(&self.config.project.name, profile_name);
+        let addr = planned.as_address(&self.config.project.name, profile_name);
         let backend = self.write_provider_for_route(&planned.route)?;
         // The provider states why a write is refused; wrapping it here would
         // only nest a second "Provider operation failed" prefix.
@@ -2303,9 +2280,9 @@ impl Secrets {
         }
 
         let profile_name = self.resolve_profile_name(None);
-        // Resolved once and reused for both the audit keys and the plan, so a
-        // failed read is still attributed to every secret it attempted without
-        // merging the profile twice.
+        // The profile is resolved once; its sorted names serve both as the
+        // audit keys and as the plan's input, so nothing is merged or sorted
+        // twice.
         let profile_result = self.resolve_profile(Some(&profile_name));
         // Keys for the single read-audit event, computed before any planning
         // can fail (e.g. on an undefined alias) so a failed read is still
@@ -2316,22 +2293,16 @@ impl Secrets {
             .map(|profile| profile.sorted_secret_names())
             .unwrap_or_default();
 
-        // Decide the whole profile up front (pure, no I/O), reject any `ref`
-        // routed at a single store that cannot honor its coordinates, then
-        // execute the plan. Each step returns `Result`, so *any* error — an undefined
+        // Decide the whole profile up front (pure, no I/O), then execute the
+        // plan. Each step returns `Result`, so *any* error — an undefined
         // alias, an unsupported `ref` coordinate, a fallback-chain outage, a
         // report-URI failure — is captured in `result` and recorded as the
         // single `Check` event below rather than escaping unaudited. `record`
         // is a no-op when auditing is off.
         let result: Result<std::result::Result<ValidatedSecrets, ValidationErrors>> =
             profile_result
-                .and_then(|profile_config| {
-                    self.build_plan_from_profile(profile_name.clone(), profile_config)
-                })
-                .and_then(|plan| {
-                    self.validate_single_store_ref_coords(&plan)?;
-                    self.execute_plan(&plan, materialize)
-                });
+                .and_then(|_| self.build_plan_from_names(profile_name.clone(), audit_keys.clone()))
+                .and_then(|plan| self.execute_plan(&plan, materialize));
 
         // Record exactly one `Check` event for the whole batch when this is a
         // top-level read, regardless of how the resolution exited — so a failed
@@ -2358,48 +2329,32 @@ impl Secrets {
         result
     }
 
-    /// Reject, before any fetch, a `ref` routed at exactly one store that cannot
-    /// honor its coordinates.
+    /// Rejects a `ref` routed at exactly one store that cannot honor its
+    /// coordinates. Run per primary-store group right after the provider is
+    /// built and before any fetch is spawned, so the definite error surfaces up
+    /// front (and, in the value-free report, without a fetch at all).
     ///
-    /// A single store is consulted when the route is an override, a
-    /// single-provider chain, or the default provider — there is no fallback that
-    /// could answer instead, so an incompatible store is a definite error worth
-    /// surfacing up front rather than at fetch time (and, in the value-free
-    /// report, without a fetch at all). A `ref` on a multi-store chain is
-    /// deliberately skipped: its coordinates are validated per store as the chain
-    /// is walked at read time, so a coordinate a later store cannot express never
-    /// blocks a primary that can.
+    /// A single store is consulted when the route has no fallback — an
+    /// override, a single-provider chain, or the default provider — so no other
+    /// store could answer instead. A `ref` on a multi-store chain is
+    /// deliberately skipped: its coordinates are validated per store as the
+    /// chain is walked at read time, so a coordinate a later store cannot
+    /// express never blocks a primary that can.
     ///
-    /// Building a provider here reads its declared supported coordinates and
-    /// opens no store; [`Provider::resolve_coords`](crate::provider::Provider::resolve_coords)
-    /// does no I/O for a native address. Construction is cheap enough that
-    /// [`Secrets::execute_plan`] simply builds the same providers again.
-    fn validate_single_store_ref_coords(&self, plan: &ResolutionPlan) -> Result<()> {
-        // The plan's groups already partition secrets by primary store, so walk
-        // that partition rather than re-deriving it: one provider per group
-        // that actually has coordinates to check.
-        for (primary, indices) in &plan.groups {
-            let refs_to_check: Vec<&NativeAddress> = indices
-                .iter()
-                .filter_map(|&i| {
-                    let planned = &plan.secrets[i];
-                    // Only the routes that consult exactly one store; a chain
-                    // with a fallback defers coordinate checking to per-store
-                    // read-time.
-                    if planned.route.has_fallback() {
-                        return None;
-                    }
-                    match &planned.address {
-                        PlannedAddress::Native(native) => Some(native),
-                        PlannedAddress::Convention { .. } => None,
-                    }
-                })
-                .collect();
-            if refs_to_check.is_empty() {
+    /// [`Provider::resolve_coords`](crate::provider::Provider::resolve_coords)
+    /// reads the provider's declared supported coordinates and does no I/O for
+    /// a native address.
+    fn check_single_store_ref_coords(
+        group: &[&PlannedSecret],
+        provider: &dyn ProviderTrait,
+    ) -> Result<()> {
+        for planned in group {
+            // Only the routes that consult exactly one store; a chain with a
+            // fallback defers coordinate checking to per-store read time.
+            if planned.route.fallback_specs().is_some() {
                 continue;
             }
-            let provider = self.get_provider(primary.as_deref())?;
-            for native in refs_to_check {
+            if let Some(native) = planned.reference() {
                 provider.resolve_coords(Address::Native(native))?;
             }
         }
@@ -2426,7 +2381,7 @@ impl Secrets {
         plan: &ResolutionPlan,
         materialize: Materialize,
     ) -> Result<std::result::Result<ValidatedSecrets, ValidationErrors>> {
-        let project = plan.project.as_str();
+        let project = self.config.project.name.as_str();
         let profile = plan.profile.as_str();
 
         let mut secrets: HashMap<String, SecretString> = HashMap::new();
@@ -2453,8 +2408,7 @@ impl Secrets {
         // concurrently below.
         let mut group_fetches: Vec<(Option<&str>, Vec<&PlannedSecret>, Box<dyn ProviderTrait>)> =
             Vec::new();
-        for (provider_uri, indices) in &plan.groups {
-            let provider_uri = provider_uri.as_deref();
+        for (provider_uri, group) in plan.groups() {
             match self.get_provider(provider_uri) {
                 Ok(provider) => {
                     // Attribute primary hits to the provider's own credential-free
@@ -2462,8 +2416,6 @@ impl Secrets {
                     // token). Recorded before the fetch so attribution survives a
                     // partial batch.
                     group_uris.insert(provider_uri, provider.uri());
-                    let group: Vec<&PlannedSecret> =
-                        indices.iter().map(|&i| &plan.secrets[i]).collect();
                     group_fetches.push((provider_uri, group, provider));
                 }
                 Err(e) => {
@@ -2473,6 +2425,14 @@ impl Secrets {
                     failed_primary_uris.insert(provider_uri, e);
                 }
             }
+        }
+
+        // Reject up front, before any store is contacted, a `ref` routed at
+        // exactly one store that cannot honor its coordinates: with no fallback
+        // to answer instead, the failure is definite and better surfaced now
+        // than mid-fetch.
+        for (_, group, provider) in &group_fetches {
+            Self::check_single_store_ref_coords(group, provider.as_ref())?;
         }
 
         // Fetch the groups concurrently: each group is at least one provider
@@ -2555,7 +2515,7 @@ impl Secrets {
                         Some(fallback) => {
                             let resolved = self.get_secret_from_providers(
                                 name,
-                                planned.address.as_address(project, profile),
+                                planned.as_address(project, profile),
                                 Some(fallback),
                             )?;
                             // A primary that errored plus an exhausted fallback
@@ -2648,7 +2608,7 @@ impl Secrets {
 
         let report_provider_uri = self.validation_report_provider_uri(
             plan.override_uri.as_deref(),
-            plan.groups.iter().map(|(uri, _)| uri.as_deref()),
+            plan.secrets.iter().map(|s| s.route.primary()),
         )?;
 
         if !missing_required.is_empty() {
@@ -3104,14 +3064,19 @@ mod reference_routing_tests {
         assert_eq!(write_provider(Some("dotenv://.env.mock")).name(), "dotenv");
     }
 
-    /// Build a plan over a single `default`-profile secret so its route can be
-    /// handed to the coordinate check.
-    fn plan_of(secret: Secret) -> (Secrets, crate::plan::ResolutionPlan) {
+    /// Run the executor's pre-fetch coordinate check over a plan holding a
+    /// single `default`-profile secret, exactly as `execute_plan` runs it: one
+    /// built provider per primary-store group.
+    fn check_ref_coords_of(secret: Secret) -> Result<()> {
         let mut secrets = HashMap::new();
         secrets.insert("SECRET".to_string(), secret);
         let spec = Secrets::new(crate::tests::resolve_test_config(secrets), None, None, None);
         let plan = spec.build_plan(None).unwrap();
-        (spec, plan)
+        for (primary, group) in plan.groups() {
+            let provider = spec.get_provider(primary).unwrap();
+            Secrets::check_single_store_ref_coords(&group, provider.as_ref())?;
+        }
+        Ok(())
     }
 
     /// A `ref` routed at a single store that cannot honor its coordinates is
@@ -3119,9 +3084,8 @@ mod reference_routing_tests {
     #[test]
     fn single_store_ref_with_unsupported_coord_is_rejected() {
         let _env = crate::tests::scrub_resolution_env();
-        let (spec, plan) = plan_of(ref_secret(Some(vec!["dotenv:///tmp/x"])));
         assert!(
-            spec.validate_single_store_ref_coords(&plan).is_err(),
+            check_ref_coords_of(ref_secret(Some(vec!["dotenv:///tmp/x"]))).is_err(),
             "a single-store ref with an unsupported coordinate must be rejected"
         );
     }
@@ -3132,9 +3096,9 @@ mod reference_routing_tests {
     #[test]
     fn multi_store_ref_defers_coord_validation() {
         let _env = crate::tests::scrub_resolution_env();
-        let (spec, plan) = plan_of(ref_secret(Some(vec!["dotenv:///tmp/a", "dotenv:///tmp/b"])));
         assert!(
-            spec.validate_single_store_ref_coords(&plan).is_ok(),
+            check_ref_coords_of(ref_secret(Some(vec!["dotenv:///tmp/a", "dotenv:///tmp/b"])))
+                .is_ok(),
             "a multi-store ref must defer coordinate checking to read time"
         );
     }

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -3,6 +3,7 @@
 use crate::audit::{AuditAction, AuditContext, AuditLogger, AuditOutcome};
 use crate::config::{Config, GlobalConfig, NativeAddress, Profile, RequireReason, Resolved};
 use crate::error::{Result, SecretSpecError};
+use crate::plan::{PlannedAddress, PlannedSecret, ResolutionPlan, Route};
 use crate::provider::{Address, Provider as ProviderTrait};
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
@@ -472,7 +473,7 @@ impl Secrets {
     /// separator) matched neither a built-in provider nor a known alias, the
     /// raw "provider not found" error is unhelpful. List the defined aliases so a
     /// mistyped alias points the user at the right names, matching the guidance
-    /// [`Self::resolve_provider_aliases`] gives for per-secret provider chains.
+    /// [`Self::resolve_one_provider`] gives for per-secret provider chains.
     fn explain_unknown_provider(&self, err: SecretSpecError, spec: &str) -> SecretSpecError {
         match err {
             SecretSpecError::ProviderNotFound(_) if !spec.contains(':') => {
@@ -546,6 +547,31 @@ impl Secrets {
                 provider_uri,
                 reference,
                 error_kind,
+                ..Default::default()
+            },
+        );
+    }
+
+    /// Records a failed single-secret operation (`get`/`set`) as an `Error`
+    /// event attributed to `key` — and to a provider, when one was determined
+    /// before the failure. The one shape every `get`/`set` failure path
+    /// records, so the paths cannot drift on which fields a failure carries.
+    fn record_key_error(
+        &self,
+        action: AuditAction,
+        profile: &str,
+        key: &str,
+        provider_uri: Option<String>,
+        err: &SecretSpecError,
+    ) {
+        self.record(
+            action,
+            profile,
+            AuditOutcome::Error,
+            AuditFields {
+                key: Some(key),
+                provider_uri,
+                error_kind: Some(err.kind()),
                 ..Default::default()
             },
         );
@@ -830,52 +856,44 @@ impl Secrets {
         names
     }
 
-    /// Resolves a list of provider aliases to their URIs, preserving order.
-    /// Used for fallback chain resolution; each alias is looked up via
-    /// [`Self::lookup_provider_alias`]. An entry that is already a URI
+    /// Resolves a single provider spec to its URI. A defined alias is expanded
+    /// via [`Self::lookup_provider_alias`]. A spec that is already a URI
     /// (contains `://`) passes through unchanged, so a chain can point at a
     /// store inline — `providers = ["onepassword://Production"]` — without
-    /// declaring an alias for it. A `scheme://` string is never an alias key,
-    /// so the two forms cannot collide.
+    /// declaring an alias for it; a `scheme://` string is never an alias key,
+    /// so the two forms cannot collide. A non-alias spec that names a
+    /// registered provider (a bare name like `keyring`, or `scheme:path`
+    /// shorthand like `dotenv:.env.production`) also passes through, so the
+    /// chain and the resolved override accept exactly the specs `--provider`
+    /// and the default provider accept; `build_provider` constructs it later.
+    /// Only a token that names neither an alias nor a provider errors.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if any alias is not defined in either the project or global config.
-    pub(crate) fn resolve_provider_aliases(
-        &self,
-        provider_aliases: Option<&[String]>,
-    ) -> Result<Option<Vec<String>>> {
-        let Some(aliases) = provider_aliases else {
-            return Ok(None);
-        };
-
-        let mut uris = Vec::with_capacity(aliases.len());
-        for alias in aliases {
-            if alias.contains("://") {
-                uris.push(alias.clone());
-                continue;
-            }
-            match self.lookup_provider_alias(alias) {
-                Some(uri) => uris.push(uri),
-                None => {
-                    let known = self.known_provider_aliases();
-                    let msg = if known.is_empty() {
-                        format!(
-                            "Provider alias '{}' is not defined. Declare it in [providers] in secretspec.toml or in the global config.",
-                            alias
-                        )
-                    } else {
-                        format!(
-                            "Provider alias '{}' is not defined. Available aliases: {}",
-                            alias,
-                            known.join(", ")
-                        )
-                    };
-                    return Err(SecretSpecError::ProviderNotFound(msg));
-                }
-            }
+    /// Used both to resolve a chain's primary up front and to resolve each
+    /// fallback entry lazily, in order, as a read actually reaches it.
+    pub(crate) fn resolve_one_provider(&self, spec: &str) -> Result<String> {
+        if spec.contains("://") {
+            return Ok(spec.to_string());
         }
-        Ok(Some(uris))
+        if let Some(uri) = self.lookup_provider_alias(spec) {
+            return Ok(uri);
+        }
+        if crate::provider::spec_names_known_provider(spec) {
+            return Ok(spec.to_string());
+        }
+        let known = self.known_provider_aliases();
+        let msg = if known.is_empty() {
+            format!(
+                "Provider alias '{}' is not defined. Declare it in [providers] in secretspec.toml or in the global config.",
+                spec
+            )
+        } else {
+            format!(
+                "Provider alias '{}' is not defined. Available aliases: {}",
+                spec,
+                known.join(", ")
+            )
+        };
+        Err(SecretSpecError::ProviderNotFound(msg))
     }
 
     /// Returns the explicit provider spec from caller arg, builder, or env, in
@@ -900,93 +918,35 @@ impl Secrets {
         Some(self.resolve_provider_spec(spec))
     }
 
-    /// The provider [`Address`] a secret's operations resolve: its native
-    /// `ref` coordinates when it has them, otherwise SecretSpec's own naming
-    /// convention. Naming is fully orthogonal to routing: the address applies
-    /// to whichever store provider resolution selects.
-    fn secret_address<'a>(
-        secret_config: &'a crate::config::Secret,
-        project: &'a str,
-        profile: &'a str,
-        key: &'a str,
-    ) -> Address<'a> {
-        match &secret_config.reference {
-            Some(native) => Address::Native(native),
-            None => Address::Convention {
-                project,
-                profile,
-                key,
-            },
-        }
-    }
-
     /// Fetches one provider group's secrets through the provider's batch
-    /// surface: every secret's [`Address`] (native `ref` coordinates or
+    /// surface: every planned secret's [`Address`] (native `ref` coordinates or
     /// convention naming) is handed to `get_many`, which dedupes identical
-    /// coordinates and batches or parallelizes as the store allows.
+    /// coordinates and batches or parallelizes as the store allows. The address
+    /// is the one the plan already derived, so naming lives in exactly one place.
     fn fetch_group(
         provider: &dyn ProviderTrait,
-        secret_names: &[String],
-        secret_configs: &HashMap<String, crate::config::Secret>,
+        group: &[&PlannedSecret],
         project: &str,
         profile: &str,
     ) -> Result<HashMap<String, SecretString>> {
-        let requests: Vec<(&str, Address<'_>)> = secret_names
+        let requests: Vec<(&str, Address<'_>)> = group
             .iter()
-            .map(|name| {
+            .map(|planned| {
                 (
-                    name.as_str(),
-                    Self::secret_address(&secret_configs[name], project, profile, name),
+                    planned.name.as_str(),
+                    planned.address.as_address(project, profile),
                 )
             })
             .collect();
         provider.get_many(&requests)
     }
 
-    /// Resolves the write target for a secret.
-    ///
-    /// Resolution order:
-    /// 1. Explicit override (`--provider` flag, `SECRETSPEC_PROVIDER`, or builder)
-    /// 2. First entry of the secret's `providers` chain
-    /// 3. Default provider from global config
-    pub(crate) fn resolve_write_provider(
-        &self,
-        secret_config: &crate::config::Secret,
-        override_arg: Option<&str>,
-    ) -> Result<Box<dyn ProviderTrait>> {
-        if let Some(uri) = self.resolve_provider_override(override_arg) {
-            return self.build_provider(uri);
-        }
-        if let Some(alias) = secret_config.providers.as_ref().and_then(|p| p.first()) {
-            let provider_uris = self.resolve_provider_aliases(Some(std::slice::from_ref(alias)))?;
-            let uri = provider_uris
-                .and_then(|uris| uris.into_iter().next())
-                .ok_or_else(|| {
-                    SecretSpecError::ProviderNotFound(format!(
-                        "Provider alias '{}' could not be resolved",
-                        alias
-                    ))
-                })?;
-            return self.build_provider(uri);
-        }
-        self.get_provider(None)
-    }
-
-    /// Resolves the read provider chain for a secret.
-    ///
-    /// If an explicit override is set, returns just that single URI (no chain fallback).
-    /// Otherwise, resolves the secret's `providers` chain to URIs, or returns `None`
-    /// to indicate the default provider should be used. A secret's `ref` never
-    /// participates: it supplies naming, not routing.
-    pub(crate) fn resolve_read_provider_uris(
-        &self,
-        secret_config: &crate::config::Secret,
-        override_arg: Option<&str>,
-    ) -> Result<Option<Vec<String>>> {
-        if let Some(uri) = self.resolve_provider_override(override_arg) {
-            return Ok(Some(vec![uri]));
-        }
-        self.resolve_provider_aliases(secret_config.providers.as_deref())
+    /// Builds the provider a write goes to for a resolved [`Route`]: the primary
+    /// store, or the default provider when the route sets none. A write never
+    /// consults the fallback, so an undefined alias further down the chain does
+    /// not affect it.
+    fn write_provider_for_route(&self, route: &Route) -> Result<Box<dyn ProviderTrait>> {
+        self.get_provider(route.primary())
     }
 
     /// Gets the provider instance to use for secret operations
@@ -1039,50 +999,52 @@ impl Secrets {
     /// override may embed a credential (`vault+token:s3cr3t@host`,
     /// `vault://host?token=...`), so raw URIs are run through `redact_uri_strict`
     /// first. The `provider.uri()` paths below are already credential-free.
-    fn validation_report_provider_uri(
+    fn validation_report_provider_uri<'a>(
         &self,
         override_uri: Option<&str>,
-        secret_primary_uris: &HashMap<String, Option<String>>,
+        primary_uris: impl Iterator<Item = Option<&'a str>>,
     ) -> Result<String> {
         if let Some(uri) = override_uri {
             return Ok(crate::audit::redact_uri_strict(uri));
         }
 
-        if secret_primary_uris.values().any(Option::is_none) {
-            return self.get_provider(None).map(|provider| provider.uri());
+        let mut provider_uris: Vec<&str> = Vec::new();
+        for uri in primary_uris {
+            match uri {
+                // Any secret on the default provider: report that provider.
+                None => return self.get_provider(None).map(|provider| provider.uri()),
+                Some(uri) => provider_uris.push(uri),
+            }
         }
+        provider_uris.sort_unstable();
 
-        let mut provider_uris: Vec<&String> = secret_primary_uris
-            .values()
-            .filter_map(Option::as_ref)
-            .collect();
-        provider_uris.sort();
-
-        if let Some(uri) = provider_uris.first() {
-            return Ok(crate::audit::redact_uri_strict(uri.as_str()));
+        match provider_uris.first() {
+            Some(uri) => Ok(crate::audit::redact_uri_strict(uri)),
+            None => self.get_provider(None).map(|provider| provider.uri()),
         }
-
-        self.get_provider(None).map(|provider| provider.uri())
     }
 
-    /// Gets a secret from a list of providers with fallback.
+    /// Gets a secret from a chain of provider specs with fallback.
     ///
-    /// Tries each provider in order until one has the secret. Errors from a
-    /// provider (e.g. authentication failure, network error) are treated like
-    /// "not found" so the chain continues; a warning is emitted and the next
-    /// provider is tried. If every provider errored without any reporting a
-    /// healthy "not found", the last error is returned so the user sees why
-    /// the secret could not be retrieved.
+    /// Tries each provider in order until one has the secret. Each spec is
+    /// resolved to a URI **only when the chain reaches it** — every earlier
+    /// provider having missed. A spec that fails to resolve (an undefined
+    /// alias) is a broken link, not a reason to abandon the chain: like a
+    /// provider that fails to construct or read (authentication failure,
+    /// network error), it is warned about and the next link is tried. If every
+    /// provider errored without any reporting a healthy "not found", the last
+    /// error is returned so the user sees why the secret could not be
+    /// retrieved.
     ///
-    /// If no provider URIs are specified, falls back to the global provider.
+    /// If no provider specs are supplied, falls back to the default provider.
     ///
     /// # Arguments
     ///
     /// * `secret_name` - The secret name, for warning messages
-    /// * `addr` - The secret's [`Address`] (see [`Self::secret_address`]); the
-    ///   same address is asked of every provider in the chain
-    /// * `provider_uris` - Optional list of provider URIs to try in order
-    /// * `default_provider_arg` - Optional default provider if no URIs provided
+    /// * `addr` - The secret's [`Address`] (see [`PlannedAddress::as_address`]);
+    ///   the same address is asked of every provider in the chain
+    /// * `provider_specs` - Optional chain of provider specs (aliases or inline
+    ///   URIs) to try in order, resolved lazily per entry
     ///
     /// # Returns
     ///
@@ -1094,21 +1056,38 @@ impl Secrets {
         &self,
         secret_name: &str,
         addr: Address<'_>,
-        provider_uris: Option<&[String]>,
-        default_provider_arg: Option<&str>,
+        provider_specs: Option<&[String]>,
     ) -> Result<(Option<SecretString>, Option<String>)> {
-        // If provider URIs are specified, try them in order
-        if let Some(uris) = provider_uris {
+        // If a provider chain is supplied, try it in order.
+        if let Some(specs) = provider_specs {
             let mut last_error: Option<SecretSpecError> = None;
             let mut any_healthy = false;
             let mut last_uri: Option<String> = None;
-            for uri in uris {
+            for spec in specs {
+                // Resolve this link only now, as the chain reaches it. An
+                // undefined alias is one broken link, treated exactly like a
+                // provider that fails to construct or read: warn and try the
+                // next, so a working provider later in the chain still answers.
+                let uri = match self.resolve_one_provider(spec) {
+                    Ok(uri) => uri,
+                    Err(e) => {
+                        // Resolution failed, so only the raw spec exists; redact it.
+                        warn_provider_failure(
+                            &crate::audit::redact_uri_strict(spec),
+                            secret_name,
+                            &e,
+                        );
+                        last_error = Some(e);
+                        continue;
+                    }
+                };
                 let provider = match self.build_provider(uri.clone()) {
                     Ok(p) => p,
                     Err(e) => {
-                        // Construction failed, so only the raw alias exists; redact it.
+                        // Construction failed after resolution, so redact the
+                        // resolved URI (it may carry an inline credential).
                         warn_provider_failure(
-                            &crate::audit::redact_uri_strict(uri),
+                            &crate::audit::redact_uri_strict(&uri),
                             secret_name,
                             &e,
                         );
@@ -1145,7 +1124,7 @@ impl Secrets {
             }
         } else {
             // No per-secret providers, use default provider
-            let backend = self.get_provider(default_provider_arg)?;
+            let backend = self.get_provider(None)?;
             let uri = backend.uri();
             backend.get(addr).map(|opt| (opt, Some(uri)))
         }
@@ -1187,16 +1166,21 @@ impl Secrets {
         let profile_name = self.resolve_profile_name(None);
         self.require_profile(&profile_name)?;
 
-        // Check if the secret exists in the profile or is inherited from default
-        let secret_config = match self.resolve_secret_config(name, None) {
-            Some(sc) => sc,
-            None => {
+        // Plan the secret exactly as batch resolution would, so the write
+        // target, address, and effective config are the same decisions
+        // `check`/`run` make. `None` means it is not declared in this profile.
+        let planned = match self.plan_secret(name, Some(&profile_name), None) {
+            Ok(Some(planned)) => planned,
+            // Planning failed (e.g. an undefined provider alias). Still an
+            // attempted write, so audit it like the batch path audits every
+            // planning failure; no provider can be attributed yet.
+            Err(err) => {
+                self.record_key_error(AuditAction::Set, &profile_name, name, None, &err);
+                return Err(err);
+            }
+            Ok(None) => {
                 let profile = self.resolve_profile(Some(&profile_name))?;
-                let mut available_secrets = profile
-                    .into_iter()
-                    .map(|(name, _)| name)
-                    .collect::<Vec<_>>();
-                available_secrets.sort();
+                let available_secrets = profile.sorted_secret_names();
 
                 let err = SecretSpecError::SecretNotFound(format!(
                     "Secret '{}' is not defined in profile '{}'. Available secrets: {}",
@@ -1205,42 +1189,26 @@ impl Secrets {
                     available_secrets.join(", ")
                 ));
                 // Provider is unknown for an undefined secret, so attribute to None.
-                self.record(
-                    AuditAction::Set,
-                    &profile_name,
-                    AuditOutcome::Error,
-                    AuditFields {
-                        key: Some(name),
-                        error_kind: Some(err.kind()),
-                        ..Default::default()
-                    },
-                );
+                self.record_key_error(AuditAction::Set, &profile_name, name, None, &err);
                 return Err(err);
             }
         };
 
-        let backend = self.resolve_write_provider(&secret_config, None)?;
+        let backend = self.write_provider_for_route(&planned.route)?;
 
-        let addr = Self::secret_address(
-            &secret_config,
-            &self.config.project.name,
-            &profile_name,
-            name,
-        );
+        let addr = planned
+            .address
+            .as_address(&self.config.project.name, &profile_name);
         // Refuse before prompting for a value. The provider states the reason:
         // a store may be writable through the convention layout yet reject the
         // `ref` this secret names.
         if let Err(err) = backend.check_writable(addr) {
-            self.record(
+            self.record_key_error(
                 AuditAction::Set,
                 &profile_name,
-                AuditOutcome::Error,
-                AuditFields {
-                    key: Some(name),
-                    provider_uri: Some(backend.uri()),
-                    error_kind: Some(err.kind()),
-                    ..Default::default()
-                },
+                name,
+                Some(backend.uri()),
+                &err,
             );
             return Err(err);
         }
@@ -1265,16 +1233,12 @@ impl Secrets {
             let err = SecretSpecError::ProviderOperationFailed(
                 "Secret value cannot be empty".to_string(),
             );
-            self.record(
+            self.record_key_error(
                 AuditAction::Set,
                 &profile_name,
-                AuditOutcome::Error,
-                AuditFields {
-                    key: Some(name),
-                    provider_uri: Some(backend.uri()),
-                    error_kind: Some(err.kind()),
-                    ..Default::default()
-                },
+                name,
+                Some(backend.uri()),
+                &err,
             );
             return Err(err);
         }
@@ -1285,7 +1249,7 @@ impl Secrets {
             name,
             &profile_name,
             Some(backend.uri()),
-            secret_config.reference.as_ref(),
+            planned.reference(),
         );
         result?;
 
@@ -1324,40 +1288,39 @@ impl Secrets {
     pub fn get(&self, name: &str) -> Result<()> {
         self.ensure_reason_for(AuditAction::Get, Some(name))?;
         let profile_name = self.resolve_profile_name(None);
-        let secret_config = match self.resolve_secret_config(name, None) {
-            Some(config) => config,
-            None => {
+        // Plan the secret exactly as batch resolution would, so the read route,
+        // address, and effective config are the same decisions `check`/`run`
+        // make. `None` means it is not declared in this profile.
+        let planned = match self.plan_secret(name, Some(&profile_name), None) {
+            Ok(Some(planned)) => planned,
+            // Planning failed (e.g. an undefined provider alias). Still an
+            // attempted read, so audit it like the batch path audits every
+            // planning failure; no provider can be attributed yet.
+            Err(err) => {
+                self.record_key_error(AuditAction::Get, &profile_name, name, None, &err);
+                return Err(err);
+            }
+            Ok(None) => {
                 // The secret is not defined, so no provider can be attributed.
                 // Audit the failed read for parity with `set`'s undefined path.
                 let err = SecretSpecError::SecretNotFound(name.to_string());
-                self.record(
-                    AuditAction::Get,
-                    &profile_name,
-                    AuditOutcome::Error,
-                    AuditFields {
-                        key: Some(name),
-                        error_kind: Some(err.kind()),
-                        ..Default::default()
-                    },
-                );
+                self.record_key_error(AuditAction::Get, &profile_name, name, None, &err);
                 return Err(err);
             }
         };
-        let default = secret_config.default.clone();
-        let as_path = secret_config.as_path.unwrap_or(false);
+        let default = planned.config.default.clone();
+        let as_path = planned.as_path();
 
-        let provider_uris = self.resolve_read_provider_uris(&secret_config, None)?;
-
+        // Walk the route's chain in order; each entry is resolved lazily and a
+        // broken link is skipped with a warning, so an undefined alias never
+        // blocks a provider elsewhere in the chain from answering.
+        let read_specs = planned.route.specs();
         let result = self.get_secret_from_providers(
             name,
-            Self::secret_address(
-                &secret_config,
-                &self.config.project.name,
-                &profile_name,
-                name,
-            ),
-            provider_uris.as_deref(),
-            None,
+            planned
+                .address
+                .as_address(&self.config.project.name, &profile_name),
+            read_specs.as_deref(),
         );
 
         // Audit the access at the provider boundary, before defaults are applied.
@@ -1365,7 +1328,7 @@ impl Secrets {
         // attributes to the last provider tried rather than guessing. The native
         // coordinates (if any) are recorded alongside, since the provider URI
         // names only the store.
-        let reference = secret_config.reference.as_ref();
+        let reference = planned.reference();
         match &result {
             Ok((Some(_), uri)) => self.record(
                 AuditAction::Get,
@@ -1536,26 +1499,25 @@ impl Secrets {
                     }
                     eprintln!();
 
-                    // Prompt for each missing secret
+                    // Prompt for each missing secret. Each write goes through the
+                    // plan's route and address, the same decisions `set` executes.
                     for (i, secret_name) in missing.iter().enumerate() {
-                        if let Some(secret_config) =
-                            self.resolve_secret_config(secret_name, Some(&profile_display))
-                        {
+                        if let Some(planned) = self.plan_secret(
+                            secret_name,
+                            Some(&profile_display),
+                            provider_arg.as_deref(),
+                        )? {
                             let prompt_msg =
                                 format!("[{}/{}] Enter value for {}:", i + 1, total, secret_name,);
                             let prompt = inquire::Password::new(&prompt_msg).without_confirmation();
 
                             let value = prompt.prompt()?;
 
-                            let backend = self
-                                .resolve_write_provider(&secret_config, provider_arg.as_deref())?;
+                            let backend = self.write_provider_for_route(&planned.route)?;
                             let set_result = backend.set(
-                                Self::secret_address(
-                                    &secret_config,
-                                    &self.config.project.name,
-                                    &profile_display,
-                                    secret_name,
-                                ),
+                                planned
+                                    .address
+                                    .as_address(&self.config.project.name, &profile_display),
                                 &SecretString::new(value.into()),
                             );
                             self.audit_write_result(
@@ -1563,7 +1525,7 @@ impl Secrets {
                                 secret_name,
                                 &profile_display,
                                 Some(backend.uri()),
-                                secret_config.reference.as_ref(),
+                                planned.reference(),
                             );
                             set_result?;
                             eprintln!(
@@ -1843,24 +1805,24 @@ impl Secrets {
             // This ensures we can import secrets defined in default profile when using other profiles
             let profile = self.resolve_profile(Some(&profile_display))?;
 
-            // Process each secret using proper profile resolution
-            for (name, config) in profile.into_iter() {
+            // Process each secret using proper profile resolution: the plan
+            // supplies the same write route and address `set` executes. Sorted
+            // names keep the per-secret summary lines in a stable order.
+            for name in profile.sorted_secret_names() {
                 read_names.push(name.clone());
-                let secret_config = self
-                    .resolve_secret_config(&name, Some(&profile_display))
+                let planned = self
+                    .plan_secret(&name, Some(&profile_display), None)?
                     .expect("Secret should exist since we're iterating over it");
+                let description = planned.config.description.as_deref();
 
-                let to_provider = self.resolve_write_provider(&secret_config, None)?;
+                let to_provider = self.write_provider_for_route(&planned.route)?;
 
                 // The secret's address (native `ref` coordinates or convention
                 // naming) applies to both stores: naming is orthogonal to
                 // which store holds the value.
-                let addr = Self::secret_address(
-                    &secret_config,
-                    &self.config.project.name,
-                    &profile_display,
-                    &name,
-                );
+                let addr = planned
+                    .address
+                    .as_address(&self.config.project.name, &profile_display);
                 // First check if the secret exists in the "from" provider
                 match from_provider_instance.get(addr)? {
                     Some(value) => {
@@ -1871,7 +1833,7 @@ impl Secrets {
                                     "{} {} - {} {} (→ {})",
                                     "○".yellow(),
                                     name,
-                                    config.description.as_deref().unwrap_or("No description"),
+                                    description.unwrap_or("No description"),
                                     "(already exists in target)".yellow(),
                                     to_provider.name().blue()
                                 );
@@ -1889,14 +1851,14 @@ impl Secrets {
                                     &name,
                                     &profile_display,
                                     Some(to_provider.uri()),
-                                    secret_config.reference.as_ref(),
+                                    planned.reference(),
                                 );
                                 set_result?;
                                 eprintln!(
                                     "{} {} - {} (→ {})",
                                     "✓".green(),
                                     name,
-                                    config.description.as_deref().unwrap_or("No description"),
+                                    description.unwrap_or("No description"),
                                     to_provider.name().blue()
                                 );
                                 imported += 1;
@@ -1912,7 +1874,7 @@ impl Secrets {
                                     "{} {} - {} {} (→ {})",
                                     "○".blue(),
                                     name,
-                                    config.description.as_deref().unwrap_or("No description"),
+                                    description.unwrap_or("No description"),
                                     "(already in target, not in source)".blue(),
                                     to_provider.name().blue()
                                 );
@@ -1923,7 +1885,7 @@ impl Secrets {
                                     "{} {} - {} {}",
                                     "✗".red(),
                                     name,
-                                    config.description.as_deref().unwrap_or("No description"),
+                                    description.unwrap_or("No description"),
                                     "(not found in source)".red()
                                 );
                                 not_found += 1;
@@ -1998,25 +1960,6 @@ impl Secrets {
         Ok(())
     }
 
-    /// Resolves a writable provider for a secret.
-    ///
-    /// Uses the first provider from the secret's provider list if specified,
-    /// otherwise falls back to the default provider. `addr` is the exact
-    /// address the caller is about to write, so writability is checked for it.
-    fn get_writable_provider_for_secret(
-        &self,
-        secret_config: &crate::config::Secret,
-        addr: Address<'_>,
-    ) -> Result<Box<dyn ProviderTrait>> {
-        let backend = self.resolve_write_provider(secret_config, None)?;
-
-        // The provider states why a write is refused; wrapping it here would
-        // only nest a second "Provider operation failed" prefix.
-        backend.check_writable(addr)?;
-
-        Ok(backend)
-    }
-
     /// Whether an absent secret would be auto-generated on a full resolve: it
     /// declares an enabled `generate` config. Lets the value-free pass report
     /// that a missing secret *would* resolve via generation without minting and
@@ -2035,16 +1978,16 @@ impl Secrets {
     /// or `Err` if generation was configured but failed.
     fn try_generate_secret(
         &self,
-        name: &str,
-        secret_config: &crate::config::Secret,
+        planned: &PlannedSecret,
         profile_name: &str,
     ) -> Result<Option<SecretString>> {
-        let gen_config = match &secret_config.generate {
+        let name = planned.name.as_str();
+        let gen_config = match &planned.config.generate {
             Some(config) if config.is_enabled() => config,
             _ => return Ok(None),
         };
 
-        let secret_type = match &secret_config.secret_type {
+        let secret_type = match &planned.config.secret_type {
             Some(t) => t.as_str(),
             None => {
                 return Err(SecretSpecError::GenerationFailed(format!(
@@ -2056,11 +1999,15 @@ impl Secrets {
 
         let value = crate::generator::generate(secret_type, gen_config)?;
 
-        // Store the generated value at the secret's address: its `ref`
-        // coordinates when it has them, otherwise the naming convention.
-        let addr =
-            Self::secret_address(secret_config, &self.config.project.name, profile_name, name);
-        let backend = self.get_writable_provider_for_secret(secret_config, addr)?;
+        // Store the generated value at the plan's address, through the plan's
+        // write route: the same decisions every other write path executes.
+        let addr = planned
+            .address
+            .as_address(&self.config.project.name, profile_name);
+        let backend = self.write_provider_for_route(&planned.route)?;
+        // The provider states why a write is refused; wrapping it here would
+        // only nest a second "Provider operation failed" prefix.
+        backend.check_writable(addr)?;
         let set_result = backend.set(addr, &value);
         // Generating a secret writes a brand-new value to the provider; record it
         // like any other write so the audit log captures every stored secret.
@@ -2069,7 +2016,7 @@ impl Secrets {
             name,
             profile_name,
             Some(backend.uri()),
-            secret_config.reference.as_ref(),
+            planned.reference(),
         );
         set_result?;
 
@@ -2356,351 +2303,35 @@ impl Secrets {
         }
 
         let profile_name = self.resolve_profile_name(None);
-        // Keys for the single read-audit event. Filled inside the closure once the
-        // profile resolves; stays empty if resolution fails before that point.
-        let mut audit_keys: Vec<String> = Vec::new();
+        // Resolved once and reused for both the audit keys and the plan, so a
+        // failed read is still attributed to every secret it attempted without
+        // merging the profile twice.
+        let profile_result = self.resolve_profile(Some(&profile_name));
+        // Keys for the single read-audit event, computed before any planning
+        // can fail (e.g. on an undefined alias) so a failed read is still
+        // attributed to every secret it attempted; they stay empty only if the
+        // profile itself fails to resolve.
+        let audit_keys: Vec<String> = profile_result
+            .as_ref()
+            .map(|profile| profile.sorted_secret_names())
+            .unwrap_or_default();
 
-        // Resolve every secret inside one fallible block so that *any* error — not
-        // just the inline primary-provider failure — is captured and recorded as a
-        // single `Check` event below before it propagates. Previously only one error
-        // arm audited, so a failed alias resolution or fallback-chain error left no
-        // trace despite being an attempted read.
+        // Decide the whole profile up front (pure, no I/O), reject any `ref`
+        // routed at a single store that cannot honor its coordinates, then
+        // execute the plan. Each step returns `Result`, so *any* error — an undefined
+        // alias, an unsupported `ref` coordinate, a fallback-chain outage, a
+        // report-URI failure — is captured in `result` and recorded as the
+        // single `Check` event below rather than escaping unaudited. `record`
+        // is a no-op when auditing is off.
         let result: Result<std::result::Result<ValidatedSecrets, ValidationErrors>> =
-            (|| -> Result<std::result::Result<ValidatedSecrets, ValidationErrors>> {
-                let mut secrets: HashMap<String, SecretString> = HashMap::new();
-                let mut missing_required = Vec::new();
-                let mut missing_optional = Vec::new();
-                let mut with_defaults = Vec::new();
-                let mut temp_files = Vec::new();
-                // Per-secret provenance for the value-free resolution report.
-                let mut resolution: Vec<SecretResolution> = Vec::new();
-                // Credential-free `uri()` of each successfully built primary
-                // provider group, keyed by the configured group URI, so a
-                // primary hit can be attributed to the provider that answered.
-                let mut group_uris: HashMap<Option<String>, String> = HashMap::new();
-
-                let profile = self.resolve_profile(Some(&profile_name))?;
-                let all_secrets: Vec<(String, crate::config::Secret)> =
-                    profile.into_iter().collect();
-
-                audit_keys = {
-                    let mut keys: Vec<String> =
-                        all_secrets.iter().map(|(name, _)| name.clone()).collect();
-                    keys.sort();
-                    keys
-                };
-
-                // Resolve each secret's effective config once. Both the
-                // provider-grouping pass and the processing pass below need it,
-                // and the field-level merge (current profile over `default`) it
-                // performs is not free — resolving it twice per secret was waste.
-                let secret_configs: HashMap<String, crate::config::Secret> = all_secrets
-                    .iter()
-                    .map(|(name, _)| {
-                        let cfg = self
-                            .resolve_secret_config(name, Some(&profile_name))
-                            .expect("Secret should exist in config since we're iterating over it");
-                        (name.clone(), cfg)
-                    })
-                    .collect();
-
-                let override_uri = self.resolve_provider_override(None);
-
-                let mut provider_groups: HashMap<Option<String>, Vec<String>> = HashMap::new();
-                let mut secret_primary_uris: HashMap<String, Option<String>> = HashMap::new();
-
-                for (name, _) in &all_secrets {
-                    let secret_config = &secret_configs[name];
-
-                    // Groups are keyed by the resolved primary *store*; ref and
-                    // convention secrets share groups, since a `ref` supplies
-                    // naming rather than routing.
-                    let provider_uri = match (&override_uri, secret_config.providers.as_deref()) {
-                        (Some(uri), _) => Some(uri.clone()),
-                        (None, Some([first_alias, ..])) => self
-                            .resolve_provider_aliases(Some(std::slice::from_ref(first_alias)))?
-                            .and_then(|uris| uris.into_iter().next()),
-                        _ => None,
-                    };
-
-                    secret_primary_uris.insert(name.clone(), provider_uri.clone());
-                    provider_groups
-                        .entry(provider_uri)
-                        .or_default()
-                        .push(name.clone());
-                }
-
-                // Batch fetch from each provider group. A failure here (e.g. an
-                // unauthenticated vault) does not abort validation: secrets that
-                // declare a fallback chain are retried per-secret below. Secrets in
-                // the failed group with no fallback to try will surface the original
-                // error instead of being silently reported as missing.
-                let mut fetched_values: HashMap<String, SecretString> = HashMap::new();
-                let mut failed_primary_uris: HashMap<Option<String>, SecretSpecError> =
-                    HashMap::new();
-
-                // Construction is cheap and stays on this thread; only the
-                // fetches run concurrently below.
-                let mut group_fetches: Vec<(Option<String>, Vec<String>, Box<dyn ProviderTrait>)> =
-                    Vec::new();
-                for (provider_uri, secret_names) in provider_groups {
-                    let provider_result = if let Some(uri) = provider_uri.clone() {
-                        self.build_provider(uri)
-                    } else {
-                        self.get_provider(None)
-                    };
-
-                    match provider_result {
-                        Ok(provider) => {
-                            // Attribute primary hits to the provider's own
-                            // credential-free `uri()`, never the raw configured
-                            // alias (which may embed a token). Recorded before
-                            // the fetch so attribution survives a partial batch.
-                            group_uris.insert(provider_uri.clone(), provider.uri());
-                            group_fetches.push((provider_uri, secret_names, provider));
-                        }
-                        Err(e) => {
-                            // Construction failed: only the raw alias exists, so redact it.
-                            let shown =
-                                provider_uri.as_deref().map(crate::audit::redact_uri_strict);
-                            warn_primary_provider_failure(shown.as_deref(), &e);
-                            failed_primary_uris.insert(provider_uri, e);
-                        }
-                    }
-                }
-
-                // Fetch the groups concurrently: each group is at least one
-                // provider round-trip. One thread per group mirrors the
-                // per-item threading providers already do inside `get_many`.
-                // A single group (the common case) stays on this thread.
-                let project_name = &self.config.project.name;
-                let profile_ref = profile_name.as_str();
-                let secret_configs_ref = &secret_configs;
-                let fetch_group = |(provider_uri, secret_names, provider): (
-                    Option<String>,
-                    Vec<String>,
-                    Box<dyn ProviderTrait>,
-                )| {
-                    let result = Self::fetch_group(
-                        &*provider,
-                        &secret_names,
-                        secret_configs_ref,
-                        project_name,
-                        profile_ref,
-                    );
-                    (provider_uri, result)
-                };
-                let fetch_results: Vec<(Option<String>, Result<_>)> = if group_fetches.len() <= 1 {
-                    group_fetches.into_iter().map(fetch_group).collect()
-                } else {
-                    std::thread::scope(|scope| {
-                        let handles: Vec<_> = group_fetches
-                            .into_iter()
-                            .map(|group| scope.spawn(|| fetch_group(group)))
-                            .collect();
-                        handles
-                            .into_iter()
-                            .map(|handle| handle.join().expect("group fetch thread panicked"))
-                            .collect()
-                    })
-                };
-
-                for (provider_uri, result) in fetch_results {
-                    match result {
-                        Ok(batch_results) => fetched_values.extend(batch_results),
-                        Err(e) => {
-                            // A provider was built; attribute to its credential-free
-                            // `uri()`, already recorded in `group_uris` above.
-                            let display_uri = group_uris.get(&provider_uri).map(String::as_str);
-                            warn_primary_provider_failure(display_uri, &e);
-                            failed_primary_uris.insert(provider_uri, e);
-                        }
-                    }
-                }
-
-                // Process results - apply defaults, handle as_path, track missing.
-                // Each secret also records a value-free provenance entry for the
-                // resolution report (status, which provider answered, generated,
-                // defaulted).
-                for (name, _) in all_secrets {
-                    let secret_config = &secret_configs[&name];
-                    let required = secret_config.required.unwrap_or(true);
-                    let default = secret_config.default.clone();
-                    let as_path = secret_config.as_path.unwrap_or(false);
-
-                    // `name` is consumed by whichever arm resolves/records it;
-                    // keep a copy for the provenance entry pushed at the end.
-                    let report_name = name.clone();
-                    let status;
-                    let mut source_provider = None;
-                    let mut default_applied = false;
-                    let mut generated = false;
-
-                    match fetched_values.remove(&name) {
-                        Some(value) => {
-                            source_provider = group_uris.get(&secret_primary_uris[&name]).cloned();
-                            // Copy the value into the response only on a full
-                            // pass; a value-free pass has the status it needs and
-                            // never materializes a value or writes a temp file.
-                            if materialize == Materialize::Values {
-                                self.insert_resolved(
-                                    &mut secrets,
-                                    &mut temp_files,
-                                    name,
-                                    value,
-                                    as_path,
-                                )?;
-                            }
-                            status = ResolutionStatus::Resolved;
-                        }
-                        None => {
-                            let primary_uri = &secret_primary_uris[&name];
-                            let primary_failed = failed_primary_uris.contains_key(primary_uri);
-
-                            // An explicit override collapses the chain to one provider, no fallback.
-                            let (fallback_value, fallback_uri) =
-                                match (override_uri.as_ref(), secret_config.providers.as_deref()) {
-                                    (None, Some(providers)) if providers.len() > 1 => {
-                                        let fallback_uris =
-                                            self.resolve_provider_aliases(Some(&providers[1..]))?;
-                                        let resolved = self.get_secret_from_providers(
-                                            &name,
-                                            Self::secret_address(
-                                                secret_config,
-                                                &self.config.project.name,
-                                                &profile_name,
-                                                &name,
-                                            ),
-                                            fallback_uris.as_deref(),
-                                            None,
-                                        )?;
-                                        // A primary that *errored* (not merely
-                                        // lacked the secret) plus an empty
-                                        // fallback chain is not "missing": the
-                                        // authoritative provider is unreachable
-                                        // and might hold the value. Surface the
-                                        // primary error, exactly as the
-                                        // single-provider arm below does, instead
-                                        // of silently downgrading to
-                                        // missing_required — a machine consumer
-                                        // must be able to tell an outage from an
-                                        // unprovisioned secret.
-                                        if resolved.0.is_none() && primary_failed {
-                                            let err = failed_primary_uris
-                                                .remove(primary_uri)
-                                                .expect("primary_failed implies entry present");
-                                            return Err(err);
-                                        }
-                                        resolved
-                                    }
-                                    // No alternative chain to try and the primary failed: surface the
-                                    // original error rather than reporting the secret as merely
-                                    // missing. The single `Check` event is recorded by the caller
-                                    // below, so this arm just propagates.
-                                    _ if primary_failed => {
-                                        let err = failed_primary_uris
-                                            .remove(primary_uri)
-                                            .expect("primary_failed implies entry present");
-                                        return Err(err);
-                                    }
-                                    _ => (None, None),
-                                };
-
-                            if let Some(value) = fallback_value {
-                                source_provider = fallback_uri;
-                                if materialize == Materialize::Values {
-                                    self.insert_resolved(
-                                        &mut secrets,
-                                        &mut temp_files,
-                                        name,
-                                        value,
-                                        as_path,
-                                    )?;
-                                }
-                                status = ResolutionStatus::Resolved;
-                            } else if Self::would_generate(secret_config) {
-                                // The secret would be auto-generated. A full pass
-                                // mints and stores it (writing a temp file when
-                                // `as_path`); a value-free pass reports that it
-                                // would resolve without minting or storing
-                                // anything.
-                                generated = true;
-                                if materialize == Materialize::Values {
-                                    let generated_value = self
-                                        .try_generate_secret(&name, secret_config, &profile_name)?
-                                        .expect("would_generate implies a generated value");
-                                    self.insert_resolved(
-                                        &mut secrets,
-                                        &mut temp_files,
-                                        name,
-                                        generated_value,
-                                        as_path,
-                                    )?;
-                                }
-                                status = ResolutionStatus::Resolved;
-                            } else if let Some(default_value) = default {
-                                default_applied = true;
-                                if materialize == Materialize::Values {
-                                    self.insert_resolved(
-                                        &mut secrets,
-                                        &mut temp_files,
-                                        name.clone(),
-                                        SecretString::new(default_value.clone().into()),
-                                        as_path,
-                                    )?;
-                                    with_defaults.push((name, default_value));
-                                }
-                                status = ResolutionStatus::Resolved;
-                            } else if required {
-                                missing_required.push(name);
-                                status = ResolutionStatus::MissingRequired;
-                            } else {
-                                missing_optional.push(name);
-                                status = ResolutionStatus::MissingOptional;
-                            }
-                        }
-                    }
-
-                    resolution.push(SecretResolution {
-                        name: report_name,
-                        status,
-                        required,
-                        source_provider,
-                        default_applied,
-                        generated,
-                        as_path,
-                    });
-                }
-
-                let report_provider_uri = self.validation_report_provider_uri(
-                    override_uri.as_deref(),
-                    &secret_primary_uris,
-                )?;
-
-                if !missing_required.is_empty() {
-                    let mut errors = ValidationErrors::new(
-                        missing_required,
-                        missing_optional,
-                        with_defaults,
-                        report_provider_uri,
-                        profile_name.to_string(),
-                    );
-                    errors.resolution = resolution;
-                    Ok(Err(errors))
-                } else {
-                    Ok(Ok(ValidatedSecrets {
-                        resolved: Resolved::new(
-                            secrets,
-                            report_provider_uri,
-                            profile_name.to_string(),
-                        ),
-                        missing_optional,
-                        with_defaults,
-                        resolution,
-                        temp_files,
-                    }))
-                }
-            })();
+            profile_result
+                .and_then(|profile_config| {
+                    self.build_plan_from_profile(profile_name.clone(), profile_config)
+                })
+                .and_then(|plan| {
+                    self.validate_single_store_ref_coords(&plan)?;
+                    self.execute_plan(&plan, materialize)
+                });
 
         // Record exactly one `Check` event for the whole batch when this is a
         // top-level read, regardless of how the resolution exited — so a failed
@@ -2725,6 +2356,320 @@ impl Secrets {
         }
 
         result
+    }
+
+    /// Reject, before any fetch, a `ref` routed at exactly one store that cannot
+    /// honor its coordinates.
+    ///
+    /// A single store is consulted when the route is an override, a
+    /// single-provider chain, or the default provider — there is no fallback that
+    /// could answer instead, so an incompatible store is a definite error worth
+    /// surfacing up front rather than at fetch time (and, in the value-free
+    /// report, without a fetch at all). A `ref` on a multi-store chain is
+    /// deliberately skipped: its coordinates are validated per store as the chain
+    /// is walked at read time, so a coordinate a later store cannot express never
+    /// blocks a primary that can.
+    ///
+    /// Building a provider here reads its declared supported coordinates and
+    /// opens no store; [`Provider::resolve_coords`](crate::provider::Provider::resolve_coords)
+    /// does no I/O for a native address. Construction is cheap enough that
+    /// [`Secrets::execute_plan`] simply builds the same providers again.
+    fn validate_single_store_ref_coords(&self, plan: &ResolutionPlan) -> Result<()> {
+        // The plan's groups already partition secrets by primary store, so walk
+        // that partition rather than re-deriving it: one provider per group
+        // that actually has coordinates to check.
+        for (primary, indices) in &plan.groups {
+            let refs_to_check: Vec<&NativeAddress> = indices
+                .iter()
+                .filter_map(|&i| {
+                    let planned = &plan.secrets[i];
+                    // Only the routes that consult exactly one store; a chain
+                    // with a fallback defers coordinate checking to per-store
+                    // read-time.
+                    if planned.route.has_fallback() {
+                        return None;
+                    }
+                    match &planned.address {
+                        PlannedAddress::Native(native) => Some(native),
+                        PlannedAddress::Convention { .. } => None,
+                    }
+                })
+                .collect();
+            if refs_to_check.is_empty() {
+                continue;
+            }
+            let provider = self.get_provider(primary.as_deref())?;
+            for native in refs_to_check {
+                provider.resolve_coords(Address::Native(native))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Executes a [`ResolutionPlan`]: the I/O half of resolution.
+    ///
+    /// Consumes the plan's already-decided groups, routes, and addresses — it
+    /// derives nothing itself. It builds a provider per primary-store group,
+    /// fetches the groups concurrently, then walks each secret: a primary hit is
+    /// recorded; a miss falls through the secret's resolved fallback chain, then
+    /// generation, then the committed default, before being reported missing. A
+    /// primary that *errored* (rather than merely lacked the secret) with no
+    /// fallback to try surfaces that error instead of a spurious "missing", so a
+    /// machine consumer can tell an outage from an unprovisioned secret.
+    ///
+    /// `materialize` gates the two side effects (minting+storing a generated
+    /// secret and writing `as_path` temp files); [`Materialize::None`] runs the
+    /// identical resolution but skips both, reaching the same per-secret status
+    /// without mutating a provider or touching disk.
+    fn execute_plan(
+        &self,
+        plan: &ResolutionPlan,
+        materialize: Materialize,
+    ) -> Result<std::result::Result<ValidatedSecrets, ValidationErrors>> {
+        let project = plan.project.as_str();
+        let profile = plan.profile.as_str();
+
+        let mut secrets: HashMap<String, SecretString> = HashMap::new();
+        let mut missing_required = Vec::new();
+        let mut missing_optional = Vec::new();
+        let mut with_defaults = Vec::new();
+        let mut temp_files = Vec::new();
+        // Per-secret provenance for the value-free resolution report.
+        let mut resolution: Vec<SecretResolution> = Vec::new();
+        // Credential-free `uri()` of each successfully built primary provider
+        // group, keyed by the group's primary URI, so a primary hit can be
+        // attributed to the provider that answered.
+        let mut group_uris: HashMap<Option<&str>, String> = HashMap::new();
+
+        // Batch fetch from each provider group. A failure here (e.g. an
+        // unauthenticated vault) does not abort resolution: secrets that declare
+        // a fallback chain are retried per-secret below, and secrets in the
+        // failed group with no fallback surface the original error rather than
+        // being reported as missing.
+        let mut fetched_values: HashMap<String, SecretString> = HashMap::new();
+        let mut failed_primary_uris: HashMap<Option<&str>, SecretSpecError> = HashMap::new();
+
+        // Construction is cheap and stays on this thread; only the fetches run
+        // concurrently below.
+        let mut group_fetches: Vec<(Option<&str>, Vec<&PlannedSecret>, Box<dyn ProviderTrait>)> =
+            Vec::new();
+        for (provider_uri, indices) in &plan.groups {
+            let provider_uri = provider_uri.as_deref();
+            match self.get_provider(provider_uri) {
+                Ok(provider) => {
+                    // Attribute primary hits to the provider's own credential-free
+                    // `uri()`, never the raw configured alias (which may embed a
+                    // token). Recorded before the fetch so attribution survives a
+                    // partial batch.
+                    group_uris.insert(provider_uri, provider.uri());
+                    let group: Vec<&PlannedSecret> =
+                        indices.iter().map(|&i| &plan.secrets[i]).collect();
+                    group_fetches.push((provider_uri, group, provider));
+                }
+                Err(e) => {
+                    // Construction failed: only the raw alias exists, so redact it.
+                    let shown = provider_uri.map(crate::audit::redact_uri_strict);
+                    warn_primary_provider_failure(shown.as_deref(), &e);
+                    failed_primary_uris.insert(provider_uri, e);
+                }
+            }
+        }
+
+        // Fetch the groups concurrently: each group is at least one provider
+        // round-trip. One thread per group mirrors the per-item threading
+        // providers already do inside `get_many`. A single group (the common
+        // case) stays on this thread.
+        let fetch_group =
+            |(provider_uri, group, provider): (_, Vec<&PlannedSecret>, Box<dyn ProviderTrait>)| {
+                let result = Self::fetch_group(&*provider, &group, project, profile);
+                (provider_uri, result)
+            };
+        let fetch_results: Vec<(Option<&str>, Result<_>)> = if group_fetches.len() <= 1 {
+            group_fetches.into_iter().map(fetch_group).collect()
+        } else {
+            std::thread::scope(|scope| {
+                let handles: Vec<_> = group_fetches
+                    .into_iter()
+                    .map(|group| scope.spawn(|| fetch_group(group)))
+                    .collect();
+                handles
+                    .into_iter()
+                    .map(|handle| handle.join().expect("group fetch thread panicked"))
+                    .collect()
+            })
+        };
+
+        for (provider_uri, result) in fetch_results {
+            match result {
+                Ok(batch_results) => fetched_values.extend(batch_results),
+                Err(e) => {
+                    // A provider was built; attribute to its credential-free
+                    // `uri()`, already recorded in `group_uris` above.
+                    let display_uri = group_uris.get(&provider_uri).map(String::as_str);
+                    warn_primary_provider_failure(display_uri, &e);
+                    failed_primary_uris.insert(provider_uri, e);
+                }
+            }
+        }
+
+        // Process each planned secret: apply the fetched value, its fallback
+        // chain, generation, or default, and record a value-free provenance entry
+        // for the resolution report.
+        for planned in &plan.secrets {
+            let name = &planned.name;
+            let required = planned.required();
+            let as_path = planned.as_path();
+            let primary_uri = planned.route.primary();
+
+            let status;
+            let mut source_provider = None;
+            let mut default_applied = false;
+            let mut generated = false;
+
+            match fetched_values.remove(name.as_str()) {
+                Some(value) => {
+                    source_provider = group_uris.get(&primary_uri).cloned();
+                    // Copy the value into the response only on a full pass; a
+                    // value-free pass has the status it needs and never
+                    // materializes a value or writes a temp file.
+                    if materialize == Materialize::Values {
+                        self.insert_resolved(
+                            &mut secrets,
+                            &mut temp_files,
+                            name.clone(),
+                            value,
+                            as_path,
+                        )?;
+                    }
+                    status = ResolutionStatus::Resolved;
+                }
+                None => {
+                    let primary_failed = failed_primary_uris.contains_key(&primary_uri);
+
+                    // The primary missed, so now walk the fallback — tried in
+                    // order, each entry resolved lazily inside the chain walk; an
+                    // undefined alias is skipped with a warning so a working
+                    // provider after it still answers. An override or the
+                    // default store has no fallback.
+                    let (fallback_value, fallback_uri) = match planned.route.fallback_specs() {
+                        Some(fallback) => {
+                            let resolved = self.get_secret_from_providers(
+                                name,
+                                planned.address.as_address(project, profile),
+                                Some(fallback),
+                            )?;
+                            // A primary that errored plus an exhausted fallback
+                            // chain is not "missing": the authoritative provider
+                            // is unreachable and might hold the value. Surface the
+                            // primary error, exactly as the no-fallback arm below.
+                            if resolved.0.is_none() && primary_failed {
+                                let err = failed_primary_uris
+                                    .remove(&primary_uri)
+                                    .expect("primary_failed implies entry present");
+                                return Err(err);
+                            }
+                            resolved
+                        }
+                        // No alternative chain and the primary failed: surface the
+                        // original error rather than reporting a spurious missing.
+                        None if primary_failed => {
+                            let err = failed_primary_uris
+                                .remove(&primary_uri)
+                                .expect("primary_failed implies entry present");
+                            return Err(err);
+                        }
+                        None => (None, None),
+                    };
+
+                    if let Some(value) = fallback_value {
+                        source_provider = fallback_uri;
+                        if materialize == Materialize::Values {
+                            self.insert_resolved(
+                                &mut secrets,
+                                &mut temp_files,
+                                name.clone(),
+                                value,
+                                as_path,
+                            )?;
+                        }
+                        status = ResolutionStatus::Resolved;
+                    } else if Self::would_generate(&planned.config) {
+                        // The secret would be auto-generated. A full pass mints and
+                        // stores it (writing a temp file when `as_path`); a
+                        // value-free pass reports that it would resolve without
+                        // minting or storing anything.
+                        generated = true;
+                        if materialize == Materialize::Values {
+                            let generated_value = self
+                                .try_generate_secret(planned, profile)?
+                                .expect("would_generate implies a generated value");
+                            self.insert_resolved(
+                                &mut secrets,
+                                &mut temp_files,
+                                name.clone(),
+                                generated_value,
+                                as_path,
+                            )?;
+                        }
+                        status = ResolutionStatus::Resolved;
+                    } else if let Some(default_value) = &planned.config.default {
+                        default_applied = true;
+                        if materialize == Materialize::Values {
+                            self.insert_resolved(
+                                &mut secrets,
+                                &mut temp_files,
+                                name.clone(),
+                                SecretString::new(default_value.clone().into()),
+                                as_path,
+                            )?;
+                            with_defaults.push((name.clone(), default_value.clone()));
+                        }
+                        status = ResolutionStatus::Resolved;
+                    } else if required {
+                        missing_required.push(name.clone());
+                        status = ResolutionStatus::MissingRequired;
+                    } else {
+                        missing_optional.push(name.clone());
+                        status = ResolutionStatus::MissingOptional;
+                    }
+                }
+            }
+
+            resolution.push(SecretResolution {
+                name: name.clone(),
+                status,
+                required,
+                source_provider,
+                default_applied,
+                generated,
+                as_path,
+            });
+        }
+
+        let report_provider_uri = self.validation_report_provider_uri(
+            plan.override_uri.as_deref(),
+            plan.groups.iter().map(|(uri, _)| uri.as_deref()),
+        )?;
+
+        if !missing_required.is_empty() {
+            let mut errors = ValidationErrors::new(
+                missing_required,
+                missing_optional,
+                with_defaults,
+                report_provider_uri,
+                profile.to_string(),
+            );
+            errors.resolution = resolution;
+            Ok(Err(errors))
+        } else {
+            Ok(Ok(ValidatedSecrets {
+                resolved: Resolved::new(secrets, report_provider_uri, profile.to_string()),
+                missing_optional,
+                with_defaults,
+                resolution,
+                temp_files,
+            }))
+        }
     }
 
     /// Runs a command with secrets injected as environment variables
@@ -3035,17 +2980,15 @@ mod report_provider_tests {
         let got = spec
             .validation_report_provider_uri(
                 Some("vault+token:s3cr3t@host/db?token=abc"),
-                &HashMap::new(),
+                std::iter::empty(),
             )
             .unwrap();
         assert_eq!(got, "vault+token:host/db");
         assert!(!got.contains("s3cr3t") && !got.contains("abc"));
 
         // Per-secret alias branch: the first sorted primary URI is redacted too.
-        let mut primaries = HashMap::new();
-        primaries.insert("DB".to_string(), Some("vault://host?token=zzz".to_string()));
         let got = spec
-            .validation_report_provider_uri(None, &primaries)
+            .validation_report_provider_uri(None, [Some("vault://host?token=zzz")].into_iter())
             .unwrap();
         assert_eq!(got, "vault://host");
         assert!(!got.contains("zzz"));
@@ -3086,15 +3029,26 @@ mod reference_routing_tests {
         }
     }
 
+    /// The read chain the shared router resolves for a secret, in the shape the
+    /// read path consumes (`None` = default provider). Exercises the same
+    /// `route_for` that the plan, `get`, and `set` route through.
+    fn read_uris(
+        spec: &Secrets,
+        config: &Secret,
+        override_arg: Option<&str>,
+    ) -> Option<Vec<String>> {
+        let override_uri = spec.resolve_provider_override(override_arg);
+        spec.route_for(config, &override_uri).unwrap().specs()
+    }
+
     /// A `ref` supplies naming only: it never contributes to the read chain,
     /// which stays whatever routing (here: nothing, so the default provider)
     /// resolves.
     #[test]
     fn reference_does_not_affect_read_routing() {
+        let _env = crate::tests::scrub_resolution_env();
         let spec = spec_with_provider(None);
-        let uris = spec
-            .resolve_read_provider_uris(&ref_secret(None), None)
-            .unwrap();
+        let uris = read_uris(&spec, &ref_secret(None), None);
         assert_eq!(uris, None, "no routing configured, default store applies");
     }
 
@@ -3103,10 +3057,9 @@ mod reference_routing_tests {
     /// during tests.
     #[test]
     fn override_redirects_reference() {
+        let _env = crate::tests::scrub_resolution_env();
         let spec = spec_with_provider(Some("keyring"));
-        let uris = spec
-            .resolve_read_provider_uris(&ref_secret(None), Some("dotenv://.env.mock"))
-            .unwrap();
+        let uris = read_uris(&spec, &ref_secret(None), Some("dotenv://.env.mock"));
         assert_eq!(uris, Some(vec!["dotenv://.env.mock".to_string()]));
     }
 
@@ -3114,13 +3067,13 @@ mod reference_routing_tests {
     /// `scheme://` entries pass through without an alias declaration.
     #[test]
     fn reference_routes_through_providers_chain() {
+        let _env = crate::tests::scrub_resolution_env();
         let spec = spec_with_provider(None);
-        let uris = spec
-            .resolve_read_provider_uris(
-                &ref_secret(Some(vec!["onepassword://Production", "keyring://"])),
-                None,
-            )
-            .unwrap();
+        let uris = read_uris(
+            &spec,
+            &ref_secret(Some(vec!["onepassword://Production", "keyring://"])),
+            None,
+        );
         assert_eq!(
             uris,
             Some(vec![
@@ -3134,18 +3087,55 @@ mod reference_routing_tests {
     /// override, the override when present.
     #[test]
     fn write_provider_follows_routing() {
+        let _env = crate::tests::scrub_resolution_env();
         let spec = spec_with_provider(None);
-        let provider = spec
-            .resolve_write_provider(&ref_secret(Some(vec!["onepassword://Production"])), None)
-            .unwrap();
-        assert_eq!(provider.name(), "onepassword");
+        let write_provider = |override_arg: Option<&str>| {
+            let override_uri = spec.resolve_provider_override(override_arg);
+            let route = spec
+                .route_for(
+                    &ref_secret(Some(vec!["onepassword://Production"])),
+                    &override_uri,
+                )
+                .unwrap();
+            spec.write_provider_for_route(&route).unwrap()
+        };
 
-        let provider = spec
-            .resolve_write_provider(
-                &ref_secret(Some(vec!["onepassword://Production"])),
-                Some("dotenv://.env.mock"),
-            )
-            .unwrap();
-        assert_eq!(provider.name(), "dotenv");
+        assert_eq!(write_provider(None).name(), "onepassword");
+        assert_eq!(write_provider(Some("dotenv://.env.mock")).name(), "dotenv");
+    }
+
+    /// Build a plan over a single `default`-profile secret so its route can be
+    /// handed to the coordinate check.
+    fn plan_of(secret: Secret) -> (Secrets, crate::plan::ResolutionPlan) {
+        let mut secrets = HashMap::new();
+        secrets.insert("SECRET".to_string(), secret);
+        let spec = Secrets::new(crate::tests::resolve_test_config(secrets), None, None, None);
+        let plan = spec.build_plan(None).unwrap();
+        (spec, plan)
+    }
+
+    /// A `ref` routed at a single store that cannot honor its coordinates is
+    /// rejected up front: dotenv keys have no `field`, so a `field` ref fails.
+    #[test]
+    fn single_store_ref_with_unsupported_coord_is_rejected() {
+        let _env = crate::tests::scrub_resolution_env();
+        let (spec, plan) = plan_of(ref_secret(Some(vec!["dotenv:///tmp/x"])));
+        assert!(
+            spec.validate_single_store_ref_coords(&plan).is_err(),
+            "a single-store ref with an unsupported coordinate must be rejected"
+        );
+    }
+
+    /// The same unsupported `ref` on a multi-store chain is NOT rejected up
+    /// front: coordinate checking defers to per-store read-time, so a later
+    /// store that cannot express the coordinate never blocks a primary that can.
+    #[test]
+    fn multi_store_ref_defers_coord_validation() {
+        let _env = crate::tests::scrub_resolution_env();
+        let (spec, plan) = plan_of(ref_secret(Some(vec!["dotenv:///tmp/a", "dotenv:///tmp/b"])));
+        assert!(
+            spec.validate_single_store_ref_coords(&plan).is_ok(),
+            "a multi-store ref must defer coordinate checking to read time"
+        );
     }
 }

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -48,6 +48,18 @@ fn test_new_with_project_config() {
 }
 
 #[test]
+fn profile_supports_consuming_iteration() {
+    let profile = Profile {
+        defaults: None,
+        secrets: HashMap::from([("API_KEY".to_string(), Secret::default())]),
+    };
+
+    let secrets: HashMap<String, Secret> = profile.into_iter().collect();
+
+    assert!(secrets.contains_key("API_KEY"));
+}
+
+#[test]
 fn test_new_with_custom_configs() {
     let temp_dir = TempDir::new().unwrap();
     let project_path = temp_dir.path().join("custom-secretspec.toml");
@@ -5895,6 +5907,27 @@ fn audit_set_undefined_records_error() {
     assert_eq!(events[0]["action"], "set");
     assert_eq!(events[0]["outcome"], "error");
     assert_eq!(events[0]["error_kind"], "secret_not_found");
+}
+
+#[test]
+fn audit_set_provider_construction_failure_records_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut spec = dotenv_spec("", required_secret_profile("REQUIRED"), &temp_dir);
+    spec.set_provider("ghost");
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    assert!(matches!(
+        spec.set("REQUIRED", Some("v".to_string())),
+        Err(SecretSpecError::ProviderNotFound(_))
+    ));
+
+    let events = audit_events(&lines);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["action"], "set");
+    assert_eq!(events[0]["outcome"], "error");
+    assert_eq!(events[0]["error_kind"], "provider_not_found");
+    assert_eq!(events[0]["key"], "REQUIRED");
 }
 
 #[test]

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -425,7 +425,7 @@ fn test_resolution_report_provenance() {
     assert!(stripe.required);
 }
 
-fn resolve_test_config(secrets: HashMap<String, Secret>) -> Config {
+pub(crate) fn resolve_test_config(secrets: HashMap<String, Secret>) -> Config {
     let mut profiles = HashMap::new();
     profiles.insert(
         "default".to_string(),
@@ -441,6 +441,49 @@ fn resolve_test_config(secrets: HashMap<String, Secret>) -> Config {
         },
         profiles,
         providers: None,
+    }
+}
+
+/// Serializes tests that scrub the `SECRETSPEC_*` process environment. The
+/// environment is shared across all test threads, so scrub/restore pairs must
+/// not interleave.
+static RESOLUTION_ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Removes `SECRETSPEC_PROVIDER` and `SECRETSPEC_PROFILE` for the guard's
+/// lifetime, restoring any previous values on drop. Tests that exercise
+/// provider or profile resolution hold this so the ambient shell of whoever
+/// runs `cargo test` (a natural place for these variables to be exported)
+/// cannot steer the routes and profiles under test.
+pub(crate) struct ResolutionEnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+pub(crate) fn scrub_resolution_env() -> ResolutionEnvGuard {
+    let lock = RESOLUTION_ENV_GUARD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let saved = ["SECRETSPEC_PROVIDER", "SECRETSPEC_PROFILE"]
+        .into_iter()
+        .map(|key| {
+            let previous = std::env::var_os(key);
+            // SAFETY: `RESOLUTION_ENV_GUARD` is held for the guard's whole
+            // lifetime, so no two guards mutate the environment concurrently.
+            unsafe { std::env::remove_var(key) };
+            (key, previous)
+        })
+        .collect();
+    ResolutionEnvGuard { _lock: lock, saved }
+}
+
+impl Drop for ResolutionEnvGuard {
+    fn drop(&mut self) {
+        for (key, previous) in self.saved.drain(..) {
+            if let Some(value) = previous {
+                // SAFETY: the lock in `_lock` is still held while `drop` runs.
+                unsafe { std::env::set_var(key, value) };
+            }
+        }
     }
 }
 
@@ -3081,40 +3124,16 @@ fn test_provider_alias_resolution() {
     );
 
     // Test resolving dev alias
-    let dev_uris = spec
-        .resolve_provider_aliases(Some(&["dev".to_string()]))
+    let dev_uri = spec
+        .resolve_one_provider("dev")
         .expect("Should resolve dev alias");
-    assert_eq!(
-        dev_uris,
-        Some(vec!["dotenv://.env.development".to_string()])
-    );
+    assert_eq!(dev_uri, "dotenv://.env.development");
 
     // Test resolving prod alias
-    let prod_uris = spec
-        .resolve_provider_aliases(Some(&["prod".to_string()]))
+    let prod_uri = spec
+        .resolve_one_provider("prod")
         .expect("Should resolve prod alias");
-    assert_eq!(
-        prod_uris,
-        Some(vec!["onepassword://Production".to_string()])
-    );
-
-    // Test resolving multiple aliases in order
-    let multi_uris = spec
-        .resolve_provider_aliases(Some(&["dev".to_string(), "prod".to_string()]))
-        .expect("Should resolve multiple aliases");
-    assert_eq!(
-        multi_uris,
-        Some(vec![
-            "dotenv://.env.development".to_string(),
-            "onepassword://Production".to_string(),
-        ])
-    );
-
-    // Test with no aliases
-    let no_uris = spec
-        .resolve_provider_aliases(None)
-        .expect("Should handle no aliases");
-    assert_eq!(no_uris, None);
+    assert_eq!(prod_uri, "onepassword://Production");
 }
 
 #[test]
@@ -3146,7 +3165,7 @@ fn test_provider_alias_not_found() {
     );
 
     // Test resolving non-existent alias
-    let result = spec.resolve_provider_aliases(Some(&["nonexistent".to_string()]));
+    let result = spec.resolve_one_provider("nonexistent");
     assert!(result.is_err());
     match result {
         Err(SecretSpecError::ProviderNotFound(msg)) => {
@@ -4721,6 +4740,66 @@ fn read_env_var(path: &std::path::Path, key: &str) -> Option<String> {
         .map(|(_, v)| v)
 }
 
+/// Builds a `Secrets` whose single required `MY_SECRET` declares the given
+/// per-secret `providers` chain (unlike [`build_chain_scenario`], whose chain
+/// lives in profile defaults). Each `files` entry (alias, initial contents)
+/// becomes a dotenv file in `temp_dir` with a same-named global alias,
+/// returned in order; chain entries without a backing file (e.g. `"ghost"`)
+/// stay undefined. The global default provider is keyring, so a chain bug
+/// cannot fall back to a dotenv store that happens to answer.
+fn chain_walk_spec(
+    temp_dir: &TempDir,
+    files: &[(&str, &str)],
+    chain: &[&str],
+) -> (Secrets, Vec<std::path::PathBuf>) {
+    let mut paths = Vec::new();
+    let mut aliases = Vec::new();
+    for (alias, contents) in files {
+        let path = temp_dir.path().join(format!(".env.{alias}"));
+        fs::write(&path, contents).unwrap();
+        aliases.push((alias.to_string(), format!("dotenv://{}", path.display())));
+        paths.push(path);
+    }
+
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "MY_SECRET".to_string(),
+        Secret {
+            description: Some("test secret".to_string()),
+            required: Some(true),
+            providers: Some(chain.iter().map(|s| s.to_string()).collect()),
+            ..Default::default()
+        },
+    );
+
+    let alias_refs: Vec<(&str, &str)> = aliases
+        .iter()
+        .map(|(alias, uri)| (alias.as_str(), uri.as_str()))
+        .collect();
+    let mut global_config = global_config_with_aliases(&alias_refs);
+    global_config.defaults.provider = Some("keyring".to_string());
+
+    let spec = Secrets::new(
+        resolve_test_config(secrets),
+        Some(global_config),
+        None,
+        None,
+    );
+    (spec, paths)
+}
+
+/// Runs a full batch resolution and returns the resolved value of `MY_SECRET`,
+/// panicking if validation errors or a required secret is missing.
+fn resolved_my_secret(spec: &Secrets) -> Option<String> {
+    spec.validate()
+        .expect("validation should not error")
+        .expect("required secret should resolve")
+        .resolved
+        .secrets
+        .get("MY_SECRET")
+        .map(|s| s.expose_secret().to_string())
+}
+
 /// Regression test for issue #81: `set --provider <alias>` must override the
 /// per-secret/profile providers chain, writing only to the chosen provider.
 #[test]
@@ -4768,18 +4847,180 @@ fn test_set_without_override_uses_chain_first() {
     );
 }
 
+/// A `providers` chain is tried in order, so an undefined alias *after* a
+/// provider that answers must not fail the operation — the broken link is never
+/// reached. Covers batch resolution (`check`/`run`), single reads (`get`), and
+/// writes (`set`, which uses only the primary).
+#[test]
+fn test_undefined_fallback_alias_is_ignored_when_the_primary_answers() {
+    let _env = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    // The primary already holds the value, so the fallback is never reached;
+    // `ghost` is not defined anywhere.
+    let (spec, paths) = chain_walk_spec(
+        &temp_dir,
+        &[("personal", "MY_SECRET=already_here\n")],
+        &["personal", "ghost"],
+    );
+
+    // Batch resolution succeeds: the primary answers, so `ghost` is never
+    // resolved and its being undefined does not matter.
+    assert_eq!(resolved_my_secret(&spec).as_deref(), Some("already_here"));
+
+    // A single read walks the chain in order: the primary answers, so the
+    // undefined fallback is never resolved.
+    spec.get("MY_SECRET")
+        .expect("get reads the primary and ignores the undefined fallback");
+
+    // A write targets only the primary, so the undefined fallback is irrelevant.
+    spec.set("MY_SECRET", Some("updated".to_string()))
+        .expect("set writes to the primary and ignores the fallback");
+    assert_eq!(
+        read_env_var(&paths[0], "MY_SECRET").as_deref(),
+        Some("updated"),
+        "set must write through the primary"
+    );
+}
+
+/// Because each link is resolved only when reached, a defined provider that
+/// holds the value wins even when a *later* chain entry names an undefined
+/// alias: the primary misses, the second provider answers, and the broken third
+/// link is never resolved.
+#[test]
+fn test_a_live_fallback_before_an_undefined_alias_still_wins() {
+    let _env = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    // Primary is empty (misses); the second provider holds the value; `ghost`
+    // is deliberately not defined.
+    let (spec, _paths) = chain_walk_spec(
+        &temp_dir,
+        &[("personal", ""), ("team", "MY_SECRET=from_team\n")],
+        &["personal", "team", "ghost"],
+    );
+
+    assert_eq!(
+        resolved_my_secret(&spec).as_deref(),
+        Some("from_team"),
+        "the live fallback must answer before the undefined link is reached",
+    );
+}
+
+/// An undefined alias in the *middle* of the chain is one broken link, not a
+/// reason to abandon the walk: the primary misses, the broken second link is
+/// skipped with a warning, and the third provider still answers. Both batch
+/// resolution and a single `get` walk the chain the same way.
+#[test]
+fn test_an_undefined_alias_mid_chain_does_not_block_a_later_provider() {
+    let _env = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    // Primary is empty (misses); `ghost` is deliberately not defined; the
+    // provider after the broken link holds the value.
+    let (spec, _paths) = chain_walk_spec(
+        &temp_dir,
+        &[("personal", ""), ("team", "MY_SECRET=from_team\n")],
+        &["personal", "ghost", "team"],
+    );
+
+    assert_eq!(
+        resolved_my_secret(&spec).as_deref(),
+        Some("from_team"),
+        "a broken link must be skipped, not abort the chain",
+    );
+
+    spec.get("MY_SECRET")
+        .expect("get walks past the broken link to the provider that answers");
+}
+
+/// A chain entry that misspells `onepassword` as `1password` gets the same
+/// corrective message `--provider 1password` gets, not a generic
+/// "alias not defined" error.
+#[test]
+fn test_chain_entry_1password_gets_the_onepassword_hint() {
+    let _env = scrub_resolution_env();
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "API_KEY".to_string(),
+        Secret {
+            description: Some("test secret".to_string()),
+            required: Some(true),
+            providers: Some(vec!["1password".to_string()]),
+            ..Default::default()
+        },
+    );
+    let spec = Secrets::new(resolve_test_config(secrets), None, None, None);
+
+    let err = match spec.validate() {
+        Ok(_) => panic!("the misspelled provider cannot be constructed"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("onepassword"),
+        "the error must point at the correct spelling: {err}"
+    );
+}
+
+/// A `ref` routed at a single store whose coordinates that store cannot honor
+/// is rejected up front — before any fetch — since there is no fallback that
+/// could answer instead. dotenv keys have no sub-fields, so a `field` ref is
+/// unsupported there.
+#[test]
+fn test_single_store_ref_rejects_unsupported_coordinate_up_front() {
+    let _env = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    let env_path = temp_dir.path().join(".env");
+    // Value present under a plain key: the failure is the coordinate, not a miss.
+    fs::write(&env_path, "db=secret\n").unwrap();
+
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "DB_PASSWORD".to_string(),
+        Secret {
+            description: Some("db password".to_string()),
+            required: Some(true),
+            reference: Some(crate::config::NativeAddress {
+                item: "db".to_string(),
+                field: Some("password".to_string()),
+                ..Default::default()
+            }),
+            providers: Some(vec![format!("dotenv://{}", env_path.display())]),
+            ..Default::default()
+        },
+    );
+    let spec = Secrets::new(resolve_test_config(secrets), None, None, None);
+
+    let err = match spec.validate() {
+        Ok(_) => panic!("an unsupported ref coordinate must be rejected"),
+        Err(e) => e,
+    };
+    match err {
+        SecretSpecError::ProviderOperationFailed(msg) => {
+            assert!(
+                msg.contains("field"),
+                "message should name the coordinate: {msg}"
+            );
+            assert!(
+                msg.contains("dotenv"),
+                "message should name the store: {msg}"
+            );
+        }
+        other => panic!("expected ProviderOperationFailed, got {other:?}"),
+    }
+}
+
 /// `get` with an explicit override must read only from that provider, never
 /// falling back through the chain.
 #[test]
-fn test_resolve_read_provider_uris_override_skips_chain() {
+fn test_override_skips_read_chain() {
     let temp_dir = TempDir::new().unwrap();
     let (config, global_config, _, team_path) = build_chain_scenario(&temp_dir);
 
     let spec = Secrets::new(config, Some(global_config), Some("team".to_string()), None);
     let secret_config = spec.resolve_secret_config("MY_SECRET", None).unwrap();
+    let override_uri = spec.resolve_provider_override(None);
     let uris = spec
-        .resolve_read_provider_uris(&secret_config, None)
+        .route_for(&secret_config, &override_uri)
         .expect("override resolution should succeed")
+        .specs()
         .expect("override should produce a URI list");
 
     assert_eq!(
@@ -4788,6 +5029,51 @@ fn test_resolve_read_provider_uris_override_skips_chain() {
         "override must collapse the chain to a single URI"
     );
     assert_eq!(uris[0], format!("dotenv://{}", team_path.display()));
+}
+
+/// `get` must accept the same provider specs `--provider` accepts everywhere
+/// else: `scheme:path` shorthand (no `://`) is a valid override, not an
+/// undefined alias. Regression test: the plan-routed read used to feed the
+/// already-resolved override back through alias resolution and reject it.
+#[test]
+fn test_get_accepts_provider_shorthand_override() {
+    let _env = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    let env_path = temp_dir.path().join(".env");
+    fs::write(&env_path, "MY_SECRET=hello\n").unwrap();
+
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "MY_SECRET".to_string(),
+        Secret {
+            description: Some("test secret".to_string()),
+            required: Some(true),
+            ..Default::default()
+        },
+    );
+    let mut spec = Secrets::new(resolve_test_config(secrets), None, None, None);
+    spec.set_provider(format!("dotenv:{}", env_path.display()));
+
+    spec.get("MY_SECRET")
+        .expect("get must honor a scheme:path shorthand override");
+}
+
+/// Provider spec resolution expands aliases and passes through anything that
+/// names a registered provider (bare name or `scheme:path` shorthand); only a
+/// token that names neither an alias nor a provider errors.
+#[test]
+fn test_resolve_one_provider_accepts_bare_names_and_shorthand() {
+    let spec = Secrets::new(resolve_test_config(HashMap::new()), None, None, None);
+
+    assert_eq!(spec.resolve_one_provider("keyring").unwrap(), "keyring");
+    assert_eq!(
+        spec.resolve_one_provider("dotenv:.env.production").unwrap(),
+        "dotenv:.env.production"
+    );
+    assert!(matches!(
+        spec.resolve_one_provider("ghost"),
+        Err(SecretSpecError::ProviderNotFound(_))
+    ));
 }
 
 /// Strip ANSI escape sequences so summary assertions don't depend on whether
@@ -4892,7 +5178,7 @@ OPTIONAL_MISSING = { description = "optional, not set", required = false }
     );
 }
 
-fn aliases_map(aliases: &[(&str, &str)]) -> HashMap<String, String> {
+pub(crate) fn aliases_map(aliases: &[(&str, &str)]) -> HashMap<String, String> {
     aliases
         .iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -4910,7 +5196,7 @@ fn config_with_project_aliases(aliases: &[(&str, &str)]) -> Config {
     }
 }
 
-fn global_config_with_aliases(aliases: &[(&str, &str)]) -> GlobalConfig {
+pub(crate) fn global_config_with_aliases(aliases: &[(&str, &str)]) -> GlobalConfig {
     GlobalConfig {
         defaults: GlobalDefaults {
             provider: None,
@@ -4962,11 +5248,10 @@ fn test_project_providers_resolve_without_global_config() {
     let spec = Secrets::new(config, None, None, None);
 
     let resolved = spec
-        .resolve_provider_aliases(Some(&["op_infra".to_string()]))
-        .expect("project alias should resolve")
-        .expect("resolved list should be present");
+        .resolve_one_provider("op_infra")
+        .expect("project alias should resolve");
 
-    assert_eq!(resolved, vec!["onepassword://Infra".to_string()]);
+    assert_eq!(resolved, "onepassword://Infra");
 }
 
 #[test]
@@ -4976,13 +5261,11 @@ fn test_project_providers_take_precedence_over_global() {
     let spec = Secrets::new(config, Some(global), None, None);
 
     let resolved = spec
-        .resolve_provider_aliases(Some(&["shared".to_string()]))
-        .expect("alias should resolve")
-        .expect("resolved list should be present");
+        .resolve_one_provider("shared")
+        .expect("alias should resolve");
 
     assert_eq!(
-        resolved,
-        vec!["dotenv://.env.team".to_string()],
+        resolved, "dotenv://.env.team",
         "project alias must win on conflict with global"
     );
 }
@@ -4994,7 +5277,7 @@ fn test_unknown_alias_error_lists_both_sources() {
     let spec = Secrets::new(config, Some(global), None, None);
 
     let err = spec
-        .resolve_provider_aliases(Some(&["does_not_exist".to_string()]))
+        .resolve_one_provider("does_not_exist")
         .expect_err("missing alias must error");
 
     let msg = err.to_string();
@@ -5088,36 +5371,47 @@ fn test_global_alias_still_resolves_when_project_providers_present() {
     let spec = Secrets::new(config, Some(global), None, None);
 
     let resolved = spec
-        .resolve_provider_aliases(Some(&["team".to_string()]))
-        .expect("global alias should resolve when project map exists but doesn't define it")
-        .expect("resolved list should be present");
+        .resolve_one_provider("team")
+        .expect("global alias should resolve when project map exists but doesn't define it");
 
-    assert_eq!(resolved, vec!["onepassword://Team".to_string()]);
+    assert_eq!(resolved, "onepassword://Team");
 }
 
 #[test]
 fn test_fallback_chain_resolves_aliases_from_mixed_sources() {
-    // Chain mixes a project-only alias and a global-only alias; order in the
-    // chain is preserved and each is resolved from whichever source defines it.
-    let config = config_with_project_aliases(&[("project_vault", "onepassword://Team")]);
-    let global = global_config_with_aliases(&[("user_dotenv", "dotenv://.env.user")]);
+    // Chain mixes a project-only alias and a global-only alias: the primary
+    // (defined in the project map) misses, so the read walks to the fallback
+    // resolved from the global map — exercising the same route and lazy
+    // per-link resolution the executor and `get` walk.
+    let _env = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    let team_path = temp_dir.path().join(".env.team");
+    let user_path = temp_dir.path().join(".env.user");
+    // The project-defined primary misses; the global-defined fallback answers.
+    fs::write(&team_path, "").unwrap();
+    fs::write(&user_path, "MY_SECRET=from_user\n").unwrap();
+
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "MY_SECRET".to_string(),
+        Secret {
+            description: Some("test secret".to_string()),
+            required: Some(true),
+            providers: Some(vec!["project_team".to_string(), "user_dotenv".to_string()]),
+            ..Default::default()
+        },
+    );
+    let mut config = resolve_test_config(secrets);
+    let team_uri = format!("dotenv://{}", team_path.display());
+    let user_uri = format!("dotenv://{}", user_path.display());
+    config.providers = Some(aliases_map(&[("project_team", &team_uri)]));
+    let global = global_config_with_aliases(&[("user_dotenv", &user_uri)]);
     let spec = Secrets::new(config, Some(global), None, None);
 
-    let resolved = spec
-        .resolve_provider_aliases(Some(&[
-            "project_vault".to_string(),
-            "user_dotenv".to_string(),
-        ]))
-        .expect("mixed-source chain should resolve")
-        .expect("resolved list should be present");
-
     assert_eq!(
-        resolved,
-        vec![
-            "onepassword://Team".to_string(),
-            "dotenv://.env.user".to_string(),
-        ],
-        "chain order must be preserved across sources"
+        resolved_my_secret(&spec).as_deref(),
+        Some("from_user"),
+        "the fallback resolved from the global source must answer after the project-defined primary misses"
     );
 }
 


### PR DESCRIPTION
Closes #124.

Splits secret resolution into a pure, I/O-free **plan** and a small **executor** that consumes it, so deciding *what to do* (profile merge, effective config, address derivation, provider routing, grouping) no longer interleaves with *doing it* (fetching, fallbacks, defaults, generation). Shipped as four reviewable slices plus one behavior fix.

### Slices

1. **Pure plan** (`secretspec/src/plan.rs`, new): `build_plan()` turns the manifest + alias maps into an immutable `ResolutionPlan` with no I/O — fully unit-testable without any provider.
2. **Executor**: `execute_plan()` builds a provider per primary-store group, fetches groups concurrently, walks fallbacks, generates, and applies defaults. `validate_audited` shrinks from ~380 lines to a reason-gate + `build_plan` → coordinate-check → `execute_plan` + one audit event.
3. **`get`/`set` on the plan**: single-secret operations plan via the same `plan_secret`/`route_for`, so per-secret decisions (effective config, address, route) can't drift between single-secret ops and batch validation.
4. **Single-store `ref` coordinate validation**: a `ref` routed at exactly one store (an explicit `--provider`, a single-provider chain, or the default) is checked for coordinate compatibility before any fetch; a `ref` on a multi-store chain defers to per-store checking at read time.

### Behavior refinements (see CHANGELOG)

- **Fallback chains are tried strictly in order.** The plan resolves only a chain's primary up front; each fallback link is resolved lazily, only when a read reaches it. So `check`/`run`/`get` stop at the first provider that answers and an undefined or unreachable link *past* it is never touched. This also fixes a pre-existing case where a live fallback sitting before an undefined alias wrongly failed the read.
- **Single-store `ref` coordinate mismatches fail fast** (e.g. a `field` ref pointed at a `.env` file), with a clear message, before contacting the store — and, for the value-free report, without contacting it at all.

### Invariants preserved

Wire formats and JSON schemas are unchanged (the plan is crate-internal, not serialized); exactly one `Check` audit event still fires per read with keys populated even on a route error; `build_plan` performs no provider construction or network I/O (the coordinate check that builds providers lives in the executor side).

### Testing

`cargo test --all` green (388 secretspec unit tests + derive/ffi/node/py/integration/doc suites, 0 failures); clippy + rustfmt clean. New unit coverage for planning, routing, tried-in-order fallback, and coordinate validation. Independently reviewed by a verification pass that traced the fallback and coordinate logic and confirmed behavior preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
