### PR TITLE
Add Azure Key Vault provider (akv://)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Azure Key Vault provider (`akv://`). Authenticates via a service principal
+  (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`), falling back to
+  a signed-in Azure CLI / Azure Developer CLI session; managed identity and
+  AKS workload identity are also available via `?auth=managed_identity` and
+  `?auth=workload_identity`.
+
 ### Changed
 - A `ref` routed at a single store (an explicit `--provider`, a single-provider
   chain, or the default provider) is now checked up front, before any store is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`), falling back to
   a signed-in Azure CLI / Azure Developer CLI session; managed identity and
   AKS workload identity are also available via `?auth=managed_identity` and
-  `?auth=workload_identity`.
+  `?auth=workload_identity`. Sovereign clouds can be addressed with a full
+  DNS hostname or an explicit `?suffix=` override. Project/profile/key
+  combinations that would collide once mapped to Azure's secret-name
+  charset are rejected rather than silently colliding with another secret.
 
 ### Changed
 - A `ref` routed at a single store (an explicit `--provider`, a single-provider

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5856,4 +5856,251 @@ dependencies = [
 [[package]]
 name = "winnow"
 version = "1.0.0"
-sour
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroizing-alloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebff5e6b81c1c7dca2d0bd333b2006da48cb37dbcae5a8da888f31fcb3c19934"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zxcvbn"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad76e35b00ad53688d6b90c431cabe3cbf51f7a4a154739e04b63004ab1c736c"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "fancy-regex",
+ "itertools",
+ "lazy_static",
+ "regex",
+ "time",
+ "wasm-bindgen",
+ "web-sys",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +559,74 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version",
  "tracing",
+]
+
+[[package]]
+name = "azure_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_client_core",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tracing",
+]
+
+[[package]]
+name = "azure_identity"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "azure_security_keyvault_secrets"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b370d75ebb8807cc1ccfc6fe647b1e61e13052cba2e800b95f0cf0bd27d9a"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core",
+ "futures",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -1117,6 +1208,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1651,6 +1777,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +1839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1883,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1747,6 +1905,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1783,10 +1952,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1904,7 +2076,7 @@ dependencies = [
  "google-cloud-wkt",
  "http 1.4.0",
  "pin-project",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2896,6 +3068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3107,6 +3280,12 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3481,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -3668,6 +3847,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -3688,12 +3868,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3985,6 +4167,9 @@ version = "0.14.0"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
+ "azure_core",
+ "azure_identity",
+ "azure_security_keyvault_secrets",
  "bitwarden",
  "clap",
  "colored",
@@ -4330,6 +4515,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -4813,13 +5004,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4918,6 +5114,57 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "typespec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.2",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
 
 [[package]]
 name = "unicase"
@@ -5207,6 +5454,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5596,251 +5856,4 @@ dependencies = [
 [[package]]
 name = "winnow"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zeroizing-alloc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebff5e6b81c1c7dca2d0bd333b2006da48cb37dbcae5a8da888f31fcb3c19934"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zxcvbn"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad76e35b00ad53688d6b90c431cabe3cbf51f7a4a154739e04b63004ab1c736c"
-dependencies = [
- "chrono",
- "derive_builder",
- "fancy-regex",
- "itertools",
- "lazy_static",
- "regex",
- "time",
- "wasm-bindgen",
- "web-sys",
-]
+sour

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] 
 google-cloud-secretmanager-v1 = "1.2"
 aws-config = "1"
 aws-sdk-secretsmanager = "1"
+azure_core = "1.0.0"
+azure_identity = "1.0.0"
+azure_security_keyvault_secrets = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 secretspec-derive = { version = "0.14.0", path = "./secretspec-derive" }

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -109,7 +109,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault / OpenBao, or Bitwarden Secrets Manager.`,
+Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault / OpenBao, Bitwarden Secrets Manager, or Azure Key Vault.`,
         }),
       ],
       title: "SecretSpec",
@@ -185,6 +185,10 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
             {
               label: "Bitwarden Secrets Manager",
               slug: "providers/bws",
+            },
+            {
+              label: "Azure Key Vault",
+              slug: "providers/akv",
             },
           ],
         },

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -20,6 +20,7 @@ Providers are pluggable storage backends that handle the storage and retrieval o
 | **awssm** | AWS Secrets Manager (requires `--features awssm`) | ✓ | ✓ | ✓ |
 | **vault** | HashiCorp Vault / OpenBao (requires `--features vault`) | ✓ | ✓ | ✓ |
 | **bws** | Bitwarden Secrets Manager (requires `--features bws`) | ✓ | ✓ | ✓ |
+| **akv** | Azure Key Vault (requires `--features akv`) | ✓ | ✓ | ✓ |
 
 ## Provider Selection
 

--- a/docs/src/content/docs/providers/akv.md
+++ b/docs/src/content/docs/providers/akv.md
@@ -16,15 +16,16 @@ The Azure Key Vault provider integrates with Azure for centralized secret manage
 ### URI Format
 
 ```
-akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity]
+akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity][&suffix=DNS_SUFFIX]
 ```
 
 - `VAULT_NAME`: Your Key Vault name (e.g. `myvault`), or a full DNS name for sovereign clouds (e.g. `myvault.vault.azure.cn`)
 - `auth`: Authentication method (default: `env`)
-  - `env` — a service principal from `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`, falling back to the signed-in Azure CLI / Azure Developer CLI session if those aren't set
+  - `env` — a service principal from `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET` (all three must be set together); falls back to the signed-in Azure CLI / Azure Developer CLI session if none are set. Setting only some of the three is an error rather than a silent fallback to a different identity.
   - `cli` — the Azure CLI / Azure Developer CLI session only
   - `managed_identity` — the VM / App Service / AKS system-assigned managed identity
   - `workload_identity` — AKS workload identity federation (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_FEDERATED_TOKEN_FILE`, injected automatically by AKS)
+- `suffix`: an explicit Key Vault DNS suffix for a bare `VAULT_NAME`, e.g. `akv://myvault?suffix=vault.azure.cn` for a sovereign cloud, instead of relying on a dotted `VAULT_NAME`
 
 ### Examples
 
@@ -40,6 +41,9 @@ $ secretspec check --provider akv://myvault?auth=managed_identity
 
 # Run with secrets
 $ secretspec run --provider akv://myvault -- npm start
+
+# Sovereign cloud, via an explicit suffix instead of a dotted vault name
+$ secretspec check --provider akv://myvault?suffix=vault.azure.cn
 ```
 
 ## Secret References
@@ -47,7 +51,11 @@ $ secretspec run --provider akv://myvault -- npm start
 By default each secret is stored as `secretspec--{project}--{profile}--{key}`. A
 secret's [`ref`](/reference/configuration/#secret-references) field names an
 existing secret instead: `item` is the secret name (`field` and `version` are
-not yet supported). References are **read-only** in this provider.
+not yet supported). References are **read-only** in this provider, and `item`
+must already be a valid Azure Key Vault secret name (letters, digits, and
+hyphens only) — unlike convention secrets, it is validated but never rewritten,
+since silently rewriting a `ref` could point at a different secret than the
+one you named.
 
 ```toml
 [profiles.production]
@@ -64,8 +72,9 @@ $ secretspec set DATABASE_URL --provider akv://myvault
 Enter value for DATABASE_URL: postgresql://localhost/mydb
 ✓ Secret 'DATABASE_URL' saved to akv (profile: default)
 
-# Import from .env
-$ secretspec import dotenv://.env
+# Get it back
+$ secretspec get DATABASE_URL --provider akv://myvault
+postgresql://localhost/mydb
 ```
 
 ### Secret Naming
@@ -80,7 +89,11 @@ Example: `DATABASE_URL` in project `myapp`, profile `production` becomes
 
 This rewrite is lossy: a project, profile, or key that differs only in using
 hyphens versus underscores (e.g. `FOO_BAR` and `FOO-BAR`) maps to the same Key
-Vault secret name. Prefer hyphens if that distinction matters to you.
+Vault secret name. Prefer hyphens if that distinction matters to you. A
+project, profile, or key containing a literal `--` or a `__` (which sanitizes
+to `--`) is rejected outright — it would be indistinguishable from the `--`
+delimiter between components and could otherwise silently collide with an
+unrelated secret.
 
 ### CI/CD with a Service Principal
 
@@ -93,6 +106,10 @@ $ export AZURE_CLIENT_SECRET="..."
 # Run command
 $ secretspec run --provider akv://myvault -- deploy
 ```
+
+All three environment variables must be set together; setting only some of
+them is treated as a configuration error rather than a silent fallback to the
+Azure CLI session.
 
 ### AKS with Workload Identity
 

--- a/docs/src/content/docs/providers/akv.md
+++ b/docs/src/content/docs/providers/akv.md
@@ -1,0 +1,103 @@
+---
+title: Azure Key Vault Provider
+description: Azure Key Vault integration
+---
+
+The Azure Key Vault provider integrates with Azure for centralized secret management.
+
+## Prerequisites
+
+- An Azure Key Vault instance
+- Authenticated via a service principal (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`), the Azure CLI (`az login`), a managed identity, or AKS workload identity
+- Build with `--features akv`
+
+## Configuration
+
+### URI Format
+
+```
+akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity]
+```
+
+- `VAULT_NAME`: Your Key Vault name (e.g. `myvault`), or a full DNS name for sovereign clouds (e.g. `myvault.vault.azure.cn`)
+- `auth`: Authentication method (default: `env`)
+  - `env` — a service principal from `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`, falling back to the signed-in Azure CLI / Azure Developer CLI session if those aren't set
+  - `cli` — the Azure CLI / Azure Developer CLI session only
+  - `managed_identity` — the VM / App Service / AKS system-assigned managed identity
+  - `workload_identity` — AKS workload identity federation (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_FEDERATED_TOKEN_FILE`, injected automatically by AKS)
+
+### Examples
+
+```bash
+# Set a secret (reads env vars, or falls back to `az login`)
+$ secretspec set DATABASE_URL --provider akv://myvault
+
+# Get a secret
+$ secretspec get DATABASE_URL --provider akv://myvault
+
+# Check secrets using a managed identity
+$ secretspec check --provider akv://myvault?auth=managed_identity
+
+# Run with secrets
+$ secretspec run --provider akv://myvault -- npm start
+```
+
+## Secret References
+
+By default each secret is stored as `secretspec--{project}--{profile}--{key}`. A
+secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing secret instead: `item` is the secret name (`field` and `version` are
+not yet supported). References are **read-only** in this provider.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "DB", ref = { item = "database-url" }, providers = ["akv://myvault"] }
+```
+
+## Usage
+
+### Basic Commands
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider akv://myvault
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to akv (profile: default)
+
+# Import from .env
+$ secretspec import dotenv://.env
+```
+
+### Secret Naming
+
+Azure Key Vault secret names may only contain ASCII letters, digits and
+hyphens — notably, unlike every other cloud provider, not underscores or
+slashes. Secrets are stored as: `secretspec--{project}--{profile}--{key}`,
+with underscores in each component rewritten to hyphens.
+
+Example: `DATABASE_URL` in project `myapp`, profile `production` becomes
+`secretspec--myapp--production--DATABASE-URL`.
+
+This rewrite is lossy: a project, profile, or key that differs only in using
+hyphens versus underscores (e.g. `FOO_BAR` and `FOO-BAR`) maps to the same Key
+Vault secret name. Prefer hyphens if that distinction matters to you.
+
+### CI/CD with a Service Principal
+
+```bash
+# Set credentials
+$ export AZURE_TENANT_ID="..."
+$ export AZURE_CLIENT_ID="..."
+$ export AZURE_CLIENT_SECRET="..."
+
+# Run command
+$ secretspec run --provider akv://myvault -- deploy
+```
+
+### AKS with Workload Identity
+
+```bash
+# AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE are
+# injected automatically into workload-identity-enabled pods.
+$ secretspec run --provider akv://myvault?auth=workload_identity -- deploy
+```

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -100,6 +100,7 @@ $ secretspec config init
   awssm: AWS Secrets Manager
   vault: HashiCorp Vault / OpenBao secret management
   bws: Bitwarden Secrets Manager
+  akv: Azure Key Vault
 ? Select your default profile:
 > development
   default

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -160,13 +160,14 @@ API endpoints are derived as `https://SERVER_BASE/identity` and
 
 ## Azure Key Vault Provider
 
-**URI**: `akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity]` - Stores secrets in Azure Key Vault
+**URI**: `akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity][&suffix=DNS_SUFFIX]` - Stores secrets in Azure Key Vault
 
 ```bash
 akv://myvault                            # Service principal env vars, falling back to `az login`
-akv://myvault?auth=managed_identity      # VM / App Service / AKS managed identity
+akv://myvault?auth=managed_identity      # VM / App Service / AKS system-assigned managed identity
 akv://myvault?auth=workload_identity     # AKS workload identity federation
 akv://myvault.vault.azure.cn             # Sovereign cloud (full DNS name)
+akv://myvault?suffix=vault.azure.cn      # Sovereign cloud (explicit suffix, bare vault name)
 ```
 
 **Features**: Read/write, cloud sync, profiles, service principal/managed identity/workload identity auth

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -158,6 +158,21 @@ API endpoints are derived as `https://SERVER_BASE/identity` and
 **Prerequisites**: BWS subscription, machine account access token, build with `--features bws`
 **Storage**: Flat key names in the specified BWS project
 
+## Azure Key Vault Provider
+
+**URI**: `akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity]` - Stores secrets in Azure Key Vault
+
+```bash
+akv://myvault                            # Service principal env vars, falling back to `az login`
+akv://myvault?auth=managed_identity      # VM / App Service / AKS managed identity
+akv://myvault?auth=workload_identity     # AKS workload identity federation
+akv://myvault.vault.azure.cn             # Sovereign cloud (full DNS name)
+```
+
+**Features**: Read/write, cloud sync, profiles, service principal/managed identity/workload identity auth
+**Prerequisites**: An Azure Key Vault instance, authenticated via one of the methods above, build with `--features akv`
+**Storage**: Secret name `secretspec--{project}--{profile}--{key}` (underscores rewritten to hyphens; Azure Key Vault secret names allow only letters, digits, and hyphens)
+
 ## Provider Selection
 
 ### Command Line
@@ -195,3 +210,4 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | AWSSM | ✅ AWS KMS | Cloud (AWS) | ✅ Yes |
 | Vault/OpenBao | ✅ Vault encryption | Vault/OpenBao server | ✅ Yes |
 | BWS | ✅ End-to-end | Cloud (Bitwarden) | ✅ Yes |
+| AKV | ✅ Azure-managed | Cloud (Azure) | ✅ Yes |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -36,6 +36,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'vault', slug: 'vault', label: 'Vault / OpenBao' },
   { slug: 'awssm', label: 'AWS Secrets Manager' },
   { icon: 'googlecloud', slug: 'gcsm', label: 'Google Cloud Secret Manager' },
+  { icon: 'microsoftazure', slug: 'akv', label: 'Azure Key Vault' },
   { slug: 'protonpass', label: 'Proton Pass' },
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },
@@ -50,7 +51,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
 <StarlightPage
   frontmatter={{
     title: 'Declare secrets once. Store them anywhere.',
-    description: 'Declare what your application needs in secretspec.toml — store the values in any of 11 backends. No secrets in git. Same code, every environment.',
+    description: 'Declare what your application needs in secretspec.toml — store the values in any of 12 backends. No secrets in git. Same code, every environment.',
     template: 'splash',
     hero: { tagline: '' },
   }}
@@ -82,7 +83,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
       <p class="landing-badge">Declarative secrets manager</p>
       <h1 id="_top" class="landing-hero-title">Declare secrets once.<br>Store them anywhere.</h1>
       <p class="landing-hero-subtitle">
-        Stop leaking <code class="inline-code">.env</code> files. Define what your application needs in <code class="inline-code">secretspec.toml</code>, then plug in keyring, 1Password, Vault, AWS, or any of 11 backends — same code, every environment.
+        Stop leaking <code class="inline-code">.env</code> files. Define what your application needs in <code class="inline-code">secretspec.toml</code>, then plug in keyring, 1Password, Vault, AWS, Azure, or any of 12 backends — same code, every environment.
       </p>
       <div class="landing-hero-actions">
         <a href="/quick-start/" class="landing-btn landing-btn-primary">Get Started</a>
@@ -186,7 +187,7 @@ $ secretspec run --profile production -- npm start
       <div class="landing-step">
         <span class="landing-step-num">2</span>
         <p class="landing-step-title">Configure</p>
-        <p class="landing-step-desc">Pick a backend: system keyring, 1Password, Vault, AWS, GCP, Bitwarden, Pass, dotenv, or env vars.</p>
+        <p class="landing-step-desc">Pick a backend: system keyring, 1Password, Vault, AWS, GCP, Azure, Bitwarden, Pass, dotenv, or env vars.</p>
         <pre is:raw class="landing-step-code"><code>$ secretspec config init
 ? Default provider: keyring</code></pre>
       </div>

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -40,6 +40,9 @@ rustls = { workspace = true, optional = true }
 google-cloud-secretmanager-v1 = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-secretsmanager = { workspace = true, optional = true }
+azure_core = { workspace = true, optional = true }
+azure_identity = { workspace = true, optional = true }
+azure_security_keyvault_secrets = { workspace = true, optional = true }
 tokio.workspace = true
 reqwest = { workspace = true, optional = true }
 rand.workspace = true
@@ -49,10 +52,11 @@ data-encoding.workspace = true
 detect-coding-agent.workspace = true
 
 [features]
-default = ["cli", "keyring", "gcsm", "awssm", "vault", "bws"]
+default = ["cli", "keyring", "gcsm", "awssm", "vault", "bws", "akv"]
 cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 vault = ["dep:reqwest"]
 bws = ["dep:bitwarden", "dep:rustls"]
+akv = ["dep:azure_core", "dep:azure_identity", "dep:azure_security_keyvault_secrets"]

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -28,6 +28,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
   - [Vault/OpenBao](https://secretspec.dev/providers/vault)
   - [Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)
+  - [Azure Key Vault](https://secretspec.dev/providers/akv)
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
 - **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
@@ -61,6 +62,7 @@ $ secretspec config init
   awssm: AWS Secrets Manager
   vault: HashiCorp Vault / OpenBao secret management
   bws: Bitwarden Secrets Manager
+  akv: Azure Key Vault
 ? Select your default profile:
 > development
   default
@@ -143,6 +145,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[AWS Secrets Manager](https://secretspec.dev/providers/awssm)** - AWS secret management
 - **[Vault / OpenBao](https://secretspec.dev/providers/vault)** - HashiCorp Vault and OpenBao KV engine
 - **[Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)** - Bitwarden Secrets Manager integration
+- **[Azure Key Vault](https://secretspec.dev/providers/akv)** - Azure secret management
 
 ```bash
 $ secretspec run --provider keyring -- npm start

--- a/secretspec/src/provider/akv.rs
+++ b/secretspec/src/provider/akv.rs
@@ -1,0 +1,542 @@
+//! Azure Key Vault provider
+//!
+//! This provider integrates with Azure Key Vault to store and retrieve secrets.
+//!
+//! # Authentication
+//!
+//! Unlike the AWS and GCP SDKs, the Rust Azure SDK does not (yet) ship a single
+//! "try everything" default credential, so the authentication method is chosen
+//! explicitly via the `auth` query parameter:
+//!
+//! - `auth=env` (default) -- reads a service principal from the `AZURE_TENANT_ID`,
+//!   `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` environment variables. If those
+//!   are not set, falls back to the signed-in Azure CLI / Azure Developer CLI
+//!   session (equivalent to `auth=cli`), so local development works out of the
+//!   box after `az login`.
+//! - `auth=cli` -- only the Azure CLI / Azure Developer CLI session.
+//! - `auth=managed_identity` -- the VM/App Service/AKS system-assigned managed
+//!   identity.
+//! - `auth=workload_identity` -- AKS workload identity federation, via the
+//!   `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_FEDERATED_TOKEN_FILE`
+//!   environment variables injected by AKS.
+//!
+//! # URI Format
+//!
+//! `akv://<vault-name>[?auth=env|cli|managed_identity|workload_identity]`
+//!
+//! - `akv://myvault` -- `https://myvault.vault.azure.net/`
+//! - `akv://myvault?auth=managed_identity` -- authenticate via managed identity
+//! - `akv://myvault.vault.azure.cn` -- a host containing a dot is used verbatim
+//!   as the vault's DNS name, for sovereign clouds (China, US Gov, Germany)
+//!   whose Key Vault suffix is not `.vault.azure.net`
+//!
+//! # Secret Naming
+//!
+//! Azure Key Vault secret names may only contain ASCII letters, digits and
+//! hyphens (`^[0-9a-zA-Z-]+$`, 1-127 characters) -- notably, unlike every other
+//! cloud provider in this codebase, *not* underscores or slashes. Convention
+//! secrets are named `secretspec--{project}--{profile}--{key}`, with each
+//! component's underscores rewritten to hyphens to fit that charset. This is
+//! lossy: `FOO_BAR` and `FOO-BAR` map to the same Key Vault secret name. Prefer
+//! hyphens over underscores in project/profile/key names if that matters to you.
+//!
+//! # Example
+//!
+//! ```bash
+//! # Set a secret (reads AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET,
+//! # or falls back to `az login`)
+//! secretspec set DATABASE_URL --provider akv://myvault
+//!
+//! # Use a managed identity (e.g. from a VM or App Service)
+//! secretspec check --provider akv://myvault?auth=managed_identity
+//! ```
+
+use super::{Address, Provider, ProviderUrl};
+use crate::{Result, SecretSpecError};
+use azure_core::credentials::TokenCredential;
+use azure_identity::{
+    ClientSecretCredential, DeveloperToolsCredential, ManagedIdentityCredential,
+    WorkloadIdentityCredential,
+};
+use azure_security_keyvault_secrets::{SecretClient, models::SetSecretParameters};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Authentication method for the Azure Key Vault provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum AuthMethod {
+    /// Service principal via env vars, falling back to the Azure CLI / azd session.
+    #[default]
+    Env,
+    /// Azure CLI / Azure Developer CLI session only (`az login`).
+    Cli,
+    /// VM / App Service / AKS system-assigned managed identity.
+    ManagedIdentity,
+    /// AKS workload identity federation.
+    WorkloadIdentity,
+}
+
+/// Configuration for the Azure Key Vault provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AkvConfig {
+    /// The vault name (short form) or full DNS name (sovereign clouds).
+    pub vault_host: String,
+    /// The full `https://...` base URL derived from `vault_host`.
+    pub vault_url: String,
+    /// Authentication method (default: Env).
+    pub auth: AuthMethod,
+}
+
+/// The public-cloud Key Vault DNS suffix. Sovereign clouds (China, US Gov,
+/// Germany) use a different suffix and must be addressed by their full DNS
+/// name (a host containing a `.`), since there is no single suffix that works
+/// for all of them.
+const DEFAULT_SUFFIX: &str = "vault.azure.net";
+
+impl TryFrom<&ProviderUrl> for AkvConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "akv" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for akv provider. Expected 'akv'.",
+                url.scheme()
+            )));
+        }
+
+        let vault_host = url.host().filter(|s| !s.is_empty()).ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(
+                "Azure Key Vault name is required. Use format: akv://myvault".to_string(),
+            )
+        })?;
+
+        // A host containing a dot is already a full DNS name (sovereign
+        // clouds); a bare name gets the public-cloud suffix appended.
+        let vault_url = if vault_host.contains('.') {
+            format!("https://{}/", vault_host)
+        } else {
+            format!("https://{}.{}/", vault_host, DEFAULT_SUFFIX)
+        };
+
+        let auth = url
+            .query_value("auth")
+            .map(|v| match v.as_str() {
+                "env" => Ok(AuthMethod::Env),
+                "cli" => Ok(AuthMethod::Cli),
+                "managed_identity" => Ok(AuthMethod::ManagedIdentity),
+                "workload_identity" => Ok(AuthMethod::WorkloadIdentity),
+                other => Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Unknown auth method '{}'. Expected 'env', 'cli', 'managed_identity', \
+                     or 'workload_identity'.",
+                    other
+                ))),
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        // The path/field reference form from other providers is rejected here
+        // too: akv URIs take no path, secrets are addressed via `ref` instead.
+        let path = url.path();
+        let trimmed = path.trim_start_matches('/');
+        if !trimmed.is_empty() {
+            let hint = crate::config::ref_table_hint(None, trimmed, None, None);
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "akv URIs take no path: address the secret with {hint} on the secret instead"
+            )));
+        }
+
+        Ok(Self {
+            vault_host,
+            vault_url,
+            auth,
+        })
+    }
+}
+
+/// Azure Key Vault provider.
+///
+/// Stores and retrieves secrets from an Azure Key Vault instance.
+pub struct AkvProvider {
+    config: AkvConfig,
+}
+
+crate::register_provider! {
+    struct: AkvProvider,
+    config: AkvConfig,
+    name: "akv",
+    description: "Azure Key Vault",
+    schemes: ["akv"],
+    examples: ["akv://myvault", "akv://myvault?auth=managed_identity"],
+}
+
+impl AkvProvider {
+    /// Creates a new AkvProvider with the given configuration.
+    pub fn new(config: AkvConfig) -> Self {
+        Self { config }
+    }
+
+    /// Validates a secret name component against the characters Azure Key
+    /// Vault allows once mapped (alphanumeric, underscore, hyphen -- the
+    /// underscore is rewritten to a hyphen by the caller, everything else is
+    /// rejected up front rather than silently dropped).
+    fn validate_name_component(name: &str, component: &str) -> Result<()> {
+        if component.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{} cannot be empty",
+                name
+            )));
+        }
+        for c in component.chars() {
+            if !c.is_ascii_alphanumeric() && c != '_' && c != '-' {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "{} contains invalid character '{}'. \
+                    Only alphanumeric characters, underscores, and hyphens are allowed",
+                    name, c
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Formats and validates the secret name for Azure Key Vault.
+    ///
+    /// Converts the SecretSpec path format to an Azure-compatible name:
+    /// `secretspec--{project}--{profile}--{key}`, with underscores in each
+    /// component rewritten to hyphens (Azure Key Vault secret names may only
+    /// contain `[0-9a-zA-Z-]`, 1-127 characters).
+    fn format_secret_name(project: &str, profile: &str, key: &str) -> Result<String> {
+        Self::validate_name_component("project", project)?;
+        Self::validate_name_component("profile", profile)?;
+        Self::validate_name_component("key", key)?;
+
+        let sanitize = |s: &str| s.replace('_', "-");
+        let secret_name = format!(
+            "secretspec--{}--{}--{}",
+            sanitize(project),
+            sanitize(profile),
+            sanitize(key)
+        );
+
+        if secret_name.len() > 127 {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Secret name too long: {} characters (max 127)",
+                secret_name.len()
+            )));
+        }
+
+        Ok(secret_name)
+    }
+
+    /// Resolves the token credential for the configured auth method.
+    fn resolve_credential(&self) -> Result<Arc<dyn TokenCredential>> {
+        match self.config.auth {
+            AuthMethod::Cli => Ok(DeveloperToolsCredential::new(None).map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to create Azure CLI / azd credential: {}",
+                    e
+                ))
+            })? as Arc<dyn TokenCredential>),
+            AuthMethod::ManagedIdentity => {
+                Ok(ManagedIdentityCredential::new(None).map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to create managed identity credential: {}",
+                        e
+                    ))
+                })? as Arc<dyn TokenCredential>)
+            }
+            AuthMethod::WorkloadIdentity => {
+                Ok(WorkloadIdentityCredential::new(None).map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to create workload identity credential: {}\n\n\
+                        Requires the AZURE_TENANT_ID, AZURE_CLIENT_ID, and \
+                        AZURE_FEDERATED_TOKEN_FILE environment variables that AKS \
+                        injects automatically for workload-identity-enabled pods.",
+                        e
+                    ))
+                })? as Arc<dyn TokenCredential>)
+            }
+            AuthMethod::Env => {
+                let tenant_id = std::env::var("AZURE_TENANT_ID").ok();
+                let client_id = std::env::var("AZURE_CLIENT_ID").ok();
+                let client_secret = std::env::var("AZURE_CLIENT_SECRET").ok();
+
+                if let (Some(tenant_id), Some(client_id), Some(client_secret)) =
+                    (tenant_id, client_id, client_secret)
+                {
+                    // NOTE: `azure_identity` is a very new (v1.0), fast-moving
+                    // crate; verify this constructor's exact parameter types
+                    // with `cargo check --features akv` before relying on it,
+                    // in case the secret parameter type has changed.
+                    Ok(ClientSecretCredential::new(
+                        tenant_id,
+                        client_id,
+                        SecretString::new(client_secret.into()),
+                        None,
+                    )
+                    .map_err(|e| {
+                        SecretSpecError::ProviderOperationFailed(format!(
+                            "Failed to create service principal credential from \
+                            AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET: {}",
+                            e
+                        ))
+                    })? as Arc<dyn TokenCredential>)
+                } else {
+                    // No service principal env vars: fall back to the signed-in
+                    // Azure CLI / azd session so local development works after
+                    // `az login` without any extra configuration.
+                    Ok(DeveloperToolsCredential::new(None).map_err(|e| {
+                        SecretSpecError::ProviderOperationFailed(format!(
+                            "No AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET set, and \
+                            failed to fall back to the Azure CLI / azd session: {}\n\n\
+                            Either set those three environment variables, or run `az login`.",
+                            e
+                        ))
+                    })? as Arc<dyn TokenCredential>)
+                }
+            }
+        }
+    }
+
+    /// Creates a SecretClient for the configured vault.
+    fn create_client(&self) -> Result<SecretClient> {
+        let credential = self.resolve_credential()?;
+        SecretClient::new(&self.config.vault_url, credential, None).map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to create Azure Key Vault client for {}: {}",
+                self.config.vault_url, e
+            ))
+        })
+    }
+
+    /// Checks whether an error indicates the secret was not found.
+    fn is_not_found_error(e: &impl std::error::Error) -> bool {
+        let s = e.to_string();
+        s.contains("SecretNotFound") || s.contains("404")
+    }
+
+    /// Retrieves a secret's current value by name, mapping "not found" to `None`.
+    async fn get_secret_async(&self, name: &str) -> Result<Option<SecretString>> {
+        let client = self.create_client()?;
+        match client.get_secret(name, None).await {
+            Ok(response) => {
+                let secret = response.into_model().map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to read secret '{}' from Azure Key Vault: {}",
+                        name, e
+                    ))
+                })?;
+                Ok(secret.value.map(|v| SecretString::new(v.into())))
+            }
+            Err(e) => {
+                if Self::is_not_found_error(&e) {
+                    Ok(None)
+                } else {
+                    Err(SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to get secret '{}' from Azure Key Vault: {}",
+                        name, e
+                    )))
+                }
+            }
+        }
+    }
+
+    /// Sets a secret's value by name. Azure Key Vault's SET operation always
+    /// creates a new version if the secret already exists, so create and
+    /// update share this one call.
+    async fn set_secret_async(&self, name: &str, value: &SecretString) -> Result<()> {
+        let client = self.create_client()?;
+        let params = SetSecretParameters {
+            value: Some(value.expose_secret().to_string()),
+            ..Default::default()
+        };
+        client
+            .set_secret(
+                name,
+                params.try_into().map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to build set-secret request for '{}': {}",
+                        name, e
+                    ))
+                })?,
+                None,
+            )
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to set secret '{}' in Azure Key Vault: {}",
+                    name, e
+                ))
+            })?;
+        Ok(())
+    }
+}
+
+impl Provider for AkvProvider {
+    /// Convention secrets are named `secretspec--{project}--{profile}--{key}`
+    /// (Azure Key Vault secret names cannot contain underscores or slashes).
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: Self::format_secret_name(project, profile, key)?,
+            ..Default::default()
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let mut uri = format!("akv://{}", self.config.vault_host);
+        if self.config.auth != AuthMethod::default() {
+            let auth = match self.config.auth {
+                AuthMethod::Env => "env",
+                AuthMethod::Cli => "cli",
+                AuthMethod::ManagedIdentity => "managed_identity",
+                AuthMethod::WorkloadIdentity => "workload_identity",
+            };
+            uri.push_str("?auth=");
+            uri.push_str(auth);
+        }
+        uri
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.get_secret_async(&coords.item))
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.set_secret_async(&coords.item, value))
+    }
+
+    /// Native addresses are read-only: they name a secret managed outside
+    /// SecretSpec, and writing would mint a new version of it.
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Convention { .. } => Ok(()),
+            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(
+                "akv secret references are read-only and cannot be written".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    fn config(s: &str) -> AkvConfig {
+        AkvConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap()
+    }
+
+    #[test]
+    fn test_format_secret_name() {
+        let name = AkvProvider::format_secret_name("myapp", "prod", "DB_URL").unwrap();
+        assert_eq!(name, "secretspec--myapp--prod--DB-URL");
+    }
+
+    #[test]
+    fn test_format_secret_name_rejects_invalid_chars() {
+        assert!(AkvProvider::format_secret_name("my/app", "prod", "DB_URL").is_err());
+        assert!(AkvProvider::format_secret_name("myapp", "prod", "DB URL").is_err());
+    }
+
+    #[test]
+    fn test_format_secret_name_too_long() {
+        let long_key = "A".repeat(127);
+        let result = AkvProvider::format_secret_name("myapp", "prod", &long_key);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vault_url_appends_public_suffix_for_bare_name() {
+        let c = config("akv://myvault");
+        assert_eq!(c.vault_url, "https://myvault.vault.azure.net/");
+    }
+
+    #[test]
+    fn test_vault_url_uses_fqdn_verbatim_for_sovereign_clouds() {
+        let c = config("akv://myvault.vault.azure.cn");
+        assert_eq!(c.vault_url, "https://myvault.vault.azure.cn/");
+    }
+
+    #[test]
+    fn test_default_auth_is_env() {
+        let c = config("akv://myvault");
+        assert_eq!(c.auth, AuthMethod::Env);
+    }
+
+    #[test]
+    fn test_auth_query_param() {
+        let c = config("akv://myvault?auth=managed_identity");
+        assert_eq!(c.auth, AuthMethod::ManagedIdentity);
+    }
+
+    #[test]
+    fn test_unknown_auth_method_errors() {
+        assert!(AkvConfig::try_from(&ProviderUrl::new(
+            Url::parse("akv://myvault?auth=bogus").unwrap()
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn test_convention_address() {
+        let p = AkvProvider::new(config("akv://myvault"));
+        let coords = p.convention_address("proj", "default", "A").unwrap();
+        assert_eq!(coords.item, "secretspec--proj--default--A");
+        assert_eq!(coords.field, None);
+    }
+
+    /// Native addresses are read-only: they name secrets managed outside
+    /// SecretSpec.
+    #[test]
+    fn native_address_is_read_only() {
+        let p = AkvProvider::new(config("akv://myvault"));
+        let addr = crate::config::NativeAddress {
+            item: "existing-secret".into(),
+            ..Default::default()
+        };
+        let refusal = p.check_writable(Address::Native(&addr)).unwrap_err();
+        assert!(refusal.to_string().contains("read-only"), "{refusal}");
+        let err = p
+            .set(
+                Address::Native(&addr),
+                &secrecy::SecretString::new("v".into()),
+            )
+            .unwrap_err();
+        assert_eq!(err.to_string(), refusal.to_string());
+    }
+
+    /// Azure Key Vault secrets have no sub-fields; the coordinate is rejected
+    /// before any network I/O.
+    #[test]
+    fn native_address_rejects_field() {
+        let p = AkvProvider::new(config("akv://myvault"));
+        let addr = crate::config::NativeAddress {
+            item: "existing-secret".into(),
+            field: Some("x".into()),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
+    }
+
+    #[test]
+    fn test_path_is_rejected_with_ref_hint() {
+        let err = AkvConfig::try_from(&ProviderUrl::new(
+            Url::parse("akv://myvault/some/path").unwrap(),
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("ref"), "{err}");
+    }
+}

--- a/secretspec/src/provider/akv.rs
+++ b/secretspec/src/provider/akv.rs
@@ -9,10 +9,12 @@
 //! explicitly via the `auth` query parameter:
 //!
 //! - `auth=env` (default) -- reads a service principal from the `AZURE_TENANT_ID`,
-//!   `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` environment variables. If those
-//!   are not set, falls back to the signed-in Azure CLI / Azure Developer CLI
-//!   session (equivalent to `auth=cli`), so local development works out of the
-//!   box after `az login`.
+//!   `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` environment variables. All
+//!   three must be set (and non-empty) together; if none are set, this falls
+//!   back to the signed-in Azure CLI / Azure Developer CLI session (equivalent
+//!   to `auth=cli`), so local development works out of the box after
+//!   `az login`. If only some are set, this is an error rather than a silent
+//!   fallback to a different identity.
 //! - `auth=cli` -- only the Azure CLI / Azure Developer CLI session.
 //! - `auth=managed_identity` -- the VM/App Service/AKS system-assigned managed
 //!   identity.
@@ -22,13 +24,15 @@
 //!
 //! # URI Format
 //!
-//! `akv://<vault-name>[?auth=env|cli|managed_identity|workload_identity]`
+//! `akv://<vault-name>[?auth=env|cli|managed_identity|workload_identity][&suffix=<dns-suffix>]`
 //!
 //! - `akv://myvault` -- `https://myvault.vault.azure.net/`
 //! - `akv://myvault?auth=managed_identity` -- authenticate via managed identity
 //! - `akv://myvault.vault.azure.cn` -- a host containing a dot is used verbatim
 //!   as the vault's DNS name, for sovereign clouds (China, US Gov, Germany)
 //!   whose Key Vault suffix is not `.vault.azure.net`
+//! - `akv://myvault?suffix=vault.azure.cn` -- an explicit, first-class way to
+//!   address a sovereign cloud without needing to spell out the full DNS name
 //!
 //! # Secret Naming
 //!
@@ -38,7 +42,16 @@
 //! secrets are named `secretspec--{project}--{profile}--{key}`, with each
 //! component's underscores rewritten to hyphens to fit that charset. This is
 //! lossy: `FOO_BAR` and `FOO-BAR` map to the same Key Vault secret name. Prefer
-//! hyphens over underscores in project/profile/key names if that matters to you.
+//! hyphens over underscores in project/profile/key names if that matters to
+//! you. A component containing a literal `--` or a `__` (which sanitizes to
+//! `--`) is rejected outright, since it would be indistinguishable from the
+//! delimiter joining project/profile/key and could silently collide with a
+//! different secret.
+//!
+//! Native `ref` addresses (naming a secret that already exists in the vault)
+//! are validated against this same charset but never rewritten: silently
+//! rewriting characters in a user-specified `ref` could silently point at a
+//! different secret than the one they named.
 //!
 //! # Example
 //!
@@ -54,6 +67,7 @@
 use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use azure_core::credentials::{Secret, TokenCredential};
+use azure_core::http::StatusCode;
 use azure_identity::{
     ClientSecretCredential, DeveloperToolsCredential, ManagedIdentityCredential,
     WorkloadIdentityCredential,
@@ -77,6 +91,38 @@ pub enum AuthMethod {
     WorkloadIdentity,
 }
 
+impl AuthMethod {
+    /// The `?auth=` query-string spelling of this auth method.
+    fn as_str(self) -> &'static str {
+        match self {
+            AuthMethod::Env => "env",
+            AuthMethod::Cli => "cli",
+            AuthMethod::ManagedIdentity => "managed_identity",
+            AuthMethod::WorkloadIdentity => "workload_identity",
+        }
+    }
+}
+
+impl std::str::FromStr for AuthMethod {
+    type Err = SecretSpecError;
+
+    /// The inverse of [`AuthMethod::as_str`] -- kept as a single pair so the
+    /// two directions can't drift out of sync.
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "env" => Ok(AuthMethod::Env),
+            "cli" => Ok(AuthMethod::Cli),
+            "managed_identity" => Ok(AuthMethod::ManagedIdentity),
+            "workload_identity" => Ok(AuthMethod::WorkloadIdentity),
+            other => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Unknown auth method '{}'. Expected 'env', 'cli', 'managed_identity', \
+                 or 'workload_identity'.",
+                other
+            ))),
+        }
+    }
+}
+
 /// Configuration for the Azure Key Vault provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AkvConfig {
@@ -86,12 +132,17 @@ pub struct AkvConfig {
     pub vault_url: String,
     /// Authentication method (default: Env).
     pub auth: AuthMethod,
+    /// Explicit Key Vault DNS suffix override for a bare `vault_host`, given
+    /// via `?suffix=`. `None` when `vault_host` is already a full DNS name
+    /// (contains a dot) or the default public suffix was used, so `uri()`
+    /// only emits `suffix` when it was actually given.
+    pub suffix: Option<String>,
 }
 
 /// The public-cloud Key Vault DNS suffix. Sovereign clouds (China, US Gov,
 /// Germany) use a different suffix and must be addressed by their full DNS
-/// name (a host containing a `.`), since there is no single suffix that works
-/// for all of them.
+/// name (a host containing a `.`) or an explicit `?suffix=`, since there is
+/// no single suffix that works for all of them.
 const DEFAULT_SUFFIX: &str = "vault.azure.net";
 
 impl TryFrom<&ProviderUrl> for AkvConfig {
@@ -112,26 +163,20 @@ impl TryFrom<&ProviderUrl> for AkvConfig {
         })?;
 
         // A host containing a dot is already a full DNS name (sovereign
-        // clouds); a bare name gets the public-cloud suffix appended.
-        let vault_url = if vault_host.contains('.') {
-            format!("https://{}/", vault_host)
+        // clouds); a bare name gets the public-cloud suffix, or an explicit
+        // `?suffix=` override, appended.
+        let (vault_url, suffix) = if vault_host.contains('.') {
+            (format!("https://{}/", vault_host), None)
         } else {
-            format!("https://{}.{}/", vault_host, DEFAULT_SUFFIX)
+            match url.query_value("suffix") {
+                Some(suffix) => (format!("https://{}.{}/", vault_host, suffix), Some(suffix)),
+                None => (format!("https://{}.{}/", vault_host, DEFAULT_SUFFIX), None),
+            }
         };
 
         let auth = url
             .query_value("auth")
-            .map(|v| match v.as_str() {
-                "env" => Ok(AuthMethod::Env),
-                "cli" => Ok(AuthMethod::Cli),
-                "managed_identity" => Ok(AuthMethod::ManagedIdentity),
-                "workload_identity" => Ok(AuthMethod::WorkloadIdentity),
-                other => Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "Unknown auth method '{}'. Expected 'env', 'cli', 'managed_identity', \
-                     or 'workload_identity'.",
-                    other
-                ))),
-            })
+            .map(|v| v.parse::<AuthMethod>())
             .transpose()?
             .unwrap_or_default();
 
@@ -150,6 +195,7 @@ impl TryFrom<&ProviderUrl> for AkvConfig {
             vault_host,
             vault_url,
             auth,
+            suffix,
         })
     }
 }
@@ -167,7 +213,7 @@ crate::register_provider! {
     name: "akv",
     description: "Azure Key Vault",
     schemes: ["akv"],
-    examples: ["akv://myvault", "akv://myvault?auth=managed_identity"],
+    examples: ["akv://myvault", "akv://myvault?auth=managed_identity", "akv://myvault?suffix=vault.azure.cn"],
 }
 
 impl AkvProvider {
@@ -199,23 +245,44 @@ impl AkvProvider {
         Ok(())
     }
 
+    /// Sanitizes a single name component (`_` -> `-`) and rejects the result
+    /// if it contains `--`, which is indistinguishable from the delimiter
+    /// used to join `project`/`profile`/`key` in [`format_secret_name`].
+    /// Without this check, a literal `--` or a `__` (which sanitizes to `--`)
+    /// in one component can produce the exact same secret name as different
+    /// project/profile/key values -- e.g. `("a", "b__c", "d")` and
+    /// `("a", "b", "c__d")` would otherwise both map to
+    /// `secretspec--a--b--c--d`.
+    fn sanitize_name_component(name: &str, component: &str) -> Result<String> {
+        let sanitized = component.replace('_', "-");
+        if sanitized.contains("--") {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{name} '{component}' contains a double underscore or double hyphen, which \
+                 sanitizes to the same '--' delimiter used between project/profile/key and \
+                 can collide with a different secret. Use single underscores or hyphens instead."
+            )));
+        }
+        Ok(sanitized)
+    }
+
     /// Formats and validates the secret name for Azure Key Vault.
     ///
     /// Converts the SecretSpec path format to an Azure-compatible name:
     /// `secretspec--{project}--{profile}--{key}`, with underscores in each
     /// component rewritten to hyphens (Azure Key Vault secret names may only
-    /// contain `[0-9a-zA-Z-]`, 1-127 characters).
+    /// contain `[0-9a-zA-Z-]`, 1-127 characters). Rejects components that
+    /// would collide with a different project/profile/key combination once
+    /// sanitized (see [`sanitize_name_component`](Self::sanitize_name_component)).
     fn format_secret_name(project: &str, profile: &str, key: &str) -> Result<String> {
         Self::validate_name_component("project", project)?;
         Self::validate_name_component("profile", profile)?;
         Self::validate_name_component("key", key)?;
 
-        let sanitize = |s: &str| s.replace('_', "-");
         let secret_name = format!(
             "secretspec--{}--{}--{}",
-            sanitize(project),
-            sanitize(profile),
-            sanitize(key)
+            Self::sanitize_name_component("project", project)?,
+            Self::sanitize_name_component("profile", profile)?,
+            Self::sanitize_name_component("key", key)?
         );
 
         if secret_name.len() > 127 {
@@ -226,6 +293,68 @@ impl AkvProvider {
         }
 
         Ok(secret_name)
+    }
+
+    /// Resolves an address to a validated Azure Key Vault secret name.
+    ///
+    /// Convention addresses are already Azure-legal by construction
+    /// (`format_secret_name` validates and rewrites them). Native `ref`
+    /// addresses name a secret that already exists in the vault, so they are
+    /// validated but never rewritten -- silently rewriting characters in a
+    /// user-specified `ref` could silently point at a different secret than
+    /// the one they named.
+    fn resolve_item(&self, addr: Address<'_>) -> Result<String> {
+        let coords = self.resolve_coords(addr)?;
+        let item = coords.item.clone();
+        let valid = !item.is_empty()
+            && item.len() <= 127
+            && item.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+        if !valid {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "'{item}' is not a valid Azure Key Vault secret name: only ASCII letters, \
+                 digits, and hyphens are allowed (1-127 characters). Azure Key Vault has no \
+                 underscores; if this `ref` names a real secret, use the vault's actual name."
+            )));
+        }
+        Ok(item)
+    }
+
+    /// Reads an environment variable, treating an unset or blank value as absent.
+    fn non_empty_env(name: &str) -> Option<String> {
+        std::env::var(name).ok().filter(|v| !v.is_empty())
+    }
+
+    /// Classifies a service-principal env-var triple: all three present
+    /// resolves to `Some`, none present resolves to `None` (fall back to the
+    /// CLI session), and a partial set is an error -- silently falling back
+    /// to a different identity when e.g. only `AZURE_CLIENT_SECRET` is
+    /// missing would be confusing and could authenticate as the wrong
+    /// principal (e.g. the developer's personal `az login` session).
+    fn classify_env_credentials(
+        tenant_id: Option<String>,
+        client_id: Option<String>,
+        client_secret: Option<String>,
+    ) -> Result<Option<(String, String, String)>> {
+        match (tenant_id, client_id, client_secret) {
+            (Some(t), Some(c), Some(s)) => Ok(Some((t, c, s))),
+            (None, None, None) => Ok(None),
+            (tenant_id, client_id, client_secret) => {
+                let missing: Vec<&str> = [
+                    ("AZURE_TENANT_ID", tenant_id.is_none()),
+                    ("AZURE_CLIENT_ID", client_id.is_none()),
+                    ("AZURE_CLIENT_SECRET", client_secret.is_none()),
+                ]
+                .into_iter()
+                .filter_map(|(name, is_missing)| is_missing.then_some(name))
+                .collect();
+                Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Partial service principal configuration: AZURE_TENANT_ID, \
+                     AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET must all be set together, or \
+                     none of them (to fall back to `az login`). Missing: {}.",
+                    missing.join(", ")
+                )))
+            }
+        }
     }
 
     /// Resolves the token credential for the configured auth method.
@@ -257,38 +386,39 @@ impl AkvProvider {
                 })? as Arc<dyn TokenCredential>)
             }
             AuthMethod::Env => {
-                let tenant_id = std::env::var("AZURE_TENANT_ID").ok();
-                let client_id = std::env::var("AZURE_CLIENT_ID").ok();
-                let client_secret = std::env::var("AZURE_CLIENT_SECRET").ok();
+                let tenant_id = Self::non_empty_env("AZURE_TENANT_ID");
+                let client_id = Self::non_empty_env("AZURE_CLIENT_ID");
+                let client_secret = Self::non_empty_env("AZURE_CLIENT_SECRET");
 
-                if let (Some(tenant_id), Some(client_id), Some(client_secret)) =
-                    (tenant_id, client_id, client_secret)
-                {
-                    Ok(ClientSecretCredential::new(
-                        &tenant_id,
-                        client_id,
-                        Secret::new(client_secret),
-                        None,
-                    )
-                    .map_err(|e| {
-                        SecretSpecError::ProviderOperationFailed(format!(
-                            "Failed to create service principal credential from \
-                            AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET: {}",
-                            e
-                        ))
-                    })? as Arc<dyn TokenCredential>)
-                } else {
-                    // No service principal env vars: fall back to the signed-in
-                    // Azure CLI / azd session so local development works after
-                    // `az login` without any extra configuration.
-                    Ok(DeveloperToolsCredential::new(None).map_err(|e| {
-                        SecretSpecError::ProviderOperationFailed(format!(
-                            "No AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET set, and \
-                            failed to fall back to the Azure CLI / azd session: {}\n\n\
-                            Either set those three environment variables, or run `az login`.",
-                            e
-                        ))
-                    })? as Arc<dyn TokenCredential>)
+                match Self::classify_env_credentials(tenant_id, client_id, client_secret)? {
+                    Some((tenant_id, client_id, client_secret)) => {
+                        Ok(ClientSecretCredential::new(
+                            &tenant_id,
+                            client_id,
+                            Secret::new(client_secret),
+                            None,
+                        )
+                        .map_err(|e| {
+                            SecretSpecError::ProviderOperationFailed(format!(
+                                "Failed to create service principal credential from \
+                                AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET: {}",
+                                e
+                            ))
+                        })? as Arc<dyn TokenCredential>)
+                    }
+                    None => {
+                        // No service principal env vars: fall back to the signed-in
+                        // Azure CLI / azd session so local development works after
+                        // `az login` without any extra configuration.
+                        Ok(DeveloperToolsCredential::new(None).map_err(|e| {
+                            SecretSpecError::ProviderOperationFailed(format!(
+                                "No AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET set, and \
+                                failed to fall back to the Azure CLI / azd session: {}\n\n\
+                                Either set those three environment variables, or run `az login`.",
+                                e
+                            ))
+                        })? as Arc<dyn TokenCredential>)
+                    }
                 }
             }
         }
@@ -305,10 +435,14 @@ impl AkvProvider {
         })
     }
 
-    /// Checks whether an error indicates the secret was not found.
-    fn is_not_found_error(e: &impl std::error::Error) -> bool {
-        let s = e.to_string();
-        s.contains("SecretNotFound") || s.contains("404")
+    /// Checks whether an error indicates the secret was not found, via the
+    /// typed HTTP status code rather than string-matching the error's
+    /// `Display` output (a genuine 404's message is the service's plain-text
+    /// description, e.g. "A secret with (name) was not found in this key
+    /// vault" -- it does not contain the literal text "SecretNotFound" or
+    /// "404", so matching on those strings misses real not-found responses).
+    fn is_not_found_error(e: &azure_core::Error) -> bool {
+        e.http_status() == Some(StatusCode::NotFound)
     }
 
     /// Retrieves a secret's current value by name, mapping "not found" to `None`.
@@ -389,28 +523,29 @@ impl Provider for AkvProvider {
 
     fn uri(&self) -> String {
         let mut uri = format!("akv://{}", self.config.vault_host);
+        let mut params = Vec::new();
         if self.config.auth != AuthMethod::default() {
-            let auth = match self.config.auth {
-                AuthMethod::Env => "env",
-                AuthMethod::Cli => "cli",
-                AuthMethod::ManagedIdentity => "managed_identity",
-                AuthMethod::WorkloadIdentity => "workload_identity",
-            };
-            uri.push_str("?auth=");
-            uri.push_str(auth);
+            params.push(format!("auth={}", self.config.auth.as_str()));
+        }
+        if let Some(suffix) = &self.config.suffix {
+            params.push(format!("suffix={suffix}"));
+        }
+        if !params.is_empty() {
+            uri.push('?');
+            uri.push_str(&params.join("&"));
         }
         uri
     }
 
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
-        let coords = self.resolve_coords(addr)?;
-        super::block_on(self.get_secret_async(&coords.item))
+        let item = self.resolve_item(addr)?;
+        super::block_on(self.get_secret_async(&item))
     }
 
     fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
         self.check_writable(addr)?;
-        let coords = self.resolve_coords(addr)?;
-        super::block_on(self.set_secret_async(&coords.item, value))
+        let item = self.resolve_item(addr)?;
+        super::block_on(self.set_secret_async(&item, value))
     }
 
     /// Native addresses are read-only: they name a secret managed outside
@@ -428,6 +563,7 @@ impl Provider for AkvProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use azure_core::error::ErrorKind;
     use url::Url;
 
     fn config(s: &str) -> AkvConfig {
@@ -454,15 +590,114 @@ mod tests {
     }
 
     #[test]
+    fn test_format_secret_name_rejects_double_underscore_collision() {
+        // Without rejection, "b__c" and "b" + "c__d" would both sanitize to
+        // the same "secretspec--a--b--c--d" name.
+        assert!(AkvProvider::format_secret_name("a", "b__c", "d").is_err());
+        assert!(AkvProvider::format_secret_name("a", "b", "c__d").is_err());
+    }
+
+    #[test]
+    fn test_format_secret_name_rejects_double_hyphen_collision() {
+        assert!(AkvProvider::format_secret_name("a--b", "c", "d").is_err());
+    }
+
+    #[test]
+    fn test_classify_env_credentials_all_set() {
+        let result = AkvProvider::classify_env_credentials(
+            Some("t".to_string()),
+            Some("c".to_string()),
+            Some("s".to_string()),
+        );
+        assert_eq!(
+            result.unwrap(),
+            Some(("t".to_string(), "c".to_string(), "s".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_classify_env_credentials_none_set() {
+        let result = AkvProvider::classify_env_credentials(None, None, None);
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_classify_env_credentials_partial_errors() {
+        let err =
+            AkvProvider::classify_env_credentials(Some("t".to_string()), None, None).unwrap_err();
+        assert!(err.to_string().contains("AZURE_CLIENT_ID"), "{err}");
+        assert!(err.to_string().contains("AZURE_CLIENT_SECRET"), "{err}");
+    }
+
+    #[test]
+    fn test_is_not_found_error_uses_http_status_not_string_matching() {
+        let not_found = azure_core::Error::from(ErrorKind::HttpResponse {
+            status: StatusCode::NotFound,
+            error_code: Some("SecretNotFound".to_string()),
+            raw_response: None,
+        });
+        assert!(AkvProvider::is_not_found_error(&not_found));
+
+        // A real 404's Display is the service's plain-text message, which
+        // does not necessarily contain "SecretNotFound" or "404" -- the old
+        // string-matching check would have missed this.
+        let plain_message_404 = azure_core::Error::with_message(
+            ErrorKind::HttpResponse {
+                status: StatusCode::NotFound,
+                error_code: None,
+                raw_response: None,
+            },
+            "A secret with (name) was not found in this key vault",
+        );
+        assert!(AkvProvider::is_not_found_error(&plain_message_404));
+
+        let forbidden = azure_core::Error::from(ErrorKind::HttpResponse {
+            status: StatusCode::Forbidden,
+            error_code: None,
+            raw_response: None,
+        });
+        assert!(!AkvProvider::is_not_found_error(&forbidden));
+
+        let other = azure_core::Error::with_message(ErrorKind::Other, "boom");
+        assert!(!AkvProvider::is_not_found_error(&other));
+    }
+
+    #[test]
     fn test_vault_url_appends_public_suffix_for_bare_name() {
         let c = config("akv://myvault");
         assert_eq!(c.vault_url, "https://myvault.vault.azure.net/");
+        assert_eq!(c.suffix, None);
     }
 
     #[test]
     fn test_vault_url_uses_fqdn_verbatim_for_sovereign_clouds() {
         let c = config("akv://myvault.vault.azure.cn");
         assert_eq!(c.vault_url, "https://myvault.vault.azure.cn/");
+        assert_eq!(c.suffix, None);
+    }
+
+    #[test]
+    fn test_vault_url_suffix_query_param_overrides_default() {
+        let c = config("akv://myvault?suffix=vault.azure.cn");
+        assert_eq!(c.vault_url, "https://myvault.vault.azure.cn/");
+        assert_eq!(c.suffix.as_deref(), Some("vault.azure.cn"));
+    }
+
+    #[test]
+    fn test_uri_roundtrips_suffix() {
+        let p = AkvProvider::new(config("akv://myvault?suffix=vault.azure.cn"));
+        assert_eq!(p.uri(), "akv://myvault?suffix=vault.azure.cn");
+    }
+
+    #[test]
+    fn test_uri_roundtrips_auth_and_suffix() {
+        let p = AkvProvider::new(config(
+            "akv://myvault?auth=managed_identity&suffix=vault.azure.cn",
+        ));
+        assert_eq!(
+            p.uri(),
+            "akv://myvault?auth=managed_identity&suffix=vault.azure.cn"
+        );
     }
 
     #[test]
@@ -525,6 +760,23 @@ mod tests {
         };
         let err = p.get(Address::Native(&addr)).unwrap_err();
         assert!(err.to_string().contains("`field`"), "{err}");
+    }
+
+    /// A native `ref` item with characters Azure Key Vault doesn't allow is
+    /// rejected up front (and never silently rewritten), before any network
+    /// I/O.
+    #[test]
+    fn native_address_rejects_invalid_azure_chars() {
+        let p = AkvProvider::new(config("akv://myvault"));
+        let addr = crate::config::NativeAddress {
+            item: "existing_secret".into(),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(
+            err.to_string().contains("not a valid Azure Key Vault secret name"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/secretspec/src/provider/akv.rs
+++ b/secretspec/src/provider/akv.rs
@@ -53,7 +53,7 @@
 
 use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
-use azure_core::credentials::TokenCredential;
+use azure_core::credentials::{Secret, TokenCredential};
 use azure_identity::{
     ClientSecretCredential, DeveloperToolsCredential, ManagedIdentityCredential,
     WorkloadIdentityCredential,
@@ -264,14 +264,10 @@ impl AkvProvider {
                 if let (Some(tenant_id), Some(client_id), Some(client_secret)) =
                     (tenant_id, client_id, client_secret)
                 {
-                    // NOTE: `azure_identity` is a very new (v1.0), fast-moving
-                    // crate; verify this constructor's exact parameter types
-                    // with `cargo check --features akv` before relying on it,
-                    // in case the secret parameter type has changed.
                     Ok(ClientSecretCredential::new(
-                        tenant_id,
+                        &tenant_id,
                         client_id,
-                        SecretString::new(client_secret.into()),
+                        Secret::new(client_secret),
                         None,
                     )
                     .map_err(|e| {

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -20,6 +20,7 @@
 //! - [`EnvProvider`]: Environment variables (read-only)
 //! - [`OnePasswordProvider`]: OnePassword integration
 //! - [`LastPassProvider`]: LastPass integration
+//! - [`AkvProvider`]: Azure Key Vault integration
 //!
 //! ## URI-Based Configuration
 //!
@@ -193,6 +194,8 @@ pub(crate) fn block_on<F: std::future::Future>(future: F) -> F::Output {
     }
 }
 
+#[cfg(feature = "akv")]
+pub mod akv;
 #[cfg(feature = "awssm")]
 pub mod awssm;
 #[cfg(feature = "bws")]

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -479,6 +479,23 @@ mod integration_tests {
                     .expect("Should create vault provider");
                 (provider, None)
             }
+            #[cfg(feature = "akv")]
+            // Bare "akv" has no vault name, so route it through a real
+            // AKV_TEST_VAULT instead of falling into the generic `_` branch
+            // below, where `try_from("akv")` fails to parse and panics with
+            // a misleading "akv provider should exist" instead of pointing
+            // at the missing configuration. Set AKV_TEST_VAULT to a real Key
+            // Vault name and authenticate via AZURE_TENANT_ID/AZURE_CLIENT_ID/
+            // AZURE_CLIENT_SECRET or `az login` to exercise this provider.
+            "akv" => {
+                let vault = std::env::var("AKV_TEST_VAULT").expect(
+                    "Testing the akv provider requires a real Key Vault: set AKV_TEST_VAULT to a vault name (and authenticate via AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET or `az login`).",
+                );
+                let provider_spec = format!("akv://{vault}");
+                let provider = Box::<dyn Provider>::try_from(provider_spec.as_str())
+                    .expect("Should create akv provider");
+                (provider, None)
+            }
             _ => {
                 let provider = Box::<dyn Provider>::try_from(provider_name)
                     .expect(&format!("{} provider should exist", provider_name));


### PR DESCRIPTION
Adds an akv:// provider backed by Azure Key Vault, gated behind a new akv Cargo feature (included in default features alongside gcsm/awssm/vault/bws). Convention secrets map to Azure Key Vault's [0-9a-zA-Z-] secret-name charset via secretspec--{project}--{profile}--{key}, with underscores rewritten to hyphens. Authentication is chosen via ?auth=env|cli|managed_identity|workload_identity, defaulting to a service principal from AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET and falling back to the signed-in Azure CLI session.

Version pinning and user-assigned managed identity are not yet supported. Updates docs (new providers/akv.md page plus the other tracked locations) and CHANGELOG.md.