### PR TITLE
feat(provider): bootstrap credentials sourced from another provider

### DIFF
--- a/.github/workflows/ffi-build.yml
+++ b/.github/workflows/ffi-build.yml
@@ -83,8 +83,6 @@ jobs:
       # On a version tag, attach the cdylib (named for its target, with a sha256
       # sidecar) to the GitHub Release so the PHP SDK's `secretspec-install-lib`
       # command can fetch the right one for a plain `composer require` install.
-      # cargo-dist's release.yml creates the release for this same tag, so wait
-      # for it to exist, then upload with --clobber (both workflows may retry).
       - name: Publish cdylib to the release
         if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
@@ -92,15 +90,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
           ext="${{ matrix.artifact }}"; ext="${ext##*.}"
           asset="secretspec-ffi-${{ matrix.target }}.${ext}"
           cp "target/${{ matrix.target }}/release/${{ matrix.artifact }}" "$asset"
-          # sha256 sidecar (BSD shasum on macOS, GNU sha256sum on Linux; both here).
-          if command -v sha256sum >/dev/null; then sha256sum "$asset" > "$asset.sha256"
-          else shasum -a 256 "$asset" > "$asset.sha256"; fi
-          # Wait for cargo-dist to create the release (concurrent workflow).
-          for _ in $(seq 1 30); do
-            gh release view "$tag" >/dev/null 2>&1 && break || sleep 20
-          done
-          gh release upload "$tag" "$asset" "$asset.sha256" --clobber
+          bash scripts/upload-release-asset.sh "${GITHUB_REF_NAME}" "$asset"

--- a/.github/workflows/php-ext.yml
+++ b/.github/workflows/php-ext.yml
@@ -71,23 +71,17 @@ jobs:
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
 
-      - name: Build the extension
-        # Each runner is the target's native arch, so a plain release build emits
-        # the target's binary (no cross-compilation).
-        run: cargo build --release -p secretspec-php-native
-
-      - name: Stage the extension under its distribution name
+      - name: Build and stage the extension under its distribution name
         id: stage
         shell: bash
+        # Each runner is the target's native arch, so a plain release build emits
+        # the target's binary (no cross-compilation). build-ext.sh owns the
+        # platform-to-library-name mapping and stages lib/secretspec.so.
         run: |
           set -euo pipefail
-          case "$(uname -s)" in
-            Darwin) built="libsecretspec_php_native.dylib" ;;
-            *)      built="libsecretspec_php_native.so" ;;
-          esac
-          # dlopen resolves by path, not suffix, so the macOS .dylib ships as .so.
+          bash secretspec-php/scripts/build-ext.sh
           asset="secretspec-php-native-${{ matrix.php }}-nts-${{ matrix.target }}.so"
-          cp "target/release/$built" "$asset"
+          cp secretspec-php/lib/secretspec.so "$asset"
           echo "asset=$asset" >> "$GITHUB_OUTPUT"
 
       - name: Smoke test (load the extension, check it registers)
@@ -110,13 +104,4 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          asset="${{ steps.stage.outputs.asset }}"
-          if command -v sha256sum >/dev/null; then sha256sum "$asset" > "$asset.sha256"
-          else shasum -a 256 "$asset" > "$asset.sha256"; fi
-          # cargo-dist's release.yml creates the release for this tag; wait for it.
-          for _ in $(seq 1 30); do
-            gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 && break || sleep 20
-          done
-          gh release upload "${GITHUB_REF_NAME}" "$asset" "$asset.sha256" --clobber
+        run: bash scripts/upload-release-asset.sh "${GITHUB_REF_NAME}" "${{ steps.stage.outputs.asset }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "secret_id" } },
   } }
   ```
+- `secretspec config provider login <alias>` prompts for each bootstrap
+  credential a provider alias declares and stores it in its source provider, so
+  it can be read back on the next resolution. `secretspec config provider add`
+  gains a repeatable `--env VAR=PROVIDER` flag for declaring bootstrap sources
+  from the command line.
 
 ### Changed
 - A `ref` routed at a single store (an explicit `--provider`, a single-provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Azure Key Vault provider (`akv://`). Authenticates via a service principal
-  (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`), falling back to
-  a signed-in Azure CLI / Azure Developer CLI session; managed identity and
+  whose `tenant_id`, `client_id`, and `client_secret` can be sourced as provider
+  credentials (with `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`
+  fallbacks), falling back to a signed-in Azure CLI / Azure Developer CLI
+  session when none are available; managed identity and
   AKS workload identity are also available via `?auth=managed_identity` and
   `?auth=workload_identity`. Sovereign clouds can be addressed with a full
   DNS hostname or an explicit `?suffix=` override. Project/profile/key
@@ -29,11 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   library at runtime for CLI and local development.
 - Provider aliases can now source their own credentials from another provider.
   An alias in `[providers]` may declare a `credentials` map binding a semantic,
-  provider-specific name (such as `access_token`, `token`, or `role_id`) to a
-  source: a bare provider spec, which reads the value at the convention path, or
-  a table with a `ref` giving the exact coordinates. The credential is fetched
-  from that provider and handed to the store, so a machine token can live in the
-  OS keyring instead of a plaintext environment variable, and is never written
+  provider-specific name (such as `access_token`, `token`, `role_id`, or
+  `client_secret`) to a source: a bare provider spec, which reads the value at
+  the convention path, or a table with a `ref` giving the exact coordinates.
+  The credential is fetched from that provider and handed to the store, so a
+  machine token can live in the OS keyring instead of a plaintext environment
+  variable, and is never written
   into the environment of processes started by `secretspec run`. A configured
   credential is authoritative; providers retain their conventional environment
   fallback when no explicit credential is supplied. Chains are limited to one
@@ -52,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```toml
   [providers]
   bws = { uri = "bws://project-uuid", credentials = { access_token = "keyring" } }
+  akv = { uri = "akv://myvault", credentials = { tenant_id = "keyring", client_id = "keyring", client_secret = "keyring" } }
   vault = { uri = "vault://kv/app?auth=approle", credentials = {
     role_id   = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } },
     secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "secret_id" } },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from that provider and handed to the store, so a machine token can live in the
   OS keyring instead of a plaintext environment variable, and it is never
   written into the environment of processes started by `secretspec run`. An
-  environment variable that is already set still wins, so CI keeps working with
-  no extra configuration. Chains are limited to one hop.
+  environment variable that is already set (non empty) still wins, so CI keeps
+  working with no extra configuration. Chains are limited to one hop, and that
+  limit is enforced wherever the alias appears, as a chain fallback or the
+  default provider included. Bootstrap credentials also apply when the alias is
+  selected with an explicit `--provider <alias>` or `SECRETSPEC_PROVIDER`, and
+  they are fetched from their source once per invocation and reused across all
+  secrets routed at the alias.
 
   ```toml
   [providers]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,40 +28,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ffi.enable`, like `ext-redis`), with an `ext-ffi` fallback that dlopens the
   library at runtime for CLI and local development.
 - Provider aliases can now source their own credentials from another provider.
-  An alias in `[providers]` may declare an `env` map binding an environment
-  variable the provider needs (such as `BWS_ACCESS_TOKEN` or `VAULT_TOKEN`) to a
+  An alias in `[providers]` may declare a `credentials` map binding a semantic,
+  provider-specific name (such as `access_token`, `token`, or `role_id`) to a
   source: a bare provider spec, which reads the value at the convention path, or
   a table with a `ref` giving the exact coordinates. The credential is fetched
   from that provider and handed to the store, so a machine token can live in the
-  OS keyring instead of a plaintext environment variable, and it is never
-  written into the environment of processes started by `secretspec run`. An
-  environment variable that is already set (non empty) still wins, so CI keeps
-  working with no extra configuration. Chains are limited to one hop, and that
-  limit is enforced wherever the alias appears, as a chain fallback or the
-  default provider included. Bootstrap credentials also apply when the alias is
-  selected with an explicit `--provider <alias>` or `SECRETSPEC_PROVIDER`, and
+  OS keyring instead of a plaintext environment variable, and is never written
+  into the environment of processes started by `secretspec run`. A configured
+  credential is authoritative; providers retain their conventional environment
+  fallback when no explicit credential is supplied. Chains are limited to one
+  hop, and that limit is enforced wherever the alias appears, as a chain
+  fallback or the default provider included. Provider credentials also apply
+  when the alias is selected with an explicit `--provider <alias>` or
+  `SECRETSPEC_PROVIDER`, and
   they are fetched from their source once per invocation and profile, then
   reused across all secrets routed at the alias (convention-path credentials
   live under a profile, so switching profiles re-reads them). Each source read,
-  and each credential stored through `login`, is audited with a `bootstrap`
-  marker naming the variable and the source store; a credential stored through
-  `login` takes effect immediately. Declaring an `env` variable the target
-  provider never reads prints a warning naming the variables it does read,
-  instead of fetching a value that would be silently ignored.
+  and each credential stored through `login`, is audited with a `credential`
+  marker naming the semantic credential and the source store; a credential
+  stored through `login` takes effect immediately. Unsupported credential names
+  fail validation before a source is accessed.
 
   ```toml
   [providers]
-  bws = { uri = "bws://project-uuid", env = { BWS_ACCESS_TOKEN = "keyring" } }
-  vault = { uri = "vault://kv/app?auth=approle", env = {
-    VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } },
-    VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "secret_id" } },
+  bws = { uri = "bws://project-uuid", credentials = { access_token = "keyring" } }
+  vault = { uri = "vault://kv/app?auth=approle", credentials = {
+    role_id   = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } },
+    secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "secret_id" } },
   } }
   ```
-- `secretspec config provider login <alias>` prompts for each bootstrap
+- `secretspec config provider login <alias>` prompts for each provider
   credential a provider alias declares and stores it in its source provider, so
   it can be read back on the next resolution. `secretspec config provider add`
-  gains a repeatable `--env VAR=PROVIDER` flag for declaring bootstrap sources
-  from the command line.
+  gains a repeatable `--credential NAME=PROVIDER` flag for declaring credential
+  sources from the command line.
 
 ### Changed
 - A `ref` routed at a single store (an explicit `--provider`, a single-provider
@@ -81,8 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead" message — the same hard error any other invalid primary gets —
   instead of warning and falling through to the rest of the chain. As a
   fallback entry it is still skipped with a warning, like any broken link.
-- Rust SDK: `ProviderAlias::env` is a plain map whose empty state means "no
-  bootstrap credentials", rather than an `Option`, so the two ways of spelling
+- Rust SDK: `ProviderAlias::credentials` is a plain map whose empty state means
+  "no provider credentials", rather than an `Option`, so the two ways of spelling
   an alias without credentials cannot diverge.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   limit is enforced wherever the alias appears, as a chain fallback or the
   default provider included. Bootstrap credentials also apply when the alias is
   selected with an explicit `--provider <alias>` or `SECRETSPEC_PROVIDER`, and
-  they are fetched from their source once per invocation and reused across all
-  secrets routed at the alias.
+  they are fetched from their source once per invocation and profile, then
+  reused across all secrets routed at the alias (convention-path credentials
+  live under a profile, so switching profiles re-reads them). Each source read,
+  and each credential stored through `login`, is audited with a `bootstrap`
+  marker naming the variable and the source store; a credential stored through
+  `login` takes effect immediately. Declaring an `env` variable the target
+  provider never reads prints a warning naming the variables it does read,
+  instead of fetching a value that would be silently ignored.
 
   ```toml
   [providers]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PHP extension that embeds the resolver (works under PHP-FPM with no
   `ffi.enable`, like `ext-redis`), with an `ext-ffi` fallback that dlopens the
   library at runtime for CLI and local development.
+- Provider aliases can now source their own credentials from another provider.
+  An alias in `[providers]` may declare an `env` map binding an environment
+  variable the provider needs (such as `BWS_ACCESS_TOKEN` or `VAULT_TOKEN`) to a
+  source: a bare provider spec, which reads the value at the convention path, or
+  a table with a `ref` giving the exact coordinates. The credential is fetched
+  from that provider and handed to the store, so a machine token can live in the
+  OS keyring instead of a plaintext environment variable, and it is never
+  written into the environment of processes started by `secretspec run`. An
+  environment variable that is already set still wins, so CI keeps working with
+  no extra configuration. Chains are limited to one hop.
+
+  ```toml
+  [providers]
+  bws = { uri = "bws://project-uuid", env = { BWS_ACCESS_TOKEN = "keyring" } }
+  vault = { uri = "vault://kv/app?auth=approle", env = {
+    VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } },
+    VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "secret_id" } },
+  } }
+  ```
 
 ### Changed
 - A `ref` routed at a single store (an explicit `--provider`, a single-provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead" message — the same hard error any other invalid primary gets —
   instead of warning and falling through to the rest of the chain. As a
   fallback entry it is still skipped with a warning, like any broken link.
+- Rust SDK: `ProviderAlias::env` is a plain map whose empty state means "no
+  bootstrap credentials", rather than an `Option`, so the two ways of spelling
+  an alias without credentials cannot diverge.
 
 ### Fixed
 - Profile overrides no longer need to repeat the secret's `description`:

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -1,154 +1,238 @@
 ---
 title: Providers
-description: Understanding secret storage providers in SecretSpec
+description: Choose and configure the storage backends SecretSpec uses for secrets
 ---
 
-Providers are pluggable storage backends that handle the storage and retrieval of secrets. They allow the same `secretspec.toml` to work across development machines, CI/CD pipelines, and production environments.
+A provider is a storage backend from which SecretSpec reads secrets and, when
+supported, writes them. Providers let one `secretspec.toml` describe the secrets
+an application needs without requiring every environment to use the same secret
+store.
 
-## Available Providers
+For example, a developer can use the system keyring, CI can supply environment
+variables, and production can use a shared password manager or cloud secret
+manager. The secret definitions stay the same; only their provider configuration
+changes.
 
-| Provider | Description | Read | Write | Encrypted |
-|----------|-------------|------|-------|-----------|
-| **keyring** | System credential storage (macOS Keychain, Windows Credential Manager, Linux Secret Service) | ✓ | ✓ | ✓ |
-| **dotenv** | Traditional `.env` file in your project directory | ✓ | ✓ | ✗ |
-| **env** | Read-only access to existing environment variables | ✓ | ✗ | ✗ |
-| **pass** | Unix password manager with GPG encryption | ✓ | ✓ | ✓ |
-| **protonpass** | Integration with Proton password manager | ✓ | ✓ | ✓ |
-| **onepassword** | Integration with OnePassword password manager | ✓ | ✓ | ✓ |
-| **lastpass** | Integration with LastPass password manager | ✓ | ✓ | ✓ |
-| **gcsm** | Google Cloud Secret Manager (requires `--features gcsm`) | ✓ | ✓ | ✓ |
-| **awssm** | AWS Secrets Manager (requires `--features awssm`) | ✓ | ✓ | ✓ |
-| **vault** | HashiCorp Vault / OpenBao (requires `--features vault`) | ✓ | ✓ | ✓ |
-| **bws** | Bitwarden Secrets Manager (requires `--features bws`) | ✓ | ✓ | ✓ |
-| **akv** | Azure Key Vault (requires `--features akv`) | ✓ | ✓ | ✓ |
+## Provider specifications
 
-## Provider Selection
+Anywhere SecretSpec accepts a provider, you can use one of three forms:
 
-SecretSpec determines which provider to use for each secret in this order:
+- A provider name, such as `keyring` or `env`.
+- A provider URI, such as `dotenv://.env.local` or
+  `onepassword://Production`. The URI configures a particular instance of the
+  provider.
+- A provider alias, such as `prod_vault`, defined in project or user
+  configuration.
 
-1. **Explicit override**: the `--provider` CLI flag or the `SECRETSPEC_PROVIDER` environment variable
-2. **Per-secret providers**: `providers` field in `secretspec.toml` (with fallback chain)
-3. **Profile defaults**: `providers` under `[profiles.<name>.defaults]`
-4. **Global default**: Default provider in user config set via `secretspec config init`
+Aliases are useful when a URI is shared by several secrets or should have a
+meaningful, store-independent name.
 
-A secret's [`ref`](/reference/configuration/#secret-references) field never
-affects provider selection: it only changes what name is looked up in the store,
-not which store is used. The same order above picks the store for ref secrets
-and convention secrets alike.
+```toml title="secretspec.toml"
+[providers]
+prod_vault = "onepassword://Production"
 
-## Configuration
+[profiles.production]
+DATABASE_URL = { description = "Production database", providers = ["prod_vault"] }
+```
 
-Set your default provider:
+## Available providers
+
+| Provider | Storage backend | Read | Write | Encrypted at rest |
+|----------|-----------------|------|-------|-------------------|
+| [keyring](/providers/keyring/) | macOS Keychain, Windows Credential Manager, or Linux Secret Service | ✓ | ✓ | ✓ |
+| [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ |
+| [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ |
+| [pass](/providers/pass/) | Unix `pass` password store | ✓ | ✓ | ✓ |
+| [protonpass](/providers/protonpass/) | Proton Pass | ✓ | ✓ | ✓ |
+| [onepassword](/providers/onepassword/) | 1Password | ✓ | ✓ | ✓ |
+| [lastpass](/providers/lastpass/) | LastPass | ✓ | ✓ | ✓ |
+| [gcsm](/providers/gcsm/) | Google Cloud Secret Manager (requires the `gcsm` build feature) | ✓ | ✓ | ✓ |
+| [awssm](/providers/awssm/) | AWS Secrets Manager (requires the `awssm` build feature) | ✓ | ✓ | ✓ |
+| [vault](/providers/vault/) | HashiCorp Vault or OpenBao (requires the `vault` build feature) | ✓ | ✓ | ✓ |
+| [bws](/providers/bws/) | Bitwarden Secrets Manager (requires the `bws` build feature) | ✓ | ✓ | ✓ |
+| [akv](/providers/akv/) | Azure Key Vault (requires the `akv` build feature) | ✓ | ✓ | ✓ |
+
+See each provider's page for its URI format, authentication requirements, and
+storage conventions.
+
+## How SecretSpec selects a provider
+
+SecretSpec resolves the provider for each secret in the following order:
+
+1. The `--provider` command-line option.
+2. The `SECRETSPEC_PROVIDER` environment variable.
+3. The secret's effective `providers` list after profile inheritance and
+   `[profiles.<name>.defaults]` are applied.
+4. The default provider in the user configuration.
+
+The first two options are explicit overrides. They route every secret to one
+provider and disable any configured fallback chain for that command.
+
+If no override is set, SecretSpec tries the effective `providers` list from
+left to right until a provider returns the secret. If the secret has no
+`providers` list, SecretSpec uses the user-level default provider.
+
+```toml title="secretspec.toml"
+[providers]
+prod_vault = "onepassword://Production"
+local = "keyring://"
+
+[profiles.production.defaults]
+providers = ["prod_vault", "local"]
+
+[profiles.production]
+# Uses the profile default: prod_vault, then local.
+DATABASE_URL = { description = "Production database" }
+
+# Overrides the profile default and reads only from the environment.
+DEPLOY_TOKEN = { description = "Deployment token", providers = ["env"] }
+```
+
+The fallback order applies to reads. Writes go only to the first provider in
+the effective list. In the example above, SecretSpec reads `DATABASE_URL` from
+`prod_vault` first and falls back to `local` only when the secret is not found;
+it writes `DATABASE_URL` only to `prod_vault`.
+
+:::note
+A secret's [`ref`](/reference/configuration/#secret-references) changes the
+address looked up inside a provider, not the provider selection rules. Explicit
+overrides and fallback chains work the same way for referenced secrets and
+convention-based secrets.
+:::
+
+## Configure the default provider
+
+Run the interactive configuration command to select the provider SecretSpec
+uses when a secret has no provider-specific configuration:
 
 ```bash
 $ secretspec config init
 ```
 
-Override for specific commands:
-
-```bash
-# Use dotenv for this command
-$ secretspec run --provider dotenv -- npm start
-
-# Set for shell session
-$ export SECRETSPEC_PROVIDER=env
-$ secretspec check
-```
-
-Configure providers with URIs:
-
-```toml
-# ~/.config/secretspec/config.toml
-[defaults]
-provider = "keyring"
-profile = "development"  # optional default profile
-```
-
-You can use provider URIs for more specific configuration:
-
-```bash
-# Use a specific OnePassword vault
-$ secretspec run --provider "onepassword://Development" -- npm start
-
-# Use a specific dotenv file
-$ secretspec run --provider "dotenv:/home/user/work/.env" -- npm test
-```
-
-## Per-Secret Provider Configuration
-
-For fine-grained control, you can specify different providers for individual secrets using the `providers` field in `secretspec.toml`. This enables fallback chains where secrets are retrieved from multiple providers in order of preference:
-
-```toml
-[profiles.production]
-DATABASE_URL = { description = "Production DB", providers = ["prod_vault", "keyring"] }
-API_KEY = { description = "API key from env", providers = ["env"] }
-SENTRY_DSN = { description = "Error tracking", providers = ["shared_vault", "keyring"] }
-```
-
-Chain entries are provider aliases (see below) or inline provider URIs, which
-need no alias declaration:
-
-```toml
-[profiles.production]
-DATABASE_URL = { description = "Production DB", providers = ["onepassword://Production", "keyring"] }
-```
-
-### Profile-Level Default Providers
-
-You can also set default providers for an entire profile using `profiles.<name>.defaults`. See [Profile-Level Defaults](/concepts/profiles/#profile-level-defaults) for details.
-
-Provider aliases can be defined in two places:
-
-- **Project-level** — a top-level `[providers]` table in `secretspec.toml`. Check this into version control so the whole team and CI runners share the same mapping.
-- **User-level** — a `[defaults.providers]` table in `~/.config/secretspec/config.toml` for personal overrides.
-
-On name conflicts the project-level alias wins, so a stale user config cannot silently shadow the team's mapping.
-
-```toml title="secretspec.toml"
-[providers]
-prod_vault = "onepassword://Production"
-shared_vault = "onepassword://Shared"
-keyring = "keyring://"
-env = "env://"
-```
+The resulting user configuration contains a default provider:
 
 ```toml title="~/.config/secretspec/config.toml"
 [defaults]
 provider = "keyring"
-
-[defaults.providers]
-prod_vault = "onepassword://Production"
-shared_vault = "onepassword://Shared"
-keyring = "keyring://"
-env = "env://"
+profile = "development" # Optional default profile
 ```
 
-### Bootstrap Credentials
+Use `--provider` for a one-off override, or `SECRETSPEC_PROVIDER` for commands
+in the current shell or CI job:
+
+```bash
+# Route every secret in this command to a project .env file.
+$ secretspec run --provider dotenv -- npm start
+
+# Route every secret in subsequent commands to existing environment variables.
+$ export SECRETSPEC_PROVIDER=env
+$ secretspec check
+```
+
+A provider URI can configure the selected backend more precisely:
+
+```bash
+# Select a specific 1Password vault.
+$ secretspec run --provider "onepassword://Development" -- npm start
+
+# Select a specific dotenv file.
+$ secretspec run --provider "dotenv:/home/user/work/.env" -- npm test
+```
+
+## Configure provider aliases
+
+Provider aliases can be declared at either project or user scope:
+
+- Define project aliases in the top-level `[providers]` table in
+  `secretspec.toml`. Commit these aliases so team members and CI use the same
+  mapping.
+- Define user aliases in `[defaults.providers]` in
+  `~/.config/secretspec/config.toml`. Use these for personal mappings that
+  should apply across projects.
+
+If both scopes define the same alias, the project alias takes precedence.
+
+```toml title="secretspec.toml"
+[providers]
+prod_vault = "onepassword://Production"
+shared_vault = "onepassword://Shared"
+local = "keyring://"
+
+[profiles.production]
+DATABASE_URL = { description = "Production database", providers = ["prod_vault", "local"] }
+SENTRY_DSN = { description = "Error reporting", providers = ["shared_vault", "local"] }
+```
+
+Provider lists may combine aliases, provider names, and inline provider URIs:
+
+```toml title="secretspec.toml"
+[profiles.production]
+DATABASE_URL = { description = "Production database", providers = ["onepassword://Production", "keyring"] }
+```
+
+Use the CLI to manage user-level aliases:
+
+```bash
+$ secretspec config provider add prod_vault "onepassword://Production"
+$ secretspec config provider list
+$ secretspec config provider remove prod_vault
+```
+
+These commands modify only `~/.config/secretspec/config.toml`. Edit the
+top-level `[providers]` table directly to change project aliases.
+
+## Bootstrap provider credentials
 
 :::note
-Bootstrap providers are available since version 0.15.
+Bootstrap credentials are supported in version 0.15 and later.
 :::
 
-Some providers need a secret of their own before they can serve any secrets — a Bitwarden machine token (`BWS_ACCESS_TOKEN`), a Vault token or AppRole credentials, a 1Password service account token. Normally these come from environment variables, which pushes plaintext tokens back into shell profiles and CI variable pages. An alias can instead source them from another provider, so the token lives in your keyring or vault:
+Some providers need credentials before they can retrieve secrets. Examples
+include `BWS_ACCESS_TOKEN` for Bitwarden Secrets Manager, a Vault token or
+AppRole credentials, and a 1Password service account token.
+
+An alias can load these credentials from another provider. This avoids storing
+long-lived provider credentials in a shell profile or CI variable when a secure
+store is available.
+
+### Use the convention address
+
+In an alias's `env` table, map each required environment variable to the
+provider that stores it:
 
 ```toml title="secretspec.toml"
 [providers]
 keyring = "keyring://"
 
-# BWS_ACCESS_TOKEN is read from keyring before the provider is used
+# Read BWS_ACCESS_TOKEN from keyring before connecting to Bitwarden.
 bws = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", env = { BWS_ACCESS_TOKEN = "keyring" } }
 ```
 
-Each entry in `env` binds an environment variable the provider needs to a source. A bare string is a provider spec and reads the credential at the convention path (`{project}/{profile}/{VAR}`) for the active profile. A table pins the exact location with the same `ref` coordinates a secret uses:
+A string value such as `"keyring"` is a provider specification. SecretSpec
+reads the credential from that provider at the conventional
+`{project}/{profile}/{VAR}` address for the active project and profile.
+
+### Use an explicit address
+
+Use a table with `provider` and `ref` when the credential already exists at a
+specific provider-native address:
 
 ```toml title="secretspec.toml"
 [providers.vault_prod]
 uri = "vault://secret/myapp?auth=approle"
-env = { VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
-        VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
+env = {
+  VAULT_ROLE_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
+  VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } }
+}
 ```
 
-Store the credentials once with [`secretspec config provider login`](/reference/cli/#config-provider-login), which prompts for each one and writes it to its source:
+The `ref` table uses the same provider-native coordinates as a secret
+[`ref`](/reference/configuration/#secret-references).
+
+### Store bootstrap credentials
+
+Use `config provider login` to prompt for every credential declared by an
+alias and write it to the configured source:
 
 ```bash
 $ secretspec config provider login bws
@@ -156,53 +240,33 @@ Enter BWS_ACCESS_TOKEN for provider 'bws' (source: keyring): ****
 ✓ stored BWS_ACCESS_TOKEN in keyring at smoke/default/BWS_ACCESS_TOKEN
 ```
 
-A few things hold by design:
-
-- **The environment still wins.** If the variable is already exported (as in CI), that value is used and the source is not consulted, so CI keeps working with no extra configuration.
-- **Nothing leaks.** The credential is handed to the provider in memory; it is never written to the environment, and never reaches processes started by `secretspec run`.
-- **One hop.** A bootstrap source may not itself declare bootstrap credentials, which is validated up front and makes cycles impossible.
-- **Machine-wide vs per-profile.** A bare-string source is stored per project and profile; use a `ref` to pin a token to one location shared across projects.
-
-### Fallback Chains
-
-When a secret specifies multiple providers, SecretSpec tries each provider in order until it finds the secret:
-
-```toml
-# Try OnePassword first, then fall back to keyring if not found
-DATABASE_URL = { description = "DB", providers = ["prod_vault", "keyring"] }
-```
-
-This enables complex workflows:
-- **Shared vs environment-specific**: Try a shared vault first, fall back to local keyring
-- **Redundancy**: Maintain secrets in multiple locations for backup
-- **Migration**: Gradually move secrets from one provider to another
-- **Multi-team setups**: Different teams can manage different providers
-
-### Managing Provider Aliases
-
-Use CLI commands to manage user-level provider aliases in `~/.config/secretspec/config.toml`:
+You can also create a user-level alias with a convention-address bootstrap
+source from the CLI:
 
 ```bash
-# Add a provider alias
-$ secretspec config provider add prod_vault "onepassword://Production"
-
-# Add an alias whose provider bootstraps a credential from another provider
 $ secretspec config provider add bws "bws://project-uuid" --env BWS_ACCESS_TOKEN=keyring
-
-# Store the bootstrap credentials an alias declares
 $ secretspec config provider login bws
-
-# List all aliases
-$ secretspec config provider list
-
-# Remove an alias
-$ secretspec config provider remove prod_vault
 ```
 
-These commands operate on the user-level config only. To change project-level aliases, edit the `[providers]` table in `secretspec.toml` directly.
+Bootstrap credentials follow these rules:
 
-## Next Steps
+- **Existing environment variables take precedence.** If a required variable
+  is already set, SecretSpec uses it and does not query the configured source.
+- **Credentials remain internal.** SecretSpec passes a retrieved credential to
+  the destination provider in memory. It does not export the credential or
+  include it in the environment of a process started by `secretspec run`.
+- **Bootstrap chains are one hop.** A source provider cannot require bootstrap
+  credentials of its own. SecretSpec validates this before accessing the
+  provider, preventing dependency cycles.
+- **Convention addresses are profile-specific.** A string source uses the
+  active project and profile. Use a `ref` source when multiple projects or
+  profiles should share one provider credential.
 
-- Browse individual provider docs in the [Providers](/providers/keyring/) section
-- Learn how [Profiles](/concepts/profiles/) control per-environment behavior
-- Share secret definitions across projects with [Configuration Inheritance](/concepts/inheritance/)
+## Next steps
+
+- Review the URI and authentication details for an individual provider in the
+  [Providers](/providers/keyring/) section.
+- Learn how [Profiles](/concepts/profiles/) apply provider defaults to an
+  environment.
+- Learn how [Secret references](/concepts/references/) separate provider
+  selection from provider-native addresses.

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -123,6 +123,46 @@ keyring = "keyring://"
 env = "env://"
 ```
 
+### Bootstrap Credentials
+
+:::note
+Bootstrap providers are available since version 0.15.
+:::
+
+Some providers need a secret of their own before they can serve any secrets — a Bitwarden machine token (`BWS_ACCESS_TOKEN`), a Vault token or AppRole credentials, a 1Password service account token. Normally these come from environment variables, which pushes plaintext tokens back into shell profiles and CI variable pages. An alias can instead source them from another provider, so the token lives in your keyring or vault:
+
+```toml title="secretspec.toml"
+[providers]
+keyring = "keyring://"
+
+# BWS_ACCESS_TOKEN is read from keyring before the provider is used
+bws = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", env = { BWS_ACCESS_TOKEN = "keyring" } }
+```
+
+Each entry in `env` binds an environment variable the provider needs to a source. A bare string is a provider spec and reads the credential at the convention path (`{project}/{profile}/{VAR}`) for the active profile. A table pins the exact location with the same `ref` coordinates a secret uses:
+
+```toml title="secretspec.toml"
+[providers.vault_prod]
+uri = "vault://secret/myapp?auth=approle"
+env = { VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
+        VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
+```
+
+Store the credentials once with [`secretspec config provider login`](/reference/cli/#config-provider-login), which prompts for each one and writes it to its source:
+
+```bash
+$ secretspec config provider login bws
+Enter BWS_ACCESS_TOKEN for provider 'bws' (source: keyring): ****
+✓ stored BWS_ACCESS_TOKEN in keyring at smoke/default/BWS_ACCESS_TOKEN
+```
+
+A few things hold by design:
+
+- **The environment still wins.** If the variable is already exported (as in CI), that value is used and the source is not consulted, so CI keeps working with no extra configuration.
+- **Nothing leaks.** The credential is handed to the provider in memory; it is never written to the environment, and never reaches processes started by `secretspec run`.
+- **One hop.** A bootstrap source may not itself declare bootstrap credentials, which is validated up front and makes cycles impossible.
+- **Machine-wide vs per-profile.** A bare-string source is stored per project and profile; use a `ref` to pin a token to one location shared across projects.
+
 ### Fallback Chains
 
 When a secret specifies multiple providers, SecretSpec tries each provider in order until it finds the secret:
@@ -145,6 +185,12 @@ Use CLI commands to manage user-level provider aliases in `~/.config/secretspec/
 ```bash
 # Add a provider alias
 $ secretspec config provider add prod_vault "onepassword://Production"
+
+# Add an alias whose provider bootstraps a credential from another provider
+$ secretspec config provider add bws "bws://project-uuid" --env BWS_ACCESS_TOKEN=keyring
+
+# Store the bootstrap credentials an alias declares
+$ secretspec config provider login bws
 
 # List all aliases
 $ secretspec config provider list

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -181,15 +181,15 @@ $ secretspec config provider remove prod_vault
 These commands modify only `~/.config/secretspec/config.toml`. Edit the
 top-level `[providers]` table directly to change project aliases.
 
-## Bootstrap provider credentials
+## Provider credentials
 
 :::note
-Bootstrap credentials are supported in version 0.15 and later.
+Provider credentials are supported in version 0.15 and later.
 :::
 
 Some providers need credentials before they can retrieve secrets. Examples
-include `BWS_ACCESS_TOKEN` for Bitwarden Secrets Manager, a Vault token or
-AppRole credentials, and a 1Password service account token.
+include an access token for Bitwarden Secrets Manager, a Vault token or AppRole
+credentials, and a 1Password service account token.
 
 An alias can load these credentials from another provider. This avoids storing
 long-lived provider credentials in a shell profile or CI variable when a secure
@@ -197,20 +197,20 @@ store is available.
 
 ### Use the convention address
 
-In an alias's `env` table, map each required environment variable to the
+In an alias's `credentials` table, map each semantic credential name to the
 provider that stores it:
 
 ```toml title="secretspec.toml"
 [providers]
 keyring = "keyring://"
 
-# Read BWS_ACCESS_TOKEN from keyring before connecting to Bitwarden.
-bws = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", env = { BWS_ACCESS_TOKEN = "keyring" } }
+# Read the access token from keyring before connecting to Bitwarden.
+bws = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", credentials = { access_token = "keyring" } }
 ```
 
 A string value such as `"keyring"` is a provider specification. SecretSpec
 reads the credential from that provider at the conventional
-`{project}/{profile}/{VAR}` address for the active project and profile.
+`{project}/{profile}/{credential}` address for the active project and profile.
 
 ### Use an explicit address
 
@@ -220,47 +220,53 @@ specific provider-native address:
 ```toml title="secretspec.toml"
 [providers.vault_prod]
 uri = "vault://secret/myapp?auth=approle"
-env = {
-  VAULT_ROLE_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
-  VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } }
+credentials = {
+  role_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
+  secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } }
 }
 ```
 
 The `ref` table uses the same provider-native coordinates as a secret
 [`ref`](/reference/configuration/#secret-references).
 
-### Store bootstrap credentials
+### Store provider credentials
 
 Use `config provider login` to prompt for every credential declared by an
 alias and write it to the configured source:
 
 ```bash
 $ secretspec config provider login bws
-Enter BWS_ACCESS_TOKEN for provider 'bws' (source: keyring): ****
-✓ stored BWS_ACCESS_TOKEN in keyring at smoke/default/BWS_ACCESS_TOKEN
+Enter access_token for provider 'bws' (source: keyring): ****
+✓ stored access_token in keyring at smoke/default/access_token
 ```
 
-You can also create a user-level alias with a convention-address bootstrap
+You can also create a user-level alias with a convention-address credential
 source from the CLI:
 
 ```bash
-$ secretspec config provider add bws "bws://project-uuid" --env BWS_ACCESS_TOKEN=keyring
+$ secretspec config provider add bws "bws://project-uuid" --credential access_token=keyring
 $ secretspec config provider login bws
 ```
 
-Bootstrap credentials follow these rules:
+Provider credentials follow these rules:
 
-- **Existing environment variables take precedence.** If a required variable
-  is already set, SecretSpec uses it and does not query the configured source.
+- **Configured credentials are authoritative.** When an alias declares a
+  credential, SecretSpec reads its configured source. Providers may still use
+  their conventional environment variables when no explicit credential is
+  supplied.
 - **Credentials remain internal.** SecretSpec passes a retrieved credential to
   the destination provider in memory. It does not export the credential or
   include it in the environment of a process started by `secretspec run`.
-- **Bootstrap chains are one hop.** A source provider cannot require bootstrap
+- **Credential chains are one hop.** A source provider cannot require provider
   credentials of its own. SecretSpec validates this before accessing the
   provider, preventing dependency cycles.
 - **Convention addresses are profile-specific.** A string source uses the
   active project and profile. Use a `ref` source when multiple projects or
   profiles should share one provider credential.
+- **Names are provider-specific.** Bitwarden accepts `access_token`; Vault
+  accepts `token`, `role_id`, and `secret_id`; 1Password accepts
+  `service_account_token`. Unsupported names are rejected before any source is
+  read.
 
 ## Next steps
 

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -189,7 +189,8 @@ Provider credentials are supported in version 0.15 and later.
 
 Some providers need credentials before they can retrieve secrets. Examples
 include an access token for Bitwarden Secrets Manager, a Vault token or AppRole
-credentials, and a 1Password service account token.
+credentials, a 1Password service account token, and Azure service-principal
+credentials.
 
 An alias can load these credentials from another provider. This avoids storing
 long-lived provider credentials in a shell profile or CI variable when a secure
@@ -265,8 +266,8 @@ Provider credentials follow these rules:
   profiles should share one provider credential.
 - **Names are provider-specific.** Bitwarden accepts `access_token`; Vault
   accepts `token`, `role_id`, and `secret_id`; 1Password accepts
-  `service_account_token`. Unsupported names are rejected before any source is
-  read.
+  `service_account_token`; Azure Key Vault accepts `tenant_id`, `client_id`, and
+  `client_secret`. Unsupported names are rejected before any source is read.
 
 ## Next steps
 

--- a/docs/src/content/docs/providers/akv.md
+++ b/docs/src/content/docs/providers/akv.md
@@ -8,7 +8,7 @@ The Azure Key Vault provider integrates with Azure for centralized secret manage
 ## Prerequisites
 
 - An Azure Key Vault instance
-- Authenticated via a service principal (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`), the Azure CLI (`az login`), a managed identity, or AKS workload identity
+- Authenticated via a service principal, the Azure CLI (`az login`), a managed identity, or AKS workload identity
 - Build with `--features akv`
 
 ## Configuration
@@ -21,7 +21,7 @@ akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity][&suffix=DNS_S
 
 - `VAULT_NAME`: Your Key Vault name (e.g. `myvault`), or a full DNS name for sovereign clouds (e.g. `myvault.vault.azure.cn`)
 - `auth`: Authentication method (default: `env`)
-  - `env` — a service principal from `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET` (all three must be set together); falls back to the signed-in Azure CLI / Azure Developer CLI session if none are set. Setting only some of the three is an error rather than a silent fallback to a different identity.
+  - `env` — a service principal from the `tenant_id`, `client_id`, and `client_secret` provider credentials, with `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET` as fallbacks (all three must be available together); falls back to the signed-in Azure CLI / Azure Developer CLI session if none are available. A partial set is an error rather than a silent fallback to a different identity.
   - `cli` — the Azure CLI / Azure Developer CLI session only
   - `managed_identity` — the VM / App Service / AKS system-assigned managed identity
   - `workload_identity` — AKS workload identity federation (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_FEDERATED_TOKEN_FILE`, injected automatically by AKS)
@@ -94,6 +94,30 @@ be confused with component data.
 
 ### CI/CD with a Service Principal
 
+The `auth=env` mode accepts `tenant_id`, `client_id`, and `client_secret` as
+[provider credentials](/concepts/providers/#provider-credentials). For example,
+the credentials can be stored in the system keyring instead of a shell profile:
+
+```toml title="secretspec.toml"
+[providers.azure]
+uri = "akv://myvault"
+
+[providers.azure.credentials]
+tenant_id = "keyring"
+client_id = "keyring"
+client_secret = "keyring"
+```
+
+Store all three declared credentials, then use the alias:
+
+```bash
+$ secretspec config provider login azure
+$ secretspec run --provider azure -- deploy
+```
+
+When a semantic credential is not explicitly configured, SecretSpec falls back
+to its matching conventional environment variable:
+
 ```bash
 # Set credentials
 $ export AZURE_TENANT_ID="..."
@@ -104,9 +128,9 @@ $ export AZURE_CLIENT_SECRET="..."
 $ secretspec run --provider akv://myvault -- deploy
 ```
 
-All three environment variables must be set together; setting only some of
-them is treated as a configuration error rather than a silent fallback to the
-Azure CLI session.
+Across provider credentials and environment fallbacks, all three values must be
+available together. A partial service principal is treated as a configuration
+error rather than a silent fallback to the Azure CLI session.
 
 ### AKS with Workload Identity
 

--- a/docs/src/content/docs/providers/bws.md
+++ b/docs/src/content/docs/providers/bws.md
@@ -68,18 +68,18 @@ DATABASE_URL = { description = "DB", ref = { item = "prod-db-connection" }, prov
 
 ### Authentication
 
-Set the `BWS_ACCESS_TOKEN` environment variable with your machine account access token. Generate access tokens from the Bitwarden Secrets Manager web interface.
-
-```bash
-export BWS_ACCESS_TOKEN="0.your-access-token..."
-```
-
-Instead of an environment variable, the token can come from another provider (for example your keyring), so it never lives in a shell profile — see [Bootstrap Credentials](/concepts/providers/#bootstrap-credentials):
+Supply the machine account access token as a provider credential. For example,
+store it in your system keyring so it never lives in a shell profile. Generate
+access tokens from the Bitwarden Secrets Manager web interface. See
+[Provider Credentials](/concepts/providers/#provider-credentials):
 
 ```toml title="secretspec.toml"
 [providers]
-bws = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", env = { BWS_ACCESS_TOKEN = "keyring" } }
+bws = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", credentials = { access_token = "keyring" } }
 ```
+
+For compatibility with standalone BWS tooling, the provider falls back to
+`BWS_ACCESS_TOKEN` when no explicit `access_token` credential is supplied.
 
 ### Basic Commands
 

--- a/docs/src/content/docs/providers/bws.md
+++ b/docs/src/content/docs/providers/bws.md
@@ -74,6 +74,13 @@ Set the `BWS_ACCESS_TOKEN` environment variable with your machine account access
 export BWS_ACCESS_TOKEN="0.your-access-token..."
 ```
 
+Instead of an environment variable, the token can come from another provider (for example your keyring), so it never lives in a shell profile — see [Bootstrap Credentials](/concepts/providers/#bootstrap-credentials):
+
+```toml title="secretspec.toml"
+[providers]
+bws = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", env = { BWS_ACCESS_TOKEN = "keyring" } }
+```
+
 ### Basic Commands
 
 ```bash

--- a/docs/src/content/docs/providers/onepassword.md
+++ b/docs/src/content/docs/providers/onepassword.md
@@ -46,6 +46,15 @@ Set `OP_SERVICE_ACCOUNT_TOKEN` in the environment, or use the
 `onepassword+token://` URI scheme. See the [CI/CD section](#cicd-with-service-accounts)
 below.
 
+The token can also be read from another provider (for example your keyring)
+rather than the environment or a plaintext URI — see
+[Bootstrap Credentials](/concepts/providers/#bootstrap-credentials):
+
+```toml title="secretspec.toml"
+[providers]
+op = { uri = "onepassword://Production", env = { OP_SERVICE_ACCOUNT_TOKEN = "keyring" } }
+```
+
 ### Manual signin (legacy)
 
 Run `eval $(op signin)` to set per-shell `OP_SESSION_*` tokens. These

--- a/docs/src/content/docs/providers/onepassword.md
+++ b/docs/src/content/docs/providers/onepassword.md
@@ -42,18 +42,18 @@ service account token for headless setups.
 
 ### Service account tokens (recommended for CI/CD)
 
-Set `OP_SERVICE_ACCOUNT_TOKEN` in the environment, or use the
-`onepassword+token://` URI scheme. See the [CI/CD section](#cicd-with-service-accounts)
-below.
-
-The token can also be read from another provider (for example your keyring)
-rather than the environment or a plaintext URI — see
-[Bootstrap Credentials](/concepts/providers/#bootstrap-credentials):
+Supply the service account token as a provider credential, for example from
+your keyring — see
+[Provider Credentials](/concepts/providers/#provider-credentials):
 
 ```toml title="secretspec.toml"
 [providers]
-op = { uri = "onepassword://Production", env = { OP_SERVICE_ACCOUNT_TOKEN = "keyring" } }
+op = { uri = "onepassword://Production", credentials = { service_account_token = "keyring" } }
 ```
+
+When no explicit `service_account_token` is supplied, the provider supports
+`OP_SERVICE_ACCOUNT_TOKEN` and the `onepassword+token://` URI scheme for
+compatibility. See the [CI/CD section](#cicd-with-service-accounts) below.
 
 ### Manual signin (legacy)
 

--- a/docs/src/content/docs/providers/vault.md
+++ b/docs/src/content/docs/providers/vault.md
@@ -140,3 +140,14 @@ export VAULT_ROLE_ID=your-role-id
 export VAULT_SECRET_ID=your-secret-id
 secretspec run --provider "vault://vault.example.com:8200/secret?auth=approle" -- deploy
 ```
+
+#### Sourcing credentials from another provider
+
+Any of these variables can be read from another provider instead of the environment, so a Vault token or AppRole credentials never live in a shell profile — see [Bootstrap Credentials](/concepts/providers/#bootstrap-credentials):
+
+```toml title="secretspec.toml"
+[providers.vault_prod]
+uri = "vault://vault.example.com:8200/secret?auth=approle"
+env = { VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
+        VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
+```

--- a/docs/src/content/docs/providers/vault.md
+++ b/docs/src/content/docs/providers/vault.md
@@ -143,11 +143,11 @@ secretspec run --provider "vault://vault.example.com:8200/secret?auth=approle" -
 
 #### Sourcing credentials from another provider
 
-Any of these variables can be read from another provider instead of the environment, so a Vault token or AppRole credentials never live in a shell profile — see [Bootstrap Credentials](/concepts/providers/#bootstrap-credentials):
+These credentials can be read from another provider instead of the environment, so a Vault token or AppRole credentials never live in a shell profile — see [Provider Credentials](/concepts/providers/#provider-credentials):
 
 ```toml title="secretspec.toml"
 [providers.vault_prod]
 uri = "vault://vault.example.com:8200/secret?auth=approle"
-env = { VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
-        VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
+credentials = { role_id   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
+                secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
 ```

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -73,7 +73,7 @@ Add a provider alias to your user-level configuration (`~/.config/secretspec/con
 To share aliases with your team, declare them in a top-level `[providers]` table in `secretspec.toml` instead — they take precedence over user-level aliases on name conflict.
 
 ```bash
-secretspec config provider add <ALIAS> <URI> [--env VAR=PROVIDER]...
+secretspec config provider add <ALIAS> <URI> [--credential NAME=PROVIDER]...
 ```
 
 **Arguments:**
@@ -81,16 +81,16 @@ secretspec config provider add <ALIAS> <URI> [--env VAR=PROVIDER]...
 - `<URI>` - Provider URI (e.g., `onepassword://Production`, `env://`)
 
 **Options:**
-- `--env <VAR=PROVIDER>` - Declare a [bootstrap credential](/concepts/providers/#bootstrap-credentials) the provider needs: the environment variable `VAR` is read from `PROVIDER` before the environment. Repeatable. Only the bare-string source form is expressible on the command line; add a `ref` by editing the config.
+- `--credential <NAME=PROVIDER>` - Declare a [provider credential](/concepts/providers/#provider-credentials) and its source. `NAME` is semantic and provider-specific, such as `access_token` or `role_id`. Repeatable. Only the bare-string source form is expressible on the command line; add a `ref` by editing the config.
 
 **Example:**
 ```bash
 $ secretspec config provider add prod_vault "onepassword://Production"
 ✓ Provider alias 'prod_vault' added: 'onepassword://Production'
 
-$ secretspec config provider add bws "bws://project-uuid" --env BWS_ACCESS_TOKEN=keyring
+$ secretspec config provider add bws "bws://project-uuid" --credential access_token=keyring
 ✓ Provider alias 'bws' added: 'bws://project-uuid'
-  bootstrap: BWS_ACCESS_TOKEN=keyring
+  credentials: access_token=keyring
   run 'secretspec config provider login bws' to store the credentials
 ```
 
@@ -126,7 +126,7 @@ $ secretspec config provider remove prod_vault
 ```
 
 ### config provider login
-Store the [bootstrap credentials](/concepts/providers/#bootstrap-credentials) a provider alias declares in its `env` map. Prompts (hidden input) for each variable and writes it to its source provider at the exact location resolution reads it back from. Runs in a project, like `set` and `check`.
+Store the [credentials](/concepts/providers/#provider-credentials) a provider alias declares. Prompts (hidden input) for each credential and writes it to its source provider at the exact location resolution reads it back from. Runs in a project, like `set` and `check`.
 
 ```bash
 secretspec config provider login <ALIAS>
@@ -138,13 +138,13 @@ secretspec config provider login <ALIAS>
 **Example:**
 ```bash
 $ secretspec config provider login bws
-Enter BWS_ACCESS_TOKEN for provider 'bws' (source: keyring): ****
-✓ stored BWS_ACCESS_TOKEN in keyring at myproject/default/BWS_ACCESS_TOKEN
+Enter access_token for provider 'bws' (source: keyring): ****
+✓ stored access_token in keyring at myproject/default/access_token
 
 Run 'secretspec check --provider bws' to verify authentication.
 ```
 
-A read-only source provider is rejected. An alias that declares no bootstrap credentials reports that there is nothing to store.
+A read-only source provider is rejected. An alias that declares no credentials reports that there is nothing to store.
 
 ### check
 Check if all required secrets are available, with interactive prompting for missing secrets.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -73,20 +73,25 @@ Add a provider alias to your user-level configuration (`~/.config/secretspec/con
 To share aliases with your team, declare them in a top-level `[providers]` table in `secretspec.toml` instead — they take precedence over user-level aliases on name conflict.
 
 ```bash
-secretspec config provider add <ALIAS> <URI>
+secretspec config provider add <ALIAS> <URI> [--env VAR=PROVIDER]...
 ```
 
 **Arguments:**
 - `<ALIAS>` - Short name for the provider (e.g., `prod_vault`, `shared`)
 - `<URI>` - Provider URI (e.g., `onepassword://Production`, `env://`)
 
+**Options:**
+- `--env <VAR=PROVIDER>` - Declare a [bootstrap credential](/concepts/providers/#bootstrap-credentials) the provider needs: the environment variable `VAR` is read from `PROVIDER` before the environment. Repeatable. Only the bare-string source form is expressible on the command line; add a `ref` by editing the config.
+
 **Example:**
 ```bash
 $ secretspec config provider add prod_vault "onepassword://Production"
-✓ Provider alias 'prod_vault' saved
+✓ Provider alias 'prod_vault' added: 'onepassword://Production'
 
-$ secretspec config provider add shared "onepassword://Shared"
-✓ Provider alias 'shared' saved
+$ secretspec config provider add bws "bws://project-uuid" --env BWS_ACCESS_TOKEN=keyring
+✓ Provider alias 'bws' added: 'bws://project-uuid'
+  bootstrap: BWS_ACCESS_TOKEN=keyring
+  run 'secretspec config provider login bws' to store the credentials
 ```
 
 ### config provider list
@@ -119,6 +124,27 @@ secretspec config provider remove <ALIAS>
 $ secretspec config provider remove prod_vault
 ✓ Provider alias 'prod_vault' removed
 ```
+
+### config provider login
+Store the [bootstrap credentials](/concepts/providers/#bootstrap-credentials) a provider alias declares in its `env` map. Prompts (hidden input) for each variable and writes it to its source provider at the exact location resolution reads it back from. Runs in a project, like `set` and `check`.
+
+```bash
+secretspec config provider login <ALIAS>
+```
+
+**Arguments:**
+- `<ALIAS>` - Name of the alias whose credentials to store
+
+**Example:**
+```bash
+$ secretspec config provider login bws
+Enter BWS_ACCESS_TOKEN for provider 'bws' (source: keyring): ****
+✓ stored BWS_ACCESS_TOKEN in keyring at myproject/default/BWS_ACCESS_TOKEN
+
+Run 'secretspec check --provider bws' to verify authentication.
+```
+
+A read-only source provider is rejected. An alias that declares no bootstrap credentials reports that there is nothing to store.
 
 ### check
 Check if all required secrets are available, with interactive prompting for missing secrets.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -186,6 +186,31 @@ $ secretspec config provider remove prod_vault
 
 The CLI commands operate on the user-global config only — edit `secretspec.toml` by hand to change project-level aliases.
 
+#### Alias value forms
+
+An alias value is either a bare provider URI string, or a table that also declares the bootstrap credentials the provider needs. Both forms are accepted in the project `[providers]` and user `[defaults.providers]` tables.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `uri` | string | Yes (table form) | The provider URI. A bare-string alias is shorthand for `{ uri = "..." }`. |
+| `env` | table | No | Maps an environment variable the provider needs to a [bootstrap source](/concepts/providers/#bootstrap-credentials). |
+
+Each `env` value is itself either a bare provider spec — read at the convention path for the active project and profile — or a table `{ provider = "...", ref = { ... } }` that pins the exact location with the same `ref` coordinates a secret uses.
+
+```toml title="secretspec.toml"
+[providers]
+keyring = "keyring://"
+# bare string: read BWS_ACCESS_TOKEN from keyring at the convention path
+bws = { uri = "bws://project-uuid", env = { BWS_ACCESS_TOKEN = "keyring" } }
+
+[providers.vault_prod]
+uri = "vault://secret/myapp?auth=approle"
+env = { VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
+        VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
+```
+
+A variable already set in the environment takes precedence over its declared source, bootstrap chains are limited to one hop, and a fetched credential is never written to the environment. Store the credentials with [`secretspec config provider login`](/reference/cli/#config-provider-login). See [Bootstrap Credentials](/concepts/providers/#bootstrap-credentials) for the full behavior.
+
 ### Audit Logging
 
 secretspec records every secret access to a local [audit log](/concepts/audit/).

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -188,28 +188,28 @@ The CLI commands operate on the user-global config only — edit `secretspec.tom
 
 #### Alias value forms
 
-An alias value is either a bare provider URI string, or a table that also declares the bootstrap credentials the provider needs. Both forms are accepted in the project `[providers]` and user `[defaults.providers]` tables.
+An alias value is either a bare provider URI string, or a table that also declares the credentials the provider needs. Both forms are accepted in the project `[providers]` and user `[defaults.providers]` tables.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `uri` | string | Yes (table form) | The provider URI. A bare-string alias is shorthand for `{ uri = "..." }`. |
-| `env` | table | No | Maps an environment variable the provider needs to a [bootstrap source](/concepts/providers/#bootstrap-credentials). |
+| `credentials` | table | No | Maps a semantic provider credential name to its [source](/concepts/providers/#provider-credentials). |
 
-Each `env` value is itself either a bare provider spec — read at the convention path for the active project and profile — or a table `{ provider = "...", ref = { ... } }` that pins the exact location with the same `ref` coordinates a secret uses.
+Each `credentials` value is either a bare provider spec — read at the convention path for the active project and profile — or a table `{ provider = "...", ref = { ... } }` that pins the exact location with the same `ref` coordinates a secret uses.
 
 ```toml title="secretspec.toml"
 [providers]
 keyring = "keyring://"
-# bare string: read BWS_ACCESS_TOKEN from keyring at the convention path
-bws = { uri = "bws://project-uuid", env = { BWS_ACCESS_TOKEN = "keyring" } }
+# bare string: read access_token from keyring at the convention path
+bws = { uri = "bws://project-uuid", credentials = { access_token = "keyring" } }
 
 [providers.vault_prod]
 uri = "vault://secret/myapp?auth=approle"
-env = { VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
-        VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
+credentials = { role_id   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
+                secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
 ```
 
-A variable already set in the environment takes precedence over its declared source, bootstrap chains are limited to one hop, and a fetched credential is never written to the environment. Store the credentials with [`secretspec config provider login`](/reference/cli/#config-provider-login). See [Bootstrap Credentials](/concepts/providers/#bootstrap-credentials) for the full behavior.
+Configured credentials take precedence over provider environment fallbacks, credential chains are limited to one hop, and a fetched credential is never written to the environment. Store the credentials with [`secretspec config provider login`](/reference/cli/#config-provider-login). See [Provider Credentials](/concepts/providers/#provider-credentials) for the full behavior.
 
 ### Audit Logging
 

--- a/scripts/ci-sdks.sh
+++ b/scripts/ci-sdks.sh
@@ -98,11 +98,8 @@ echo "==> PHP (ext-ffi fallback, dlopens the cdylib via SECRETSPEC_FFI_LIB)"
 echo "==> PHP (secretspec-php-native extension, ext-php-rs)"
 # Build the extension in debug and load it directly; when it is present the SDK
 # prefers it over ext-ffi. This also proves the extension registers its functions.
-cargo build -p secretspec-php-native
-case "$(uname -s)" in
-  Darwin) php_ext="$target_dir/debug/libsecretspec_php_native.dylib" ;;
-  *)      php_ext="$target_dir/debug/libsecretspec_php_native.so" ;;
-esac
-( cd secretspec-php && php -d extension="$php_ext" ./vendor/bin/phpunit )
+CARGO_TARGET_DIR="$target_dir" SECRETSPEC_PHP_PROFILE=debug \
+  bash secretspec-php/scripts/build-ext.sh
+( cd secretspec-php && php -d extension="$PWD/lib/secretspec.so" ./vendor/bin/phpunit )
 
 echo "==> All SDK suites passed"

--- a/scripts/upload-release-asset.sh
+++ b/scripts/upload-release-asset.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Attach release assets (each with a sha256 sidecar) to the GitHub Release for
+# a tag:
+#
+#     upload-release-asset.sh <tag> <asset> [asset...]
+#
+# cargo-dist's release.yml creates the release for the same tag concurrently,
+# so wait for it to exist, then upload with --clobber (either workflow may
+# retry). Needs GH_TOKEN with contents: write.
+set -euo pipefail
+
+tag="$1"
+shift
+
+files=()
+for asset in "$@"; do
+  # sha256 sidecar (BSD shasum on macOS, GNU sha256sum on Linux; both here).
+  if command -v sha256sum >/dev/null; then sha256sum "$asset" > "$asset.sha256"
+  else shasum -a 256 "$asset" > "$asset.sha256"; fi
+  files+=("$asset" "$asset.sha256")
+done
+
+# Wait for cargo-dist to create the release (concurrent workflow).
+for _ in $(seq 1 30); do
+  gh release view "$tag" >/dev/null 2>&1 && break || sleep 20
+done
+gh release upload "$tag" "${files[@]}" --clobber

--- a/secretspec-php/scripts/build-ext.sh
+++ b/secretspec-php/scripts/build-ext.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 pkg_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_root="$(cd "$pkg_dir/.." && pwd)"
 profile="${SECRETSPEC_PHP_PROFILE:-release}"
+target_dir="${CARGO_TARGET_DIR:-$repo_root/target}"
 
 case "$(uname -s)" in
   Darwin)               built="libsecretspec_php_native.dylib"; staged="secretspec.so" ;;
@@ -26,5 +27,5 @@ build_flag=()
 mkdir -p "$pkg_dir/lib"
 # dlopen (which PHP uses to load extensions) resolves by path, not by suffix, so
 # staging the macOS .dylib under a .so name loads fine.
-cp -f "$repo_root/target/$profile/$built" "$pkg_dir/lib/$staged"
+cp -f "$target_dir/$profile/$built" "$pkg_dir/lib/$staged"
 echo "built $pkg_dir/lib/$staged"

--- a/secretspec-py/.gitignore
+++ b/secretspec-py/.gitignore
@@ -7,3 +7,5 @@ dist/
 # Compiled pyo3 extension (secretspec/_native.abi3.so), built by maturin.
 *.so
 *.o
+# C source emitted by cffi's builder.
+*_cffi.c

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -517,7 +517,7 @@ pub fn main() -> Result<()> {
 
                         // Add or update the provider alias
                         if let Some(providers) = &mut config.defaults.providers {
-                            let existing = providers.insert(name.clone(), uri.clone());
+                            let existing = providers.insert(name.clone(), uri.clone().into());
                             config.save().into_diagnostic()?;
 
                             if existing.is_some() {

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -173,6 +173,12 @@ enum ProviderAction {
         name: String,
         /// Provider URI (e.g., "keyring://", "onepassword://Shared", "dotenv://.env.local")
         uri: String,
+        /// Bootstrap credential binding `VAR=PROVIDER` (repeatable): the alias's
+        /// provider reads `VAR` from `PROVIDER` before the environment. Only the
+        /// bare-string source form is expressible here; add a `ref` by editing
+        /// the config.
+        #[arg(long = "env", value_name = "VAR=PROVIDER")]
+        env: Vec<String>,
     },
     /// Remove a provider alias
     Remove {
@@ -181,6 +187,11 @@ enum ProviderAction {
     },
     /// List all configured provider aliases
     List,
+    /// Store the bootstrap credentials a provider alias declares in `env`
+    Login {
+        /// Name of the provider alias to store credentials for
+        name: String,
+    },
 }
 
 /// Returns an example TOML configuration string
@@ -496,7 +507,32 @@ pub fn main() -> Result<()> {
             // Manage provider aliases
             ConfigAction::Provider(action) => {
                 match action {
-                    ProviderAction::Add { name, uri } => {
+                    ProviderAction::Add { name, uri, env } => {
+                        // Parse each `VAR=PROVIDER` binding into a bootstrap source.
+                        let mut bootstrap = HashMap::new();
+                        for binding in &env {
+                            let (var, spec) = binding.split_once('=').ok_or_else(|| {
+                                miette!("--env expects VAR=PROVIDER, got '{binding}'")
+                            })?;
+                            if var.is_empty() || spec.is_empty() {
+                                return Err(miette!(
+                                    "--env expects a non-empty VAR=PROVIDER, got '{binding}'"
+                                ));
+                            }
+                            bootstrap.insert(
+                                var.to_string(),
+                                crate::config::BootstrapSource::from(spec),
+                            );
+                        }
+                        let alias_value = if bootstrap.is_empty() {
+                            crate::config::ProviderAlias::from(uri.clone())
+                        } else {
+                            crate::config::ProviderAlias {
+                                uri: uri.clone(),
+                                env: Some(bootstrap),
+                            }
+                        };
+
                         // Load or create config
                         let mut config =
                             GlobalConfig::load()
@@ -517,13 +553,19 @@ pub fn main() -> Result<()> {
 
                         // Add or update the provider alias
                         if let Some(providers) = &mut config.defaults.providers {
-                            let existing = providers.insert(name.clone(), uri.clone().into());
+                            let display = providers
+                                .insert(name.clone(), alias_value)
+                                .map_or("added", |_| "updated");
                             config.save().into_diagnostic()?;
-
-                            if existing.is_some() {
-                                println!("✓ Provider alias '{}' updated to '{}'", name, uri);
-                            } else {
-                                println!("✓ Provider alias '{}' added: '{}'", name, uri);
+                            println!("✓ Provider alias '{name}' {display}: '{uri}'");
+                            if !env.is_empty() {
+                                println!(
+                                    "  bootstrap: {}",
+                                    env.iter().cloned().collect::<Vec<_>>().join(", ")
+                                );
+                                println!(
+                                    "  run 'secretspec config provider login {name}' to store the credentials"
+                                );
                             }
                         }
                         Ok(())
@@ -575,6 +617,41 @@ pub fn main() -> Result<()> {
                                 );
                             }
                         }
+                        Ok(())
+                    }
+                    ProviderAction::Login { name } => {
+                        let app = load_secrets(&cli.file, &cli.reason)?;
+                        let credentials = app.bootstrap_credentials(&name).into_diagnostic()?;
+                        if credentials.is_empty() {
+                            println!(
+                                "Provider alias '{name}' declares no bootstrap credentials (no `env`)."
+                            );
+                            return Ok(());
+                        }
+                        for (var, source) in credentials {
+                            let entered = inquire::Password::new(&format!(
+                                "Enter {var} for provider '{name}' (source: {}):",
+                                source.provider
+                            ))
+                            .without_confirmation()
+                            .prompt()
+                            .into_diagnostic()?;
+                            if entered.is_empty() {
+                                println!("✗ Skipped {var} (empty)");
+                                continue;
+                            }
+                            let location = app
+                                .store_bootstrap_credential(
+                                    &source,
+                                    &var,
+                                    &secrecy::SecretString::new(entered.into()),
+                                )
+                                .into_diagnostic()?;
+                            println!("✓ stored {var} in {location}");
+                        }
+                        println!(
+                            "\nRun 'secretspec check --provider {name}' to verify authentication."
+                        );
                         Ok(())
                     }
                 }
@@ -1200,6 +1277,47 @@ mod tests {
         match cli.command {
             Commands::Check { no_prompt, .. } => assert!(no_prompt),
             _ => panic!("expected Check command"),
+        }
+    }
+
+    #[test]
+    fn provider_add_parses_repeated_env_bindings() {
+        let cli = Cli::try_parse_from([
+            "secretspec",
+            "config",
+            "provider",
+            "add",
+            "bws",
+            "bws://proj",
+            "--env",
+            "BWS_ACCESS_TOKEN=keyring",
+            "--env",
+            "OTHER=dotenv://.env",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Config {
+                action: ConfigAction::Provider(ProviderAction::Add { name, uri, env }),
+            } => {
+                assert_eq!(name, "bws");
+                assert_eq!(uri, "bws://proj");
+                assert_eq!(env, vec!["BWS_ACCESS_TOKEN=keyring", "OTHER=dotenv://.env"]);
+            }
+            _ => panic!("expected config provider add"),
+        }
+    }
+
+    #[test]
+    fn provider_login_parses() {
+        let cli =
+            Cli::try_parse_from(["secretspec", "config", "provider", "login", "bws"]).unwrap();
+        match cli.command {
+            Commands::Config {
+                action: ConfigAction::Provider(ProviderAction::Login { name }),
+            } => {
+                assert_eq!(name, "bws");
+            }
+            _ => panic!("expected config provider login"),
         }
     }
 }

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -173,12 +173,12 @@ enum ProviderAction {
         name: String,
         /// Provider URI (e.g., "keyring://", "onepassword://Shared", "dotenv://.env.local")
         uri: String,
-        /// Bootstrap credential binding `VAR=PROVIDER` (repeatable): the alias's
-        /// provider uses a non-empty `VAR` from the environment first, falling
-        /// back to `PROVIDER`. Only the bare-string source form is expressible
-        /// here; add a `ref` by editing the config.
-        #[arg(long = "env", value_name = "VAR=PROVIDER")]
-        env: Vec<String>,
+        /// Provider credential binding `NAME=PROVIDER` (repeatable). `NAME` is
+        /// semantic and provider-specific, such as `access_token` or `role_id`.
+        /// Only the bare-string source form is expressible here; add a `ref` by
+        /// editing the config.
+        #[arg(long = "credential", value_name = "NAME=PROVIDER")]
+        credential: Vec<String>,
     },
     /// Remove a provider alias
     Remove {
@@ -187,7 +187,7 @@ enum ProviderAction {
     },
     /// List all configured provider aliases
     List,
-    /// Store the bootstrap credentials a provider alias declares in `env`
+    /// Store the credentials declared by a provider alias
     Login {
         /// Name of the provider alias to store credentials for
         name: String,
@@ -507,28 +507,32 @@ pub fn main() -> Result<()> {
             // Manage provider aliases
             ConfigAction::Provider(action) => {
                 match action {
-                    ProviderAction::Add { name, uri, env } => {
-                        // Parse each `VAR=PROVIDER` binding into a bootstrap source.
-                        let mut bootstrap = HashMap::new();
-                        for binding in &env {
-                            let (var, spec) = binding.split_once('=').ok_or_else(|| {
-                                miette!("--env expects VAR=PROVIDER, got '{binding}'")
-                            })?;
-                            if var.is_empty() || spec.is_empty() {
+                    ProviderAction::Add {
+                        name,
+                        uri,
+                        credential,
+                    } => {
+                        // Parse each `NAME=PROVIDER` binding into a credential source.
+                        let mut credentials = HashMap::new();
+                        for binding in &credential {
+                            let (credential_name, spec) =
+                                binding.split_once('=').ok_or_else(|| {
+                                    miette!("--credential expects NAME=PROVIDER, got '{binding}'")
+                                })?;
+                            if credential_name.is_empty() || spec.is_empty() {
                                 return Err(miette!(
-                                    "--env expects a non-empty VAR=PROVIDER, got '{binding}'"
+                                    "--credential expects a non-empty NAME=PROVIDER, got '{binding}'"
                                 ));
                             }
-                            bootstrap.insert(
-                                var.to_string(),
-                                crate::config::BootstrapSource::from(spec),
+                            credentials.insert(
+                                credential_name.to_string(),
+                                crate::config::CredentialSource::from(spec),
                             );
                         }
-                        // An empty map means no `env`, so a plain add round-trips
-                        // as a bare-string alias.
+                        // An empty map keeps the compact bare-string alias form.
                         let alias_value = crate::config::ProviderAlias {
                             uri: uri.clone(),
-                            env: bootstrap,
+                            credentials,
                         };
 
                         // Load or create config
@@ -556,8 +560,8 @@ pub fn main() -> Result<()> {
                                 .map_or("added", |_| "updated");
                             config.save().into_diagnostic()?;
                             println!("✓ Provider alias '{name}' {display}: '{uri}'");
-                            if !env.is_empty() {
-                                println!("  bootstrap: {}", env.join(", "));
+                            if !credential.is_empty() {
+                                println!("  credentials: {}", credential.join(", "));
                                 println!(
                                     "  run 'secretspec config provider login {name}' to store the credentials"
                                 );
@@ -616,33 +620,32 @@ pub fn main() -> Result<()> {
                     }
                     ProviderAction::Login { name } => {
                         let app = load_secrets(&cli.file, &cli.reason)?;
-                        let credentials = app.bootstrap_credentials(&name).into_diagnostic()?;
+                        let credentials =
+                            app.declared_provider_credentials(&name).into_diagnostic()?;
                         if credentials.is_empty() {
-                            println!(
-                                "Provider alias '{name}' declares no bootstrap credentials (no `env`)."
-                            );
+                            println!("Provider alias '{name}' declares no credentials.");
                             return Ok(());
                         }
-                        for (var, source) in credentials {
+                        for (credential_name, source) in credentials {
                             let entered = inquire::Password::new(&format!(
-                                "Enter {var} for provider '{name}' (source: {}):",
+                                "Enter {credential_name} for provider '{name}' (source: {}):",
                                 source.display_provider()
                             ))
                             .without_confirmation()
                             .prompt()
                             .into_diagnostic()?;
                             if entered.is_empty() {
-                                println!("✗ Skipped {var} (empty)");
+                                println!("✗ Skipped {credential_name} (empty)");
                                 continue;
                             }
                             let location = app
-                                .store_bootstrap_credential(
+                                .store_provider_credential(
                                     &source,
-                                    &var,
+                                    &credential_name,
                                     &secrecy::SecretString::new(entered.into()),
                                 )
                                 .into_diagnostic()?;
-                            println!("✓ stored {var} in {location}");
+                            println!("✓ stored {credential_name} in {location}");
                         }
                         println!(
                             "\nRun 'secretspec check --provider {name}' to verify authentication."
@@ -1276,8 +1279,54 @@ mod tests {
     }
 
     #[test]
-    fn provider_add_parses_repeated_env_bindings() {
+    fn provider_add_parses_repeated_credential_bindings() {
         let cli = Cli::try_parse_from([
+            "secretspec",
+            "config",
+            "provider",
+            "add",
+            "bws",
+            "bws://proj",
+            "--credential",
+            "access_token=keyring",
+            "--credential",
+            "other=dotenv://.env",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Config {
+                action:
+                    ConfigAction::Provider(ProviderAction::Add {
+                        name,
+                        uri,
+                        credential,
+                    }),
+            } => {
+                assert_eq!(name, "bws");
+                assert_eq!(uri, "bws://proj");
+                assert_eq!(
+                    credential,
+                    vec!["access_token=keyring", "other=dotenv://.env"]
+                );
+            }
+            _ => panic!("expected config provider add"),
+        }
+    }
+
+    #[test]
+    fn provider_add_help_describes_semantic_credentials() {
+        let help = Cli::try_parse_from(["secretspec", "config", "provider", "add", "--help"])
+            .err()
+            .expect("--help should stop parsing")
+            .to_string();
+
+        assert!(help.contains("semantic and provider-specific"));
+        assert!(help.contains("access_token"));
+    }
+
+    #[test]
+    fn provider_add_rejects_the_environment_shaped_flag() {
+        let error = Cli::try_parse_from([
             "secretspec",
             "config",
             "provider",
@@ -1286,32 +1335,11 @@ mod tests {
             "bws://proj",
             "--env",
             "BWS_ACCESS_TOKEN=keyring",
-            "--env",
-            "OTHER=dotenv://.env",
         ])
-        .unwrap();
-        match cli.command {
-            Commands::Config {
-                action: ConfigAction::Provider(ProviderAction::Add { name, uri, env }),
-            } => {
-                assert_eq!(name, "bws");
-                assert_eq!(uri, "bws://proj");
-                assert_eq!(env, vec!["BWS_ACCESS_TOKEN=keyring", "OTHER=dotenv://.env"]);
-            }
-            _ => panic!("expected config provider add"),
-        }
-    }
+        .err()
+        .expect("--env should be rejected");
 
-    #[test]
-    fn provider_add_help_describes_environment_first_precedence() {
-        let help = Cli::try_parse_from(["secretspec", "config", "provider", "add", "--help"])
-            .err()
-            .expect("--help should stop parsing")
-            .to_string();
-
-        assert!(help.contains("uses a non-empty `VAR` from the environment first"));
-        assert!(help.contains("falling back to `PROVIDER`"));
-        assert!(!help.contains("from `PROVIDER` before the environment"));
+        assert!(error.to_string().contains("--env"));
     }
 
     #[test]

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -528,7 +528,7 @@ pub fn main() -> Result<()> {
                         // as a bare-string alias.
                         let alias_value = crate::config::ProviderAlias {
                             uri: uri.clone(),
-                            env: (!bootstrap.is_empty()).then_some(bootstrap),
+                            env: bootstrap,
                         };
 
                         // Load or create config

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -174,9 +174,9 @@ enum ProviderAction {
         /// Provider URI (e.g., "keyring://", "onepassword://Shared", "dotenv://.env.local")
         uri: String,
         /// Bootstrap credential binding `VAR=PROVIDER` (repeatable): the alias's
-        /// provider reads `VAR` from `PROVIDER` before the environment. Only the
-        /// bare-string source form is expressible here; add a `ref` by editing
-        /// the config.
+        /// provider uses a non-empty `VAR` from the environment first, falling
+        /// back to `PROVIDER`. Only the bare-string source form is expressible
+        /// here; add a `ref` by editing the config.
         #[arg(long = "env", value_name = "VAR=PROVIDER")]
         env: Vec<String>,
     },
@@ -626,7 +626,7 @@ pub fn main() -> Result<()> {
                         for (var, source) in credentials {
                             let entered = inquire::Password::new(&format!(
                                 "Enter {var} for provider '{name}' (source: {}):",
-                                source.provider
+                                source.display_provider()
                             ))
                             .without_confirmation()
                             .prompt()
@@ -1300,6 +1300,18 @@ mod tests {
             }
             _ => panic!("expected config provider add"),
         }
+    }
+
+    #[test]
+    fn provider_add_help_describes_environment_first_precedence() {
+        let help = Cli::try_parse_from(["secretspec", "config", "provider", "add", "--help"])
+            .err()
+            .expect("--help should stop parsing")
+            .to_string();
+
+        assert!(help.contains("uses a non-empty `VAR` from the environment first"));
+        assert!(help.contains("falling back to `PROVIDER`"));
+        assert!(!help.contains("from `PROVIDER` before the environment"));
     }
 
     #[test]

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -524,13 +524,11 @@ pub fn main() -> Result<()> {
                                 crate::config::BootstrapSource::from(spec),
                             );
                         }
-                        let alias_value = if bootstrap.is_empty() {
-                            crate::config::ProviderAlias::from(uri.clone())
-                        } else {
-                            crate::config::ProviderAlias {
-                                uri: uri.clone(),
-                                env: Some(bootstrap),
-                            }
+                        // An empty map means no `env`, so a plain add round-trips
+                        // as a bare-string alias.
+                        let alias_value = crate::config::ProviderAlias {
+                            uri: uri.clone(),
+                            env: (!bootstrap.is_empty()).then_some(bootstrap),
                         };
 
                         // Load or create config
@@ -559,10 +557,7 @@ pub fn main() -> Result<()> {
                             config.save().into_diagnostic()?;
                             println!("✓ Provider alias '{name}' {display}: '{uri}'");
                             if !env.is_empty() {
-                                println!(
-                                    "  bootstrap: {}",
-                                    env.iter().cloned().collect::<Vec<_>>().join(", ")
-                                );
+                                println!("  bootstrap: {}", env.join(", "));
                                 println!(
                                     "  run 'secretspec config provider login {name}' to store the credentials"
                                 );

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -40,6 +40,112 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+/// Where one bootstrap credential of a provider comes from.
+///
+/// Written in an alias's `env` map either as a bare provider spec, which reads
+/// the credential from that provider at the convention path for the active
+/// project and profile:
+///
+/// ```toml
+/// env = { BWS_ACCESS_TOKEN = "keyring" }
+/// ```
+///
+/// or as a table that pins the exact location with the same `ref` coordinates a
+/// secret uses:
+///
+/// ```toml
+/// env = { VAULT_ROLE_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } } }
+/// ```
+///
+/// Reusing `ref` means bootstrap credentials are addressed exactly like every
+/// other secret — no separate storage convention. A bare spec round-trips back
+/// to a bare string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootstrapSource {
+    /// Provider spec (alias, bare provider name, or URI) supplying the credential.
+    pub provider: String,
+    /// Native coordinates within that provider. When absent, the credential is
+    /// read at the convention path (the variable name as key) for the active
+    /// project and profile.
+    pub reference: Option<NativeAddress>,
+}
+
+impl BootstrapSource {
+    /// A source that reads from `provider` using convention naming.
+    pub fn from_provider(provider: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            reference: None,
+        }
+    }
+}
+
+impl From<String> for BootstrapSource {
+    fn from(provider: String) -> Self {
+        Self::from_provider(provider)
+    }
+}
+
+impl From<&str> for BootstrapSource {
+    fn from(provider: &str) -> Self {
+        Self::from_provider(provider)
+    }
+}
+
+impl Serialize for BootstrapSource {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match &self.reference {
+            // A ref-less source round-trips back to the bare-string form.
+            None => serializer.serialize_str(&self.provider),
+            Some(reference) => {
+                use serde::ser::SerializeStruct;
+                let mut table = serializer.serialize_struct("BootstrapSource", 2)?;
+                table.serialize_field("provider", &self.provider)?;
+                table.serialize_field("ref", reference)?;
+                table.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BootstrapSource {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SourceVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for SourceVisitor {
+            type Value = BootstrapSource;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a provider spec string or a { provider, ref } table")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, provider: &str) -> Result<BootstrapSource, E> {
+                Ok(BootstrapSource::from_provider(provider))
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                map: M,
+            ) -> Result<BootstrapSource, M::Error> {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct Table {
+                    provider: String,
+                    #[serde(default, rename = "ref")]
+                    reference: Option<NativeAddress>,
+                }
+                let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(BootstrapSource {
+                    provider: table.provider,
+                    reference: table.reference,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(SourceVisitor)
+    }
+}
+
 /// A provider alias: a provider URI plus an optional bootstrap-credential map.
 ///
 /// In TOML an alias is written either as a bare string, which is just the URI:
@@ -65,10 +171,9 @@ use std::str::FromStr;
 pub struct ProviderAlias {
     /// The provider URI (e.g. `keyring://`, `bws://project-uuid`).
     pub uri: String,
-    /// Bootstrap credentials: environment variable name to the provider spec
-    /// (alias, bare provider name, or URI) that supplies it. `None` for a bare
-    /// string alias.
-    pub env: Option<HashMap<String, String>>,
+    /// Bootstrap credentials: environment variable name to the [`BootstrapSource`]
+    /// that supplies it. `None` for a bare string alias.
+    pub env: Option<HashMap<String, BootstrapSource>>,
 }
 
 impl ProviderAlias {
@@ -96,12 +201,12 @@ impl From<&str> for ProviderAlias {
 impl std::fmt::Display for ProviderAlias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.uri)?;
-        if let Some(env) = &self.env {
-            if !env.is_empty() {
-                let mut vars: Vec<&str> = env.keys().map(String::as_str).collect();
-                vars.sort();
-                write!(f, " (bootstrap: {})", vars.join(", "))?;
-            }
+        if let Some(env) = &self.env
+            && !env.is_empty()
+        {
+            let mut vars: Vec<&str> = env.keys().map(String::as_str).collect();
+            vars.sort();
+            write!(f, " (bootstrap: {})", vars.join(", "))?;
         }
         Ok(())
     }
@@ -151,7 +256,7 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                 struct Table {
                     uri: String,
                     #[serde(default)]
-                    env: Option<HashMap<String, String>>,
+                    env: Option<HashMap<String, BootstrapSource>>,
                 }
                 let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
                 Ok(ProviderAlias {
@@ -2305,14 +2410,50 @@ mod provider_alias_tests {
         let map = parse(r#"bws = { uri = "bws://proj", env = { BWS_ACCESS_TOKEN = "keyring" } }"#);
         let alias = &map["bws"];
         assert_eq!(alias.uri, "bws://proj");
-        assert_eq!(
-            alias
-                .env
-                .as_ref()
-                .and_then(|env| env.get("BWS_ACCESS_TOKEN"))
-                .map(String::as_str),
-            Some("keyring"),
+        let source = alias
+            .env
+            .as_ref()
+            .and_then(|env| env.get("BWS_ACCESS_TOKEN"))
+            .expect("env carries the variable");
+        assert_eq!(source, &BootstrapSource::from("keyring"));
+    }
+
+    #[test]
+    fn env_source_with_ref_parses_provider_and_coordinates() {
+        let map = parse(
+            r#"vault = { uri = "vault://kv", env = { VAULT_ROLE_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } } } }"#,
         );
+        let source = map["vault"].env.as_ref().unwrap()["VAULT_ROLE_ID"].clone();
+        assert_eq!(source.provider, "onepassword");
+        let reference = source.reference.expect("ref present");
+        assert_eq!(reference.vault.as_deref(), Some("Infra"));
+        assert_eq!(reference.item, "approle");
+        assert_eq!(reference.field.as_deref(), Some("role_id"));
+    }
+
+    #[test]
+    fn env_source_round_trips() {
+        let bare = BootstrapSource::from("keyring");
+        let with_ref = BootstrapSource {
+            provider: "onepassword".to_string(),
+            reference: Some(NativeAddress {
+                item: "approle".to_string(),
+                field: Some("role_id".to_string()),
+                ..Default::default()
+            }),
+        };
+        for source in [bare, with_ref] {
+            let alias = ProviderAlias {
+                uri: "vault://kv".to_string(),
+                env: Some(HashMap::from([(
+                    "VAULT_ROLE_ID".to_string(),
+                    source.clone(),
+                )])),
+            };
+            let map = HashMap::from([("vault".to_string(), alias.clone())]);
+            let serialized = toml::to_string(&map).unwrap();
+            assert_eq!(parse(&serialized)["vault"], alias);
+        }
     }
 
     #[test]
@@ -2349,7 +2490,7 @@ mod provider_alias_tests {
             uri: "bws://proj".to_string(),
             env: Some(HashMap::from([(
                 "BWS_ACCESS_TOKEN".to_string(),
-                "keyring".to_string(),
+                BootstrapSource::from("keyring"),
             )])),
         };
         let map = HashMap::from([("bws".to_string(), alias.clone())]);

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -40,37 +40,37 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-/// Where one bootstrap credential of a provider comes from.
+/// Where one credential required by a provider comes from.
 ///
-/// Written in an alias's `env` map either as a bare provider spec, which reads
-/// the credential from that provider at the convention path for the active
-/// project and profile:
+/// Written in an alias's `credentials` map either as a bare provider spec,
+/// which reads the credential from that provider at the convention path for
+/// the active project and profile:
 ///
 /// ```toml
-/// env = { BWS_ACCESS_TOKEN = "keyring" }
+/// credentials = { access_token = "keyring" }
 /// ```
 ///
 /// or as a table that pins the exact location with the same `ref` coordinates a
 /// secret uses:
 ///
 /// ```toml
-/// env = { VAULT_ROLE_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } } }
+/// credentials = { role_id = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } } }
 /// ```
 ///
-/// Reusing `ref` means bootstrap credentials are addressed exactly like every
+/// Reusing `ref` means provider credentials are addressed exactly like every
 /// other secret — no separate storage convention. A bare spec round-trips back
 /// to a bare string.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BootstrapSource {
+pub struct CredentialSource {
     /// Provider spec (alias, bare provider name, or URI) supplying the credential.
     pub provider: String,
     /// Native coordinates within that provider. When absent, the credential is
-    /// read at the convention path (the variable name as key) for the active
+    /// read at the convention path (the credential name as key) for the active
     /// project and profile.
     pub reference: Option<NativeAddress>,
 }
 
-impl BootstrapSource {
+impl CredentialSource {
     /// A source that reads from `provider` using convention naming.
     pub fn from_provider(provider: impl Into<String>) -> Self {
         Self {
@@ -80,26 +80,26 @@ impl BootstrapSource {
     }
 }
 
-impl From<String> for BootstrapSource {
+impl From<String> for CredentialSource {
     fn from(provider: String) -> Self {
         Self::from_provider(provider)
     }
 }
 
-impl From<&str> for BootstrapSource {
+impl From<&str> for CredentialSource {
     fn from(provider: &str) -> Self {
         Self::from_provider(provider)
     }
 }
 
-impl Serialize for BootstrapSource {
+impl Serialize for CredentialSource {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match &self.reference {
             // A ref-less source round-trips back to the bare-string form.
             None => serializer.serialize_str(&self.provider),
             Some(reference) => {
                 use serde::ser::SerializeStruct;
-                let mut table = serializer.serialize_struct("BootstrapSource", 2)?;
+                let mut table = serializer.serialize_struct("CredentialSource", 2)?;
                 table.serialize_field("provider", &self.provider)?;
                 table.serialize_field("ref", reference)?;
                 table.end()
@@ -108,25 +108,25 @@ impl Serialize for BootstrapSource {
     }
 }
 
-impl<'de> Deserialize<'de> for BootstrapSource {
+impl<'de> Deserialize<'de> for CredentialSource {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct SourceVisitor;
 
         impl<'de> serde::de::Visitor<'de> for SourceVisitor {
-            type Value = BootstrapSource;
+            type Value = CredentialSource;
 
             fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.write_str("a provider spec string or a { provider, ref } table")
             }
 
-            fn visit_str<E: serde::de::Error>(self, provider: &str) -> Result<BootstrapSource, E> {
-                Ok(BootstrapSource::from_provider(provider))
+            fn visit_str<E: serde::de::Error>(self, provider: &str) -> Result<CredentialSource, E> {
+                Ok(CredentialSource::from_provider(provider))
             }
 
             fn visit_map<M: serde::de::MapAccess<'de>>(
                 self,
                 map: M,
-            ) -> Result<BootstrapSource, M::Error> {
+            ) -> Result<CredentialSource, M::Error> {
                 #[derive(Deserialize)]
                 #[serde(deny_unknown_fields)]
                 struct Table {
@@ -135,7 +135,7 @@ impl<'de> Deserialize<'de> for BootstrapSource {
                     reference: Option<NativeAddress>,
                 }
                 let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
-                Ok(BootstrapSource {
+                Ok(CredentialSource {
                     provider: table.provider,
                     reference: table.reference,
                 })
@@ -146,7 +146,7 @@ impl<'de> Deserialize<'de> for BootstrapSource {
     }
 }
 
-/// A provider alias: a provider URI plus an optional bootstrap-credential map.
+/// A provider alias: a provider URI plus an optional credential-source map.
 ///
 /// In TOML an alias is written either as a bare string, which is just the URI:
 ///
@@ -155,34 +155,32 @@ impl<'de> Deserialize<'de> for BootstrapSource {
 /// keyring = "keyring://"
 /// ```
 ///
-/// or as a table carrying an `env` map, whose entries name an environment
-/// variable the provider needs (e.g. an access token) and the provider spec to
-/// source it from — so a provider's own credentials can come from another
-/// provider instead of a plaintext environment variable:
+/// or as a table carrying a `credentials` map, whose entries name semantic
+/// credentials the provider needs and the provider spec to source them from:
 ///
 /// ```toml
 /// [providers]
-/// bws = { uri = "bws://project-uuid", env = { BWS_ACCESS_TOKEN = "keyring" } }
+/// bws = { uri = "bws://project-uuid", credentials = { access_token = "keyring" } }
 /// ```
 ///
-/// The two forms round-trip losslessly: an alias with no `env` serializes back
-/// to a bare string, so existing configs are untouched.
+/// The two forms round-trip losslessly: an alias with no credentials serializes
+/// back to a bare string, so existing configs are untouched.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ProviderAlias {
     /// The provider URI (e.g. `keyring://`, `bws://project-uuid`).
     pub uri: String,
-    /// Bootstrap credentials: environment variable name to the [`BootstrapSource`]
-    /// that supplies it. Empty for a bare string alias, so "declares no
-    /// bootstrap credentials" has exactly one representation.
-    pub env: HashMap<String, BootstrapSource>,
+    /// Semantic credential name to the [`CredentialSource`] that supplies it.
+    /// Empty for a bare string alias, so "declares no credentials" has exactly
+    /// one representation.
+    pub credentials: HashMap<String, CredentialSource>,
 }
 
 impl ProviderAlias {
-    /// A bare alias carrying only a URI and no bootstrap credentials.
+    /// A bare alias carrying only a URI and no credentials.
     pub fn from_uri(uri: impl Into<String>) -> Self {
         Self {
             uri: uri.into(),
-            env: HashMap::new(),
+            credentials: HashMap::new(),
         }
     }
 }
@@ -202,10 +200,10 @@ impl From<&str> for ProviderAlias {
 impl std::fmt::Display for ProviderAlias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.uri)?;
-        if !self.env.is_empty() {
-            let mut vars: Vec<&str> = self.env.keys().map(String::as_str).collect();
-            vars.sort();
-            write!(f, " (bootstrap: {})", vars.join(", "))?;
+        if !self.credentials.is_empty() {
+            let mut names: Vec<&str> = self.credentials.keys().map(String::as_str).collect();
+            names.sort();
+            write!(f, " (credentials: {})", names.join(", "))?;
         }
         Ok(())
     }
@@ -213,7 +211,7 @@ impl std::fmt::Display for ProviderAlias {
 
 impl Serialize for ProviderAlias {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        if self.env.is_empty() {
+        if self.credentials.is_empty() {
             // A bare alias serializes back to the plain-string form, so an alias
             // that was written as a string round-trips unchanged.
             serializer.serialize_str(&self.uri)
@@ -221,7 +219,7 @@ impl Serialize for ProviderAlias {
             use serde::ser::SerializeStruct;
             let mut table = serializer.serialize_struct("ProviderAlias", 2)?;
             table.serialize_field("uri", &self.uri)?;
-            table.serialize_field("env", &self.env)?;
+            table.serialize_field("credentials", &self.credentials)?;
             table.end()
         }
     }
@@ -235,7 +233,7 @@ impl<'de> Deserialize<'de> for ProviderAlias {
             type Value = ProviderAlias;
 
             fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_str("a provider URI string or a { uri, env } table")
+                f.write_str("a provider URI string or a { uri, credentials } table")
             }
 
             fn visit_str<E: serde::de::Error>(self, uri: &str) -> Result<ProviderAlias, E> {
@@ -254,12 +252,12 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                 struct Table {
                     uri: String,
                     #[serde(default)]
-                    env: Option<HashMap<String, BootstrapSource>>,
+                    credentials: Option<HashMap<String, CredentialSource>>,
                 }
                 let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
                 Ok(ProviderAlias {
                     uri: table.uri,
-                    env: table.env.unwrap_or_default(),
+                    credentials: table.credentials.unwrap_or_default(),
                 })
             }
         }
@@ -381,7 +379,7 @@ impl Config {
         }
 
         // Merge provider aliases - current entries win. Whole entries merge
-        // (URI and any bootstrap `env` together); there is no per-field merge.
+        // (URI and any credentials together); there is no per-field merge.
         if let Some(other_providers) = other.providers {
             let merged = self.providers.get_or_insert_with(HashMap::new);
             for (alias, alias_value) in other_providers {
@@ -2397,30 +2395,31 @@ mod provider_alias_tests {
     }
 
     #[test]
-    fn bare_string_parses_as_uri_without_env() {
+    fn bare_string_parses_as_uri_without_credentials() {
         let map = parse(r#"keyring = "keyring://""#);
         assert_eq!(map["keyring"], ProviderAlias::from("keyring://"));
-        assert!(map["keyring"].env.is_empty());
+        assert!(map["keyring"].credentials.is_empty());
     }
 
     #[test]
-    fn table_with_env_parses_uri_and_env() {
-        let map = parse(r#"bws = { uri = "bws://proj", env = { BWS_ACCESS_TOKEN = "keyring" } }"#);
+    fn table_with_credentials_parses_uri_and_credentials() {
+        let map =
+            parse(r#"bws = { uri = "bws://proj", credentials = { access_token = "keyring" } }"#);
         let alias = &map["bws"];
         assert_eq!(alias.uri, "bws://proj");
         let source = alias
-            .env
-            .get("BWS_ACCESS_TOKEN")
-            .expect("env carries the variable");
-        assert_eq!(source, &BootstrapSource::from("keyring"));
+            .credentials
+            .get("access_token")
+            .expect("credentials carries the semantic name");
+        assert_eq!(source, &CredentialSource::from("keyring"));
     }
 
     #[test]
-    fn env_source_with_ref_parses_provider_and_coordinates() {
+    fn credential_source_with_ref_parses_provider_and_coordinates() {
         let map = parse(
-            r#"vault = { uri = "vault://kv", env = { VAULT_ROLE_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } } } }"#,
+            r#"vault = { uri = "vault://kv", credentials = { role_id = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } } } }"#,
         );
-        let source = map["vault"].env["VAULT_ROLE_ID"].clone();
+        let source = map["vault"].credentials["role_id"].clone();
         assert_eq!(source.provider, "onepassword");
         let reference = source.reference.expect("ref present");
         assert_eq!(reference.vault.as_deref(), Some("Infra"));
@@ -2429,9 +2428,9 @@ mod provider_alias_tests {
     }
 
     #[test]
-    fn env_source_round_trips() {
-        let bare = BootstrapSource::from("keyring");
-        let with_ref = BootstrapSource {
+    fn credential_source_round_trips() {
+        let bare = CredentialSource::from("keyring");
+        let with_ref = CredentialSource {
             provider: "onepassword".to_string(),
             reference: Some(NativeAddress {
                 item: "approle".to_string(),
@@ -2442,7 +2441,7 @@ mod provider_alias_tests {
         for source in [bare, with_ref] {
             let alias = ProviderAlias {
                 uri: "vault://kv".to_string(),
-                env: HashMap::from([("VAULT_ROLE_ID".to_string(), source.clone())]),
+                credentials: HashMap::from([("role_id".to_string(), source.clone())]),
             };
             let map = HashMap::from([("vault".to_string(), alias.clone())]);
             let serialized = toml::to_string(&map).unwrap();
@@ -2451,16 +2450,16 @@ mod provider_alias_tests {
     }
 
     #[test]
-    fn table_without_env_is_equivalent_to_bare_string() {
+    fn table_without_credentials_is_equivalent_to_bare_string() {
         let map = parse(r#"bws = { uri = "bws://proj" }"#);
         assert_eq!(map["bws"], ProviderAlias::from("bws://proj"));
     }
 
     #[test]
-    fn empty_env_table_is_equivalent_to_no_env() {
-        // `env = {}` declares nothing: the alias equals its bare-string form
+    fn empty_credentials_table_is_equivalent_to_no_credentials() {
+        // `credentials = {}` declares nothing: the alias equals its bare-string form
         // and serializes back to it.
-        let map = parse(r#"keyring = { uri = "keyring://", env = {} }"#);
+        let map = parse(r#"keyring = { uri = "keyring://", credentials = {} }"#);
         assert_eq!(map["keyring"], ProviderAlias::from("keyring://"));
     }
 
@@ -2477,7 +2476,16 @@ mod provider_alias_tests {
     }
 
     #[test]
-    fn env_less_alias_round_trips_as_a_bare_string() {
+    fn environment_shaped_credential_field_is_rejected() {
+        let error = toml::from_str::<HashMap<String, ProviderAlias>>(
+            r#"bws = { uri = "bws://proj", env = { BWS_ACCESS_TOKEN = "keyring" } }"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("env"), "{error}");
+    }
+
+    #[test]
+    fn credential_less_alias_round_trips_as_a_bare_string() {
         let alias = ProviderAlias::from("keyring://");
         let map = HashMap::from([("keyring".to_string(), alias.clone())]);
         let serialized = toml::to_string(&map).unwrap();
@@ -2487,12 +2495,12 @@ mod provider_alias_tests {
     }
 
     #[test]
-    fn alias_with_env_round_trips_through_toml() {
+    fn alias_with_credentials_round_trips_through_toml() {
         let alias = ProviderAlias {
             uri: "bws://proj".to_string(),
-            env: HashMap::from([(
-                "BWS_ACCESS_TOKEN".to_string(),
-                BootstrapSource::from("keyring"),
+            credentials: HashMap::from([(
+                "access_token".to_string(),
+                CredentialSource::from("keyring"),
             )]),
         };
         let map = HashMap::from([("bws".to_string(), alias.clone())]);
@@ -2510,7 +2518,7 @@ revision = "1.0"
 
 [providers]
 keyring = "keyring://"
-bws = { uri = "bws://proj", env = { BWS_ACCESS_TOKEN = "keyring" } }
+bws = { uri = "bws://proj", credentials = { access_token = "keyring" } }
 
 [profiles.default]
 API_KEY = { description = "key", required = true }
@@ -2520,6 +2528,6 @@ API_KEY = { description = "key", required = true }
         let providers = config.providers.expect("[providers] present");
         assert_eq!(providers["keyring"], ProviderAlias::from("keyring://"));
         assert_eq!(providers["bws"].uri, "bws://proj");
-        assert!(providers["bws"].env.contains_key("BWS_ACCESS_TOKEN"));
+        assert!(providers["bws"].credentials.contains_key("access_token"));
     }
 }

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -40,6 +40,131 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+/// A provider alias: a provider URI plus an optional bootstrap-credential map.
+///
+/// In TOML an alias is written either as a bare string, which is just the URI:
+///
+/// ```toml
+/// [providers]
+/// keyring = "keyring://"
+/// ```
+///
+/// or as a table carrying an `env` map, whose entries name an environment
+/// variable the provider needs (e.g. an access token) and the provider spec to
+/// source it from — so a provider's own credentials can come from another
+/// provider instead of a plaintext environment variable:
+///
+/// ```toml
+/// [providers]
+/// bws = { uri = "bws://project-uuid", env = { BWS_ACCESS_TOKEN = "keyring" } }
+/// ```
+///
+/// The two forms round-trip losslessly: an alias with no `env` serializes back
+/// to a bare string, so existing configs are untouched.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProviderAlias {
+    /// The provider URI (e.g. `keyring://`, `bws://project-uuid`).
+    pub uri: String,
+    /// Bootstrap credentials: environment variable name to the provider spec
+    /// (alias, bare provider name, or URI) that supplies it. `None` for a bare
+    /// string alias.
+    pub env: Option<HashMap<String, String>>,
+}
+
+impl ProviderAlias {
+    /// A bare alias carrying only a URI and no bootstrap credentials.
+    pub fn from_uri(uri: impl Into<String>) -> Self {
+        Self {
+            uri: uri.into(),
+            env: None,
+        }
+    }
+}
+
+impl From<String> for ProviderAlias {
+    fn from(uri: String) -> Self {
+        Self::from_uri(uri)
+    }
+}
+
+impl From<&str> for ProviderAlias {
+    fn from(uri: &str) -> Self {
+        Self::from_uri(uri)
+    }
+}
+
+impl std::fmt::Display for ProviderAlias {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.uri)?;
+        if let Some(env) = &self.env {
+            if !env.is_empty() {
+                let mut vars: Vec<&str> = env.keys().map(String::as_str).collect();
+                vars.sort();
+                write!(f, " (bootstrap: {})", vars.join(", "))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for ProviderAlias {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match &self.env {
+            // A bare alias serializes back to the plain-string form, so an alias
+            // that was written as a string round-trips unchanged.
+            None => serializer.serialize_str(&self.uri),
+            Some(env) => {
+                use serde::ser::SerializeStruct;
+                let mut table = serializer.serialize_struct("ProviderAlias", 2)?;
+                table.serialize_field("uri", &self.uri)?;
+                table.serialize_field("env", env)?;
+                table.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderAlias {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct AliasVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for AliasVisitor {
+            type Value = ProviderAlias;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a provider URI string or a { uri, env } table")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, uri: &str) -> Result<ProviderAlias, E> {
+                Ok(ProviderAlias::from_uri(uri))
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                map: M,
+            ) -> Result<ProviderAlias, M::Error> {
+                // A dedicated struct gives precise field-level errors (unknown
+                // key, missing `uri`) rather than the opaque message an
+                // `#[serde(untagged)]` enum would produce on any typo.
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct Table {
+                    uri: String,
+                    #[serde(default)]
+                    env: Option<HashMap<String, String>>,
+                }
+                let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(ProviderAlias {
+                    uri: table.uri,
+                    env: table.env,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(AliasVisitor)
+    }
+}
+
 /// The root configuration structure for a SecretSpec project.
 ///
 /// This is the top-level type that represents the entire `secretspec.toml` file.
@@ -56,7 +181,7 @@ pub struct Config {
     /// (`~/.config/secretspec/config.toml`), so teams can check vault mappings
     /// into version control instead of replicating them on every machine.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub providers: Option<HashMap<String, String>>,
+    pub providers: Option<HashMap<String, ProviderAlias>>,
 }
 
 impl Config {
@@ -152,11 +277,12 @@ impl Config {
             }
         }
 
-        // Merge provider aliases - current entries win.
+        // Merge provider aliases - current entries win. Whole entries merge
+        // (URI and any bootstrap `env` together); there is no per-field merge.
         if let Some(other_providers) = other.providers {
             let merged = self.providers.get_or_insert_with(HashMap::new);
-            for (alias, uri) in other_providers {
-                merged.entry(alias).or_insert(uri);
+            for (alias, alias_value) in other_providers {
+                merged.entry(alias).or_insert(alias_value);
             }
         }
     }
@@ -1167,7 +1293,7 @@ pub struct GlobalDefaults {
     /// local = "dotenv://.env.local"
     /// ```
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub providers: Option<HashMap<String, String>>,
+    pub providers: Option<HashMap<String, ProviderAlias>>,
 }
 
 impl GlobalConfig {
@@ -2156,5 +2282,107 @@ ref = 3"#,
         assert!(!GenerateConfig::Bool(false).is_enabled());
         assert!(GenerateConfig::Bool(true).is_enabled());
         assert!(GenerateConfig::Options(GenerateOptions::default()).is_enabled());
+    }
+}
+
+#[cfg(test)]
+mod provider_alias_tests {
+    use super::*;
+
+    fn parse(providers_toml: &str) -> HashMap<String, ProviderAlias> {
+        toml::from_str(providers_toml).expect("valid [providers] table")
+    }
+
+    #[test]
+    fn bare_string_parses_as_uri_without_env() {
+        let map = parse(r#"keyring = "keyring://""#);
+        assert_eq!(map["keyring"], ProviderAlias::from("keyring://"));
+        assert_eq!(map["keyring"].env, None);
+    }
+
+    #[test]
+    fn table_with_env_parses_uri_and_env() {
+        let map = parse(r#"bws = { uri = "bws://proj", env = { BWS_ACCESS_TOKEN = "keyring" } }"#);
+        let alias = &map["bws"];
+        assert_eq!(alias.uri, "bws://proj");
+        assert_eq!(
+            alias
+                .env
+                .as_ref()
+                .and_then(|env| env.get("BWS_ACCESS_TOKEN"))
+                .map(String::as_str),
+            Some("keyring"),
+        );
+    }
+
+    #[test]
+    fn table_without_env_is_equivalent_to_bare_string() {
+        let map = parse(r#"bws = { uri = "bws://proj" }"#);
+        assert_eq!(map["bws"], ProviderAlias::from("bws://proj"));
+    }
+
+    #[test]
+    fn unknown_table_field_is_rejected() {
+        let err = toml::from_str::<HashMap<String, ProviderAlias>>(
+            r#"bws = { uri = "bws://proj", oops = "x" }"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("oops") || err.to_string().contains("unknown"),
+            "error should point at the unknown field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn env_less_alias_round_trips_as_a_bare_string() {
+        let alias = ProviderAlias::from("keyring://");
+        let map = HashMap::from([("keyring".to_string(), alias.clone())]);
+        let serialized = toml::to_string(&map).unwrap();
+        // The bare-string form is preserved so existing configs are untouched.
+        assert_eq!(serialized.trim(), r#"keyring = "keyring://""#);
+        assert_eq!(parse(&serialized)["keyring"], alias);
+    }
+
+    #[test]
+    fn alias_with_env_round_trips_through_toml() {
+        let alias = ProviderAlias {
+            uri: "bws://proj".to_string(),
+            env: Some(HashMap::from([(
+                "BWS_ACCESS_TOKEN".to_string(),
+                "keyring".to_string(),
+            )])),
+        };
+        let map = HashMap::from([("bws".to_string(), alias.clone())]);
+        let serialized = toml::to_string(&map).unwrap();
+        assert_eq!(parse(&serialized)["bws"], alias);
+    }
+
+    #[test]
+    fn config_providers_accepts_both_forms_end_to_end() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "app"
+revision = "1.0"
+
+[providers]
+keyring = "keyring://"
+bws = { uri = "bws://proj", env = { BWS_ACCESS_TOKEN = "keyring" } }
+
+[profiles.default]
+API_KEY = { description = "key", required = true }
+"#,
+        )
+        .unwrap();
+        let providers = config.providers.expect("[providers] present");
+        assert_eq!(providers["keyring"], ProviderAlias::from("keyring://"));
+        assert_eq!(providers["bws"].uri, "bws://proj");
+        assert!(
+            providers["bws"]
+                .env
+                .as_ref()
+                .unwrap()
+                .contains_key("BWS_ACCESS_TOKEN")
+        );
     }
 }

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -261,7 +261,12 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                 let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
                 Ok(ProviderAlias {
                     uri: table.uri,
-                    env: table.env,
+                    // Normalize an explicit empty table (`env = {}`) to `None`:
+                    // "declares no bootstrap credentials" then has a single
+                    // representation, so consumers checking `env.is_some()`
+                    // (e.g. the one-hop rule) cannot disagree with consumers
+                    // iterating the entries.
+                    env: table.env.filter(|env| !env.is_empty()),
                 })
             }
         }
@@ -2460,6 +2465,16 @@ mod provider_alias_tests {
     fn table_without_env_is_equivalent_to_bare_string() {
         let map = parse(r#"bws = { uri = "bws://proj" }"#);
         assert_eq!(map["bws"], ProviderAlias::from("bws://proj"));
+    }
+
+    #[test]
+    fn empty_env_table_is_equivalent_to_no_env() {
+        // `env = {}` declares nothing, so it must normalize to `None`: the
+        // one-hop rule checks `env.is_some()` and would otherwise reject the
+        // alias as a bootstrap source while login reports nothing to store.
+        let map = parse(r#"keyring = { uri = "keyring://", env = {} }"#);
+        assert_eq!(map["keyring"], ProviderAlias::from("keyring://"));
+        assert_eq!(map["keyring"].env, None);
     }
 
     #[test]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -172,8 +172,9 @@ pub struct ProviderAlias {
     /// The provider URI (e.g. `keyring://`, `bws://project-uuid`).
     pub uri: String,
     /// Bootstrap credentials: environment variable name to the [`BootstrapSource`]
-    /// that supplies it. `None` for a bare string alias.
-    pub env: Option<HashMap<String, BootstrapSource>>,
+    /// that supplies it. Empty for a bare string alias, so "declares no
+    /// bootstrap credentials" has exactly one representation.
+    pub env: HashMap<String, BootstrapSource>,
 }
 
 impl ProviderAlias {
@@ -181,7 +182,7 @@ impl ProviderAlias {
     pub fn from_uri(uri: impl Into<String>) -> Self {
         Self {
             uri: uri.into(),
-            env: None,
+            env: HashMap::new(),
         }
     }
 }
@@ -201,10 +202,8 @@ impl From<&str> for ProviderAlias {
 impl std::fmt::Display for ProviderAlias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.uri)?;
-        if let Some(env) = &self.env
-            && !env.is_empty()
-        {
-            let mut vars: Vec<&str> = env.keys().map(String::as_str).collect();
+        if !self.env.is_empty() {
+            let mut vars: Vec<&str> = self.env.keys().map(String::as_str).collect();
             vars.sort();
             write!(f, " (bootstrap: {})", vars.join(", "))?;
         }
@@ -214,17 +213,16 @@ impl std::fmt::Display for ProviderAlias {
 
 impl Serialize for ProviderAlias {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match &self.env {
+        if self.env.is_empty() {
             // A bare alias serializes back to the plain-string form, so an alias
             // that was written as a string round-trips unchanged.
-            None => serializer.serialize_str(&self.uri),
-            Some(env) => {
-                use serde::ser::SerializeStruct;
-                let mut table = serializer.serialize_struct("ProviderAlias", 2)?;
-                table.serialize_field("uri", &self.uri)?;
-                table.serialize_field("env", env)?;
-                table.end()
-            }
+            serializer.serialize_str(&self.uri)
+        } else {
+            use serde::ser::SerializeStruct;
+            let mut table = serializer.serialize_struct("ProviderAlias", 2)?;
+            table.serialize_field("uri", &self.uri)?;
+            table.serialize_field("env", &self.env)?;
+            table.end()
         }
     }
 }
@@ -261,12 +259,7 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                 let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
                 Ok(ProviderAlias {
                     uri: table.uri,
-                    // Normalize an explicit empty table (`env = {}`) to `None`:
-                    // "declares no bootstrap credentials" then has a single
-                    // representation, so consumers checking `env.is_some()`
-                    // (e.g. the one-hop rule) cannot disagree with consumers
-                    // iterating the entries.
-                    env: table.env.filter(|env| !env.is_empty()),
+                    env: table.env.unwrap_or_default(),
                 })
             }
         }
@@ -2407,7 +2400,7 @@ mod provider_alias_tests {
     fn bare_string_parses_as_uri_without_env() {
         let map = parse(r#"keyring = "keyring://""#);
         assert_eq!(map["keyring"], ProviderAlias::from("keyring://"));
-        assert_eq!(map["keyring"].env, None);
+        assert!(map["keyring"].env.is_empty());
     }
 
     #[test]
@@ -2417,8 +2410,7 @@ mod provider_alias_tests {
         assert_eq!(alias.uri, "bws://proj");
         let source = alias
             .env
-            .as_ref()
-            .and_then(|env| env.get("BWS_ACCESS_TOKEN"))
+            .get("BWS_ACCESS_TOKEN")
             .expect("env carries the variable");
         assert_eq!(source, &BootstrapSource::from("keyring"));
     }
@@ -2428,7 +2420,7 @@ mod provider_alias_tests {
         let map = parse(
             r#"vault = { uri = "vault://kv", env = { VAULT_ROLE_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } } } }"#,
         );
-        let source = map["vault"].env.as_ref().unwrap()["VAULT_ROLE_ID"].clone();
+        let source = map["vault"].env["VAULT_ROLE_ID"].clone();
         assert_eq!(source.provider, "onepassword");
         let reference = source.reference.expect("ref present");
         assert_eq!(reference.vault.as_deref(), Some("Infra"));
@@ -2450,10 +2442,7 @@ mod provider_alias_tests {
         for source in [bare, with_ref] {
             let alias = ProviderAlias {
                 uri: "vault://kv".to_string(),
-                env: Some(HashMap::from([(
-                    "VAULT_ROLE_ID".to_string(),
-                    source.clone(),
-                )])),
+                env: HashMap::from([("VAULT_ROLE_ID".to_string(), source.clone())]),
             };
             let map = HashMap::from([("vault".to_string(), alias.clone())]);
             let serialized = toml::to_string(&map).unwrap();
@@ -2469,12 +2458,10 @@ mod provider_alias_tests {
 
     #[test]
     fn empty_env_table_is_equivalent_to_no_env() {
-        // `env = {}` declares nothing, so it must normalize to `None`: the
-        // one-hop rule checks `env.is_some()` and would otherwise reject the
-        // alias as a bootstrap source while login reports nothing to store.
+        // `env = {}` declares nothing: the alias equals its bare-string form
+        // and serializes back to it.
         let map = parse(r#"keyring = { uri = "keyring://", env = {} }"#);
         assert_eq!(map["keyring"], ProviderAlias::from("keyring://"));
-        assert_eq!(map["keyring"].env, None);
     }
 
     #[test]
@@ -2503,10 +2490,10 @@ mod provider_alias_tests {
     fn alias_with_env_round_trips_through_toml() {
         let alias = ProviderAlias {
             uri: "bws://proj".to_string(),
-            env: Some(HashMap::from([(
+            env: HashMap::from([(
                 "BWS_ACCESS_TOKEN".to_string(),
                 BootstrapSource::from("keyring"),
-            )])),
+            )]),
         };
         let map = HashMap::from([("bws".to_string(), alias.clone())]);
         let serialized = toml::to_string(&map).unwrap();
@@ -2533,12 +2520,6 @@ API_KEY = { description = "key", required = true }
         let providers = config.providers.expect("[providers] present");
         assert_eq!(providers["keyring"], ProviderAlias::from("keyring://"));
         assert_eq!(providers["bws"].uri, "bws://proj");
-        assert!(
-            providers["bws"]
-                .env
-                .as_ref()
-                .unwrap()
-                .contains_key("BWS_ACCESS_TOKEN")
-        );
+        assert!(providers["bws"].env.contains_key("BWS_ACCESS_TOKEN"));
     }
 }

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -22,17 +22,6 @@ use crate::provider::Address;
 use crate::secrets::Secrets;
 use std::collections::HashMap;
 
-/// Where a planned secret reads and writes.
-///
-/// A `providers` chain is a fallback list tried in order. Only the primary
-/// (always tried first, the write target, and the grouping key) is resolved to
-/// a URI up front; the rest are carried as raw specs and resolved lazily, when
-/// and only when a read actually falls through to them. That keeps the chain
-/// tried in order: an undefined alias further down never fails an operation
-/// the primary satisfies, and never fails a write at all.
-///
-/// An explicit `--provider`/`SECRETSPEC_PROVIDER`/builder override collapses
-/// any chain to just that store: it becomes the primary with no fallback.
 /// The resolved primary store: the raw spec used to build it, plus its resolved
 /// URI for display.
 ///
@@ -50,6 +39,17 @@ pub(crate) struct ResolvedPrimary {
     pub uri: String,
 }
 
+/// Where a planned secret reads and writes.
+///
+/// A `providers` chain is a fallback list tried in order. Only the primary
+/// (always tried first, the write target, and the grouping key) is resolved to
+/// a URI up front; the rest are carried as raw specs and resolved lazily, when
+/// and only when a read actually falls through to them. That keeps the chain
+/// tried in order: an undefined alias further down never fails an operation
+/// the primary satisfies, and never fails a write at all.
+///
+/// An explicit `--provider`/`SECRETSPEC_PROVIDER`/builder override collapses
+/// any chain to just that store: it becomes the primary with no fallback.
 #[derive(Debug)]
 pub(crate) struct Route {
     /// The store consulted first — the resolved chain head or the explicit
@@ -180,7 +180,7 @@ impl Secrets {
     /// derive its resolved route.
     ///
     /// The explicit provider override (builder or `SECRETSPEC_PROVIDER`) is
-    /// picked up via [`Secrets::resolve_provider_override`]. Production code
+    /// picked up via [`Secrets::explicit_provider_spec`]. Production code
     /// resolves the profile itself and calls [`Secrets::build_plan_from_names`]
     /// directly (it needs the sorted names for audit attribution too, and
     /// shouldn't merge and sort twice); this one-call form is for tests that
@@ -205,17 +205,20 @@ impl Secrets {
         profile_name: String,
         names: Vec<String>,
     ) -> Result<ResolutionPlan> {
-        let override_uri = self.resolve_provider_override(None);
+        // Routes carry the raw override spec (it may be an alias whose bootstrap
+        // `env` must stay reachable at build time); the plan's `override_uri`
+        // field is the resolved form, for display and the resolution report.
+        let override_spec = self.explicit_provider_spec(None);
 
         let mut secrets = Vec::with_capacity(names.len());
         for name in names {
             let config = self.effective_secret_config(&name, &profile_name);
-            secrets.push(self.plan_one_secret(name, config, &override_uri)?);
+            secrets.push(self.plan_one_secret(name, config, &override_spec)?);
         }
 
         Ok(ResolutionPlan {
             profile: profile_name,
-            override_uri,
+            override_uri: override_spec.map(|spec| self.resolve_provider_spec(spec)),
             secrets,
         })
     }
@@ -229,7 +232,7 @@ impl Secrets {
     /// `profile_name` is the already-resolved profile. `override_arg` is the
     /// caller's explicit provider (the `--provider` flag); like
     /// [`Secrets::build_plan`] it also picks up the builder and
-    /// `SECRETSPEC_PROVIDER` via [`Secrets::resolve_provider_override`].
+    /// `SECRETSPEC_PROVIDER` via [`Secrets::explicit_provider_spec`].
     pub(crate) fn plan_secret(
         &self,
         name: &str,
@@ -239,26 +242,26 @@ impl Secrets {
         let Some(config) = self.resolve_secret_config(name, Some(profile_name)) else {
             return Ok(None);
         };
-        let override_uri = self.resolve_provider_override(override_arg);
+        let override_spec = self.explicit_provider_spec(override_arg);
         Ok(Some(self.plan_one_secret(
             name.to_string(),
             config,
-            &override_uri,
+            &override_spec,
         )?))
     }
 
-    /// Derive one [`PlannedSecret`] from its effective config and the resolved
-    /// override. The single place per-secret decisions are made, shared by the
-    /// whole-profile [`Secrets::build_plan_from_names`] and the single-secret
-    /// [`Secrets::plan_secret`], so `get`, `set`, and batch validation cannot
-    /// drift.
+    /// Derive one [`PlannedSecret`] from its effective config and the raw
+    /// override spec. The single place per-secret decisions are made, shared by
+    /// the whole-profile [`Secrets::build_plan_from_names`] and the
+    /// single-secret [`Secrets::plan_secret`], so `get`, `set`, and batch
+    /// validation cannot drift.
     fn plan_one_secret(
         &self,
         name: String,
         config: Secret,
-        override_uri: &Option<String>,
+        override_spec: &Option<String>,
     ) -> Result<PlannedSecret> {
-        let route = self.route_for(&config, override_uri)?;
+        let route = self.route_for(&config, override_spec)?;
         Ok(PlannedSecret {
             name,
             config,
@@ -278,28 +281,29 @@ impl Secrets {
     pub(crate) fn route_for(
         &self,
         config: &Secret,
-        override_uri: &Option<String>,
+        override_spec: &Option<String>,
     ) -> Result<Route> {
-        if let Some(uri) = override_uri {
-            // An override is already resolved to a URI, so it carries no alias
-            // and no bootstrap `env`; spec and uri are the same.
+        // Either arm keeps the raw spec as the build key (the spec may be an
+        // alias whose bootstrap `env` must stay reachable when the store is
+        // constructed — a resolved URI has lost it), resolves the URI for
+        // display, and validates any bootstrap `env` (unknown source, one-hop)
+        // up front — all pure map lookups.
+        if let Some(spec) = override_spec {
+            self.validate_bootstrap_sources(spec)?;
             return Ok(Route {
                 primary: Some(ResolvedPrimary {
-                    spec: uri.clone(),
-                    uri: uri.clone(),
+                    spec: spec.clone(),
+                    uri: self.resolve_provider_spec(spec.clone()),
                 }),
                 fallback: Vec::new(),
             });
         }
         match config.providers.as_deref() {
             Some([first, fallback @ ..]) => {
-                // Resolve the primary URI for display and to fail fast on an
-                // undefined primary alias, and validate its bootstrap `env`
-                // (unknown source, one-hop) — both pure map lookups. The raw
-                // spec is kept as the build key so the alias's `env` is still
-                // reachable when the store is constructed.
+                // Unlike an override, an undefined alias as chain primary is a
+                // hard error here (`resolve_one_provider` fails fast).
                 let uri = self.resolve_one_provider(first)?;
-                self.validate_primary_bootstrap(first)?;
+                self.validate_bootstrap_sources(first)?;
                 Ok(Route {
                     primary: Some(ResolvedPrimary {
                         spec: first.clone(),
@@ -393,6 +397,22 @@ mod tests {
             planned.route.fallback.is_empty(),
             "the override must collapse the chain: no fallback survives"
         );
+        assert_eq!(plan.override_uri, Some("dotenv://.env.mock".to_string()));
+    }
+
+    #[test]
+    fn override_alias_keeps_the_raw_spec_as_build_key() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([("API_KEY".to_string(), secret(None))]);
+        // `--provider mock` names an alias: the route keeps the raw spec so the
+        // alias's bootstrap `env` stays reachable at build time, and resolves
+        // the URI for display and the report.
+        let spec = spec(secrets, Some("mock"), &[("mock", "dotenv://.env.mock")]);
+        let plan = plan(&spec);
+
+        let planned = find(&plan, "API_KEY");
+        assert_eq!(planned.route.group_key(), Some("mock"));
+        assert_eq!(planned.route.primary(), Some("dotenv://.env.mock"));
         assert_eq!(plan.override_uri, Some("dotenv://.env.mock".to_string()));
     }
 

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 /// URI for display.
 ///
 /// Construction and grouping key on [`spec`](Self::spec) rather than the URI so
-/// that an alias's bootstrap `env` map is still reachable when the provider is
+/// that an alias's `credentials` map is still reachable when the provider is
 /// built (a resolved URI is not an alias and has lost it), and so two aliases
 /// that happen to share a URI but declare different credentials never merge into
 /// one group.
@@ -72,7 +72,7 @@ impl Route {
     /// meaning the default provider. Distinct from [`Route::primary`] (the
     /// resolved URI): secrets sharing a primary store are fetched together and a
     /// write goes to the primary, and keying on the spec keeps an alias's
-    /// bootstrap `env` reachable at build time.
+    /// `credentials` reachable at build time.
     pub(crate) fn group_key(&self) -> Option<&str> {
         self.primary.as_ref().map(|primary| primary.spec.as_str())
     }
@@ -87,7 +87,7 @@ impl Route {
 
     /// The ordered provider specs a read walks — the primary spec followed by
     /// the raw fallback — or `None` for the default provider. Each entry is
-    /// resolved (and bootstrapped) only when the read reaches it, so the chain
+    /// resolved (and credential-backed) only when the read reaches it, so the chain
     /// is genuinely tried in order.
     pub(crate) fn specs(&self) -> Option<Vec<String>> {
         self.primary.as_ref().map(|primary| {
@@ -155,7 +155,7 @@ impl ResolutionPlan {
     /// (`None` = default provider) with the planned secrets fetched together.
     /// Derived from each secret's [`Route::group_key`] on demand, so grouping
     /// can never drift from the routes. Keying on the spec (not the resolved
-    /// URI) keeps an alias's bootstrap `env` reachable at build time and keeps
+    /// URI) keeps an alias's `credentials` reachable at build time and keeps
     /// two aliases that share a URI but differ in credentials in separate groups.
     pub(crate) fn groups(&self) -> Vec<(Option<&str>, Vec<&PlannedSecret>)> {
         let mut groups: Vec<(Option<&str>, Vec<&PlannedSecret>)> = Vec::new();
@@ -205,7 +205,7 @@ impl Secrets {
         profile_name: String,
         names: Vec<String>,
     ) -> Result<ResolutionPlan> {
-        // Routes carry the raw override spec (it may be an alias whose bootstrap
+        // Routes carry the raw override spec (it may be an alias whose provider
         // `env` must stay reachable at build time); the plan's `override_uri`
         // field is the resolved form, for display and the resolution report.
         let override_spec = self.explicit_provider_spec(None);
@@ -284,12 +284,12 @@ impl Secrets {
         override_spec: &Option<String>,
     ) -> Result<Route> {
         // Either arm keeps the raw spec as the build key (the spec may be an
-        // alias whose bootstrap `env` must stay reachable when the store is
+        // alias whose `credentials` must stay reachable when the store is
         // constructed — a resolved URI has lost it), resolves the URI for
-        // display, and validates any bootstrap `env` (unknown source, one-hop)
+        // display, and validates any `credentials` (unknown source, one-hop)
         // up front — all pure map lookups.
         if let Some(spec) = override_spec {
-            self.validate_bootstrap_sources(spec)?;
+            self.validate_credential_sources(spec)?;
             return Ok(Route {
                 primary: Some(ResolvedPrimary {
                     spec: spec.clone(),
@@ -303,7 +303,7 @@ impl Secrets {
                 // Unlike an override, an undefined alias as chain primary is a
                 // hard error here (`resolve_one_provider` fails fast).
                 let uri = self.resolve_one_provider(first)?;
-                self.validate_bootstrap_sources(first)?;
+                self.validate_credential_sources(first)?;
                 Ok(Route {
                     primary: Some(ResolvedPrimary {
                         spec: first.clone(),
@@ -405,7 +405,7 @@ mod tests {
         let _env = scrub_resolution_env();
         let secrets = HashMap::from([("API_KEY".to_string(), secret(None))]);
         // `--provider mock` names an alias: the route keeps the raw spec so the
-        // alias's bootstrap `env` stays reachable at build time, and resolves
+        // alias's `credentials` stays reachable at build time, and resolves
         // the URI for display and the report.
         let spec = spec(secrets, Some("mock"), &[("mock", "dotenv://.env.mock")]);
         let plan = plan(&spec);
@@ -538,7 +538,7 @@ mod tests {
             ("B".to_string(), secret(Some(vec!["two"]))),
         ]);
         // Two aliases, same URI, different names: grouping keys on the spec, so
-        // they stay in separate groups (they could carry different bootstrap
+        // they stay in separate groups (they could carry different provider
         // credentials, which the resolved URI has lost).
         let plan = plan(&spec(
             secrets,

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -33,22 +33,48 @@ use std::collections::HashMap;
 ///
 /// An explicit `--provider`/`SECRETSPEC_PROVIDER`/builder override collapses
 /// any chain to just that store: it becomes the primary with no fallback.
+/// The resolved primary store: the raw spec used to build it, plus its resolved
+/// URI for display.
+///
+/// Construction and grouping key on [`spec`](Self::spec) rather than the URI so
+/// that an alias's bootstrap `env` map is still reachable when the provider is
+/// built (a resolved URI is not an alias and has lost it), and so two aliases
+/// that happen to share a URI but declare different credentials never merge into
+/// one group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedPrimary {
+    /// The raw primary chain entry: an alias name, a bare provider name, or a
+    /// URI. The build key.
+    pub spec: String,
+    /// The resolved, credential-free URI, for display and the resolution report.
+    pub uri: String,
+}
+
 #[derive(Debug)]
 pub(crate) struct Route {
     /// The store consulted first — the resolved chain head or the explicit
     /// override — or `None` for the default provider.
-    pub primary: Option<String>,
+    pub primary: Option<ResolvedPrimary>,
     /// The chain's remaining specs (aliases or URIs), raw, tried in order —
     /// and resolved — only after the primary misses.
     pub fallback: Vec<String>,
 }
 
 impl Route {
-    /// The store consulted first, `None` meaning the default provider. This is
-    /// the grouping key and the write target: secrets sharing a primary store
-    /// are fetched together, and a write goes to the primary.
+    /// The resolved, credential-free URI of the store consulted first, `None`
+    /// meaning the default provider. Used for display and the resolution report,
+    /// never as the grouping/build key — see [`Route::group_key`].
     pub(crate) fn primary(&self) -> Option<&str> {
-        self.primary.as_deref()
+        self.primary.as_ref().map(|primary| primary.uri.as_str())
+    }
+
+    /// The raw primary spec that groups secrets and builds the store, `None`
+    /// meaning the default provider. Distinct from [`Route::primary`] (the
+    /// resolved URI): secrets sharing a primary store are fetched together and a
+    /// write goes to the primary, and keying on the spec keeps an alias's
+    /// bootstrap `env` reachable at build time.
+    pub(crate) fn group_key(&self) -> Option<&str> {
+        self.primary.as_ref().map(|primary| primary.spec.as_str())
     }
 
     /// The raw fallback specs a read walks after the primary misses, when
@@ -59,13 +85,14 @@ impl Route {
         (!self.fallback.is_empty()).then_some(self.fallback.as_slice())
     }
 
-    /// The ordered provider specs a read walks — the primary followed by the raw
-    /// fallback — or `None` for the default provider. Each entry is resolved only
-    /// when the read reaches it, so the chain is genuinely tried in order.
+    /// The ordered provider specs a read walks — the primary spec followed by
+    /// the raw fallback — or `None` for the default provider. Each entry is
+    /// resolved (and bootstrapped) only when the read reaches it, so the chain
+    /// is genuinely tried in order.
     pub(crate) fn specs(&self) -> Option<Vec<String>> {
         self.primary.as_ref().map(|primary| {
             let mut specs = Vec::with_capacity(1 + self.fallback.len());
-            specs.push(primary.clone());
+            specs.push(primary.spec.clone());
             specs.extend(self.fallback.iter().cloned());
             specs
         })
@@ -124,15 +151,17 @@ pub(crate) struct ResolutionPlan {
 }
 
 impl ResolutionPlan {
-    /// Primary-store groups in first-seen order: each pairs a store URI
+    /// Primary-store groups in first-seen order: each pairs a primary spec
     /// (`None` = default provider) with the planned secrets fetched together.
-    /// Derived from each secret's [`Route::primary`] on demand, so grouping
-    /// can never drift from the routes.
+    /// Derived from each secret's [`Route::group_key`] on demand, so grouping
+    /// can never drift from the routes. Keying on the spec (not the resolved
+    /// URI) keeps an alias's bootstrap `env` reachable at build time and keeps
+    /// two aliases that share a URI but differ in credentials in separate groups.
     pub(crate) fn groups(&self) -> Vec<(Option<&str>, Vec<&PlannedSecret>)> {
         let mut groups: Vec<(Option<&str>, Vec<&PlannedSecret>)> = Vec::new();
         let mut group_index: HashMap<Option<&str>, usize> = HashMap::new();
         for secret in &self.secrets {
-            let primary = secret.route.primary();
+            let primary = secret.route.group_key();
             match group_index.get(&primary) {
                 Some(&idx) => groups[idx].1.push(secret),
                 None => {
@@ -252,16 +281,33 @@ impl Secrets {
         override_uri: &Option<String>,
     ) -> Result<Route> {
         if let Some(uri) = override_uri {
+            // An override is already resolved to a URI, so it carries no alias
+            // and no bootstrap `env`; spec and uri are the same.
             return Ok(Route {
-                primary: Some(uri.clone()),
+                primary: Some(ResolvedPrimary {
+                    spec: uri.clone(),
+                    uri: uri.clone(),
+                }),
                 fallback: Vec::new(),
             });
         }
         match config.providers.as_deref() {
-            Some([first, fallback @ ..]) => Ok(Route {
-                primary: Some(self.resolve_one_provider(first)?),
-                fallback: fallback.to_vec(),
-            }),
+            Some([first, fallback @ ..]) => {
+                // Resolve the primary URI for display and to fail fast on an
+                // undefined primary alias, and validate its bootstrap `env`
+                // (unknown source, one-hop) — both pure map lookups. The raw
+                // spec is kept as the build key so the alias's `env` is still
+                // reachable when the store is constructed.
+                let uri = self.resolve_one_provider(first)?;
+                self.validate_primary_bootstrap(first)?;
+                Ok(Route {
+                    primary: Some(ResolvedPrimary {
+                        spec: first.clone(),
+                        uri,
+                    }),
+                    fallback: fallback.to_vec(),
+                })
+            }
             _ => Ok(Route {
                 primary: None,
                 fallback: Vec::new(),
@@ -461,6 +507,27 @@ mod tests {
         assert_eq!(
             group_names(&plan),
             vec![(None, vec!["A"]), (Some("keyring://"), vec!["B", "C"])]
+        );
+    }
+
+    #[test]
+    fn distinct_aliases_sharing_a_uri_do_not_merge() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([
+            ("A".to_string(), secret(Some(vec!["one"]))),
+            ("B".to_string(), secret(Some(vec!["two"]))),
+        ]);
+        // Two aliases, same URI, different names: grouping keys on the spec, so
+        // they stay in separate groups (they could carry different bootstrap
+        // credentials, which the resolved URI has lost).
+        let plan = plan(&spec(
+            secrets,
+            None,
+            &[("one", "keyring://"), ("two", "keyring://")],
+        ));
+        assert_eq!(
+            group_names(&plan),
+            vec![(Some("one"), vec!["A"]), (Some("two"), vec!["B"])]
         );
     }
 

--- a/secretspec/src/provider/akv.rs
+++ b/secretspec/src/provider/akv.rs
@@ -8,13 +8,14 @@
 //! "try everything" default credential, so the authentication method is chosen
 //! explicitly via the `auth` query parameter:
 //!
-//! - `auth=env` (default) -- reads a service principal from the `AZURE_TENANT_ID`,
-//!   `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` environment variables. All
-//!   three must be set (and non-empty) together; if none are set, this falls
-//!   back to the signed-in Azure CLI / Azure Developer CLI session (equivalent
-//!   to `auth=cli`), so local development works out of the box after
-//!   `az login`. If only some are set, this is an error rather than a silent
-//!   fallback to a different identity.
+//! - `auth=env` (default) -- reads a service principal from the `tenant_id`,
+//!   `client_id`, and `client_secret` provider credentials, falling back to
+//!   the matching `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and
+//!   `AZURE_CLIENT_SECRET` environment variables. All three must be supplied
+//!   together; if none are available, this falls back to the signed-in Azure
+//!   CLI / Azure Developer CLI session (equivalent to `auth=cli`), so local
+//!   development works out of the box after `az login`. A partial set is an
+//!   error rather than a silent fallback to a different identity.
 //! - `auth=cli` -- only the Azure CLI / Azure Developer CLI session.
 //! - `auth=managed_identity` -- the VM/App Service/AKS system-assigned managed
 //!   identity.
@@ -61,7 +62,7 @@
 //! secretspec check --provider akv://myvault?auth=managed_identity
 //! ```
 
-use super::{Address, Provider, ProviderUrl};
+use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
 use crate::{Result, SecretSpecError};
 use azure_core::credentials::{Secret, TokenCredential};
 use azure_core::http::StatusCode;
@@ -203,7 +204,16 @@ impl TryFrom<&ProviderUrl> for AkvConfig {
 /// Stores and retrieves secrets from an Azure Key Vault instance.
 pub struct AkvProvider {
     config: AkvConfig,
+    /// Service-principal credentials supplied by the provider alias.
+    credentials: ProviderCredentials,
 }
+
+const TENANT_ID: &str = "tenant_id";
+const CLIENT_ID: &str = "client_id";
+const CLIENT_SECRET: &str = "client_secret";
+const AZURE_TENANT_ID_ENV: &str = "AZURE_TENANT_ID";
+const AZURE_CLIENT_ID_ENV: &str = "AZURE_CLIENT_ID";
+const AZURE_CLIENT_SECRET_ENV: &str = "AZURE_CLIENT_SECRET";
 
 crate::register_provider! {
     struct: AkvProvider,
@@ -212,12 +222,16 @@ crate::register_provider! {
     description: "Azure Key Vault",
     schemes: ["akv"],
     examples: ["akv://myvault", "akv://myvault?auth=managed_identity", "akv://myvault?suffix=vault.azure.cn"],
+    credential_names: [TENANT_ID, CLIENT_ID, CLIENT_SECRET],
 }
 
 impl AkvProvider {
     /// Creates a new AkvProvider with the given configuration.
     pub fn new(config: AkvConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+        }
     }
 
     /// Validates a convention-name component before encoding it.
@@ -303,12 +317,18 @@ impl AkvProvider {
         Ok(item)
     }
 
-    /// Reads an environment variable, treating an unset or blank value as absent.
-    fn non_empty_env(name: &str) -> Option<String> {
-        std::env::var(name).ok().filter(|v| !v.is_empty())
+    /// Resolves each service-principal input from its semantic provider
+    /// credential, retaining the conventional Azure environment variable as a
+    /// fallback when that credential was not supplied.
+    fn service_principal_inputs(&self) -> (Option<String>, Option<String>, Option<String>) {
+        (
+            credential_or_env(&self.credentials, TENANT_ID, AZURE_TENANT_ID_ENV),
+            credential_or_env(&self.credentials, CLIENT_ID, AZURE_CLIENT_ID_ENV),
+            credential_or_env(&self.credentials, CLIENT_SECRET, AZURE_CLIENT_SECRET_ENV),
+        )
     }
 
-    /// Classifies a service-principal env-var triple: all three present
+    /// Classifies a service-principal credential triple: all three present
     /// resolves to `Some`, none present resolves to `None` (fall back to the
     /// CLI session), and a partial set is an error -- silently falling back
     /// to a different identity when e.g. only `AZURE_CLIENT_SECRET` is
@@ -368,9 +388,7 @@ impl AkvProvider {
                 })? as Arc<dyn TokenCredential>)
             }
             AuthMethod::Env => {
-                let tenant_id = Self::non_empty_env("AZURE_TENANT_ID");
-                let client_id = Self::non_empty_env("AZURE_CLIENT_ID");
-                let client_secret = Self::non_empty_env("AZURE_CLIENT_SECRET");
+                let (tenant_id, client_id, client_secret) = self.service_principal_inputs();
 
                 match Self::classify_env_credentials(tenant_id, client_id, client_secret)? {
                     Some((tenant_id, client_id, client_secret)) => Ok(ClientSecretCredential::new(
@@ -498,6 +516,10 @@ impl Provider for AkvProvider {
         })
     }
 
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }
@@ -544,11 +566,24 @@ impl Provider for AkvProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::EnvVarGuard;
     use azure_core::error::ErrorKind;
     use url::Url;
 
     fn config(s: &str) -> AkvConfig {
         AkvConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap()
+    }
+
+    fn credentials(entries: &[(&str, &str)]) -> ProviderCredentials {
+        entries
+            .iter()
+            .map(|(name, value)| {
+                (
+                    (*name).to_string(),
+                    SecretString::new((*value).to_string().into()),
+                )
+            })
+            .collect()
     }
 
     #[test]
@@ -618,6 +653,36 @@ mod tests {
             AkvProvider::classify_env_credentials(Some("t".to_string()), None, None).unwrap_err();
         assert!(err.to_string().contains("AZURE_CLIENT_ID"), "{err}");
         assert!(err.to_string().contains("AZURE_CLIENT_SECRET"), "{err}");
+    }
+
+    #[test]
+    fn service_principal_credentials_override_environment_individually() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let _tenant = EnvVarGuard::set(AZURE_TENANT_ID_ENV, "tenant-from-env");
+        let _client = EnvVarGuard::set(AZURE_CLIENT_ID_ENV, "client-from-env");
+        let _secret = EnvVarGuard::set(AZURE_CLIENT_SECRET_ENV, "secret-from-env");
+        let mut provider = AkvProvider::new(config("akv://myvault"));
+        provider.with_credentials(credentials(&[
+            (TENANT_ID, "tenant-from-provider"),
+            (CLIENT_SECRET, "secret-from-provider"),
+        ]));
+
+        assert_eq!(
+            provider.service_principal_inputs(),
+            (
+                Some("tenant-from-provider".to_string()),
+                Some("client-from-env".to_string()),
+                Some("secret-from-provider".to_string()),
+            )
+        );
+    }
+
+    #[test]
+    fn registration_advertises_service_principal_credentials() {
+        assert_eq!(
+            crate::provider::credential_names_for_spec("akv://myvault"),
+            &[TENANT_ID, CLIENT_ID, CLIENT_SECRET]
+        );
     }
 
     #[test]

--- a/secretspec/src/provider/bws.rs
+++ b/secretspec/src/provider/bws.rs
@@ -4,7 +4,8 @@
 //!
 //! # Authentication
 //!
-//! Uses a machine account access token via the `BWS_ACCESS_TOKEN` environment variable.
+//! Uses a machine account access token supplied as a provider credential or via
+//! the `BWS_ACCESS_TOKEN` environment variable.
 //! Generate access tokens from the Bitwarden Secrets Manager web interface.
 //!
 //! # URI Format
@@ -36,7 +37,7 @@
 //! secretspec check --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
 //! ```
 
-use super::{Address, BootstrapEnv, Provider, ProviderUrl, env_or_overlay_var};
+use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
 use crate::{Result, SecretSpecError};
 use bitwarden::auth::login::AccessTokenLoginRequest;
 use bitwarden::secrets_manager::ClientSecretsExt;
@@ -110,14 +111,12 @@ pub struct BwsProvider {
     config: BwsConfig,
     client: OnceLock<Client>,
     secrets_cache: OnceLock<Vec<SecretResponse>>,
-    /// Bootstrap-credential overlay consulted after the process environment.
-    bootstrap_env: BootstrapEnv,
+    /// Credentials supplied by the provider alias.
+    credentials: ProviderCredentials,
 }
 
-/// The credential variable this provider reads through the bootstrap overlay.
-/// Shared between the registration's `bootstrap_vars` and the read site, so
-/// the declared list cannot drift from what the provider actually consults.
-const BWS_ACCESS_TOKEN: &str = "BWS_ACCESS_TOKEN";
+const ACCESS_TOKEN: &str = "access_token";
+const BWS_ACCESS_TOKEN_ENV: &str = "BWS_ACCESS_TOKEN";
 
 crate::register_provider! {
     struct: BwsProvider,
@@ -126,7 +125,7 @@ crate::register_provider! {
     description: "Bitwarden Secrets Manager",
     schemes: ["bws"],
     examples: ["bws://a9230ec4-5507-4870-b8b5-b3f500587e4c"],
-    bootstrap_vars: [BWS_ACCESS_TOKEN],
+    credential_names: [ACCESS_TOKEN],
 }
 
 impl BwsProvider {
@@ -136,13 +135,14 @@ impl BwsProvider {
             config,
             client: OnceLock::new(),
             secrets_cache: OnceLock::new(),
-            bootstrap_env: BootstrapEnv::new(),
+            credentials: ProviderCredentials::new(),
         }
     }
 
-    /// Resolves the BWS access token from the environment or bootstrap overlay.
+    /// Resolves the supplied access token, with the conventional environment
+    /// variable retained as a provider-level fallback.
     fn access_token(&self) -> Option<String> {
-        env_or_overlay_var(&self.bootstrap_env, BWS_ACCESS_TOKEN)
+        credential_or_env(&self.credentials, ACCESS_TOKEN, BWS_ACCESS_TOKEN_ENV)
     }
 
     /// Strips the BWS access token from error messages to avoid leaking credentials.
@@ -157,7 +157,7 @@ impl BwsProvider {
 
     /// Returns a reference to the authenticated Client, creating it if needed.
     ///
-    /// Reads `BWS_ACCESS_TOKEN` from the environment and authenticates on first call.
+    /// Resolves an access token and authenticates on first call.
     /// Subsequent calls return the cached client.
     async fn ensure_client(&self) -> Result<&Client> {
         if let Some(client) = self.client.get() {
@@ -166,17 +166,16 @@ impl BwsProvider {
 
         let token = self.access_token().ok_or_else(|| {
             SecretSpecError::ProviderOperationFailed(
-                "BWS_ACCESS_TOKEN environment variable is not set. \
-                 Generate an access token from the Bitwarden Secrets Manager web interface \
-                 and set it as BWS_ACCESS_TOKEN."
+                "BWS access_token credential is not set. Configure \
+                 credentials.access_token or set the BWS_ACCESS_TOKEN environment variable."
                     .to_string(),
             )
         })?;
 
         if token.is_empty() {
             return Err(SecretSpecError::ProviderOperationFailed(
-                "BWS_ACCESS_TOKEN environment variable is empty. \
-                 Generate an access token from the Bitwarden Secrets Manager web interface."
+                "BWS access_token credential is empty. Configure \
+                 credentials.access_token or set a non-empty BWS_ACCESS_TOKEN environment variable."
                     .to_string(),
             ));
         }
@@ -360,8 +359,8 @@ impl Provider for BwsProvider {
         })
     }
 
-    fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
-        self.bootstrap_env = env;
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
     }
 
     fn name(&self) -> &'static str {

--- a/secretspec/src/provider/bws.rs
+++ b/secretspec/src/provider/bws.rs
@@ -114,6 +114,11 @@ pub struct BwsProvider {
     bootstrap_env: BootstrapEnv,
 }
 
+/// The credential variable this provider reads through the bootstrap overlay.
+/// Shared between the registration's `bootstrap_vars` and the read site, so
+/// the declared list cannot drift from what the provider actually consults.
+const BWS_ACCESS_TOKEN: &str = "BWS_ACCESS_TOKEN";
+
 crate::register_provider! {
     struct: BwsProvider,
     config: BwsConfig,
@@ -121,7 +126,7 @@ crate::register_provider! {
     description: "Bitwarden Secrets Manager",
     schemes: ["bws"],
     examples: ["bws://a9230ec4-5507-4870-b8b5-b3f500587e4c"],
-    bootstrap_vars: ["BWS_ACCESS_TOKEN"],
+    bootstrap_vars: [BWS_ACCESS_TOKEN],
 }
 
 impl BwsProvider {
@@ -137,7 +142,7 @@ impl BwsProvider {
 
     /// Resolves the BWS access token from the environment or bootstrap overlay.
     fn access_token(&self) -> Option<String> {
-        env_or_overlay_var(&self.bootstrap_env, "BWS_ACCESS_TOKEN")
+        env_or_overlay_var(&self.bootstrap_env, BWS_ACCESS_TOKEN)
     }
 
     /// Strips the BWS access token from error messages to avoid leaking credentials.

--- a/secretspec/src/provider/bws.rs
+++ b/secretspec/src/provider/bws.rs
@@ -121,6 +121,7 @@ crate::register_provider! {
     description: "Bitwarden Secrets Manager",
     schemes: ["bws"],
     examples: ["bws://a9230ec4-5507-4870-b8b5-b3f500587e4c"],
+    bootstrap_vars: ["BWS_ACCESS_TOKEN"],
 }
 
 impl BwsProvider {

--- a/secretspec/src/provider/bws.rs
+++ b/secretspec/src/provider/bws.rs
@@ -36,7 +36,7 @@
 //! secretspec check --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
 //! ```
 
-use super::{Address, Provider, ProviderUrl};
+use super::{Address, BootstrapEnv, Provider, ProviderUrl, env_or_overlay_var};
 use crate::{Result, SecretSpecError};
 use bitwarden::auth::login::AccessTokenLoginRequest;
 use bitwarden::secrets_manager::ClientSecretsExt;
@@ -110,6 +110,8 @@ pub struct BwsProvider {
     config: BwsConfig,
     client: OnceLock<Client>,
     secrets_cache: OnceLock<Vec<SecretResponse>>,
+    /// Bootstrap-credential overlay consulted after the process environment.
+    bootstrap_env: BootstrapEnv,
 }
 
 crate::register_provider! {
@@ -128,12 +130,18 @@ impl BwsProvider {
             config,
             client: OnceLock::new(),
             secrets_cache: OnceLock::new(),
+            bootstrap_env: BootstrapEnv::new(),
         }
     }
 
+    /// Resolves the BWS access token from the environment or bootstrap overlay.
+    fn access_token(&self) -> Option<String> {
+        env_or_overlay_var(&self.bootstrap_env, "BWS_ACCESS_TOKEN")
+    }
+
     /// Strips the BWS access token from error messages to avoid leaking credentials.
-    fn sanitize_error(message: &str) -> String {
-        if let Ok(token) = std::env::var("BWS_ACCESS_TOKEN") {
+    fn sanitize_error(&self, message: &str) -> String {
+        if let Some(token) = self.access_token() {
             if !token.is_empty() {
                 return message.replace(&token, "[REDACTED]");
             }
@@ -150,7 +158,7 @@ impl BwsProvider {
             return Ok(client);
         }
 
-        let token = std::env::var("BWS_ACCESS_TOKEN").map_err(|_| {
+        let token = self.access_token().ok_or_else(|| {
             SecretSpecError::ProviderOperationFailed(
                 "BWS_ACCESS_TOKEN environment variable is not set. \
                  Generate an access token from the Bitwarden Secrets Manager web interface \
@@ -189,7 +197,7 @@ impl BwsProvider {
             })
             .await
             .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(Self::sanitize_error(&format!(
+                SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
                     "Failed to authenticate with Bitwarden Secrets Manager: {}",
                     e
                 )))
@@ -223,7 +231,7 @@ impl BwsProvider {
             })
             .await
             .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(Self::sanitize_error(&format!(
+                SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
                     "Failed to list secrets in BWS project '{}': {}",
                     self.config.project_id, e
                 )))
@@ -240,7 +248,7 @@ impl BwsProvider {
             .get_by_ids(SecretsGetRequest { ids })
             .await
             .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(Self::sanitize_error(&format!(
+                SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
                     "Failed to fetch secret values from BWS project '{}': {}",
                     self.config.project_id, e
                 )))
@@ -302,7 +310,7 @@ impl BwsProvider {
                 })
                 .await
                 .map_err(|e| {
-                    SecretSpecError::ProviderOperationFailed(Self::sanitize_error(&format!(
+                    SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
                         "Failed to update secret '{}' in BWS: {}",
                         key, e
                     )))
@@ -320,7 +328,7 @@ impl BwsProvider {
                 })
                 .await
                 .map_err(|e| {
-                    SecretSpecError::ProviderOperationFailed(Self::sanitize_error(&format!(
+                    SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
                         "Failed to create secret '{}' in BWS: {}",
                         key, e
                     )))
@@ -344,6 +352,10 @@ impl Provider for BwsProvider {
             item: key.to_string(),
             ..Default::default()
         })
+    }
+
+    fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
+        self.bootstrap_env = env;
     }
 
     fn name(&self) -> &'static str {

--- a/secretspec/src/provider/macros.rs
+++ b/secretspec/src/provider/macros.rs
@@ -1,4 +1,4 @@
-use super::{ProviderInfo, ProviderUrl, ProviderWithPreflight};
+use super::{BootstrapEnv, ProviderInfo, ProviderUrl, ProviderWithPreflight};
 use crate::Result;
 
 /// Internal registration structure used by the macro.
@@ -6,7 +6,7 @@ use crate::Result;
 pub struct ProviderRegistration {
     pub info: ProviderInfo,
     pub schemes: &'static [&'static str],
-    pub factory: fn(&ProviderUrl) -> Result<ProviderWithPreflight>,
+    pub factory: fn(&ProviderUrl, BootstrapEnv) -> Result<ProviderWithPreflight>,
 }
 
 /// Distributed slice that collects all provider registrations.
@@ -113,9 +113,14 @@ macro_rules! register_provider {
                     examples: &[$($example,)*],
                 },
                 schemes: &[$($scheme,)*],
-                factory: |url| {
+                factory: |url, bootstrap| {
                     let config = <$config_type>::try_from(url)?;
-                    let provider = <$struct_name>::new(config);
+                    let mut provider = <$struct_name>::new(config);
+                    // Inject the bootstrap overlay while the provider is still a
+                    // concrete `&mut` value, before any Arc/Box wrapping — a
+                    // preflight provider becomes `Box<Arc<P>>`, through which a
+                    // `&mut self` hook cannot be forwarded.
+                    $crate::provider::Provider::with_bootstrap_env(&mut provider, bootstrap);
                     let wrap: fn($struct_name) -> $crate::Result<$crate::provider::ProviderWithPreflight> = $wrap;
                     wrap(provider)
                 },

--- a/secretspec/src/provider/macros.rs
+++ b/secretspec/src/provider/macros.rs
@@ -6,6 +6,11 @@ use crate::Result;
 pub struct ProviderRegistration {
     pub info: ProviderInfo,
     pub schemes: &'static [&'static str],
+    /// Environment variables the provider reads through the bootstrap overlay
+    /// (see [`super::BootstrapEnv`]). Empty for providers that consult no
+    /// bootstrap credentials; used to warn when an alias declares a variable
+    /// the provider would silently ignore.
+    pub bootstrap_vars: &'static [&'static str],
     pub factory: fn(&ProviderUrl, BootstrapEnv) -> Result<ProviderWithPreflight>,
 }
 
@@ -28,6 +33,23 @@ pub static PROVIDER_REGISTRY: [ProviderRegistration];
 ///     description: "Uses system keychain (Recommended)",
 ///     schemes: ["keyring"],
 ///     examples: ["keyring://"],
+/// }
+/// ```
+///
+/// Providers that read bootstrap credentials through the overlay (see
+/// [`Provider::with_bootstrap_env`](super::Provider::with_bootstrap_env)) declare
+/// the variable names in a `bootstrap_vars` field, so an alias declaring a
+/// variable the provider never reads can be diagnosed:
+///
+/// ```ignore
+/// register_provider! {
+///     struct: BwsProvider,
+///     config: BwsConfig,
+///     name: "bws",
+///     description: "Bitwarden Secrets Manager",
+///     schemes: ["bws"],
+///     examples: ["bws://project-uuid"],
+///     bootstrap_vars: ["BWS_ACCESS_TOKEN"],
 /// }
 /// ```
 ///
@@ -55,11 +77,13 @@ macro_rules! register_provider {
         name: $name:expr,
         description: $description:expr,
         schemes: [$($scheme:expr),* $(,)?],
-        examples: [$($example:expr),* $(,)?] $(,)?
+        examples: [$($example:expr),* $(,)?]
+        $(, bootstrap_vars: [$($bootstrap_var:expr),* $(,)?])? $(,)?
     ) => {
         $crate::register_provider!(@register
             $struct_name, $config_type, $name, $description,
             [$($scheme,)*], [$($example,)*],
+            [$($($bootstrap_var,)*)?],
             |provider| {
                 Ok($crate::provider::ProviderWithPreflight {
                     provider: Box::new(provider),
@@ -77,11 +101,13 @@ macro_rules! register_provider {
         description: $description:expr,
         schemes: [$($scheme:expr),* $(,)?],
         examples: [$($example:expr),* $(,)?],
+        $(bootstrap_vars: [$($bootstrap_var:expr),* $(,)?],)?
         preflight: $preflight:ident $(,)?
     ) => {
         $crate::register_provider!(@register
             $struct_name, $config_type, $name, $description,
             [$($scheme,)*], [$($example,)*],
+            [$($($bootstrap_var,)*)?],
             |provider| {
                 let provider = std::sync::Arc::new(provider);
                 let preflight_provider = std::sync::Arc::clone(&provider);
@@ -97,6 +123,7 @@ macro_rules! register_provider {
     (@register
         $struct_name:ident, $config_type:ty, $name:expr, $description:expr,
         [$($scheme:expr,)*], [$($example:expr,)*],
+        [$($bootstrap_var:expr,)*],
         $wrap:expr
     ) => {
         impl $struct_name {
@@ -113,6 +140,7 @@ macro_rules! register_provider {
                     examples: &[$($example,)*],
                 },
                 schemes: &[$($scheme,)*],
+                bootstrap_vars: &[$($bootstrap_var,)*],
                 factory: |url, bootstrap| {
                     let config = <$config_type>::try_from(url)?;
                     let mut provider = <$struct_name>::new(config);

--- a/secretspec/src/provider/macros.rs
+++ b/secretspec/src/provider/macros.rs
@@ -1,4 +1,4 @@
-use super::{BootstrapEnv, ProviderInfo, ProviderUrl, ProviderWithPreflight};
+use super::{ProviderCredentials, ProviderInfo, ProviderUrl, ProviderWithPreflight};
 use crate::Result;
 
 /// Internal registration structure used by the macro.
@@ -6,12 +6,10 @@ use crate::Result;
 pub struct ProviderRegistration {
     pub info: ProviderInfo,
     pub schemes: &'static [&'static str],
-    /// Environment variables the provider reads through the bootstrap overlay
-    /// (see [`super::BootstrapEnv`]). Empty for providers that consult no
-    /// bootstrap credentials; used to warn when an alias declares a variable
-    /// the provider would silently ignore.
-    pub bootstrap_vars: &'static [&'static str],
-    pub factory: fn(&ProviderUrl, BootstrapEnv) -> Result<ProviderWithPreflight>,
+    /// Semantic credential names accepted by the provider. Empty for providers
+    /// that accept no injected credentials; used to reject unsupported names.
+    pub credential_names: &'static [&'static str],
+    pub factory: fn(&ProviderUrl, ProviderCredentials) -> Result<ProviderWithPreflight>,
 }
 
 /// Distributed slice that collects all provider registrations.
@@ -36,10 +34,9 @@ pub static PROVIDER_REGISTRY: [ProviderRegistration];
 /// }
 /// ```
 ///
-/// Providers that read bootstrap credentials through the overlay (see
-/// [`Provider::with_bootstrap_env`](super::Provider::with_bootstrap_env)) declare
-/// the variable names in a `bootstrap_vars` field, so an alias declaring a
-/// variable the provider never reads can be diagnosed:
+/// Providers that accept injected credentials declare their semantic names in
+/// a `credential_names` field, so an alias declaring an unsupported credential
+/// can be diagnosed:
 ///
 /// ```ignore
 /// register_provider! {
@@ -49,7 +46,7 @@ pub static PROVIDER_REGISTRY: [ProviderRegistration];
 ///     description: "Bitwarden Secrets Manager",
 ///     schemes: ["bws"],
 ///     examples: ["bws://project-uuid"],
-///     bootstrap_vars: ["BWS_ACCESS_TOKEN"],
+///     credential_names: ["access_token"],
 /// }
 /// ```
 ///
@@ -78,12 +75,12 @@ macro_rules! register_provider {
         description: $description:expr,
         schemes: [$($scheme:expr),* $(,)?],
         examples: [$($example:expr),* $(,)?]
-        $(, bootstrap_vars: [$($bootstrap_var:expr),* $(,)?])? $(,)?
+        $(, credential_names: [$($credential_name:expr),* $(,)?])? $(,)?
     ) => {
         $crate::register_provider!(@register
             $struct_name, $config_type, $name, $description,
             [$($scheme,)*], [$($example,)*],
-            [$($($bootstrap_var,)*)?],
+            [$($($credential_name,)*)?],
             |provider| {
                 Ok($crate::provider::ProviderWithPreflight {
                     provider: Box::new(provider),
@@ -101,13 +98,13 @@ macro_rules! register_provider {
         description: $description:expr,
         schemes: [$($scheme:expr),* $(,)?],
         examples: [$($example:expr),* $(,)?],
-        $(bootstrap_vars: [$($bootstrap_var:expr),* $(,)?],)?
+        $(credential_names: [$($credential_name:expr),* $(,)?],)?
         preflight: $preflight:ident $(,)?
     ) => {
         $crate::register_provider!(@register
             $struct_name, $config_type, $name, $description,
             [$($scheme,)*], [$($example,)*],
-            [$($($bootstrap_var,)*)?],
+            [$($($credential_name,)*)?],
             |provider| {
                 let provider = std::sync::Arc::new(provider);
                 let preflight_provider = std::sync::Arc::clone(&provider);
@@ -123,7 +120,7 @@ macro_rules! register_provider {
     (@register
         $struct_name:ident, $config_type:ty, $name:expr, $description:expr,
         [$($scheme:expr,)*], [$($example:expr,)*],
-        [$($bootstrap_var:expr,)*],
+        [$($credential_name:expr,)*],
         $wrap:expr
     ) => {
         impl $struct_name {
@@ -140,15 +137,15 @@ macro_rules! register_provider {
                     examples: &[$($example,)*],
                 },
                 schemes: &[$($scheme,)*],
-                bootstrap_vars: &[$($bootstrap_var,)*],
-                factory: |url, bootstrap| {
+                credential_names: &[$($credential_name,)*],
+                factory: |url, credentials| {
                     let config = <$config_type>::try_from(url)?;
                     let mut provider = <$struct_name>::new(config);
-                    // Inject the bootstrap overlay while the provider is still a
+                    // Inject credentials while the provider is still a
                     // concrete `&mut` value, before any Arc/Box wrapping — a
                     // preflight provider becomes `Box<Arc<P>>`, through which a
                     // `&mut self` hook cannot be forwarded.
-                    $crate::provider::Provider::with_bootstrap_env(&mut provider, bootstrap);
+                    $crate::provider::Provider::with_credentials(&mut provider, credentials);
                     let wrap: fn($struct_name) -> $crate::Result<$crate::provider::ProviderWithPreflight> = $wrap;
                     wrap(provider)
                 },

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -984,71 +984,79 @@ impl TryFrom<&str> for Box<dyn Provider> {
     type Error = SecretSpecError;
 
     fn try_from(s: &str) -> Result<Self> {
-        // Parse the scheme from the input string
-        let (scheme, rest) = split_spec(s);
+        provider_from_spec(s, BootstrapEnv::new())
+    }
+}
 
-        // Reject the `1password` misspelling (with its corrective error) and
-        // check the scheme against the registry, through the same gate alias
-        // resolution uses.
-        if !spec_names_known_provider(s)? {
-            // Check if it's a known provider name to give a better error
-            if PROVIDER_REGISTRY.iter().any(|reg| reg.info.name == scheme) {
-                return Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "Provider '{}' exists but URI parsing failed",
-                    scheme
-                )));
-            } else {
-                return Err(SecretSpecError::ProviderNotFound(scheme.to_string()));
-            }
-        }
+/// Builds a boxed provider from a spec string (a bare name, `scheme:...`
+/// shorthand, or full URI), handing it the given bootstrap overlay. The shared
+/// body of the string `TryFrom` impls: construction funnels here so URL
+/// normalization and overlay injection have exactly one home.
+pub(crate) fn provider_from_spec(s: &str, bootstrap: BootstrapEnv) -> Result<Box<dyn Provider>> {
+    // Parse the scheme from the input string
+    let (scheme, rest) = split_spec(s);
 
-        // Build a proper URL with the correct scheme.
-        //
-        // Windows absolute paths (e.g. `dotenv://C:\path\.env`) need special care:
-        // the drive-letter colon looks like a `host:port` separator and parsing
-        // fails with "invalid port number". Encode the whole path (drive colon and
-        // backslashes included) into an opaque host so it round-trips back out via
-        // `ProviderUrl::host()`. A Unix absolute path stays in the authority-less
-        // `scheme:///abs/path` form, which already parses cleanly.
-        let path_candidate = rest.trim_start_matches('/');
-        let url_string = if is_windows_abs_path(path_candidate) {
-            format!(
-                "{}://{}",
-                scheme,
-                percent_encode(path_candidate.as_bytes(), WINDOWS_PATH_ENCODE_SET)
-            )
+    // Reject the `1password` misspelling (with its corrective error) and
+    // check the scheme against the registry, through the same gate alias
+    // resolution uses.
+    if !spec_names_known_provider(s)? {
+        // Check if it's a known provider name to give a better error
+        if PROVIDER_REGISTRY.iter().any(|reg| reg.info.name == scheme) {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Provider '{}' exists but URI parsing failed",
+                scheme
+            )));
         } else {
-            let url_string = match rest {
-                // Just scheme name (e.g., "keyring")
-                "" | ":" => format!("{}://", scheme),
-                // Standard URI format already has // (e.g., "onepassword://vault")
-                s if s.starts_with("//") => format!("{}:{}", scheme, s),
-                // Path only format (e.g., "dotenv:/path/to/.env")
-                s if s.starts_with('/') => format!("{}://{}", scheme, s),
-                // Everything else - assume it's a host or path component
-                s => format!("{}://{}", scheme, s),
-            };
+            return Err(SecretSpecError::ProviderNotFound(scheme.to_string()));
+        }
+    }
 
-            // Percent-encode characters that are invalid in URIs but might appear in
-            // provider config values (e.g., spaces in 1Password vault names like "Home Lab")
-            let scheme_end = url_string.find("://").unwrap() + 3;
-            let (prefix, rest) = url_string.split_at(scheme_end);
-            format!(
-                "{}{}",
-                prefix,
-                percent_encode(rest.as_bytes(), URI_ENCODE_SET)
-            )
+    // Build a proper URL with the correct scheme.
+    //
+    // Windows absolute paths (e.g. `dotenv://C:\path\.env`) need special care:
+    // the drive-letter colon looks like a `host:port` separator and parsing
+    // fails with "invalid port number". Encode the whole path (drive colon and
+    // backslashes included) into an opaque host so it round-trips back out via
+    // `ProviderUrl::host()`. A Unix absolute path stays in the authority-less
+    // `scheme:///abs/path` form, which already parses cleanly.
+    let path_candidate = rest.trim_start_matches('/');
+    let url_string = if is_windows_abs_path(path_candidate) {
+        format!(
+            "{}://{}",
+            scheme,
+            percent_encode(path_candidate.as_bytes(), WINDOWS_PATH_ENCODE_SET)
+        )
+    } else {
+        let url_string = match rest {
+            // Just scheme name (e.g., "keyring")
+            "" | ":" => format!("{}://", scheme),
+            // Standard URI format already has // (e.g., "onepassword://vault")
+            s if s.starts_with("//") => format!("{}:{}", scheme, s),
+            // Path only format (e.g., "dotenv:/path/to/.env")
+            s if s.starts_with('/') => format!("{}://{}", scheme, s),
+            // Everything else - assume it's a host or path component
+            s => format!("{}://{}", scheme, s),
         };
 
-        let proper_url = Url::parse(&url_string).map_err(|e| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "Invalid provider specification '{}': {}",
-                s, e
-            ))
-        })?;
+        // Percent-encode characters that are invalid in URIs but might appear in
+        // provider config values (e.g., spaces in 1Password vault names like "Home Lab")
+        let scheme_end = url_string.find("://").unwrap() + 3;
+        let (prefix, rest) = url_string.split_at(scheme_end);
+        format!(
+            "{}{}",
+            prefix,
+            percent_encode(rest.as_bytes(), URI_ENCODE_SET)
+        )
+    };
 
-        provider_from_url(&ProviderUrl::new(proper_url), BootstrapEnv::new())
-    }
+    let proper_url = Url::parse(&url_string).map_err(|e| {
+        SecretSpecError::ProviderOperationFailed(format!(
+            "Invalid provider specification '{}': {}",
+            s, e
+        ))
+    })?;
+
+    provider_from_url(&ProviderUrl::new(proper_url), bootstrap)
 }
 
 impl TryFrom<&Url> for Box<dyn Provider> {

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -658,7 +658,7 @@ pub trait Provider: Send + Sync {
     fn with_base_dir(&mut self, _base_dir: &std::path::Path) {}
 
     /// Hands the provider its bootstrap-credential overlay (see [`BootstrapEnv`])
-    /// so credential reads can prefer it over the process environment.
+    /// as a fallback when the process environment has no non-empty value.
     ///
     /// Called once inside the registration factory, on the concrete provider
     /// value *before* any `Arc`/`Box` wrapping. This must not be a

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -438,6 +438,32 @@ pub(crate) fn spec_names_known_provider(spec: &str) -> Result<bool> {
         .any(|reg| reg.schemes.contains(&scheme)))
 }
 
+/// The bootstrap variables the provider named by `spec` reads through the
+/// overlay (its registration's `bootstrap_vars`), or an empty slice for an
+/// unknown scheme. Lets alias validation diagnose an `env` declaration the
+/// provider would silently ignore.
+pub(crate) fn bootstrap_vars_for_spec(spec: &str) -> &'static [&'static str] {
+    let (scheme, _) = split_spec(spec);
+    PROVIDER_REGISTRY
+        .iter()
+        .find(|reg| reg.schemes.contains(&scheme))
+        .map(|reg| reg.bootstrap_vars)
+        .unwrap_or(&[])
+}
+
+/// The registered display name for the provider `spec` names, falling back to
+/// the spec's scheme token. Pure registry lookup: lets callers show which
+/// provider a spec routes to without constructing it (construction now fetches
+/// bootstrap credentials, so a display-only build could fail or do I/O).
+pub(crate) fn provider_display_name_for_spec(spec: &str) -> String {
+    let (scheme, _) = split_spec(spec);
+    PROVIDER_REGISTRY
+        .iter()
+        .find(|reg| reg.schemes.contains(&scheme))
+        .map(|reg| reg.info.name.to_string())
+        .unwrap_or_else(|| scheme.to_string())
+}
+
 /// Trait defining the interface for secret storage providers.
 ///
 /// All secret storage backends must implement this trait to integrate with SecretSpec.
@@ -1295,6 +1321,7 @@ mod url_tests {
 #[cfg(test)]
 mod bootstrap_env_tests {
     use super::{BootstrapEnv, bootstrap_env_var, env_or_overlay_var};
+    use crate::tests::EnvVarGuard;
     use secrecy::SecretString;
 
     fn overlay(var: &str, value: &str) -> BootstrapEnv {
@@ -1305,30 +1332,23 @@ mod bootstrap_env_tests {
 
     #[test]
     fn env_var_wins_over_overlay() {
-        // Unique per-test var name so the process-global mutation cannot race
-        // other tests that touch the environment.
+        // The lock guard serializes all env mutation across the test binary;
+        // the var guard restores the previous value even if an assert panics.
+        let _lock = crate::tests::scrub_resolution_env();
         const VAR: &str = "SECRETSPEC_TEST_BOOTSTRAP_ENV_WINS";
-        let prev = std::env::var(VAR).ok();
-        // SAFETY: unique-per-test var, restored below (mirrors tests.rs).
-        unsafe { std::env::set_var(VAR, "from-env") };
+        let _var = EnvVarGuard::set(VAR, "from-env");
 
         assert_eq!(
             env_or_overlay_var(&overlay(VAR, "from-overlay"), VAR).as_deref(),
             Some("from-env"),
         );
-
-        match prev {
-            Some(value) => unsafe { std::env::set_var(VAR, value) },
-            None => unsafe { std::env::remove_var(VAR) },
-        }
     }
 
     #[test]
     fn overlay_used_only_when_env_absent() {
+        let _lock = crate::tests::scrub_resolution_env();
         const VAR: &str = "SECRETSPEC_TEST_BOOTSTRAP_OVERLAY_FALLBACK";
-        let prev = std::env::var(VAR).ok();
-        // SAFETY: unique-per-test var, restored below.
-        unsafe { std::env::remove_var(VAR) };
+        let _var = EnvVarGuard::remove(VAR);
 
         // Overlay hit when the environment has nothing.
         assert_eq!(
@@ -1341,17 +1361,12 @@ mod bootstrap_env_tests {
         assert_eq!(env_or_overlay_var(&overlay(VAR, ""), VAR), None);
 
         // A set-but-empty environment value is also treated as unset, so the
-        // overlay still wins — matching the resolver's fetch-skip predicate.
-        unsafe { std::env::set_var(VAR, "") };
+        // overlay still wins, matching the resolver's fetch-skip predicate.
+        let _empty = EnvVarGuard::set(VAR, "");
         assert_eq!(bootstrap_env_var(VAR), None);
         assert_eq!(
             env_or_overlay_var(&overlay(VAR, "from-overlay"), VAR).as_deref(),
             Some("from-overlay"),
         );
-
-        match prev {
-            Some(value) => unsafe { std::env::set_var(VAR, value) },
-            None => unsafe { std::env::remove_var(VAR) },
-        }
     }
 }

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -60,6 +60,8 @@ use secrecy::{ExposeSecret, SecretString};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use url::Url;
 
 /// An overlay of bootstrap credentials handed to a provider at construction.
 ///
@@ -67,29 +69,34 @@ use std::convert::TryFrom;
 /// participating provider consults *after* the real process environment (see
 /// [`env_or_overlay_var`]). It exists so a provider's own credentials can be
 /// sourced from another provider without ever calling `std::env::set_var`,
-/// which would leak them into the child environment of `secretspec run`. In the
-/// current slice the overlay is always empty in production, so every path
-/// behaves exactly as it would reading the environment directly.
+/// which would leak them into the child environment of `secretspec run`.
 pub(crate) type BootstrapEnv = HashMap<String, SecretString>;
+
+/// A bootstrap variable's value from the process environment, with a
+/// set-but-empty variable treated as unset.
+///
+/// The single owner of the env-wins rule: the overlay resolver skips fetching a
+/// credential exactly when this returns `Some`, and [`env_or_overlay_var`]
+/// prefers the same value on the provider side, so the two layers can never
+/// disagree about whether the environment already satisfies a variable.
+pub(crate) fn bootstrap_env_var(var: &str) -> Option<String> {
+    std::env::var(var).ok().filter(|value| !value.is_empty())
+}
 
 /// Resolves a bootstrap variable, preferring the process environment over the
 /// overlay.
 ///
-/// A variable set in the environment (even to an empty string) wins, preserving
-/// the exact behavior of the direct `std::env::var` reads this replaces. Only
-/// when the variable is absent from the environment is the overlay consulted,
-/// and an empty overlay value is treated as unset.
+/// A variable set (non-empty) in the environment wins — see
+/// [`bootstrap_env_var`]. Only otherwise is the overlay consulted, and an empty
+/// overlay value is likewise treated as unset.
 pub(crate) fn env_or_overlay_var(overlay: &BootstrapEnv, var: &str) -> Option<String> {
-    if let Ok(value) = std::env::var(var) {
-        return Some(value);
-    }
-    overlay
-        .get(var)
-        .map(|secret| secret.expose_secret().to_string())
-        .filter(|value| !value.is_empty())
+    bootstrap_env_var(var).or_else(|| {
+        overlay
+            .get(var)
+            .map(|secret| secret.expose_secret().to_string())
+            .filter(|value| !value.is_empty())
+    })
 }
-use std::sync::{Arc, LazyLock, Mutex, OnceLock};
-use url::Url;
 
 /// Characters that are invalid in URI hosts but might appear in provider config
 /// values like vault names (e.g., 1Password vault "Home Lab").
@@ -1287,7 +1294,7 @@ mod url_tests {
 
 #[cfg(test)]
 mod bootstrap_env_tests {
-    use super::{BootstrapEnv, env_or_overlay_var};
+    use super::{BootstrapEnv, bootstrap_env_var, env_or_overlay_var};
     use secrecy::SecretString;
 
     fn overlay(var: &str, value: &str) -> BootstrapEnv {
@@ -1333,8 +1340,18 @@ mod bootstrap_env_tests {
         // An empty overlay value is treated as unset.
         assert_eq!(env_or_overlay_var(&overlay(VAR, ""), VAR), None);
 
-        if let Some(value) = prev {
-            unsafe { std::env::set_var(VAR, value) };
+        // A set-but-empty environment value is also treated as unset, so the
+        // overlay still wins — matching the resolver's fetch-skip predicate.
+        unsafe { std::env::set_var(VAR, "") };
+        assert_eq!(bootstrap_env_var(VAR), None);
+        assert_eq!(
+            env_or_overlay_var(&overlay(VAR, "from-overlay"), VAR).as_deref(),
+            Some("from-overlay"),
+        );
+
+        match prev {
+            Some(value) => unsafe { std::env::set_var(VAR, value) },
+            None => unsafe { std::env::remove_var(VAR) },
         }
     }
 }

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -415,6 +415,15 @@ fn split_spec(spec: &str) -> (&str, &str) {
     }
 }
 
+/// The registry entry whose schemes contain `scheme`. The one definition of
+/// "which registration a scheme resolves to", shared by every lookup below and
+/// by [`provider_from_url`], so they cannot drift on the matching rule.
+fn registration_for_scheme(scheme: &str) -> Option<&'static ProviderRegistration> {
+    PROVIDER_REGISTRY
+        .iter()
+        .find(|reg| reg.schemes.contains(&scheme))
+}
+
 /// Whether `spec` names a registered provider: a bare name (`keyring`), a
 /// `scheme:path` shorthand (`dotenv:.env.production`), or a full URI. Checks
 /// the leading scheme token against the registry without constructing a
@@ -433,9 +442,7 @@ pub(crate) fn spec_names_known_provider(spec: &str) -> Result<bool> {
                 .to_string(),
         ));
     }
-    Ok(PROVIDER_REGISTRY
-        .iter()
-        .any(|reg| reg.schemes.contains(&scheme)))
+    Ok(registration_for_scheme(scheme).is_some())
 }
 
 /// The bootstrap variables the provider named by `spec` reads through the
@@ -444,11 +451,7 @@ pub(crate) fn spec_names_known_provider(spec: &str) -> Result<bool> {
 /// provider would silently ignore.
 pub(crate) fn bootstrap_vars_for_spec(spec: &str) -> &'static [&'static str] {
     let (scheme, _) = split_spec(spec);
-    PROVIDER_REGISTRY
-        .iter()
-        .find(|reg| reg.schemes.contains(&scheme))
-        .map(|reg| reg.bootstrap_vars)
-        .unwrap_or(&[])
+    registration_for_scheme(scheme).map_or(&[], |reg| reg.bootstrap_vars)
 }
 
 /// The registered display name for the provider `spec` names, falling back to
@@ -457,9 +460,7 @@ pub(crate) fn bootstrap_vars_for_spec(spec: &str) -> &'static [&'static str] {
 /// bootstrap credentials, so a display-only build could fail or do I/O).
 pub(crate) fn provider_display_name_for_spec(spec: &str) -> String {
     let (scheme, _) = split_spec(spec);
-    PROVIDER_REGISTRY
-        .iter()
-        .find(|reg| reg.schemes.contains(&scheme))
+    registration_for_scheme(scheme)
         .map(|reg| reg.info.name.to_string())
         .unwrap_or_else(|| scheme.to_string())
 }
@@ -1106,10 +1107,7 @@ pub(crate) fn provider_from_url(
 ) -> Result<Box<dyn Provider>> {
     let scheme = url.scheme();
 
-    // Find the provider registration for this scheme
-    let registration = PROVIDER_REGISTRY
-        .iter()
-        .find(|reg| reg.schemes.contains(&scheme))
+    let registration = registration_for_scheme(scheme)
         .ok_or_else(|| SecretSpecError::ProviderNotFound(scheme.to_string()))?;
 
     let pwp = (registration.factory)(url, bootstrap)?;

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -56,10 +56,38 @@
 use crate::config::NativeAddress;
 use crate::{Result, SecretSpecError};
 use percent_encoding::{AsciiSet, CONTROLS, percent_decode_str, percent_encode};
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+
+/// An overlay of bootstrap credentials handed to a provider at construction.
+///
+/// Maps an environment variable name (e.g. `BWS_ACCESS_TOKEN`) to a value a
+/// participating provider consults *after* the real process environment (see
+/// [`env_or_overlay_var`]). It exists so a provider's own credentials can be
+/// sourced from another provider without ever calling `std::env::set_var`,
+/// which would leak them into the child environment of `secretspec run`. In the
+/// current slice the overlay is always empty in production, so every path
+/// behaves exactly as it would reading the environment directly.
+pub(crate) type BootstrapEnv = HashMap<String, SecretString>;
+
+/// Resolves a bootstrap variable, preferring the process environment over the
+/// overlay.
+///
+/// A variable set in the environment (even to an empty string) wins, preserving
+/// the exact behavior of the direct `std::env::var` reads this replaces. Only
+/// when the variable is absent from the environment is the overlay consulted,
+/// and an empty overlay value is treated as unset.
+pub(crate) fn env_or_overlay_var(overlay: &BootstrapEnv, var: &str) -> Option<String> {
+    if let Ok(value) = std::env::var(var) {
+        return Some(value);
+    }
+    overlay
+        .get(var)
+        .map(|secret| secret.expose_secret().to_string())
+        .filter(|value| !value.is_empty())
+}
 use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use url::Url;
 
@@ -595,6 +623,22 @@ pub trait Provider: Send + Sync {
     /// [`Secrets`]: crate::Secrets
     fn with_base_dir(&mut self, _base_dir: &std::path::Path) {}
 
+    /// Hands the provider its bootstrap-credential overlay (see [`BootstrapEnv`])
+    /// so credential reads can prefer it over the process environment.
+    ///
+    /// Called once inside the registration factory, on the concrete provider
+    /// value *before* any `Arc`/`Box` wrapping. This must not be a
+    /// post-construction call on a `Box<dyn Provider>`: like [`with_base_dir`],
+    /// a `&mut self` hook cannot be forwarded through the blanket
+    /// `impl Provider for Arc<T>` (an `Arc` gives no `&mut` access to its
+    /// inner value), so a preflight provider — wrapped as `Box<Arc<P>>` — would
+    /// silently receive the default no-op. The default implementation ignores
+    /// the overlay, which is correct for providers that read no bootstrap
+    /// credentials.
+    ///
+    /// [`with_base_dir`]: Provider::with_base_dir
+    fn with_bootstrap_env(&mut self, _env: BootstrapEnv) {}
+
     /// Discovers and returns all secrets available in this provider.
     ///
     /// This method is used to introspect the provider and find all available secrets.
@@ -885,6 +929,10 @@ impl Provider for PreflightGuard {
         self.inner.with_base_dir(base_dir);
     }
 
+    fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
+        self.inner.with_bootstrap_env(env);
+    }
+
     fn reflect(&self) -> Result<HashMap<String, crate::config::Secret>> {
         self.check()?;
         self.inner.reflect()
@@ -999,7 +1047,7 @@ impl TryFrom<&str> for Box<dyn Provider> {
             ))
         })?;
 
-        provider_from_url(&ProviderUrl::new(proper_url))
+        provider_from_url(&ProviderUrl::new(proper_url), BootstrapEnv::new())
     }
 }
 
@@ -1007,11 +1055,14 @@ impl TryFrom<&Url> for Box<dyn Provider> {
     type Error = SecretSpecError;
 
     fn try_from(url: &Url) -> Result<Self> {
-        provider_from_url(&ProviderUrl::new(url.clone()))
+        provider_from_url(&ProviderUrl::new(url.clone()), BootstrapEnv::new())
     }
 }
 
-fn provider_from_url(url: &ProviderUrl) -> Result<Box<dyn Provider>> {
+pub(crate) fn provider_from_url(
+    url: &ProviderUrl,
+    bootstrap: BootstrapEnv,
+) -> Result<Box<dyn Provider>> {
     let scheme = url.scheme();
 
     // Find the provider registration for this scheme
@@ -1020,7 +1071,7 @@ fn provider_from_url(url: &ProviderUrl) -> Result<Box<dyn Provider>> {
         .find(|reg| reg.schemes.contains(&scheme))
         .ok_or_else(|| SecretSpecError::ProviderNotFound(scheme.to_string()))?;
 
-    let pwp = (registration.factory)(url)?;
+    let pwp = (registration.factory)(url, bootstrap)?;
     if pwp.preflight.is_some() {
         Ok(Box::new(PreflightGuard::new(pwp)))
     } else {
@@ -1223,5 +1274,59 @@ mod url_tests {
             without.display_with_examples(),
             "env: Environment variables"
         );
+    }
+}
+
+#[cfg(test)]
+mod bootstrap_env_tests {
+    use super::{BootstrapEnv, env_or_overlay_var};
+    use secrecy::SecretString;
+
+    fn overlay(var: &str, value: &str) -> BootstrapEnv {
+        let mut overlay = BootstrapEnv::new();
+        overlay.insert(var.to_string(), SecretString::new(value.into()));
+        overlay
+    }
+
+    #[test]
+    fn env_var_wins_over_overlay() {
+        // Unique per-test var name so the process-global mutation cannot race
+        // other tests that touch the environment.
+        const VAR: &str = "SECRETSPEC_TEST_BOOTSTRAP_ENV_WINS";
+        let prev = std::env::var(VAR).ok();
+        // SAFETY: unique-per-test var, restored below (mirrors tests.rs).
+        unsafe { std::env::set_var(VAR, "from-env") };
+
+        assert_eq!(
+            env_or_overlay_var(&overlay(VAR, "from-overlay"), VAR).as_deref(),
+            Some("from-env"),
+        );
+
+        match prev {
+            Some(value) => unsafe { std::env::set_var(VAR, value) },
+            None => unsafe { std::env::remove_var(VAR) },
+        }
+    }
+
+    #[test]
+    fn overlay_used_only_when_env_absent() {
+        const VAR: &str = "SECRETSPEC_TEST_BOOTSTRAP_OVERLAY_FALLBACK";
+        let prev = std::env::var(VAR).ok();
+        // SAFETY: unique-per-test var, restored below.
+        unsafe { std::env::remove_var(VAR) };
+
+        // Overlay hit when the environment has nothing.
+        assert_eq!(
+            env_or_overlay_var(&overlay(VAR, "from-overlay"), VAR).as_deref(),
+            Some("from-overlay"),
+        );
+        // No environment value and no overlay entry -> None.
+        assert_eq!(env_or_overlay_var(&BootstrapEnv::new(), VAR), None);
+        // An empty overlay value is treated as unset.
+        assert_eq!(env_or_overlay_var(&overlay(VAR, ""), VAR), None);
+
+        if let Some(value) = prev {
+            unsafe { std::env::set_var(VAR, value) };
+        }
     }
 }

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -63,39 +63,29 @@ use std::convert::TryFrom;
 use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use url::Url;
 
-/// An overlay of bootstrap credentials handed to a provider at construction.
+/// Credentials handed to a provider at construction.
 ///
-/// Maps an environment variable name (e.g. `BWS_ACCESS_TOKEN`) to a value a
-/// participating provider consults *after* the real process environment (see
-/// [`env_or_overlay_var`]). It exists so a provider's own credentials can be
-/// sourced from another provider without ever calling `std::env::set_var`,
-/// which would leak them into the child environment of `secretspec run`.
-pub(crate) type BootstrapEnv = HashMap<String, SecretString>;
+/// Maps semantic provider-specific names (for example `access_token`) to
+/// secret values. Providers may retain environment-variable fallback for
+/// standalone compatibility, but environment names are not part of this API.
+pub(crate) type ProviderCredentials = HashMap<String, SecretString>;
 
-/// A bootstrap variable's value from the process environment, with a
-/// set-but-empty variable treated as unset.
-///
-/// The single owner of the env-wins rule: the overlay resolver skips fetching a
-/// credential exactly when this returns `Some`, and [`env_or_overlay_var`]
-/// prefers the same value on the provider side, so the two layers can never
-/// disagree about whether the environment already satisfies a variable.
-pub(crate) fn bootstrap_env_var(var: &str) -> Option<String> {
-    std::env::var(var).ok().filter(|value| !value.is_empty())
-}
-
-/// Resolves a bootstrap variable, preferring the process environment over the
-/// overlay.
-///
-/// A variable set (non-empty) in the environment wins — see
-/// [`bootstrap_env_var`]. Only otherwise is the overlay consulted, and an empty
-/// overlay value is likewise treated as unset.
-pub(crate) fn env_or_overlay_var(overlay: &BootstrapEnv, var: &str) -> Option<String> {
-    bootstrap_env_var(var).or_else(|| {
-        overlay
-            .get(var)
-            .map(|secret| secret.expose_secret().to_string())
-            .filter(|value| !value.is_empty())
-    })
+/// Resolves a semantic provider credential, falling back to the provider's
+/// conventional environment variable when no explicit credential was supplied.
+pub(crate) fn credential_or_env(
+    credentials: &ProviderCredentials,
+    name: &str,
+    env_var: &str,
+) -> Option<String> {
+    credentials
+        .get(name)
+        .map(|secret| secret.expose_secret().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var(env_var)
+                .ok()
+                .filter(|value| !value.is_empty())
+        })
 }
 
 /// Characters that are invalid in URI hosts but might appear in provider config
@@ -445,19 +435,18 @@ pub(crate) fn spec_names_known_provider(spec: &str) -> Result<bool> {
     Ok(registration_for_scheme(scheme).is_some())
 }
 
-/// The bootstrap variables the provider named by `spec` reads through the
-/// overlay (its registration's `bootstrap_vars`), or an empty slice for an
-/// unknown scheme. Lets alias validation diagnose an `env` declaration the
-/// provider would silently ignore.
-pub(crate) fn bootstrap_vars_for_spec(spec: &str) -> &'static [&'static str] {
+/// The semantic credential names accepted by the provider named by `spec`, or
+/// an empty slice for an unknown scheme. Lets alias validation reject a
+/// declaration the provider would silently ignore.
+pub(crate) fn credential_names_for_spec(spec: &str) -> &'static [&'static str] {
     let (scheme, _) = split_spec(spec);
-    registration_for_scheme(scheme).map_or(&[], |reg| reg.bootstrap_vars)
+    registration_for_scheme(scheme).map_or(&[], |reg| reg.credential_names)
 }
 
 /// The registered display name for the provider `spec` names, falling back to
 /// the spec's scheme token. Pure registry lookup: lets callers show which
 /// provider a spec routes to without constructing it (construction now fetches
-/// bootstrap credentials, so a display-only build could fail or do I/O).
+/// provider credentials, so a display-only build could fail or do I/O).
 pub(crate) fn provider_display_name_for_spec(spec: &str) -> String {
     let (scheme, _) = split_spec(spec);
     registration_for_scheme(scheme)
@@ -657,8 +646,7 @@ pub trait Provider: Send + Sync {
     /// [`Secrets`]: crate::Secrets
     fn with_base_dir(&mut self, _base_dir: &std::path::Path) {}
 
-    /// Hands the provider its bootstrap-credential overlay (see [`BootstrapEnv`])
-    /// as a fallback when the process environment has no non-empty value.
+    /// Hands semantic credentials to the provider.
     ///
     /// Called once inside the registration factory, on the concrete provider
     /// value *before* any `Arc`/`Box` wrapping. This must not be a
@@ -667,11 +655,10 @@ pub trait Provider: Send + Sync {
     /// `impl Provider for Arc<T>` (an `Arc` gives no `&mut` access to its
     /// inner value), so a preflight provider — wrapped as `Box<Arc<P>>` — would
     /// silently receive the default no-op. The default implementation ignores
-    /// the overlay, which is correct for providers that read no bootstrap
-    /// credentials.
+    /// the values, which is correct for providers that need no credentials.
     ///
     /// [`with_base_dir`]: Provider::with_base_dir
-    fn with_bootstrap_env(&mut self, _env: BootstrapEnv) {}
+    fn with_credentials(&mut self, _credentials: ProviderCredentials) {}
 
     /// Discovers and returns all secrets available in this provider.
     ///
@@ -963,8 +950,8 @@ impl Provider for PreflightGuard {
         self.inner.with_base_dir(base_dir);
     }
 
-    fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
-        self.inner.with_bootstrap_env(env);
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.inner.with_credentials(credentials);
     }
 
     fn reflect(&self) -> Result<HashMap<String, crate::config::Secret>> {
@@ -1018,15 +1005,18 @@ impl TryFrom<&str> for Box<dyn Provider> {
     type Error = SecretSpecError;
 
     fn try_from(s: &str) -> Result<Self> {
-        provider_from_spec(s, BootstrapEnv::new())
+        provider_from_spec(s, ProviderCredentials::new())
     }
 }
 
 /// Builds a boxed provider from a spec string (a bare name, `scheme:...`
-/// shorthand, or full URI), handing it the given bootstrap overlay. The shared
+/// shorthand, or full URI), handing it the supplied credentials. The shared
 /// body of the string `TryFrom` impls: construction funnels here so URL
-/// normalization and overlay injection have exactly one home.
-pub(crate) fn provider_from_spec(s: &str, bootstrap: BootstrapEnv) -> Result<Box<dyn Provider>> {
+/// normalization and credential injection have exactly one home.
+pub(crate) fn provider_from_spec(
+    s: &str,
+    credentials: ProviderCredentials,
+) -> Result<Box<dyn Provider>> {
     // Parse the scheme from the input string
     let (scheme, rest) = split_spec(s);
 
@@ -1090,27 +1080,27 @@ pub(crate) fn provider_from_spec(s: &str, bootstrap: BootstrapEnv) -> Result<Box
         ))
     })?;
 
-    provider_from_url(&ProviderUrl::new(proper_url), bootstrap)
+    provider_from_url(&ProviderUrl::new(proper_url), credentials)
 }
 
 impl TryFrom<&Url> for Box<dyn Provider> {
     type Error = SecretSpecError;
 
     fn try_from(url: &Url) -> Result<Self> {
-        provider_from_url(&ProviderUrl::new(url.clone()), BootstrapEnv::new())
+        provider_from_url(&ProviderUrl::new(url.clone()), ProviderCredentials::new())
     }
 }
 
 pub(crate) fn provider_from_url(
     url: &ProviderUrl,
-    bootstrap: BootstrapEnv,
+    credentials: ProviderCredentials,
 ) -> Result<Box<dyn Provider>> {
     let scheme = url.scheme();
 
     let registration = registration_for_scheme(scheme)
         .ok_or_else(|| SecretSpecError::ProviderNotFound(scheme.to_string()))?;
 
-    let pwp = (registration.factory)(url, bootstrap)?;
+    let pwp = (registration.factory)(url, credentials)?;
     if pwp.preflight.is_some() {
         Ok(Box::new(PreflightGuard::new(pwp)))
     } else {
@@ -1317,54 +1307,49 @@ mod url_tests {
 }
 
 #[cfg(test)]
-mod bootstrap_env_tests {
-    use super::{BootstrapEnv, bootstrap_env_var, env_or_overlay_var};
+mod provider_credentials_tests {
+    use super::{ProviderCredentials, credential_or_env};
     use crate::tests::EnvVarGuard;
     use secrecy::SecretString;
 
-    fn overlay(var: &str, value: &str) -> BootstrapEnv {
-        let mut overlay = BootstrapEnv::new();
-        overlay.insert(var.to_string(), SecretString::new(value.into()));
-        overlay
+    fn credentials(name: &str, value: &str) -> ProviderCredentials {
+        let mut credentials = ProviderCredentials::new();
+        credentials.insert(name.to_string(), SecretString::new(value.into()));
+        credentials
     }
 
     #[test]
-    fn env_var_wins_over_overlay() {
+    fn explicit_credential_wins_over_environment() {
         // The lock guard serializes all env mutation across the test binary;
         // the var guard restores the previous value even if an assert panics.
         let _lock = crate::tests::scrub_resolution_env();
-        const VAR: &str = "SECRETSPEC_TEST_BOOTSTRAP_ENV_WINS";
-        let _var = EnvVarGuard::set(VAR, "from-env");
+        const NAME: &str = "access_token";
+        const ENV_VAR: &str = "SECRETSPEC_TEST_PROVIDER_CREDENTIAL";
+        let _var = EnvVarGuard::set(ENV_VAR, "from-env");
 
         assert_eq!(
-            env_or_overlay_var(&overlay(VAR, "from-overlay"), VAR).as_deref(),
-            Some("from-env"),
+            credential_or_env(&credentials(NAME, "explicit"), NAME, ENV_VAR).as_deref(),
+            Some("explicit"),
         );
     }
 
     #[test]
-    fn overlay_used_only_when_env_absent() {
+    fn environment_is_a_fallback() {
         let _lock = crate::tests::scrub_resolution_env();
-        const VAR: &str = "SECRETSPEC_TEST_BOOTSTRAP_OVERLAY_FALLBACK";
-        let _var = EnvVarGuard::remove(VAR);
+        const NAME: &str = "access_token";
+        const ENV_VAR: &str = "SECRETSPEC_TEST_PROVIDER_CREDENTIAL_FALLBACK";
+        let _var = EnvVarGuard::set(ENV_VAR, "from-env");
 
-        // Overlay hit when the environment has nothing.
+        // With no explicit credential, the provider's conventional environment
+        // variable remains available as a fallback.
         assert_eq!(
-            env_or_overlay_var(&overlay(VAR, "from-overlay"), VAR).as_deref(),
-            Some("from-overlay"),
+            credential_or_env(&ProviderCredentials::new(), NAME, ENV_VAR).as_deref(),
+            Some("from-env"),
         );
-        // No environment value and no overlay entry -> None.
-        assert_eq!(env_or_overlay_var(&BootstrapEnv::new(), VAR), None);
-        // An empty overlay value is treated as unset.
-        assert_eq!(env_or_overlay_var(&overlay(VAR, ""), VAR), None);
-
-        // A set-but-empty environment value is also treated as unset, so the
-        // overlay still wins, matching the resolver's fetch-skip predicate.
-        let _empty = EnvVarGuard::set(VAR, "");
-        assert_eq!(bootstrap_env_var(VAR), None);
+        // Empty explicit values are ignored and fall through as well.
         assert_eq!(
-            env_or_overlay_var(&overlay(VAR, "from-overlay"), VAR).as_deref(),
-            Some("from-overlay"),
+            credential_or_env(&credentials(NAME, ""), NAME, ENV_VAR).as_deref(),
+            Some("from-env"),
         );
     }
 }

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -1,4 +1,4 @@
-use crate::provider::{Address, BootstrapEnv, Provider, ProviderUrl, env_or_overlay_var};
+use crate::provider::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -311,14 +311,12 @@ pub struct OnePasswordProvider {
     config: OnePasswordConfig,
     /// The OnePassword CLI command to use (either "op" or a custom path).
     op_command: String,
-    /// Bootstrap-credential overlay consulted after the process environment.
-    bootstrap_env: BootstrapEnv,
+    /// Credentials supplied by the provider alias.
+    credentials: ProviderCredentials,
 }
 
-/// The credential variable this provider reads through the bootstrap overlay.
-/// Shared between the registration's `bootstrap_vars` and the read site, so
-/// the declared list cannot drift from what the provider actually consults.
-const OP_SERVICE_ACCOUNT_TOKEN: &str = "OP_SERVICE_ACCOUNT_TOKEN";
+const SERVICE_ACCOUNT_TOKEN: &str = "service_account_token";
+const OP_SERVICE_ACCOUNT_TOKEN_ENV: &str = "OP_SERVICE_ACCOUNT_TOKEN";
 
 crate::register_provider! {
     struct: OnePasswordProvider,
@@ -327,7 +325,7 @@ crate::register_provider! {
     description: "OnePassword password manager",
     schemes: ["onepassword", "onepassword+token", "op"],
     examples: ["onepassword://vault", "onepassword://work@Production", "onepassword+token://vault"],
-    bootstrap_vars: [OP_SERVICE_ACCOUNT_TOKEN],
+    credential_names: [SERVICE_ACCOUNT_TOKEN],
     preflight: check_auth,
 }
 
@@ -348,19 +346,22 @@ impl OnePasswordProvider {
         Self {
             config,
             op_command,
-            bootstrap_env: BootstrapEnv::new(),
+            credentials: ProviderCredentials::new(),
         }
     }
 
     /// The service account token in effect: the URI-supplied one
-    /// (`onepassword+token://`), else the environment or bootstrap overlay via
-    /// the shared env-wins rule. When all are absent, `op` falls back to its
-    /// own authentication (desktop app or manual signin) exactly as before.
+    /// (`onepassword+token://`), else an explicitly supplied credential, then
+    /// the conventional environment variable. When all are absent, `op` falls
+    /// back to its own authentication (desktop app or manual signin) exactly as before.
     fn effective_service_account_token(&self) -> Option<String> {
-        self.config
-            .service_account_token
-            .clone()
-            .or_else(|| env_or_overlay_var(&self.bootstrap_env, OP_SERVICE_ACCOUNT_TOKEN))
+        self.config.service_account_token.clone().or_else(|| {
+            credential_or_env(
+                &self.credentials,
+                SERVICE_ACCOUNT_TOKEN,
+                OP_SERVICE_ACCOUNT_TOKEN_ENV,
+            )
+        })
     }
 
     /// Executes a OnePassword CLI command with proper error handling.
@@ -397,7 +398,7 @@ impl OnePasswordProvider {
         // Set service account token if provided. Passing an environment-supplied
         // token explicitly is equivalent to `op` inheriting it.
         if let Some(token) = self.effective_service_account_token() {
-            cmd.env(OP_SERVICE_ACCOUNT_TOKEN, token);
+            cmd.env(OP_SERVICE_ACCOUNT_TOKEN_ENV, token);
         }
 
         // Add account if specified
@@ -827,12 +828,12 @@ impl Provider for OnePasswordProvider {
         &["field", "vault", "section"]
     }
 
-    fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
-        // Stored, not folded into the config: the token is resolved through the
-        // shared env-wins rule where it is consumed (`execute_op_command`,
-        // `auth_scope_key`), and `uri()` keeps reporting the scheme the user
-        // actually configured rather than flipping to `onepassword+token://`.
-        self.bootstrap_env = env;
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        // Stored, not folded into the config: the token is resolved where it is
+        // consumed (`execute_op_command`, `auth_scope_key`), and `uri()` keeps
+        // reporting the scheme the user actually configured rather than
+        // flipping to `onepassword+token://`.
+        self.credentials = credentials;
     }
 
     fn name(&self) -> &'static str {
@@ -845,10 +846,10 @@ impl Provider for OnePasswordProvider {
     /// referenced secret; without this, N references would run N identical
     /// `op vault list` round-trips.
     fn auth_scope_key(&self) -> Option<String> {
-        // The token actually in effect, so two instances bootstrapped with
+        // The token actually in effect, so two instances supplied with
         // different tokens never share a preflight probe. Hashed rather than
         // embedded: the scope key lives in a process-lifetime cache, and a
-        // bootstrap-sourced token is kept as a `SecretString` precisely so its
+        // sourced token is kept as a `SecretString` precisely so its
         // plaintext never sits in long-lived memory.
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -315,6 +315,11 @@ pub struct OnePasswordProvider {
     bootstrap_env: BootstrapEnv,
 }
 
+/// The credential variable this provider reads through the bootstrap overlay.
+/// Shared between the registration's `bootstrap_vars` and the read site, so
+/// the declared list cannot drift from what the provider actually consults.
+const OP_SERVICE_ACCOUNT_TOKEN: &str = "OP_SERVICE_ACCOUNT_TOKEN";
+
 crate::register_provider! {
     struct: OnePasswordProvider,
     config: OnePasswordConfig,
@@ -322,7 +327,7 @@ crate::register_provider! {
     description: "OnePassword password manager",
     schemes: ["onepassword", "onepassword+token", "op"],
     examples: ["onepassword://vault", "onepassword://work@Production", "onepassword+token://vault"],
-    bootstrap_vars: ["OP_SERVICE_ACCOUNT_TOKEN"],
+    bootstrap_vars: [OP_SERVICE_ACCOUNT_TOKEN],
     preflight: check_auth,
 }
 
@@ -355,7 +360,7 @@ impl OnePasswordProvider {
         self.config
             .service_account_token
             .clone()
-            .or_else(|| env_or_overlay_var(&self.bootstrap_env, "OP_SERVICE_ACCOUNT_TOKEN"))
+            .or_else(|| env_or_overlay_var(&self.bootstrap_env, OP_SERVICE_ACCOUNT_TOKEN))
     }
 
     /// Executes a OnePassword CLI command with proper error handling.
@@ -392,7 +397,7 @@ impl OnePasswordProvider {
         // Set service account token if provided. Passing an environment-supplied
         // token explicitly is equivalent to `op` inheriting it.
         if let Some(token) = self.effective_service_account_token() {
-            cmd.env("OP_SERVICE_ACCOUNT_TOKEN", token);
+            cmd.env(OP_SERVICE_ACCOUNT_TOKEN, token);
         }
 
         // Add account if specified

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -1,4 +1,4 @@
-use crate::provider::{Address, BootstrapEnv, Provider, ProviderUrl};
+use crate::provider::{Address, BootstrapEnv, Provider, ProviderUrl, env_or_overlay_var};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -311,6 +311,8 @@ pub struct OnePasswordProvider {
     config: OnePasswordConfig,
     /// The OnePassword CLI command to use (either "op" or a custom path).
     op_command: String,
+    /// Bootstrap-credential overlay consulted after the process environment.
+    bootstrap_env: BootstrapEnv,
 }
 
 crate::register_provider! {
@@ -337,7 +339,22 @@ impl OnePasswordProvider {
                 "op".to_string()
             }
         });
-        Self { config, op_command }
+        Self {
+            config,
+            op_command,
+            bootstrap_env: BootstrapEnv::new(),
+        }
+    }
+
+    /// The service account token in effect: the URI-supplied one
+    /// (`onepassword+token://`), else the environment or bootstrap overlay via
+    /// the shared env-wins rule. When all are absent, `op` falls back to its
+    /// own authentication (desktop app or manual signin) exactly as before.
+    fn effective_service_account_token(&self) -> Option<String> {
+        self.config
+            .service_account_token
+            .clone()
+            .or_else(|| env_or_overlay_var(&self.bootstrap_env, "OP_SERVICE_ACCOUNT_TOKEN"))
     }
 
     /// Executes a OnePassword CLI command with proper error handling.
@@ -371,8 +388,9 @@ impl OnePasswordProvider {
         let mut cmd = Command::new(&self.op_command);
         strip_op_session_env(&mut cmd);
 
-        // Set service account token if provided
-        if let Some(token) = &self.config.service_account_token {
+        // Set service account token if provided. Passing an environment-supplied
+        // token explicitly is equivalent to `op` inheriting it.
+        if let Some(token) = self.effective_service_account_token() {
             cmd.env("OP_SERVICE_ACCOUNT_TOKEN", token);
         }
 
@@ -804,19 +822,11 @@ impl Provider for OnePasswordProvider {
     }
 
     fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
-        // Fill the service account token from the overlay only when the URI form
-        // (`onepassword+token://`) has not already supplied one. When neither is
-        // set, `op` inherits `OP_SERVICE_ACCOUNT_TOKEN` from the process
-        // environment exactly as before, so an empty overlay changes nothing.
-        if self.config.service_account_token.is_none() {
-            if let Some(token) = env
-                .get("OP_SERVICE_ACCOUNT_TOKEN")
-                .map(|secret| secret.expose_secret().to_string())
-                .filter(|token| !token.is_empty())
-            {
-                self.config.service_account_token = Some(token);
-            }
-        }
+        // Stored, not folded into the config: the token is resolved through the
+        // shared env-wins rule where it is consumed (`execute_op_command`,
+        // `auth_scope_key`), and `uri()` keeps reporting the scheme the user
+        // actually configured rather than flipping to `onepassword+token://`.
+        self.bootstrap_env = env;
     }
 
     fn name(&self) -> &'static str {
@@ -833,7 +843,9 @@ impl Provider for OnePasswordProvider {
             "{:?}",
             (
                 &self.config.account,
-                &self.config.service_account_token,
+                // The token actually in effect, so two instances bootstrapped
+                // with different tokens never share a preflight probe.
+                self.effective_service_account_token(),
                 &self.op_command
             )
         ))

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -1,4 +1,4 @@
-use crate::provider::{Address, Provider, ProviderUrl};
+use crate::provider::{Address, BootstrapEnv, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -801,6 +801,22 @@ impl Provider for OnePasswordProvider {
     /// component within the item. 1Password items are not versioned.
     fn supported_coords(&self) -> &'static [&'static str] {
         &["field", "vault", "section"]
+    }
+
+    fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
+        // Fill the service account token from the overlay only when the URI form
+        // (`onepassword+token://`) has not already supplied one. When neither is
+        // set, `op` inherits `OP_SERVICE_ACCOUNT_TOKEN` from the process
+        // environment exactly as before, so an empty overlay changes nothing.
+        if self.config.service_account_token.is_none() {
+            if let Some(token) = env
+                .get("OP_SERVICE_ACCOUNT_TOKEN")
+                .map(|secret| secret.expose_secret().to_string())
+                .filter(|token| !token.is_empty())
+            {
+                self.config.service_account_token = Some(token);
+            }
+        }
     }
 
     fn name(&self) -> &'static str {

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -322,6 +322,7 @@ crate::register_provider! {
     description: "OnePassword password manager",
     schemes: ["onepassword", "onepassword+token", "op"],
     examples: ["onepassword://vault", "onepassword://work@Production", "onepassword+token://vault"],
+    bootstrap_vars: ["OP_SERVICE_ACCOUNT_TOKEN"],
     preflight: check_auth,
 }
 
@@ -839,15 +840,18 @@ impl Provider for OnePasswordProvider {
     /// referenced secret; without this, N references would run N identical
     /// `op vault list` round-trips.
     fn auth_scope_key(&self) -> Option<String> {
+        // The token actually in effect, so two instances bootstrapped with
+        // different tokens never share a preflight probe. Hashed rather than
+        // embedded: the scope key lives in a process-lifetime cache, and a
+        // bootstrap-sourced token is kept as a `SecretString` precisely so its
+        // plaintext never sits in long-lived memory.
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.effective_service_account_token().hash(&mut hasher);
+        let token_scope = hasher.finish();
         Some(format!(
             "{:?}",
-            (
-                &self.config.account,
-                // The token actually in effect, so two instances bootstrapped
-                // with different tokens never share a preflight probe.
-                self.effective_service_account_token(),
-                &self.op_command
-            )
+            (&self.config.account, token_scope, &self.op_command)
         ))
     }
 

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1065,4 +1065,33 @@ mod integration_tests {
         let provider = Box::<dyn Provider>::try_from("gcsm://project123").unwrap();
         assert_eq!(provider.name(), "gcsm");
     }
+
+    /// The bootstrap overlay must reach a preflight-wrapped provider. onepassword
+    /// is built as `Box<Arc<OnePasswordProvider>>` behind a `PreflightGuard`, so a
+    /// `&mut self` hook applied post-construction would be swallowed by the `Arc`
+    /// layer (which cannot forward `&mut self`); this passes only because the
+    /// overlay is injected inside the factory, before wrapping. The delivered
+    /// token surfaces in `auth_scope_key`.
+    #[test]
+    fn bootstrap_overlay_reaches_preflight_wrapped_provider() {
+        use crate::provider::{BootstrapEnv, ProviderUrl, provider_from_url};
+        use url::Url;
+
+        let mut overlay = BootstrapEnv::new();
+        overlay.insert(
+            "OP_SERVICE_ACCOUNT_TOKEN".to_string(),
+            SecretString::new("tok-xyz".into()),
+        );
+
+        let url = ProviderUrl::new(Url::parse("onepassword://Private").unwrap());
+        let provider = provider_from_url(&url, overlay).unwrap();
+
+        let scope = provider
+            .auth_scope_key()
+            .expect("onepassword advertises an auth scope");
+        assert!(
+            scope.contains("tok-xyz"),
+            "bootstrap token should be injected before Arc-wrapping, got: {scope}"
+        );
+    }
 }

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1071,27 +1071,48 @@ mod integration_tests {
     /// `&mut self` hook applied post-construction would be swallowed by the `Arc`
     /// layer (which cannot forward `&mut self`); this passes only because the
     /// overlay is injected inside the factory, before wrapping. The delivered
-    /// token surfaces in `auth_scope_key`.
+    /// token folds into `auth_scope_key` as a hash, so injection shows up as a
+    /// scope-key difference while the plaintext never reaches the
+    /// process-lifetime preflight cache.
     #[test]
     fn bootstrap_overlay_reaches_preflight_wrapped_provider() {
         use crate::provider::{BootstrapEnv, ProviderUrl, provider_from_url};
         use url::Url;
 
-        let mut overlay = BootstrapEnv::new();
-        overlay.insert(
-            "OP_SERVICE_ACCOUNT_TOKEN".to_string(),
-            SecretString::new("tok-xyz".into()),
+        // Clear any ambient token under the env lock: with one exported, every
+        // instance would resolve the same effective token and the scope keys
+        // below could not tell injection from a silent no-op.
+        let _lock = crate::tests::scrub_resolution_env();
+        let _env = crate::tests::EnvVarGuard::remove("OP_SERVICE_ACCOUNT_TOKEN");
+
+        let scope_with = |token: Option<&str>| {
+            let mut overlay = BootstrapEnv::new();
+            if let Some(token) = token {
+                overlay.insert(
+                    "OP_SERVICE_ACCOUNT_TOKEN".to_string(),
+                    SecretString::new(token.into()),
+                );
+            }
+            let url = ProviderUrl::new(Url::parse("onepassword://Private").unwrap());
+            provider_from_url(&url, overlay)
+                .unwrap()
+                .auth_scope_key()
+                .expect("onepassword advertises an auth scope")
+        };
+
+        let without_token = scope_with(None);
+        let with_token = scope_with(Some("tok-xyz"));
+        assert_ne!(
+            with_token, without_token,
+            "bootstrap token should be injected before Arc-wrapping"
         );
-
-        let url = ProviderUrl::new(Url::parse("onepassword://Private").unwrap());
-        let provider = provider_from_url(&url, overlay).unwrap();
-
-        let scope = provider
-            .auth_scope_key()
-            .expect("onepassword advertises an auth scope");
+        // Same token, same scope; different tokens probe auth separately.
+        assert_eq!(with_token, scope_with(Some("tok-xyz")));
+        assert_ne!(with_token, scope_with(Some("tok-other")));
+        // The scope key carries a hash of the token, never its plaintext.
         assert!(
-            scope.contains("tok-xyz"),
-            "bootstrap token should be injected before Arc-wrapping, got: {scope}"
+            !with_token.contains("tok-xyz"),
+            "auth scope key must not embed the plaintext token: {with_token}"
         );
     }
 }

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1066,17 +1066,17 @@ mod integration_tests {
         assert_eq!(provider.name(), "gcsm");
     }
 
-    /// The bootstrap overlay must reach a preflight-wrapped provider. onepassword
+    /// Provider credentials must reach a preflight-wrapped provider. onepassword
     /// is built as `Box<Arc<OnePasswordProvider>>` behind a `PreflightGuard`, so a
     /// `&mut self` hook applied post-construction would be swallowed by the `Arc`
     /// layer (which cannot forward `&mut self`); this passes only because the
-    /// overlay is injected inside the factory, before wrapping. The delivered
+    /// credentials are injected inside the factory, before wrapping. The delivered
     /// token folds into `auth_scope_key` as a hash, so injection shows up as a
     /// scope-key difference while the plaintext never reaches the
     /// process-lifetime preflight cache.
     #[test]
-    fn bootstrap_overlay_reaches_preflight_wrapped_provider() {
-        use crate::provider::{BootstrapEnv, ProviderUrl, provider_from_url};
+    fn credentials_reach_preflight_wrapped_provider() {
+        use crate::provider::{ProviderCredentials, ProviderUrl, provider_from_url};
         use url::Url;
 
         // Clear any ambient token under the env lock: with one exported, every
@@ -1086,15 +1086,15 @@ mod integration_tests {
         let _env = crate::tests::EnvVarGuard::remove("OP_SERVICE_ACCOUNT_TOKEN");
 
         let scope_with = |token: Option<&str>| {
-            let mut overlay = BootstrapEnv::new();
+            let mut credentials = ProviderCredentials::new();
             if let Some(token) = token {
-                overlay.insert(
-                    "OP_SERVICE_ACCOUNT_TOKEN".to_string(),
+                credentials.insert(
+                    "service_account_token".to_string(),
                     SecretString::new(token.into()),
                 );
             }
             let url = ProviderUrl::new(Url::parse("onepassword://Private").unwrap());
-            provider_from_url(&url, overlay)
+            provider_from_url(&url, credentials)
                 .unwrap()
                 .auth_scope_key()
                 .expect("onepassword advertises an auth scope")
@@ -1104,7 +1104,7 @@ mod integration_tests {
         let with_token = scope_with(Some("tok-xyz"));
         assert_ne!(
             with_token, without_token,
-            "bootstrap token should be injected before Arc-wrapping"
+            "provider credential should be injected before Arc-wrapping"
         );
         // Same token, same scope; different tokens probe auth separately.
         assert_eq!(with_token, scope_with(Some("tok-xyz")));

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -47,7 +47,7 @@
 //! secretspec check --provider vault://team-a@vault.example.com:8200/secret
 //! ```
 
-use super::{Address, Provider, ProviderUrl};
+use super::{Address, BootstrapEnv, Provider, ProviderUrl, env_or_overlay_var};
 use crate::{Result, SecretSpecError};
 use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
@@ -222,6 +222,8 @@ impl TryFrom<&ProviderUrl> for VaultConfig {
 /// KV secrets engine (v1 or v2) with token-based authentication.
 pub struct VaultProvider {
     config: VaultConfig,
+    /// Bootstrap-credential overlay consulted after the process environment.
+    bootstrap_env: BootstrapEnv,
 }
 
 crate::register_provider! {
@@ -236,7 +238,10 @@ crate::register_provider! {
 impl VaultProvider {
     /// Creates a new VaultProvider with the given configuration.
     pub fn new(config: VaultConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            bootstrap_env: BootstrapEnv::new(),
+        }
     }
 
     /// Formats the secret path within the KV engine.
@@ -265,14 +270,14 @@ impl VaultProvider {
     /// Resolves the Vault token using the configured authentication method.
     fn resolve_token(&self) -> Result<SecretString> {
         match self.config.auth {
-            AuthMethod::Token => Self::resolve_token_auth(),
+            AuthMethod::Token => self.resolve_token_auth(),
             AuthMethod::AppRole => super::block_on(self.resolve_approle_auth()),
         }
     }
 
     /// Resolves a token via static token sources.
-    fn resolve_token_auth() -> Result<SecretString> {
-        if let Ok(token) = std::env::var("VAULT_TOKEN") {
+    fn resolve_token_auth(&self) -> Result<SecretString> {
+        if let Some(token) = env_or_overlay_var(&self.bootstrap_env, "VAULT_TOKEN") {
             if !token.is_empty() {
                 return Ok(SecretString::new(token.into()));
             }
@@ -300,19 +305,21 @@ impl VaultProvider {
 
     /// Authenticates via AppRole and returns a client token.
     async fn resolve_approle_auth(&self) -> Result<SecretString> {
-        let role_id = std::env::var("VAULT_ROLE_ID").map_err(|_| {
-            SecretSpecError::ProviderOperationFailed(
-                "VAULT_ROLE_ID environment variable is required for AppRole authentication."
-                    .to_string(),
-            )
-        })?;
+        let role_id =
+            env_or_overlay_var(&self.bootstrap_env, "VAULT_ROLE_ID").ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(
+                    "VAULT_ROLE_ID environment variable is required for AppRole authentication."
+                        .to_string(),
+                )
+            })?;
 
-        let secret_id = std::env::var("VAULT_SECRET_ID").map_err(|_| {
-            SecretSpecError::ProviderOperationFailed(
-                "VAULT_SECRET_ID environment variable is required for AppRole authentication."
-                    .to_string(),
-            )
-        })?;
+        let secret_id =
+            env_or_overlay_var(&self.bootstrap_env, "VAULT_SECRET_ID").ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(
+                    "VAULT_SECRET_ID environment variable is required for AppRole authentication."
+                        .to_string(),
+                )
+            })?;
 
         let url = format!("{}/v1/auth/approle/login", self.config.endpoint);
         let body = serde_json::json!({
@@ -512,6 +519,10 @@ impl Provider for VaultProvider {
             field: Some("value".to_string()),
             ..Default::default()
         })
+    }
+
+    fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
+        self.bootstrap_env = env;
     }
 
     fn name(&self) -> &'static str {

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -233,6 +233,7 @@ crate::register_provider! {
     description: "HashiCorp Vault / OpenBao secret management",
     schemes: ["vault", "openbao"],
     examples: ["vault://vault.example.com:8200/secret", "openbao://bao.internal:8200/secret"],
+    bootstrap_vars: ["VAULT_ROLE_ID", "VAULT_SECRET_ID", "VAULT_TOKEN"],
 }
 
 impl VaultProvider {

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -47,7 +47,7 @@
 //! secretspec check --provider vault://team-a@vault.example.com:8200/secret
 //! ```
 
-use super::{Address, BootstrapEnv, Provider, ProviderUrl, env_or_overlay_var};
+use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
 use crate::{Result, SecretSpecError};
 use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
@@ -222,16 +222,16 @@ impl TryFrom<&ProviderUrl> for VaultConfig {
 /// KV secrets engine (v1 or v2) with token-based authentication.
 pub struct VaultProvider {
     config: VaultConfig,
-    /// Bootstrap-credential overlay consulted after the process environment.
-    bootstrap_env: BootstrapEnv,
+    /// Credentials supplied by the provider alias.
+    credentials: ProviderCredentials,
 }
 
-/// The credential variables this provider reads through the bootstrap overlay.
-/// Shared between the registration's `bootstrap_vars` and the read sites, so
-/// the declared list cannot drift from what the provider actually consults.
-const VAULT_ROLE_ID: &str = "VAULT_ROLE_ID";
-const VAULT_SECRET_ID: &str = "VAULT_SECRET_ID";
-const VAULT_TOKEN: &str = "VAULT_TOKEN";
+const ROLE_ID: &str = "role_id";
+const SECRET_ID: &str = "secret_id";
+const TOKEN: &str = "token";
+const VAULT_ROLE_ID_ENV: &str = "VAULT_ROLE_ID";
+const VAULT_SECRET_ID_ENV: &str = "VAULT_SECRET_ID";
+const VAULT_TOKEN_ENV: &str = "VAULT_TOKEN";
 
 crate::register_provider! {
     struct: VaultProvider,
@@ -240,7 +240,7 @@ crate::register_provider! {
     description: "HashiCorp Vault / OpenBao secret management",
     schemes: ["vault", "openbao"],
     examples: ["vault://vault.example.com:8200/secret", "openbao://bao.internal:8200/secret"],
-    bootstrap_vars: [VAULT_ROLE_ID, VAULT_SECRET_ID, VAULT_TOKEN],
+    credential_names: [ROLE_ID, SECRET_ID, TOKEN],
 }
 
 impl VaultProvider {
@@ -248,7 +248,7 @@ impl VaultProvider {
     pub fn new(config: VaultConfig) -> Self {
         Self {
             config,
-            bootstrap_env: BootstrapEnv::new(),
+            credentials: ProviderCredentials::new(),
         }
     }
 
@@ -285,8 +285,8 @@ impl VaultProvider {
 
     /// Resolves a token via static token sources.
     fn resolve_token_auth(&self) -> Result<SecretString> {
-        // `env_or_overlay_var` never yields an empty value.
-        if let Some(token) = env_or_overlay_var(&self.bootstrap_env, VAULT_TOKEN) {
+        // `credential_or_env` never yields an empty value.
+        if let Some(token) = credential_or_env(&self.credentials, TOKEN, VAULT_TOKEN_ENV) {
             return Ok(SecretString::new(token.into()));
         }
 
@@ -304,25 +304,28 @@ impl VaultProvider {
         }
 
         Err(SecretSpecError::ProviderOperationFailed(
-            "No Vault token found. Set the VAULT_TOKEN environment variable \
-             or create a ~/.vault-token file."
+            "No Vault token found. Configure the token provider credential, set the \
+             VAULT_TOKEN environment variable, or create a ~/.vault-token file."
                 .to_string(),
         ))
     }
 
     /// Authenticates via AppRole and returns a client token.
     async fn resolve_approle_auth(&self) -> Result<SecretString> {
-        let role_id = env_or_overlay_var(&self.bootstrap_env, VAULT_ROLE_ID).ok_or_else(|| {
-            SecretSpecError::ProviderOperationFailed(
-                "VAULT_ROLE_ID environment variable is required for AppRole authentication."
-                    .to_string(),
-            )
-        })?;
-
-        let secret_id =
-            env_or_overlay_var(&self.bootstrap_env, VAULT_SECRET_ID).ok_or_else(|| {
+        let role_id =
+            credential_or_env(&self.credentials, ROLE_ID, VAULT_ROLE_ID_ENV).ok_or_else(|| {
                 SecretSpecError::ProviderOperationFailed(
-                    "VAULT_SECRET_ID environment variable is required for AppRole authentication."
+                    "Vault role_id credential is required for AppRole authentication; configure \
+                     credentials.role_id or set VAULT_ROLE_ID."
+                        .to_string(),
+                )
+            })?;
+
+        let secret_id = credential_or_env(&self.credentials, SECRET_ID, VAULT_SECRET_ID_ENV)
+            .ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(
+                    "Vault secret_id credential is required for AppRole authentication; configure \
+                     credentials.secret_id or set VAULT_SECRET_ID."
                         .to_string(),
                 )
             })?;
@@ -527,8 +530,8 @@ impl Provider for VaultProvider {
         })
     }
 
-    fn with_bootstrap_env(&mut self, env: BootstrapEnv) {
-        self.bootstrap_env = env;
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
     }
 
     fn name(&self) -> &'static str {

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -226,6 +226,13 @@ pub struct VaultProvider {
     bootstrap_env: BootstrapEnv,
 }
 
+/// The credential variables this provider reads through the bootstrap overlay.
+/// Shared between the registration's `bootstrap_vars` and the read sites, so
+/// the declared list cannot drift from what the provider actually consults.
+const VAULT_ROLE_ID: &str = "VAULT_ROLE_ID";
+const VAULT_SECRET_ID: &str = "VAULT_SECRET_ID";
+const VAULT_TOKEN: &str = "VAULT_TOKEN";
+
 crate::register_provider! {
     struct: VaultProvider,
     config: VaultConfig,
@@ -233,7 +240,7 @@ crate::register_provider! {
     description: "HashiCorp Vault / OpenBao secret management",
     schemes: ["vault", "openbao"],
     examples: ["vault://vault.example.com:8200/secret", "openbao://bao.internal:8200/secret"],
-    bootstrap_vars: ["VAULT_ROLE_ID", "VAULT_SECRET_ID", "VAULT_TOKEN"],
+    bootstrap_vars: [VAULT_ROLE_ID, VAULT_SECRET_ID, VAULT_TOKEN],
 }
 
 impl VaultProvider {
@@ -279,7 +286,7 @@ impl VaultProvider {
     /// Resolves a token via static token sources.
     fn resolve_token_auth(&self) -> Result<SecretString> {
         // `env_or_overlay_var` never yields an empty value.
-        if let Some(token) = env_or_overlay_var(&self.bootstrap_env, "VAULT_TOKEN") {
+        if let Some(token) = env_or_overlay_var(&self.bootstrap_env, VAULT_TOKEN) {
             return Ok(SecretString::new(token.into()));
         }
 
@@ -305,16 +312,15 @@ impl VaultProvider {
 
     /// Authenticates via AppRole and returns a client token.
     async fn resolve_approle_auth(&self) -> Result<SecretString> {
-        let role_id =
-            env_or_overlay_var(&self.bootstrap_env, "VAULT_ROLE_ID").ok_or_else(|| {
-                SecretSpecError::ProviderOperationFailed(
-                    "VAULT_ROLE_ID environment variable is required for AppRole authentication."
-                        .to_string(),
-                )
-            })?;
+        let role_id = env_or_overlay_var(&self.bootstrap_env, VAULT_ROLE_ID).ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(
+                "VAULT_ROLE_ID environment variable is required for AppRole authentication."
+                    .to_string(),
+            )
+        })?;
 
         let secret_id =
-            env_or_overlay_var(&self.bootstrap_env, "VAULT_SECRET_ID").ok_or_else(|| {
+            env_or_overlay_var(&self.bootstrap_env, VAULT_SECRET_ID).ok_or_else(|| {
                 SecretSpecError::ProviderOperationFailed(
                     "VAULT_SECRET_ID environment variable is required for AppRole authentication."
                         .to_string(),

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -277,10 +277,9 @@ impl VaultProvider {
 
     /// Resolves a token via static token sources.
     fn resolve_token_auth(&self) -> Result<SecretString> {
+        // `env_or_overlay_var` never yields an empty value.
         if let Some(token) = env_or_overlay_var(&self.bootstrap_env, "VAULT_TOKEN") {
-            if !token.is_empty() {
-                return Ok(SecretString::new(token.into()));
-            }
+            return Ok(SecretString::new(token.into()));
         }
 
         let token_path = std::env::var_os("HOME")

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -65,11 +65,15 @@ impl BootstrapSource {
     }
 
     /// Human-readable `<provider> at <location>` for prompts and errors,
-    /// describing exactly what [`Self::address`] resolves to.
+    /// describing exactly what [`Self::address`] resolves to. The source spec
+    /// is redacted: a URI-form source may embed an inline credential
+    /// (`onepassword+token://tok@Vault`), and this string reaches stderr and
+    /// the `config provider login` output.
     fn location(&self, project: &str, profile: &str, var: &str) -> String {
+        let provider = crate::audit::redact_uri_strict(&self.provider);
         match &self.reference {
-            Some(reference) => format!("{} at {}", self.provider, reference.render()),
-            None => format!("{} at {project}/{profile}/{var}", self.provider),
+            Some(reference) => format!("{provider} at {}", reference.render()),
+            None => format!("{provider} at {project}/{profile}/{var}"),
         }
     }
 }
@@ -171,10 +175,15 @@ pub struct Secrets {
     /// Audit logger, if auditing is enabled (user-global `[audit]` config). `None`
     /// disables auditing. Built once per `Secrets` so all events share a session id.
     audit: Option<AuditLogger>,
-    /// Bootstrap overlays memoized per raw provider spec, so N secrets routed
-    /// at one bootstrapped alias fetch its credentials from the source provider
-    /// once per session, not once per provider build.
-    bootstrap_overlays: Mutex<HashMap<String, BootstrapEnv>>,
+    /// Bootstrap overlays memoized per (profile, raw provider spec), so N
+    /// secrets routed at one bootstrapped alias fetch its credentials from the
+    /// source provider once per session, not once per provider build. Keyed by
+    /// profile because a convention-path credential lives at
+    /// `{project}/{profile}/{VAR}`: switching profiles on one instance must
+    /// not reuse the other profile's credential. Cleared by
+    /// [`Secrets::store_bootstrap_credential`] so a freshly stored credential
+    /// is re-read.
+    bootstrap_overlays: Mutex<HashMap<(String, String), BootstrapEnv>>,
 }
 
 /// secretspec's own opt-in for marking the current process as an agent. Lets any
@@ -520,21 +529,35 @@ impl Secrets {
     ///
     /// All provider construction in this module goes through here so that the
     /// reason set via [`Secrets::with_reason`] reaches every provider instance.
-    fn build_provider(&self, spec: String) -> Result<Box<dyn ProviderTrait>> {
+    ///
+    /// `profile` is the profile the caller resolved for the surrounding
+    /// operation (`None` falls back to the session profile): a bootstrapped
+    /// alias's convention-path credentials live at `{project}/{profile}/{VAR}`,
+    /// so the provider must be built for the same profile its secrets are
+    /// addressed under.
+    fn build_provider(
+        &self,
+        spec: String,
+        profile: Option<&str>,
+    ) -> Result<Box<dyn ProviderTrait>> {
         // When `spec` names an alias with a bootstrap `env` map, resolve those
         // credentials from their source providers into an overlay the built
-        // provider reads before the process environment. Memoized per spec so
-        // rebuilding a provider (per-secret chain walks, interactive prompting)
-        // does not refetch the same credentials from the source store.
-        let cached = self.bootstrap_overlays.lock().unwrap().get(&spec).cloned();
+        // provider reads before the process environment. Memoized per
+        // (profile, spec) so rebuilding a provider (per-secret chain walks,
+        // interactive prompting) does not refetch the same credentials from
+        // the source store, while a profile switch on this instance does not
+        // reuse the other profile's credentials.
+        let profile = self.resolve_profile_name(profile);
+        let key = (profile.clone(), spec.clone());
+        let cached = self.bootstrap_overlays.lock().unwrap().get(&key).cloned();
         let overlay = match cached {
             Some(overlay) => overlay,
             None => {
-                let overlay = self.resolve_bootstrap_overlay(&spec)?;
+                let overlay = self.resolve_bootstrap_overlay(&spec, &profile)?;
                 self.bootstrap_overlays
                     .lock()
                     .unwrap()
-                    .insert(spec.clone(), overlay.clone());
+                    .insert(key, overlay.clone());
                 overlay
             }
         };
@@ -573,13 +596,20 @@ impl Secrets {
     /// its alias declares in `env`, fetch the credential from the source provider
     /// and collect it, so the built provider reads it before the environment.
     ///
+    /// `profile` scopes the convention path a bare-string source reads from.
     /// Returns an empty overlay for a spec that is not an alias, or an alias with
     /// no `env`. A variable already set (non-empty) in the process environment
     /// wins and is not fetched. A declared credential that cannot be found is a
     /// hard error naming exactly how to fix it. Sources pass
     /// [`Self::validate_bootstrap_sources`] and are built non-bootstrap, so a
-    /// chain is at most one hop and cannot recurse.
-    pub(crate) fn resolve_bootstrap_overlay(&self, spec: &str) -> Result<BootstrapEnv> {
+    /// chain is at most one hop and cannot recurse. Each source read is audited
+    /// with a `bootstrap` marker, so the audit trail explains why the source
+    /// store was touched during an operation on the target provider.
+    pub(crate) fn resolve_bootstrap_overlay(
+        &self,
+        spec: &str,
+        profile: &str,
+    ) -> Result<BootstrapEnv> {
         let mut overlay = BootstrapEnv::new();
         if self
             .lookup_provider_alias_entry(spec)
@@ -588,8 +618,8 @@ impl Secrets {
             return Ok(overlay);
         }
         self.validate_bootstrap_sources(spec)?;
+        self.warn_unconsumed_bootstrap_vars(spec);
 
-        let profile = self.resolve_profile_name(None);
         let project = self.config.project.name.clone();
 
         // One provider per distinct source spec, so credentials sharing a source
@@ -613,7 +643,30 @@ impl Secrets {
                     entry.insert(self.build_source_provider(&source.provider)?)
                 }
             };
-            match source_provider.get(source.address(&project, &profile, &var))? {
+            let fetched = source_provider.get(source.address(&project, profile, &var));
+            // Audit the source read (design: every secret access is recorded).
+            // The key is the bootstrap variable and the event carries a
+            // `bootstrap` marker plus the source provider's credential-free
+            // `uri()`, so the trail explains why this store was touched.
+            let (outcome, error_kind) = match &fetched {
+                Ok(Some(_)) => (AuditOutcome::Found, None),
+                Ok(None) => (AuditOutcome::Missing, None),
+                Err(e) => (AuditOutcome::Error, Some(e.kind())),
+            };
+            self.record(
+                AuditAction::Get,
+                profile,
+                outcome,
+                AuditFields {
+                    key: Some(&var),
+                    command: Some("bootstrap"),
+                    provider_uri: Some(source_provider.uri()),
+                    reference: source.reference.as_ref(),
+                    error_kind,
+                    ..Default::default()
+                },
+            );
+            match fetched? {
                 Some(value) => {
                     overlay.insert(var, value);
                 }
@@ -621,13 +674,47 @@ impl Secrets {
                     return Err(bootstrap_missing_error(
                         &var,
                         spec,
-                        &source.location(&project, &profile, &var),
+                        &source.location(&project, profile, &var),
                     ));
                 }
             }
         }
 
         Ok(overlay)
+    }
+
+    /// Warns once (per overlay resolution, which is memoized per session) about
+    /// each declared bootstrap variable the target provider never reads: only
+    /// providers that register `bootstrap_vars` consult the overlay, and only
+    /// for those names, so any other declaration is fetched and then silently
+    /// ignored. A warning rather than an error, because a declaration can be
+    /// legitimate for values the provider reads from the real environment.
+    fn warn_unconsumed_bootstrap_vars(&self, spec: &str) {
+        let Some(env) = self
+            .lookup_provider_alias_entry(spec)
+            .and_then(|alias| alias.env.as_ref())
+        else {
+            return;
+        };
+        let resolved = self.resolve_provider_spec(spec.to_string());
+        let supported = crate::provider::bootstrap_vars_for_spec(&resolved);
+        let provider_name = crate::provider::provider_display_name_for_spec(&resolved);
+        let mut vars: Vec<&String> = env.keys().collect();
+        vars.sort();
+        for var in vars {
+            if !supported.contains(&var.as_str()) {
+                let supported_display = if supported.is_empty() {
+                    format!("provider '{provider_name}' reads no bootstrap credentials")
+                } else {
+                    format!("provider '{provider_name}' reads: {}", supported.join(", "))
+                };
+                eprintln!(
+                    "{} bootstrap variable '{var}' declared for provider alias '{spec}' is not \
+                     read by its provider and will be ignored ({supported_display})",
+                    "⚠".yellow(),
+                );
+            }
+        }
     }
 
     /// The bootstrap credentials a provider alias declares, sorted by variable
@@ -651,18 +738,46 @@ impl Secrets {
     /// or the convention path for the active project and profile). Errors if the
     /// source provider is read-only. Returns a human-readable description of
     /// where it was stored.
+    ///
+    /// Like every other write path, the write is gated by the `require_reason`
+    /// policy and audited (with a `bootstrap` marker). A successful store also
+    /// clears the overlay memo, so a credential rotated through this instance
+    /// is re-read instead of resolving to the stale cached value.
     pub(crate) fn store_bootstrap_credential(
         &self,
         source: &BootstrapSource,
         var: &str,
         value: &SecretString,
     ) -> Result<String> {
+        self.ensure_reason_for(AuditAction::Set, Some(var))?;
         let provider = self.build_source_provider(&source.provider)?;
         let profile = self.resolve_profile_name(None);
         let project = self.config.project.name.clone();
         let address = source.address(&project, &profile, var);
-        provider.check_writable(address)?;
-        provider.set(address, value)?;
+        let result = provider
+            .check_writable(address)
+            .and_then(|()| provider.set(address, value));
+        let (outcome, error_kind) = match &result {
+            Ok(()) => (AuditOutcome::Written, None),
+            Err(e) => (AuditOutcome::Error, Some(e.kind())),
+        };
+        self.record(
+            AuditAction::Set,
+            &profile,
+            outcome,
+            AuditFields {
+                key: Some(var),
+                command: Some("bootstrap"),
+                provider_uri: Some(provider.uri()),
+                reference: source.reference.as_ref(),
+                error_kind,
+                ..Default::default()
+            },
+        );
+        result?;
+        // The stored credential replaces whatever an earlier resolution
+        // memoized; drop the memo so the next build re-reads it.
+        self.bootstrap_overlays.lock().unwrap().clear();
         Ok(source.location(&project, &profile, var))
     }
 
@@ -681,16 +796,38 @@ impl Secrets {
         let Some(env) = alias.env.as_ref() else {
             return Ok(());
         };
-        for (var, source) in env {
-            self.resolve_one_provider(&source.provider).map_err(|_| {
-                SecretSpecError::ProviderNotFound(format!(
-                    "bootstrap source for '{var}' in provider alias '{spec}' names an unknown \
-                     provider '{}'",
-                    source.provider
+        // Sorted so the reported error is deterministic when several entries
+        // are invalid, matching the sorted fetch order of the resolver.
+        let mut entries: Vec<(&String, &BootstrapSource)> = env.iter().collect();
+        entries.sort_by_key(|(var, _)| var.as_str());
+        for (var, source) in entries {
+            // Compose the underlying error into the message instead of
+            // replacing it: it carries the corrective guidance (the
+            // `1password` -> `onepassword` hint, the defined-aliases listing)
+            // that the other resolution paths give for the same mistakes.
+            let resolved = self.resolve_one_provider(&source.provider).map_err(|err| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "bootstrap source for '{var}' in provider alias '{spec}': {err}"
                 ))
             })?;
+            // `resolve_one_provider` passes URI-form specs through untouched,
+            // so gate the resolved spec's scheme against the registry here:
+            // a typo'd scheme should fail at plan time, not surface later as
+            // a construction failure a fallback chain downgrades to a warning.
+            let known = crate::provider::spec_names_known_provider(&resolved).map_err(|err| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "bootstrap source for '{var}' in provider alias '{spec}': {err}"
+                ))
+            })?;
+            if !known {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "bootstrap source for '{var}' in provider alias '{spec}' names an unknown \
+                     provider '{}'",
+                    crate::audit::redact_uri_strict(&source.provider)
+                )));
+            }
             if let Some(source_alias) = self.lookup_provider_alias_entry(&source.provider)
-                && source_alias.env.is_some()
+                && source_alias.env.as_ref().is_some_and(|env| !env.is_empty())
             {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
                     "provider alias '{}' cannot be a bootstrap source for '{spec}' because it \
@@ -1154,11 +1291,15 @@ impl Secrets {
     /// Builds the provider a write goes to for a resolved [`Route`]: the primary
     /// store, or the default provider when the route sets none. A write never
     /// consults the fallback, so an undefined alias further down the chain does
-    /// not affect it.
-    fn write_provider_for_route(&self, route: &Route) -> Result<Box<dyn ProviderTrait>> {
+    /// not affect it. `profile` is the profile the write is addressed under.
+    fn write_provider_for_route(
+        &self,
+        route: &Route,
+        profile: Option<&str>,
+    ) -> Result<Box<dyn ProviderTrait>> {
         // Build from the primary spec (not the resolved URI) so an alias's
         // bootstrap `env` is applied to the write target too.
-        self.get_provider(route.group_key())
+        self.get_provider(route.group_key(), profile)
     }
 
     /// Gets the provider instance to use for secret operations
@@ -1173,6 +1314,9 @@ impl Secrets {
     /// # Arguments
     ///
     /// * `provider_arg` - Optional provider specification (name or URI)
+    /// * `profile` - The profile the operation is addressed under (`None`
+    ///   falls back to the session profile); scopes any bootstrap credentials
+    ///   fetched during construction
     ///
     /// # Returns
     ///
@@ -1186,20 +1330,29 @@ impl Secrets {
     pub(crate) fn get_provider(
         &self,
         provider_arg: Option<&str>,
+        profile: Option<&str>,
     ) -> Result<Box<dyn ProviderTrait>> {
-        let provider_spec = self
-            .explicit_provider_spec(provider_arg)
+        let provider_spec = self.default_provider_spec(provider_arg)?;
+
+        // Alias resolution happens inside `build_provider`.
+        let provider = self.build_provider(provider_spec, profile)?;
+
+        Ok(provider)
+    }
+
+    /// The raw provider spec [`Self::get_provider`] would build for
+    /// `provider_arg`: the explicit override, else the user-global default.
+    /// Split out so display paths can name the provider without constructing
+    /// it (construction fetches bootstrap credentials, so a display-only build
+    /// could fail or do I/O).
+    fn default_provider_spec(&self, provider_arg: Option<&str>) -> Result<String> {
+        self.explicit_provider_spec(provider_arg)
             .or_else(|| {
                 self.global_config
                     .as_ref()
                     .and_then(|gc| gc.defaults.provider.clone())
             })
-            .ok_or(SecretSpecError::NoProviderConfigured)?;
-
-        // Alias resolution happens inside `build_provider`.
-        let provider = self.build_provider(provider_spec)?;
-
-        Ok(provider)
+            .ok_or(SecretSpecError::NoProviderConfigured)
     }
 
     /// Returns a provider URI for validation result metadata without forcing a
@@ -1215,6 +1368,7 @@ impl Secrets {
         &self,
         override_uri: Option<&str>,
         primary_uris: impl Iterator<Item = Option<&'a str>>,
+        profile: Option<&str>,
     ) -> Result<String> {
         if let Some(uri) = override_uri {
             return Ok(crate::audit::redact_uri_strict(uri));
@@ -1226,7 +1380,9 @@ impl Secrets {
         match provider_uris.and_then(|uris| uris.into_iter().min()) {
             Some(uri) => Ok(crate::audit::redact_uri_strict(uri)),
             // A secret on the default provider, or no secrets at all.
-            None => self.get_provider(None).map(|provider| provider.uri()),
+            None => self
+                .get_provider(None, profile)
+                .map(|provider| provider.uri()),
         }
     }
 
@@ -1251,6 +1407,8 @@ impl Secrets {
     ///   the same address is asked of every provider in the chain
     /// * `provider_specs` - Optional chain of provider specs (aliases or inline
     ///   URIs) to try in order, resolved lazily per entry
+    /// * `profile` - The profile the read is addressed under; scopes any
+    ///   bootstrap credentials fetched when a chain link is built
     ///
     /// # Returns
     ///
@@ -1263,6 +1421,7 @@ impl Secrets {
         secret_name: &str,
         addr: Address<'_>,
         provider_specs: Option<&[String]>,
+        profile: Option<&str>,
     ) -> Result<(Option<SecretString>, Option<String>)> {
         // If a provider chain is supplied, try it in order.
         if let Some(specs) = provider_specs {
@@ -1289,7 +1448,7 @@ impl Secrets {
                 };
                 // Build from the raw spec (not the resolved URI) so an alias's
                 // bootstrap `env` is applied to this chain link too.
-                let provider = match self.build_provider(spec.clone()) {
+                let provider = match self.build_provider(spec.clone(), profile) {
                     Ok(p) => p,
                     Err(e) => {
                         // Construction failed after resolution, so redact the
@@ -1332,7 +1491,7 @@ impl Secrets {
             }
         } else {
             // No per-secret providers, use default provider
-            let backend = self.get_provider(None)?;
+            let backend = self.get_provider(None, profile)?;
             let uri = backend.uri();
             backend.get(addr).map(|opt| (opt, Some(uri)))
         }
@@ -1402,7 +1561,7 @@ impl Secrets {
             }
         };
 
-        let backend = match self.write_provider_for_route(&planned.route) {
+        let backend = match self.write_provider_for_route(&planned.route, Some(&profile_name)) {
             Ok(backend) => backend,
             Err(err) => {
                 self.record_key_error(AuditAction::Set, &profile_name, name, None, None, &err);
@@ -1533,6 +1692,7 @@ impl Secrets {
             name,
             planned.as_address(&self.config.project.name, &profile_name),
             read_specs.as_deref(),
+            Some(&profile_name),
         );
 
         // Audit the access at the provider boundary, before defaults are applied.
@@ -1671,7 +1831,16 @@ impl Secrets {
 
                     let missing = &validation_errors.missing_required;
                     let total = missing.len();
-                    let default_backend = self.get_provider(provider_arg.as_deref())?;
+                    // Name the provider without constructing it: this value is
+                    // display-only (each prompted write builds its own route's
+                    // provider below), and construction now fetches bootstrap
+                    // credentials, so a display-only build could hard-error on
+                    // a bootstrapped default alias no missing secret routes to.
+                    let default_backend_name = crate::provider::provider_display_name_for_spec(
+                        &self.resolve_provider_spec(
+                            self.default_provider_spec(provider_arg.as_deref())?,
+                        ),
+                    );
 
                     // List all missing secrets upfront
                     eprintln!(
@@ -1683,7 +1852,7 @@ impl Secrets {
                             "secrets are"
                         },
                         profile_display.bold(),
-                        default_backend.name().bold(),
+                        default_backend_name.bold(),
                     );
                     for secret_name in missing {
                         let description = self
@@ -1717,7 +1886,8 @@ impl Secrets {
 
                             let value = prompt.prompt()?;
 
-                            let backend = self.write_provider_for_route(&planned.route)?;
+                            let backend = self
+                                .write_provider_for_route(&planned.route, Some(&profile_display))?;
                             let set_result = backend.set(
                                 planned.as_address(&self.config.project.name, &profile_display),
                                 &SecretString::new(value.into()),
@@ -1992,7 +2162,8 @@ impl Secrets {
         let copy_result = (|| -> Result<()> {
             // Create the "from" provider and check availability. `build_provider`
             // expands a provider alias used as the import source.
-            let from_provider_instance = self.build_provider(from_provider.to_string())?;
+            let from_provider_instance =
+                self.build_provider(from_provider.to_string(), Some(&profile_display))?;
             source_uri = Some(from_provider_instance.uri());
 
             eprintln!(
@@ -2015,7 +2186,8 @@ impl Secrets {
                     .expect("Secret should exist since we're iterating over it");
                 let description = planned.config.description.as_deref();
 
-                let to_provider = self.write_provider_for_route(&planned.route)?;
+                let to_provider =
+                    self.write_provider_for_route(&planned.route, Some(&profile_display))?;
 
                 // The secret's address (native `ref` coordinates or convention
                 // naming) applies to both stores: naming is orthogonal to
@@ -2199,7 +2371,7 @@ impl Secrets {
         // Store the generated value at the plan's address, through the plan's
         // write route: the same decisions every other write path executes.
         let addr = planned.as_address(&self.config.project.name, profile_name);
-        let backend = self.write_provider_for_route(&planned.route)?;
+        let backend = self.write_provider_for_route(&planned.route, Some(profile_name))?;
         // The provider states why a write is refused; wrapping it here would
         // only nest a second "Provider operation failed" prefix.
         backend.check_writable(addr)?;
@@ -2630,7 +2802,7 @@ impl Secrets {
         let mut group_fetches: Vec<(Option<&str>, Vec<&PlannedSecret>, Box<dyn ProviderTrait>)> =
             Vec::new();
         for (provider_uri, group) in plan.groups() {
-            match self.get_provider(provider_uri) {
+            match self.get_provider(provider_uri, Some(&plan.profile)) {
                 Ok(provider) => {
                     // Attribute primary hits to the provider's own credential-free
                     // `uri()`, never the raw configured alias (which may embed a
@@ -2740,6 +2912,7 @@ impl Secrets {
                                 name,
                                 planned.as_address(project, profile),
                                 Some(fallback),
+                                Some(profile),
                             )?;
                             // A primary that errored plus an exhausted fallback
                             // chain is not "missing": the authoritative provider
@@ -2832,6 +3005,7 @@ impl Secrets {
         let report_provider_uri = self.validation_report_provider_uri(
             plan.override_uri.as_deref(),
             plan.secrets.iter().map(|s| s.route.primary()),
+            Some(&plan.profile),
         )?;
 
         if !missing_required.is_empty() {
@@ -3209,6 +3383,7 @@ mod report_provider_tests {
             .validation_report_provider_uri(
                 Some("vault+token:s3cr3t@host/db?token=abc"),
                 std::iter::empty(),
+                None,
             )
             .unwrap();
         assert_eq!(got, "vault+token:host/db");
@@ -3216,7 +3391,11 @@ mod report_provider_tests {
 
         // Per-secret alias branch: the first sorted primary URI is redacted too.
         let got = spec
-            .validation_report_provider_uri(None, [Some("vault://host?token=zzz")].into_iter())
+            .validation_report_provider_uri(
+                None,
+                [Some("vault://host?token=zzz")].into_iter(),
+                None,
+            )
             .unwrap();
         assert_eq!(got, "vault://host");
         assert!(!got.contains("zzz"));
@@ -3325,7 +3504,7 @@ mod reference_routing_tests {
                     &override_spec,
                 )
                 .unwrap();
-            spec.write_provider_for_route(&route).unwrap()
+            spec.write_provider_for_route(&route, None).unwrap()
         };
 
         assert_eq!(write_provider(None).name(), "onepassword");
@@ -3341,7 +3520,7 @@ mod reference_routing_tests {
         let spec = Secrets::new(crate::tests::resolve_test_config(secrets), None, None, None);
         let plan = spec.build_plan(None).unwrap();
         for (primary, group) in plan.groups() {
-            let provider = spec.get_provider(primary).unwrap();
+            let provider = spec.get_provider(primary, None).unwrap();
             Secrets::check_single_store_ref_coords(&group, provider.as_ref())?;
         }
         Ok(())

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -2,12 +2,12 @@
 
 use crate::audit::{AuditAction, AuditContext, AuditLogger, AuditOutcome};
 use crate::config::{
-    BootstrapSource, Config, GlobalConfig, NativeAddress, Profile, ProviderAlias, RequireReason,
+    Config, CredentialSource, GlobalConfig, NativeAddress, Profile, ProviderAlias, RequireReason,
     Resolved,
 };
 use crate::error::{Result, SecretSpecError};
 use crate::plan::{PlannedSecret, ResolutionPlan, Route};
-use crate::provider::{Address, BootstrapEnv, Provider as ProviderTrait};
+use crate::provider::{Address, Provider as ProviderTrait, ProviderCredentials};
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
 use crate::validation::{ValidatedSecrets, ValidationErrors};
@@ -41,28 +41,28 @@ fn warn_provider_failure(display_uri: &str, secret_name: &str, err: &SecretSpecE
     );
 }
 
-/// The error for a declared bootstrap credential that could not be found in its
-/// source provider. Names the variable, the provider needing it, the exact
+/// The error for a declared provider credential that could not be found in its
+/// source provider. Names the credential, the provider needing it, the exact
 /// location searched, and how to fix it.
-fn bootstrap_missing_error(var: &str, alias_spec: &str, location: &str) -> SecretSpecError {
+fn credential_missing_error(name: &str, alias_spec: &str, location: &str) -> SecretSpecError {
     SecretSpecError::ProviderOperationFailed(format!(
-        "bootstrap credential '{var}' for provider '{alias_spec}' was not found in {location}; \
-         store it there, or set {var} in the environment"
+        "credential '{name}' for provider '{alias_spec}' was not found in {location}; \
+         store it there with `secretspec config provider login {alias_spec}`"
     ))
 }
 
-/// An alias's bootstrap `env` entries sorted by variable name. The one
+/// An alias's credential entries sorted by semantic name. The one
 /// ordering rule, so fetch order, validation-error order, and the login prompt
 /// order all agree.
-fn sorted_bootstrap_entries(
-    env: &HashMap<String, BootstrapSource>,
-) -> Vec<(&String, &BootstrapSource)> {
-    let mut entries: Vec<(&String, &BootstrapSource)> = env.iter().collect();
-    entries.sort_by_key(|(var, _)| var.as_str());
+fn sorted_credential_entries(
+    credentials: &HashMap<String, CredentialSource>,
+) -> Vec<(&String, &CredentialSource)> {
+    let mut entries: Vec<(&String, &CredentialSource)> = credentials.iter().collect();
+    entries.sort_by_key(|(name, _)| name.as_str());
     entries
 }
 
-impl BootstrapSource {
+impl CredentialSource {
     /// Credential-free provider text for prompts and diagnostics.
     pub(crate) fn display_provider(&self) -> String {
         crate::audit::redact_uri_strict(&self.provider)
@@ -70,13 +70,13 @@ impl BootstrapSource {
 
     /// The store location this source reads and writes: the pinned `ref`, or
     /// the convention path for the active project and profile. The single
-    /// derivation both [`Secrets::resolve_bootstrap_overlay`] (read) and
-    /// [`Secrets::store_bootstrap_credential`] (write) use, so login-then-resolve
+    /// derivation both [`Secrets::resolve_provider_credentials`] (read) and
+    /// [`Secrets::store_provider_credential`] (write) use, so login-then-resolve
     /// round-trips by construction.
-    fn address<'a>(&'a self, project: &'a str, profile: &'a str, var: &'a str) -> Address<'a> {
+    fn address<'a>(&'a self, project: &'a str, profile: &'a str, name: &'a str) -> Address<'a> {
         match &self.reference {
             Some(reference) => Address::Native(reference),
-            None => Address::convention(project, profile, var),
+            None => Address::convention(project, profile, name),
         }
     }
 
@@ -85,32 +85,36 @@ impl BootstrapSource {
     /// is redacted: a URI-form source may embed an inline credential
     /// (`onepassword+token://tok@Vault`), and this string reaches stderr and
     /// the `config provider login` output.
-    fn location(&self, project: &str, profile: &str, var: &str) -> String {
+    fn location(&self, project: &str, profile: &str, name: &str) -> String {
         let provider = self.display_provider();
         match &self.reference {
             Some(reference) => format!("{provider} at {}", reference.render()),
-            None => format!("{provider} at {project}/{profile}/{var}"),
+            None => format!("{provider} at {project}/{profile}/{name}"),
         }
     }
 }
 
-type BootstrapOverlayKey = (String, String);
-type BootstrapOverlaySlot = Arc<Mutex<Option<BootstrapEnv>>>;
+type ProviderCredentialsKey = (String, String);
+type ProviderCredentialsSlot = Arc<Mutex<Option<ProviderCredentials>>>;
 
-/// Memoized bootstrap overlays with single-flight population per key.
+/// Memoized provider credentials with single-flight population per key.
 ///
 /// The outer mutex protects only the key-to-slot map. Resolution runs while
 /// holding the selected slot, so callers for the same alias/profile wait for
 /// its first fetch while unrelated keys can populate concurrently.
 #[derive(Default)]
-struct BootstrapOverlayCache {
-    entries: Mutex<HashMap<BootstrapOverlayKey, BootstrapOverlaySlot>>,
+struct ProviderCredentialsCache {
+    entries: Mutex<HashMap<ProviderCredentialsKey, ProviderCredentialsSlot>>,
 }
 
-impl BootstrapOverlayCache {
-    fn get_or_try_init<F>(&self, key: BootstrapOverlayKey, resolve: F) -> Result<BootstrapEnv>
+impl ProviderCredentialsCache {
+    fn get_or_try_init<F>(
+        &self,
+        key: ProviderCredentialsKey,
+        resolve: F,
+    ) -> Result<ProviderCredentials>
     where
-        F: FnOnce() -> Result<BootstrapEnv>,
+        F: FnOnce() -> Result<ProviderCredentials>,
     {
         let slot = {
             let mut entries = self.entries.lock().unwrap();
@@ -122,14 +126,14 @@ impl BootstrapOverlayCache {
         };
 
         let mut cached = slot.lock().unwrap();
-        if let Some(overlay) = cached.as_ref() {
-            return Ok(overlay.clone());
+        if let Some(credentials) = cached.as_ref() {
+            return Ok(credentials.clone());
         }
 
         match resolve() {
-            Ok(overlay) => {
-                *cached = Some(overlay.clone());
-                Ok(overlay)
+            Ok(credentials) => {
+                *cached = Some(credentials.clone());
+                Ok(credentials)
             }
             Err(err) => {
                 // Do not memoize failures: a later operation may succeed after
@@ -249,15 +253,15 @@ pub struct Secrets {
     /// Audit logger, if auditing is enabled (user-global `[audit]` config). `None`
     /// disables auditing. Built once per `Secrets` so all events share a session id.
     audit: Option<AuditLogger>,
-    /// Bootstrap overlays memoized per (profile, raw provider spec), so N
-    /// secrets routed at one bootstrapped alias fetch its credentials from the
+    /// Provider credentials memoized per (profile, raw provider spec), so N
+    /// secrets routed at one alias fetch its credentials from the
     /// source provider once per session, not once per provider build. Keyed by
     /// profile because a convention-path credential lives at
-    /// `{project}/{profile}/{VAR}`: switching profiles on one instance must
+    /// `{project}/{profile}/{credential}`: switching profiles on one instance must
     /// not reuse the other profile's credential. Cleared by
-    /// [`Secrets::store_bootstrap_credential`] so a freshly stored credential
+    /// [`Secrets::store_provider_credential`] so a freshly stored credential
     /// is re-read.
-    bootstrap_overlays: BootstrapOverlayCache,
+    provider_credentials_cache: ProviderCredentialsCache,
 }
 
 /// secretspec's own opt-in for marking the current process as an agent. Lets any
@@ -426,7 +430,7 @@ impl Secrets {
             reason: None,
             require_reason: RequireReason::Never,
             audit: None,
-            bootstrap_overlays: BootstrapOverlayCache::default(),
+            provider_credentials_cache: ProviderCredentialsCache::default(),
         }
     }
 
@@ -502,7 +506,7 @@ impl Secrets {
             profile: None,
             reason: env_reason(),
             audit,
-            bootstrap_overlays: BootstrapOverlayCache::default(),
+            provider_credentials_cache: ProviderCredentialsCache::default(),
         })
     }
 
@@ -605,8 +609,8 @@ impl Secrets {
     /// reason set via [`Secrets::with_reason`] reaches every provider instance.
     ///
     /// `profile` is the profile the caller resolved for the surrounding
-    /// operation (`None` falls back to the session profile): a bootstrapped
-    /// alias's convention-path credentials live at `{project}/{profile}/{VAR}`,
+    /// operation (`None` falls back to the session profile): an alias's
+    /// convention-path credentials live at `{project}/{profile}/{credential}`,
     /// so the provider must be built for the same profile its secrets are
     /// addressed under.
     fn build_provider(
@@ -614,35 +618,33 @@ impl Secrets {
         spec: String,
         profile: Option<&str>,
     ) -> Result<Box<dyn ProviderTrait>> {
-        // When `spec` names an alias with a bootstrap `env` map, resolve those
-        // credentials from their source providers into an overlay the built
-        // provider uses when the process environment has no non-empty value.
+        // When `spec` names an alias with a `credentials` map, resolve those
+        // values from their source providers and hand them to the built provider.
         // Memoized per (profile, spec) so rebuilding a provider (per-secret chain walks,
         // interactive prompting) does not refetch the same credentials from
         // the source store, while a profile switch on this instance does not
         // reuse the other profile's credentials.
         let profile = self.resolve_profile_name(profile);
         let key = (profile.clone(), spec.clone());
-        let overlay = self
-            .bootstrap_overlays
-            .get_or_try_init(key, || self.resolve_bootstrap_overlay(&spec, &profile))?;
-        self.build_provider_with_overlay(&spec, overlay)
+        let credentials = self
+            .provider_credentials_cache
+            .get_or_try_init(key, || self.resolve_provider_credentials(&spec, &profile))?;
+        self.build_provider_with_credentials(&spec, credentials)
     }
 
-    /// Builds a bootstrap *source* provider: like [`Self::build_provider`] but
-    /// never itself bootstrapped, so a bootstrap chain is at most one hop and can
-    /// never recurse. This is the store an alias's `env` credential is read from.
+    /// Builds a credential source provider without resolving credentials for it,
+    /// so credential-source chains are at most one hop and cannot recurse.
     fn build_source_provider(&self, spec: &str) -> Result<Box<dyn ProviderTrait>> {
-        self.build_provider_with_overlay(spec, BootstrapEnv::new())
+        self.build_provider_with_credentials(spec, ProviderCredentials::new())
     }
 
     /// The shared construction body behind [`Self::build_provider`] and
     /// [`Self::build_source_provider`]: alias expansion, error enrichment, and
     /// the base-dir/reason hooks live only here, so the two paths cannot drift.
-    fn build_provider_with_overlay(
+    fn build_provider_with_credentials(
         &self,
         spec: &str,
-        overlay: BootstrapEnv,
+        credentials: ProviderCredentials,
     ) -> Result<Box<dyn ProviderTrait>> {
         // Resolve provider aliases here, at the single construction chokepoint, so
         // every caller that hands us a user-supplied spec gets alias expansion for
@@ -650,41 +652,38 @@ impl Secrets {
         // already-resolved URI (a `scheme://...` string is never an alias key), so
         // callers that pass pre-resolved URIs (the per-secret chain) are unaffected.
         let resolved = self.resolve_provider_spec(spec.to_string());
-        let mut provider = crate::provider::provider_from_spec(resolved.as_str(), overlay)
+        let mut provider = crate::provider::provider_from_spec(resolved.as_str(), credentials)
             .map_err(|err| self.explain_unknown_provider(err, &resolved))?;
         provider.with_base_dir(&self.config_dir);
         provider.set_reason(self.reason.clone());
         Ok(provider)
     }
 
-    /// Resolves the bootstrap overlay for a provider spec: for each `(VAR, source)`
-    /// its alias declares in `env`, fetch the credential from the source provider
-    /// and collect it as a fallback for a missing or empty environment value.
+    /// Resolves the credentials declared by a provider alias, fetching each
+    /// semantic `(name, source)` entry from its source provider.
     ///
     /// `profile` scopes the convention path a bare-string source reads from.
-    /// Returns an empty overlay for a spec that is not an alias, or an alias with
-    /// no `env`. A variable already set (non-empty) in the process environment
-    /// wins and is not fetched. A declared credential that cannot be found is a
+    /// Returns an empty map for a spec that is not an alias, or an alias with
+    /// no credentials. A declared credential that cannot be found is a
     /// hard error naming exactly how to fix it. Sources pass
-    /// [`Self::validate_bootstrap_sources`] and are built non-bootstrap, so a
+    /// [`Self::validate_credential_sources`] and are built without credentials, so a
     /// chain is at most one hop and cannot recurse. Each source read is audited
-    /// with a `bootstrap` marker, so the audit trail explains why the source
+    /// with a `credential` marker, so the audit trail explains why the source
     /// store was touched during an operation on the target provider.
-    pub(crate) fn resolve_bootstrap_overlay(
+    pub(crate) fn resolve_provider_credentials(
         &self,
         spec: &str,
         profile: &str,
-    ) -> Result<BootstrapEnv> {
-        let mut overlay = BootstrapEnv::new();
-        let Some(env) = self
+    ) -> Result<ProviderCredentials> {
+        let mut credentials = ProviderCredentials::new();
+        let Some(declared) = self
             .lookup_provider_alias_entry(spec)
-            .map(|alias| &alias.env)
-            .filter(|env| !env.is_empty())
+            .map(|alias| &alias.credentials)
+            .filter(|credentials| !credentials.is_empty())
         else {
-            return Ok(overlay);
+            return Ok(credentials);
         };
-        self.validate_bootstrap_sources(spec)?;
-        self.warn_unconsumed_bootstrap_vars(spec, env);
+        self.validate_credential_sources(spec)?;
 
         let project = self.config.project.name.clone();
 
@@ -693,24 +692,17 @@ impl Secrets {
         // and whatever it caches, instead of authenticating once per variable.
         let mut sources: HashMap<String, Box<dyn ProviderTrait>> = HashMap::new();
 
-        for (var, source) in sorted_bootstrap_entries(env) {
-            // Env wins: an exported value is used by the provider directly, so
-            // the declared chain is not consulted (this is what keeps CI working
-            // with plain environment variables and no extra configuration).
-            if crate::provider::bootstrap_env_var(var).is_some() {
-                continue;
-            }
-
+        for (name, source) in sorted_credential_entries(declared) {
             let source_provider = match sources.entry(source.provider.clone()) {
                 std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
                 std::collections::hash_map::Entry::Vacant(entry) => {
                     entry.insert(self.build_source_provider(&source.provider)?)
                 }
             };
-            let fetched = source_provider.get(source.address(&project, profile, var));
+            let fetched = source_provider.get(source.address(&project, profile, name));
             // Audit the source read (design: every secret access is recorded).
-            // The key is the bootstrap variable and the event carries a
-            // `bootstrap` marker plus the source provider's credential-free
+            // The key is the semantic credential name and the event carries a
+            // `credential` marker plus the source provider's credential-free
             // `uri()`, so the trail explains why this store was touched.
             let (outcome, error_kind) = match &fetched {
                 Ok(Some(_)) => (AuditOutcome::Found, None),
@@ -722,8 +714,8 @@ impl Secrets {
                 profile,
                 outcome,
                 AuditFields {
-                    key: Some(var),
-                    command: Some("bootstrap"),
+                    key: Some(name),
+                    command: Some("credential"),
                     provider_uri: Some(source_provider.uri()),
                     reference: source.reference.as_ref(),
                     error_kind,
@@ -732,131 +724,115 @@ impl Secrets {
             );
             match fetched? {
                 Some(value) => {
-                    overlay.insert(var.clone(), value);
+                    credentials.insert(name.clone(), value);
                 }
                 None => {
-                    return Err(bootstrap_missing_error(
-                        var,
+                    return Err(credential_missing_error(
+                        name,
                         spec,
-                        &source.location(&project, profile, var),
+                        &source.location(&project, profile, name),
                     ));
                 }
             }
         }
 
-        Ok(overlay)
+        Ok(credentials)
     }
 
-    /// Warns once (per overlay resolution, which is memoized per session) about
-    /// each declared bootstrap variable in `env` the target provider never
-    /// reads: only providers that register `bootstrap_vars` consult the
-    /// overlay, and only for those names, so any other declaration is fetched
-    /// and then silently ignored. A warning rather than an error, because a
-    /// declaration can be legitimate for values the provider reads from the
-    /// real environment. `spec` is the alias declaring `env`, named in the
-    /// warning.
-    fn warn_unconsumed_bootstrap_vars(&self, spec: &str, env: &HashMap<String, BootstrapSource>) {
-        let resolved = self.resolve_provider_spec(spec.to_string());
-        let supported = crate::provider::bootstrap_vars_for_spec(&resolved);
-        let provider_name = crate::provider::provider_display_name_for_spec(&resolved);
-        let mut vars: Vec<&String> = env.keys().collect();
-        vars.sort();
-        for var in vars {
-            if !supported.contains(&var.as_str()) {
-                let supported_display = if supported.is_empty() {
-                    format!("provider '{provider_name}' reads no bootstrap credentials")
-                } else {
-                    format!("provider '{provider_name}' reads: {}", supported.join(", "))
-                };
-                eprintln!(
-                    "{} bootstrap variable '{var}' declared for provider alias '{spec}' is not \
-                     read by its provider and will be ignored ({supported_display})",
-                    "⚠".yellow(),
-                );
-            }
-        }
-    }
-
-    /// The bootstrap credentials a provider alias declares, sorted by variable
+    /// The credentials a provider alias declares, sorted by semantic name
     /// name, for the `config provider login` flow. Validates every source before
     /// returning any credentials. Errors if the alias is not defined; returns
-    /// an empty list for an alias with no `env`.
-    pub(crate) fn bootstrap_credentials(
+    /// an empty list for an alias with no `credentials`.
+    pub(crate) fn declared_provider_credentials(
         &self,
         alias: &str,
-    ) -> Result<Vec<(String, BootstrapSource)>> {
+    ) -> Result<Vec<(String, CredentialSource)>> {
         // Validate the complete map before returning any entry. The login CLI
         // prompts and writes only after this method succeeds, so a later-sorted
         // invalid source cannot leave earlier credentials partially stored.
-        self.validate_bootstrap_sources(alias)?;
+        self.validate_credential_sources(alias)?;
         let entry = self
             .lookup_provider_alias_entry(alias)
             .ok_or_else(|| SecretSpecError::ProviderNotFound(alias.to_string()))?;
-        Ok(sorted_bootstrap_entries(&entry.env)
+        Ok(sorted_credential_entries(&entry.credentials)
             .into_iter()
-            .map(|(var, source)| (var.clone(), source.clone()))
+            .map(|(name, source)| (name.clone(), source.clone()))
             .collect())
     }
 
-    /// Stores one bootstrap credential at its source provider — the exact
-    /// location [`Self::resolve_bootstrap_overlay`] later reads it from (a `ref`
+    /// Stores one provider credential at its source provider — the exact
+    /// location [`Self::resolve_provider_credentials`] later reads it from (a `ref`
     /// or the convention path for the active project and profile). Errors if the
     /// source provider is read-only. Returns a human-readable description of
     /// where it was stored.
     ///
     /// Like every other write path, the write is gated by the `require_reason`
-    /// policy and audited (with a `bootstrap` marker). A successful store also
-    /// clears the overlay memo, so a credential rotated through this instance
+    /// policy and audited (with a `credential` marker). A successful store also
+    /// clears the credential memo, so a credential rotated through this instance
     /// is re-read instead of resolving to the stale cached value.
-    pub(crate) fn store_bootstrap_credential(
+    pub(crate) fn store_provider_credential(
         &self,
-        source: &BootstrapSource,
-        var: &str,
+        source: &CredentialSource,
+        name: &str,
         value: &SecretString,
     ) -> Result<String> {
-        self.ensure_reason_for(AuditAction::Set, Some(var))?;
+        self.ensure_reason_for(AuditAction::Set, Some(name))?;
         let provider = self.build_source_provider(&source.provider)?;
         let profile = self.resolve_profile_name(None);
         let project = self.config.project.name.clone();
-        let address = source.address(&project, &profile, var);
+        let address = source.address(&project, &profile, name);
         let result = provider
             .check_writable(address)
             .and_then(|()| provider.set(address, value));
         self.audit_write_result(
             &result,
-            var,
+            name,
             &profile,
             Some(provider.uri()),
             source.reference.as_ref(),
-            Some("bootstrap"),
+            Some("credential"),
         );
         result?;
         // The stored credential replaces whatever an earlier resolution
         // memoized; drop the memo so the next build re-reads it.
-        self.bootstrap_overlays.clear();
-        Ok(source.location(&project, &profile, var))
+        self.provider_credentials_cache.clear();
+        Ok(source.location(&project, &profile, name))
     }
 
-    /// Validates a spec's bootstrap `env` (pure map lookups, no I/O): every
-    /// source must resolve to a known provider, and no source may itself declare
-    /// bootstrap `env` (chains are limited to one hop, which also makes cycles
-    /// impossible). A no-op for a spec that is not an alias or has no `env`.
+    /// Validates a spec's `credentials` (pure map lookups, no I/O): every name
+    /// must be accepted by the target provider, every source must resolve to a
+    /// known provider, and no source may itself declare credentials. Credential
+    /// chains are limited to one hop, which also makes cycles impossible.
     /// Run at plan time to fail fast on a routed primary or override, and again
-    /// by [`Self::resolve_bootstrap_overlay`], so every construction path —
+    /// by [`Self::resolve_provider_credentials`], so every construction path —
     /// fallback links and the default provider included — enforces the same
-    /// invariants instead of silently dropping a chained source's `env`.
-    pub(crate) fn validate_bootstrap_sources(&self, spec: &str) -> Result<()> {
+    /// invariants instead of silently dropping a chained source's credentials.
+    pub(crate) fn validate_credential_sources(&self, spec: &str) -> Result<()> {
         let Some(alias) = self.lookup_provider_alias_entry(spec) else {
             return Ok(());
         };
-        for (var, source) in sorted_bootstrap_entries(&alias.env) {
+        let resolved_target = self.resolve_provider_spec(spec.to_string());
+        let supported = crate::provider::credential_names_for_spec(&resolved_target);
+        let provider_name = crate::provider::provider_display_name_for_spec(&resolved_target);
+        for (name, source) in sorted_credential_entries(&alias.credentials) {
+            if !supported.contains(&name.as_str()) {
+                let supported_display = if supported.is_empty() {
+                    "none".to_string()
+                } else {
+                    supported.join(", ")
+                };
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "credential '{name}' is not supported by provider '{provider_name}' \
+                     for alias '{spec}' (supported credentials: {supported_display})"
+                )));
+            }
             // Compose the underlying error into the message instead of
             // replacing it: it carries the corrective guidance (the
             // `1password` -> `onepassword` hint, the defined-aliases listing)
             // that the other resolution paths give for the same mistakes.
             let context = |err: SecretSpecError| {
                 SecretSpecError::ProviderOperationFailed(format!(
-                    "bootstrap source for '{var}' in provider alias '{spec}': {err}"
+                    "credential source for '{name}' in provider alias '{spec}': {err}"
                 ))
             };
             let resolved = self
@@ -869,17 +845,17 @@ impl Secrets {
             let known = crate::provider::spec_names_known_provider(&resolved).map_err(context)?;
             if !known {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "bootstrap source for '{var}' in provider alias '{spec}' names an unknown \
+                    "credential source for '{name}' in provider alias '{spec}' names an unknown \
                      provider '{}'",
                     crate::audit::redact_uri_strict(&source.provider)
                 )));
             }
             if let Some(source_alias) = self.lookup_provider_alias_entry(&source.provider)
-                && !source_alias.env.is_empty()
+                && !source_alias.credentials.is_empty()
             {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "provider alias '{}' cannot be a bootstrap source for '{spec}' because it \
-                     declares its own bootstrap env; bootstrap chains are limited to one hop",
+                    "provider alias '{}' cannot be a credential source for '{spec}' because it \
+                     declares its own credentials; credential chains are limited to one hop",
                     source.provider
                 )));
             }
@@ -940,12 +916,12 @@ impl Secrets {
         }
     }
 
-    /// Audits the result of a single secret write (`set`/generate/prompt/
-    /// bootstrap): a `Written` event on success, an `Error` event (tagged with
+    /// Audits the result of a single secret or provider-credential write: a
+    /// `Written` event on success, an `Error` event (tagged with
     /// the error kind) on failure. Centralizes the write-audit so every write
     /// path records the same way and a new one cannot accidentally diverge or
-    /// skip auditing. `command` marks a special-purpose write (the `bootstrap`
-    /// credential store); `None` for a plain secret write.
+    /// skip auditing. `command` marks a special-purpose credential store;
+    /// `None` denotes a plain secret write.
     fn audit_write_result(
         &self,
         result: &Result<()>,
@@ -1237,8 +1213,8 @@ impl Secrets {
         )
     }
 
-    /// Resolves a provider alias to its full entry (URI plus any bootstrap
-    /// `env`), walking [`Self::provider_alias_sources`] in order. Project
+    /// Resolves a provider alias to its full entry (URI plus any provider
+    /// credentials), walking [`Self::provider_alias_sources`] in order. Project
     /// entries win over user-global ones.
     fn lookup_provider_alias_entry(&self, alias: &str) -> Option<&ProviderAlias> {
         self.provider_alias_sources().find_map(|m| m.get(alias))
@@ -1350,7 +1326,7 @@ impl Secrets {
         profile: Option<&str>,
     ) -> Result<Box<dyn ProviderTrait>> {
         // Build from the primary spec (not the resolved URI) so an alias's
-        // bootstrap `env` is applied to the write target too.
+        // `credentials` is applied to the write target too.
         self.get_provider(route.group_key(), profile)
     }
 
@@ -1367,7 +1343,7 @@ impl Secrets {
     ///
     /// * `provider_arg` - Optional provider specification (name or URI)
     /// * `profile` - The profile the operation is addressed under (`None`
-    ///   falls back to the session profile); scopes any bootstrap credentials
+    ///   falls back to the session profile); scopes any provider credentials
     ///   fetched during construction
     ///
     /// # Returns
@@ -1395,7 +1371,7 @@ impl Secrets {
     /// The raw provider spec [`Self::get_provider`] would build for
     /// `provider_arg`: the explicit override, else the user-global default.
     /// Split out so display paths can name the provider without constructing
-    /// it (construction fetches bootstrap credentials, so a display-only build
+    /// it (construction fetches provider credentials, so a display-only build
     /// could fail or do I/O).
     fn default_provider_spec(&self, provider_arg: Option<&str>) -> Result<String> {
         self.explicit_provider_spec(provider_arg)
@@ -1460,7 +1436,7 @@ impl Secrets {
     /// * `provider_specs` - Optional chain of provider specs (aliases or inline
     ///   URIs) to try in order, resolved lazily per entry
     /// * `profile` - The profile the read is addressed under; scopes any
-    ///   bootstrap credentials fetched when a chain link is built
+    ///   provider credentials fetched when a chain link is built
     ///
     /// # Returns
     ///
@@ -1499,7 +1475,7 @@ impl Secrets {
                     }
                 };
                 // Build from the raw spec (not the resolved URI) so an alias's
-                // bootstrap `env` is applied to this chain link too.
+                // `credentials` is applied to this chain link too.
                 let provider = match self.build_provider(spec.clone(), profile) {
                     Ok(p) => p,
                     Err(e) => {
@@ -1886,9 +1862,9 @@ impl Secrets {
                     let total = missing.len();
                     // Name the provider without constructing it: this value is
                     // display-only (each prompted write builds its own route's
-                    // provider below), and construction now fetches bootstrap
+                    // provider below), and construction now fetches provider
                     // credentials, so a display-only build could hard-error on
-                    // a bootstrapped default alias no missing secret routes to.
+                    // a credential-backed default alias no missing secret routes to.
                     let default_backend_name = crate::provider::provider_display_name_for_spec(
                         &self.resolve_provider_spec(
                             self.default_provider_spec(provider_arg.as_deref())?,
@@ -2852,8 +2828,8 @@ impl Secrets {
 
         // Construction stays on this thread: the up-front single-store `ref`
         // check below must see every built provider before any store is
-        // contacted. Building a bootstrapped alias's provider already fetches
-        // its bootstrap credentials here (memoized per spec); only the group
+        // contacted. Building a credential-backed alias's provider already fetches
+        // its provider credentials here (memoized per spec); only the group
         // fetches run concurrently below.
         let mut group_fetches: Vec<(Option<&str>, Vec<&PlannedSecret>, Box<dyn ProviderTrait>)> =
             Vec::new();
@@ -3312,7 +3288,7 @@ mod policy_tests {
 }
 
 #[cfg(test)]
-mod bootstrap_overlay_cache_tests {
+mod provider_credentials_cache_tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Barrier};
@@ -3322,7 +3298,7 @@ mod bootstrap_overlay_cache_tests {
     #[test]
     fn concurrent_population_for_one_key_is_single_flight() {
         const CALLERS: usize = 8;
-        let cache = Arc::new(BootstrapOverlayCache::default());
+        let cache = Arc::new(ProviderCredentialsCache::default());
         let start = Arc::new(Barrier::new(CALLERS));
         let fetches = Arc::new(AtomicUsize::new(0));
 
@@ -3339,9 +3315,9 @@ mod bootstrap_overlay_cache_tests {
                             // Keep the first population in flight long enough for
                             // every caller to contend on the same key.
                             thread::sleep(Duration::from_millis(50));
-                            let mut overlay = BootstrapEnv::new();
-                            overlay.insert("TOKEN".into(), SecretString::new("value".into()));
-                            Ok(overlay)
+                            let mut credentials = ProviderCredentials::new();
+                            credentials.insert("token".into(), SecretString::new("value".into()));
+                            Ok(credentials)
                         })
                         .unwrap()
                 })
@@ -3349,9 +3325,9 @@ mod bootstrap_overlay_cache_tests {
             .collect();
 
         for thread in threads {
-            let overlay = thread.join().unwrap();
+            let credentials = thread.join().unwrap();
             assert_eq!(
-                overlay.get("TOKEN").map(|value| value.expose_secret()),
+                credentials.get("token").map(|value| value.expose_secret()),
                 Some("value")
             );
         }

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -829,7 +829,9 @@ impl Secrets {
     /// then user-global config. Project entries win on conflict so teams can
     /// pin shareable mappings in version control while still allowing per-user
     /// overrides via the global config.
-    fn provider_alias_sources(&self) -> impl Iterator<Item = &HashMap<String, String>> {
+    fn provider_alias_sources(
+        &self,
+    ) -> impl Iterator<Item = &HashMap<String, crate::config::ProviderAlias>> {
         self.config.providers.iter().chain(
             self.global_config
                 .as_ref()
@@ -842,7 +844,7 @@ impl Secrets {
     fn lookup_provider_alias(&self, alias: &str) -> Option<String> {
         self.provider_alias_sources()
             .find_map(|m| m.get(alias))
-            .cloned()
+            .map(|alias| alias.uri.clone())
     }
 
     fn resolve_provider_spec(&self, spec: String) -> String {

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -584,6 +584,48 @@ impl Secrets {
         Ok(overlay)
     }
 
+    /// The bootstrap credentials a provider alias declares, sorted by variable
+    /// name, for the `config provider login` flow. Errors if the alias is not
+    /// defined; returns an empty list for an alias with no `env`.
+    pub(crate) fn bootstrap_credentials(
+        &self,
+        alias: &str,
+    ) -> Result<Vec<(String, BootstrapSource)>> {
+        let entry = self
+            .lookup_provider_alias_entry(alias)
+            .ok_or_else(|| SecretSpecError::ProviderNotFound(alias.to_string()))?;
+        let mut credentials: Vec<(String, BootstrapSource)> =
+            entry.env.clone().unwrap_or_default().into_iter().collect();
+        credentials.sort_by(|(a, _), (b, _)| a.cmp(b));
+        Ok(credentials)
+    }
+
+    /// Stores one bootstrap credential at its source provider — the exact
+    /// location [`Self::resolve_bootstrap_overlay`] later reads it from (a `ref`
+    /// or the convention path for the active project and profile). Errors if the
+    /// source provider is read-only. Returns a human-readable description of
+    /// where it was stored.
+    pub(crate) fn store_bootstrap_credential(
+        &self,
+        source: &BootstrapSource,
+        var: &str,
+        value: &SecretString,
+    ) -> Result<String> {
+        let provider = self.build_source_provider(&source.provider)?;
+        let profile = self.resolve_profile_name(None);
+        let project = self.config.project.name.clone();
+        let address = match &source.reference {
+            Some(reference) => Address::Native(reference),
+            None => Address::convention(&project, &profile, var),
+        };
+        provider.check_writable(address)?;
+        provider.set(address, value)?;
+        Ok(match &source.reference {
+            Some(reference) => format!("{} at {}", source.provider, reference.render()),
+            None => format!("{} at {project}/{profile}/{var}", source.provider),
+        })
+    }
+
     /// Validates a primary spec's bootstrap `env` at plan time (pure): every
     /// source must resolve to a known provider, and no source may itself declare
     /// bootstrap `env` (chains are limited to one hop, which also makes cycles

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -51,6 +51,17 @@ fn bootstrap_missing_error(var: &str, alias_spec: &str, location: &str) -> Secre
     ))
 }
 
+/// An alias's bootstrap `env` entries sorted by variable name. The one
+/// ordering rule, so fetch order, validation-error order, and the login prompt
+/// order all agree.
+fn sorted_bootstrap_entries(
+    env: &HashMap<String, BootstrapSource>,
+) -> Vec<(&String, &BootstrapSource)> {
+    let mut entries: Vec<(&String, &BootstrapSource)> = env.iter().collect();
+    entries.sort_by_key(|(var, _)| var.as_str());
+    entries
+}
+
 impl BootstrapSource {
     /// The store location this source reads and writes: the pinned `ref`, or
     /// the convention path for the active project and profile. The single
@@ -611,14 +622,15 @@ impl Secrets {
         profile: &str,
     ) -> Result<BootstrapEnv> {
         let mut overlay = BootstrapEnv::new();
-        if self
+        let Some(env) = self
             .lookup_provider_alias_entry(spec)
-            .is_none_or(|alias| alias.env.is_none())
-        {
+            .map(|alias| &alias.env)
+            .filter(|env| !env.is_empty())
+        else {
             return Ok(overlay);
-        }
+        };
         self.validate_bootstrap_sources(spec)?;
-        self.warn_unconsumed_bootstrap_vars(spec);
+        self.warn_unconsumed_bootstrap_vars(spec, env);
 
         let project = self.config.project.name.clone();
 
@@ -627,13 +639,11 @@ impl Secrets {
         // and whatever it caches, instead of authenticating once per variable.
         let mut sources: HashMap<String, Box<dyn ProviderTrait>> = HashMap::new();
 
-        // `bootstrap_credentials` sorts by variable name, so fetch order, error
-        // messages, and the login prompt order all agree.
-        for (var, source) in self.bootstrap_credentials(spec)? {
+        for (var, source) in sorted_bootstrap_entries(env) {
             // Env wins: an exported value is used by the provider directly, so
             // the declared chain is not consulted (this is what keeps CI working
             // with plain environment variables and no extra configuration).
-            if crate::provider::bootstrap_env_var(&var).is_some() {
+            if crate::provider::bootstrap_env_var(var).is_some() {
                 continue;
             }
 
@@ -643,7 +653,7 @@ impl Secrets {
                     entry.insert(self.build_source_provider(&source.provider)?)
                 }
             };
-            let fetched = source_provider.get(source.address(&project, profile, &var));
+            let fetched = source_provider.get(source.address(&project, profile, var));
             // Audit the source read (design: every secret access is recorded).
             // The key is the bootstrap variable and the event carries a
             // `bootstrap` marker plus the source provider's credential-free
@@ -658,7 +668,7 @@ impl Secrets {
                 profile,
                 outcome,
                 AuditFields {
-                    key: Some(&var),
+                    key: Some(var),
                     command: Some("bootstrap"),
                     provider_uri: Some(source_provider.uri()),
                     reference: source.reference.as_ref(),
@@ -668,13 +678,13 @@ impl Secrets {
             );
             match fetched? {
                 Some(value) => {
-                    overlay.insert(var, value);
+                    overlay.insert(var.clone(), value);
                 }
                 None => {
                     return Err(bootstrap_missing_error(
-                        &var,
+                        var,
                         spec,
-                        &source.location(&project, profile, &var),
+                        &source.location(&project, profile, var),
                     ));
                 }
             }
@@ -684,18 +694,14 @@ impl Secrets {
     }
 
     /// Warns once (per overlay resolution, which is memoized per session) about
-    /// each declared bootstrap variable the target provider never reads: only
-    /// providers that register `bootstrap_vars` consult the overlay, and only
-    /// for those names, so any other declaration is fetched and then silently
-    /// ignored. A warning rather than an error, because a declaration can be
-    /// legitimate for values the provider reads from the real environment.
-    fn warn_unconsumed_bootstrap_vars(&self, spec: &str) {
-        let Some(env) = self
-            .lookup_provider_alias_entry(spec)
-            .and_then(|alias| alias.env.as_ref())
-        else {
-            return;
-        };
+    /// each declared bootstrap variable in `env` the target provider never
+    /// reads: only providers that register `bootstrap_vars` consult the
+    /// overlay, and only for those names, so any other declaration is fetched
+    /// and then silently ignored. A warning rather than an error, because a
+    /// declaration can be legitimate for values the provider reads from the
+    /// real environment. `spec` is the alias declaring `env`, named in the
+    /// warning.
+    fn warn_unconsumed_bootstrap_vars(&self, spec: &str, env: &HashMap<String, BootstrapSource>) {
         let resolved = self.resolve_provider_spec(spec.to_string());
         let supported = crate::provider::bootstrap_vars_for_spec(&resolved);
         let provider_name = crate::provider::provider_display_name_for_spec(&resolved);
@@ -727,10 +733,10 @@ impl Secrets {
         let entry = self
             .lookup_provider_alias_entry(alias)
             .ok_or_else(|| SecretSpecError::ProviderNotFound(alias.to_string()))?;
-        let mut credentials: Vec<(String, BootstrapSource)> =
-            entry.env.clone().unwrap_or_default().into_iter().collect();
-        credentials.sort_by(|(a, _), (b, _)| a.cmp(b));
-        Ok(credentials)
+        Ok(sorted_bootstrap_entries(&entry.env)
+            .into_iter()
+            .map(|(var, source)| (var.clone(), source.clone()))
+            .collect())
     }
 
     /// Stores one bootstrap credential at its source provider — the exact
@@ -757,22 +763,13 @@ impl Secrets {
         let result = provider
             .check_writable(address)
             .and_then(|()| provider.set(address, value));
-        let (outcome, error_kind) = match &result {
-            Ok(()) => (AuditOutcome::Written, None),
-            Err(e) => (AuditOutcome::Error, Some(e.kind())),
-        };
-        self.record(
-            AuditAction::Set,
+        self.audit_write_result(
+            &result,
+            var,
             &profile,
-            outcome,
-            AuditFields {
-                key: Some(var),
-                command: Some("bootstrap"),
-                provider_uri: Some(provider.uri()),
-                reference: source.reference.as_ref(),
-                error_kind,
-                ..Default::default()
-            },
+            Some(provider.uri()),
+            source.reference.as_ref(),
+            Some("bootstrap"),
         );
         result?;
         // The stored credential replaces whatever an earlier resolution
@@ -793,32 +790,24 @@ impl Secrets {
         let Some(alias) = self.lookup_provider_alias_entry(spec) else {
             return Ok(());
         };
-        let Some(env) = alias.env.as_ref() else {
-            return Ok(());
-        };
-        // Sorted so the reported error is deterministic when several entries
-        // are invalid, matching the sorted fetch order of the resolver.
-        let mut entries: Vec<(&String, &BootstrapSource)> = env.iter().collect();
-        entries.sort_by_key(|(var, _)| var.as_str());
-        for (var, source) in entries {
+        for (var, source) in sorted_bootstrap_entries(&alias.env) {
             // Compose the underlying error into the message instead of
             // replacing it: it carries the corrective guidance (the
             // `1password` -> `onepassword` hint, the defined-aliases listing)
             // that the other resolution paths give for the same mistakes.
-            let resolved = self.resolve_one_provider(&source.provider).map_err(|err| {
+            let context = |err: SecretSpecError| {
                 SecretSpecError::ProviderOperationFailed(format!(
                     "bootstrap source for '{var}' in provider alias '{spec}': {err}"
                 ))
-            })?;
+            };
+            let resolved = self
+                .resolve_one_provider(&source.provider)
+                .map_err(context)?;
             // `resolve_one_provider` passes URI-form specs through untouched,
             // so gate the resolved spec's scheme against the registry here:
             // a typo'd scheme should fail at plan time, not surface later as
             // a construction failure a fallback chain downgrades to a warning.
-            let known = crate::provider::spec_names_known_provider(&resolved).map_err(|err| {
-                SecretSpecError::ProviderOperationFailed(format!(
-                    "bootstrap source for '{var}' in provider alias '{spec}': {err}"
-                ))
-            })?;
+            let known = crate::provider::spec_names_known_provider(&resolved).map_err(context)?;
             if !known {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
                     "bootstrap source for '{var}' in provider alias '{spec}' names an unknown \
@@ -827,7 +816,7 @@ impl Secrets {
                 )));
             }
             if let Some(source_alias) = self.lookup_provider_alias_entry(&source.provider)
-                && source_alias.env.as_ref().is_some_and(|env| !env.is_empty())
+                && !source_alias.env.is_empty()
             {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
                     "provider alias '{}' cannot be a bootstrap source for '{spec}' because it \
@@ -892,10 +881,12 @@ impl Secrets {
         }
     }
 
-    /// Audits the result of a single secret write (`set`/generate/prompt): a
-    /// `Written` event on success, an `Error` event (tagged with the error kind)
-    /// on failure. Centralizes the write-audit so every write path records the
-    /// same way and a new one cannot accidentally diverge or skip auditing.
+    /// Audits the result of a single secret write (`set`/generate/prompt/
+    /// bootstrap): a `Written` event on success, an `Error` event (tagged with
+    /// the error kind) on failure. Centralizes the write-audit so every write
+    /// path records the same way and a new one cannot accidentally diverge or
+    /// skip auditing. `command` marks a special-purpose write (the `bootstrap`
+    /// credential store); `None` for a plain secret write.
     fn audit_write_result(
         &self,
         result: &Result<()>,
@@ -903,6 +894,7 @@ impl Secrets {
         profile: &str,
         provider_uri: Option<String>,
         reference: Option<&NativeAddress>,
+        command: Option<&str>,
     ) {
         let (outcome, error_kind) = match result {
             Ok(()) => (AuditOutcome::Written, None),
@@ -914,6 +906,7 @@ impl Secrets {
             outcome,
             AuditFields {
                 key: Some(key),
+                command,
                 provider_uri,
                 reference,
                 error_kind,
@@ -1623,6 +1616,7 @@ impl Secrets {
             &profile_name,
             Some(backend.uri()),
             planned.reference(),
+            None,
         );
         result?;
 
@@ -1898,6 +1892,7 @@ impl Secrets {
                                 &profile_display,
                                 Some(backend.uri()),
                                 planned.reference(),
+                                None,
                             );
                             set_result?;
                             eprintln!(
@@ -2222,6 +2217,7 @@ impl Secrets {
                                     &profile_display,
                                     Some(to_provider.uri()),
                                     planned.reference(),
+                                    None,
                                 );
                                 set_result?;
                                 eprintln!(
@@ -2384,6 +2380,7 @@ impl Secrets {
             profile_name,
             Some(backend.uri()),
             planned.reference(),
+            None,
         );
         set_result?;
 

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -19,6 +19,7 @@ use std::env;
 use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
 
 /// Emits a warning when a provider in a fallback chain fails so the user
 /// can see why a particular link was skipped, without aborting the chain.
@@ -41,22 +42,36 @@ fn warn_provider_failure(display_uri: &str, secret_name: &str, err: &SecretSpecE
 }
 
 /// The error for a declared bootstrap credential that could not be found in its
-/// source provider. Names the variable, the provider needing it, the source, and
-/// exactly how to fix it.
-fn bootstrap_missing_error(
-    var: &str,
-    alias_spec: &str,
-    source: &BootstrapSource,
-) -> SecretSpecError {
-    let location = match &source.reference {
-        Some(reference) => format!("at {}", reference.render()),
-        None => "at the convention path".to_string(),
-    };
+/// source provider. Names the variable, the provider needing it, the exact
+/// location searched, and how to fix it.
+fn bootstrap_missing_error(var: &str, alias_spec: &str, location: &str) -> SecretSpecError {
     SecretSpecError::ProviderOperationFailed(format!(
-        "bootstrap credential '{var}' for provider '{alias_spec}' was not found in '{}' {location}; \
-         store it there, or set {var} in the environment",
-        source.provider
+        "bootstrap credential '{var}' for provider '{alias_spec}' was not found in {location}; \
+         store it there, or set {var} in the environment"
     ))
+}
+
+impl BootstrapSource {
+    /// The store location this source reads and writes: the pinned `ref`, or
+    /// the convention path for the active project and profile. The single
+    /// derivation both [`Secrets::resolve_bootstrap_overlay`] (read) and
+    /// [`Secrets::store_bootstrap_credential`] (write) use, so login-then-resolve
+    /// round-trips by construction.
+    fn address<'a>(&'a self, project: &'a str, profile: &'a str, var: &'a str) -> Address<'a> {
+        match &self.reference {
+            Some(reference) => Address::Native(reference),
+            None => Address::convention(project, profile, var),
+        }
+    }
+
+    /// Human-readable `<provider> at <location>` for prompts and errors,
+    /// describing exactly what [`Self::address`] resolves to.
+    fn location(&self, project: &str, profile: &str, var: &str) -> String {
+        match &self.reference {
+            Some(reference) => format!("{} at {}", self.provider, reference.render()),
+            None => format!("{} at {project}/{profile}/{var}", self.provider),
+        }
+    }
 }
 
 /// Emits a warning when the primary provider for a batch fetch fails (either
@@ -156,6 +171,10 @@ pub struct Secrets {
     /// Audit logger, if auditing is enabled (user-global `[audit]` config). `None`
     /// disables auditing. Built once per `Secrets` so all events share a session id.
     audit: Option<AuditLogger>,
+    /// Bootstrap overlays memoized per raw provider spec, so N secrets routed
+    /// at one bootstrapped alias fetch its credentials from the source provider
+    /// once per session, not once per provider build.
+    bootstrap_overlays: Mutex<HashMap<String, BootstrapEnv>>,
 }
 
 /// secretspec's own opt-in for marking the current process as an agent. Lets any
@@ -324,6 +343,7 @@ impl Secrets {
             reason: None,
             require_reason: RequireReason::Never,
             audit: None,
+            bootstrap_overlays: Mutex::new(HashMap::new()),
         }
     }
 
@@ -399,6 +419,7 @@ impl Secrets {
             profile: None,
             reason: env_reason(),
             audit,
+            bootstrap_overlays: Mutex::new(HashMap::new()),
         })
     }
 
@@ -500,34 +521,49 @@ impl Secrets {
     /// All provider construction in this module goes through here so that the
     /// reason set via [`Secrets::with_reason`] reaches every provider instance.
     fn build_provider(&self, spec: String) -> Result<Box<dyn ProviderTrait>> {
-        // Resolve provider aliases here, at the single construction chokepoint, so
-        // every caller that hands us a user-supplied spec gets alias expansion for
-        // free and no new entry point can forget it. Resolution is a no-op on an
-        // already-resolved URI (a `scheme://...` string is never an alias key), so
-        // callers that pass pre-resolved URIs (the per-secret chain) are unaffected.
-        //
         // When `spec` names an alias with a bootstrap `env` map, resolve those
         // credentials from their source providers into an overlay the built
-        // provider reads before the process environment. Sources are built
-        // non-bootstrap (see `build_source_provider`), so a chain is at most one
-        // hop and cannot recurse.
-        let overlay = self.resolve_bootstrap_overlay(&spec)?;
-        let resolved = self.resolve_provider_spec(spec);
-        let mut provider = crate::provider::provider_from_spec(resolved.as_str(), overlay)
-            .map_err(|err| self.explain_unknown_provider(err, &resolved))?;
-        provider.with_base_dir(&self.config_dir);
-        provider.set_reason(self.reason.clone());
-        Ok(provider)
+        // provider reads before the process environment. Memoized per spec so
+        // rebuilding a provider (per-secret chain walks, interactive prompting)
+        // does not refetch the same credentials from the source store.
+        let cached = self.bootstrap_overlays.lock().unwrap().get(&spec).cloned();
+        let overlay = match cached {
+            Some(overlay) => overlay,
+            None => {
+                let overlay = self.resolve_bootstrap_overlay(&spec)?;
+                self.bootstrap_overlays
+                    .lock()
+                    .unwrap()
+                    .insert(spec.clone(), overlay.clone());
+                overlay
+            }
+        };
+        self.build_provider_with_overlay(&spec, overlay)
     }
 
     /// Builds a bootstrap *source* provider: like [`Self::build_provider`] but
     /// never itself bootstrapped, so a bootstrap chain is at most one hop and can
     /// never recurse. This is the store an alias's `env` credential is read from.
     fn build_source_provider(&self, spec: &str) -> Result<Box<dyn ProviderTrait>> {
+        self.build_provider_with_overlay(spec, BootstrapEnv::new())
+    }
+
+    /// The shared construction body behind [`Self::build_provider`] and
+    /// [`Self::build_source_provider`]: alias expansion, error enrichment, and
+    /// the base-dir/reason hooks live only here, so the two paths cannot drift.
+    fn build_provider_with_overlay(
+        &self,
+        spec: &str,
+        overlay: BootstrapEnv,
+    ) -> Result<Box<dyn ProviderTrait>> {
+        // Resolve provider aliases here, at the single construction chokepoint, so
+        // every caller that hands us a user-supplied spec gets alias expansion for
+        // free and no new entry point can forget it. Resolution is a no-op on an
+        // already-resolved URI (a `scheme://...` string is never an alias key), so
+        // callers that pass pre-resolved URIs (the per-secret chain) are unaffected.
         let resolved = self.resolve_provider_spec(spec.to_string());
-        let mut provider =
-            crate::provider::provider_from_spec(resolved.as_str(), BootstrapEnv::new())
-                .map_err(|err| self.explain_unknown_provider(err, &resolved))?;
+        let mut provider = crate::provider::provider_from_spec(resolved.as_str(), overlay)
+            .map_err(|err| self.explain_unknown_provider(err, &resolved))?;
         provider.with_base_dir(&self.config_dir);
         provider.set_reason(self.reason.clone());
         Ok(provider)
@@ -538,46 +574,56 @@ impl Secrets {
     /// and collect it, so the built provider reads it before the environment.
     ///
     /// Returns an empty overlay for a spec that is not an alias, or an alias with
-    /// no `env`. A variable already present (non-empty) in the process
-    /// environment wins and is not fetched. A declared credential that cannot be
-    /// found is a hard error naming exactly how to fix it.
+    /// no `env`. A variable already set (non-empty) in the process environment
+    /// wins and is not fetched. A declared credential that cannot be found is a
+    /// hard error naming exactly how to fix it. Sources pass
+    /// [`Self::validate_bootstrap_sources`] and are built non-bootstrap, so a
+    /// chain is at most one hop and cannot recurse.
     pub(crate) fn resolve_bootstrap_overlay(&self, spec: &str) -> Result<BootstrapEnv> {
         let mut overlay = BootstrapEnv::new();
-        let Some(alias) = self.lookup_provider_alias_entry(spec) else {
+        if self
+            .lookup_provider_alias_entry(spec)
+            .is_none_or(|alias| alias.env.is_none())
+        {
             return Ok(overlay);
-        };
-        let Some(env) = alias.env.as_ref() else {
-            return Ok(overlay);
-        };
+        }
+        self.validate_bootstrap_sources(spec)?;
 
         let profile = self.resolve_profile_name(None);
         let project = self.config.project.name.clone();
 
-        // Sorted for deterministic fetch order and error messages.
-        let mut vars: Vec<(&String, &BootstrapSource)> = env.iter().collect();
-        vars.sort_by(|(a, _), (b, _)| a.cmp(b));
+        // One provider per distinct source spec, so credentials sharing a source
+        // (e.g. AppRole role and secret ids from one vault) reuse the instance
+        // and whatever it caches, instead of authenticating once per variable.
+        let mut sources: HashMap<String, Box<dyn ProviderTrait>> = HashMap::new();
 
-        for (var, source) in vars {
+        // `bootstrap_credentials` sorts by variable name, so fetch order, error
+        // messages, and the login prompt order all agree.
+        for (var, source) in self.bootstrap_credentials(spec)? {
             // Env wins: an exported value is used by the provider directly, so
             // the declared chain is not consulted (this is what keeps CI working
             // with plain environment variables and no extra configuration).
-            if env::var(var)
-                .map(|value| !value.is_empty())
-                .unwrap_or(false)
-            {
+            if crate::provider::bootstrap_env_var(&var).is_some() {
                 continue;
             }
 
-            let source_provider = self.build_source_provider(&source.provider)?;
-            let value = match &source.reference {
-                Some(reference) => source_provider.get(Address::Native(reference))?,
-                None => source_provider.get(Address::convention(&project, &profile, var))?,
-            };
-            match value {
-                Some(value) => {
-                    overlay.insert(var.clone(), value);
+            let source_provider = match sources.entry(source.provider.clone()) {
+                std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(self.build_source_provider(&source.provider)?)
                 }
-                None => return Err(bootstrap_missing_error(var, spec, source)),
+            };
+            match source_provider.get(source.address(&project, &profile, &var))? {
+                Some(value) => {
+                    overlay.insert(var, value);
+                }
+                None => {
+                    return Err(bootstrap_missing_error(
+                        &var,
+                        spec,
+                        &source.location(&project, &profile, &var),
+                    ));
+                }
             }
         }
 
@@ -614,23 +660,21 @@ impl Secrets {
         let provider = self.build_source_provider(&source.provider)?;
         let profile = self.resolve_profile_name(None);
         let project = self.config.project.name.clone();
-        let address = match &source.reference {
-            Some(reference) => Address::Native(reference),
-            None => Address::convention(&project, &profile, var),
-        };
+        let address = source.address(&project, &profile, var);
         provider.check_writable(address)?;
         provider.set(address, value)?;
-        Ok(match &source.reference {
-            Some(reference) => format!("{} at {}", source.provider, reference.render()),
-            None => format!("{} at {project}/{profile}/{var}", source.provider),
-        })
+        Ok(source.location(&project, &profile, var))
     }
 
-    /// Validates a primary spec's bootstrap `env` at plan time (pure): every
+    /// Validates a spec's bootstrap `env` (pure map lookups, no I/O): every
     /// source must resolve to a known provider, and no source may itself declare
     /// bootstrap `env` (chains are limited to one hop, which also makes cycles
     /// impossible). A no-op for a spec that is not an alias or has no `env`.
-    pub(crate) fn validate_primary_bootstrap(&self, spec: &str) -> Result<()> {
+    /// Run at plan time to fail fast on a routed primary or override, and again
+    /// by [`Self::resolve_bootstrap_overlay`], so every construction path —
+    /// fallback links and the default provider included — enforces the same
+    /// invariants instead of silently dropping a chained source's `env`.
+    pub(crate) fn validate_bootstrap_sources(&self, spec: &str) -> Result<()> {
         let Some(alias) = self.lookup_provider_alias_entry(spec) else {
             return Ok(());
         };
@@ -1018,7 +1062,7 @@ impl Secrets {
             .map(|alias| alias.uri.clone())
     }
 
-    fn resolve_provider_spec(&self, spec: String) -> String {
+    pub(crate) fn resolve_provider_spec(&self, spec: String) -> String {
         self.lookup_provider_alias(&spec).unwrap_or(spec)
     }
 
@@ -1082,20 +1126,11 @@ impl Secrets {
     /// Used as the shared head of provider resolution so the precedence between
     /// the `--provider` flag (forwarded via `set_provider`) and the
     /// `SECRETSPEC_PROVIDER` env var stays consistent across resolvers.
-    fn explicit_provider_spec(&self, override_arg: Option<&str>) -> Option<String> {
+    pub(crate) fn explicit_provider_spec(&self, override_arg: Option<&str>) -> Option<String> {
         override_arg
             .map(|spec| spec.to_string())
             .or_else(|| self.provider.clone())
             .or_else(|| env::var("SECRETSPEC_PROVIDER").ok())
-    }
-
-    /// Returns the explicit provider override resolved to a URI, if one is set.
-    ///
-    /// Resolves the explicit spec via [`Self::explicit_provider_spec`], then
-    /// expands any matching alias via [`Self::lookup_provider_alias`].
-    pub(crate) fn resolve_provider_override(&self, override_arg: Option<&str>) -> Option<String> {
-        let spec = self.explicit_provider_spec(override_arg)?;
-        Some(self.resolve_provider_spec(spec))
     }
 
     /// Fetches one provider group's secrets through the provider's batch
@@ -2587,8 +2622,11 @@ impl Secrets {
         let mut fetched_values: HashMap<String, SecretString> = HashMap::new();
         let mut failed_primary_uris: HashMap<Option<&str>, SecretSpecError> = HashMap::new();
 
-        // Construction is cheap and stays on this thread; only the fetches run
-        // concurrently below.
+        // Construction stays on this thread: the up-front single-store `ref`
+        // check below must see every built provider before any store is
+        // contacted. Building a bootstrapped alias's provider already fetches
+        // its bootstrap credentials here (memoized per spec); only the group
+        // fetches run concurrently below.
         let mut group_fetches: Vec<(Option<&str>, Vec<&PlannedSecret>, Box<dyn ProviderTrait>)> =
             Vec::new();
         for (provider_uri, group) in plan.groups() {
@@ -3227,8 +3265,8 @@ mod reference_routing_tests {
         config: &Secret,
         override_arg: Option<&str>,
     ) -> Option<Vec<String>> {
-        let override_uri = spec.resolve_provider_override(override_arg);
-        spec.route_for(config, &override_uri).unwrap().specs()
+        let override_spec = spec.explicit_provider_spec(override_arg);
+        spec.route_for(config, &override_spec).unwrap().specs()
     }
 
     /// A `ref` supplies naming only: it never contributes to the read chain,
@@ -3280,11 +3318,11 @@ mod reference_routing_tests {
         let _env = crate::tests::scrub_resolution_env();
         let spec = spec_with_provider(None);
         let write_provider = |override_arg: Option<&str>| {
-            let override_uri = spec.resolve_provider_override(override_arg);
+            let override_spec = spec.explicit_provider_spec(override_arg);
             let route = spec
                 .route_for(
                     &ref_secret(Some(vec!["onepassword://Production"])),
-                    &override_uri,
+                    &override_spec,
                 )
                 .unwrap();
             spec.write_provider_for_route(&route).unwrap()

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1,10 +1,13 @@
 //! Core secrets management functionality
 
 use crate::audit::{AuditAction, AuditContext, AuditLogger, AuditOutcome};
-use crate::config::{Config, GlobalConfig, NativeAddress, Profile, RequireReason, Resolved};
+use crate::config::{
+    BootstrapSource, Config, GlobalConfig, NativeAddress, Profile, ProviderAlias, RequireReason,
+    Resolved,
+};
 use crate::error::{Result, SecretSpecError};
 use crate::plan::{PlannedSecret, ResolutionPlan, Route};
-use crate::provider::{Address, Provider as ProviderTrait};
+use crate::provider::{Address, BootstrapEnv, Provider as ProviderTrait};
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
 use crate::validation::{ValidatedSecrets, ValidationErrors};
@@ -35,6 +38,25 @@ fn warn_provider_failure(display_uri: &str, secret_name: &str, err: &SecretSpecE
         secret_name.bold(),
         err
     );
+}
+
+/// The error for a declared bootstrap credential that could not be found in its
+/// source provider. Names the variable, the provider needing it, the source, and
+/// exactly how to fix it.
+fn bootstrap_missing_error(
+    var: &str,
+    alias_spec: &str,
+    source: &BootstrapSource,
+) -> SecretSpecError {
+    let location = match &source.reference {
+        Some(reference) => format!("at {}", reference.render()),
+        None => "at the convention path".to_string(),
+    };
+    SecretSpecError::ProviderOperationFailed(format!(
+        "bootstrap credential '{var}' for provider '{alias_spec}' was not found in '{}' {location}; \
+         store it there, or set {var} in the environment",
+        source.provider
+    ))
 }
 
 /// Emits a warning when the primary provider for a batch fetch fails (either
@@ -483,12 +505,115 @@ impl Secrets {
         // free and no new entry point can forget it. Resolution is a no-op on an
         // already-resolved URI (a `scheme://...` string is never an alias key), so
         // callers that pass pre-resolved URIs (the per-secret chain) are unaffected.
+        //
+        // When `spec` names an alias with a bootstrap `env` map, resolve those
+        // credentials from their source providers into an overlay the built
+        // provider reads before the process environment. Sources are built
+        // non-bootstrap (see `build_source_provider`), so a chain is at most one
+        // hop and cannot recurse.
+        let overlay = self.resolve_bootstrap_overlay(&spec)?;
         let resolved = self.resolve_provider_spec(spec);
-        let mut provider = Box::<dyn ProviderTrait>::try_from(resolved.as_str())
+        let mut provider = crate::provider::provider_from_spec(resolved.as_str(), overlay)
             .map_err(|err| self.explain_unknown_provider(err, &resolved))?;
         provider.with_base_dir(&self.config_dir);
         provider.set_reason(self.reason.clone());
         Ok(provider)
+    }
+
+    /// Builds a bootstrap *source* provider: like [`Self::build_provider`] but
+    /// never itself bootstrapped, so a bootstrap chain is at most one hop and can
+    /// never recurse. This is the store an alias's `env` credential is read from.
+    fn build_source_provider(&self, spec: &str) -> Result<Box<dyn ProviderTrait>> {
+        let resolved = self.resolve_provider_spec(spec.to_string());
+        let mut provider =
+            crate::provider::provider_from_spec(resolved.as_str(), BootstrapEnv::new())
+                .map_err(|err| self.explain_unknown_provider(err, &resolved))?;
+        provider.with_base_dir(&self.config_dir);
+        provider.set_reason(self.reason.clone());
+        Ok(provider)
+    }
+
+    /// Resolves the bootstrap overlay for a provider spec: for each `(VAR, source)`
+    /// its alias declares in `env`, fetch the credential from the source provider
+    /// and collect it, so the built provider reads it before the environment.
+    ///
+    /// Returns an empty overlay for a spec that is not an alias, or an alias with
+    /// no `env`. A variable already present (non-empty) in the process
+    /// environment wins and is not fetched. A declared credential that cannot be
+    /// found is a hard error naming exactly how to fix it.
+    pub(crate) fn resolve_bootstrap_overlay(&self, spec: &str) -> Result<BootstrapEnv> {
+        let mut overlay = BootstrapEnv::new();
+        let Some(alias) = self.lookup_provider_alias_entry(spec) else {
+            return Ok(overlay);
+        };
+        let Some(env) = alias.env.as_ref() else {
+            return Ok(overlay);
+        };
+
+        let profile = self.resolve_profile_name(None);
+        let project = self.config.project.name.clone();
+
+        // Sorted for deterministic fetch order and error messages.
+        let mut vars: Vec<(&String, &BootstrapSource)> = env.iter().collect();
+        vars.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        for (var, source) in vars {
+            // Env wins: an exported value is used by the provider directly, so
+            // the declared chain is not consulted (this is what keeps CI working
+            // with plain environment variables and no extra configuration).
+            if env::var(var)
+                .map(|value| !value.is_empty())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            let source_provider = self.build_source_provider(&source.provider)?;
+            let value = match &source.reference {
+                Some(reference) => source_provider.get(Address::Native(reference))?,
+                None => source_provider.get(Address::convention(&project, &profile, var))?,
+            };
+            match value {
+                Some(value) => {
+                    overlay.insert(var.clone(), value);
+                }
+                None => return Err(bootstrap_missing_error(var, spec, source)),
+            }
+        }
+
+        Ok(overlay)
+    }
+
+    /// Validates a primary spec's bootstrap `env` at plan time (pure): every
+    /// source must resolve to a known provider, and no source may itself declare
+    /// bootstrap `env` (chains are limited to one hop, which also makes cycles
+    /// impossible). A no-op for a spec that is not an alias or has no `env`.
+    pub(crate) fn validate_primary_bootstrap(&self, spec: &str) -> Result<()> {
+        let Some(alias) = self.lookup_provider_alias_entry(spec) else {
+            return Ok(());
+        };
+        let Some(env) = alias.env.as_ref() else {
+            return Ok(());
+        };
+        for (var, source) in env {
+            self.resolve_one_provider(&source.provider).map_err(|_| {
+                SecretSpecError::ProviderNotFound(format!(
+                    "bootstrap source for '{var}' in provider alias '{spec}' names an unknown \
+                     provider '{}'",
+                    source.provider
+                ))
+            })?;
+            if let Some(source_alias) = self.lookup_provider_alias_entry(&source.provider)
+                && source_alias.env.is_some()
+            {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "provider alias '{}' cannot be a bootstrap source for '{spec}' because it \
+                     declares its own bootstrap env; bootstrap chains are limited to one hop",
+                    source.provider
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Enriches a provider-construction failure: when a bare token (no scheme
@@ -829,9 +954,7 @@ impl Secrets {
     /// then user-global config. Project entries win on conflict so teams can
     /// pin shareable mappings in version control while still allowing per-user
     /// overrides via the global config.
-    fn provider_alias_sources(
-        &self,
-    ) -> impl Iterator<Item = &HashMap<String, crate::config::ProviderAlias>> {
+    fn provider_alias_sources(&self) -> impl Iterator<Item = &HashMap<String, ProviderAlias>> {
         self.config.providers.iter().chain(
             self.global_config
                 .as_ref()
@@ -839,11 +962,17 @@ impl Secrets {
         )
     }
 
+    /// Resolves a provider alias to its full entry (URI plus any bootstrap
+    /// `env`), walking [`Self::provider_alias_sources`] in order. Project
+    /// entries win over user-global ones.
+    fn lookup_provider_alias_entry(&self, alias: &str) -> Option<&ProviderAlias> {
+        self.provider_alias_sources().find_map(|m| m.get(alias))
+    }
+
     /// Resolves a single provider alias to its URI, walking
     /// [`Self::provider_alias_sources`] in order.
     fn lookup_provider_alias(&self, alias: &str) -> Option<String> {
-        self.provider_alias_sources()
-            .find_map(|m| m.get(alias))
+        self.lookup_provider_alias_entry(alias)
             .map(|alias| alias.uri.clone())
     }
 
@@ -950,7 +1079,9 @@ impl Secrets {
     /// consults the fallback, so an undefined alias further down the chain does
     /// not affect it.
     fn write_provider_for_route(&self, route: &Route) -> Result<Box<dyn ProviderTrait>> {
-        self.get_provider(route.primary())
+        // Build from the primary spec (not the resolved URI) so an alias's
+        // bootstrap `env` is applied to the write target too.
+        self.get_provider(route.group_key())
     }
 
     /// Gets the provider instance to use for secret operations
@@ -1079,7 +1210,9 @@ impl Secrets {
                         continue;
                     }
                 };
-                let provider = match self.build_provider(uri.clone()) {
+                // Build from the raw spec (not the resolved URI) so an alias's
+                // bootstrap `env` is applied to this chain link too.
+                let provider = match self.build_provider(spec.clone()) {
                     Ok(p) => p,
                     Err(e) => {
                         // Construction failed after resolution, so redact the
@@ -2487,7 +2620,9 @@ impl Secrets {
             let name = &planned.name;
             let required = planned.required();
             let as_path = planned.as_path();
-            let primary_uri = planned.route.primary();
+            // The group key (primary spec), matching how `group_uris` and
+            // `failed_primary_uris` were keyed from `plan.groups()` above.
+            let primary_uri = planned.route.group_key();
 
             let status;
             let mut source_provider = None;

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -19,7 +19,7 @@ use std::env;
 use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// Emits a warning when a provider in a fallback chain fails so the user
 /// can see why a particular link was skipped, without aborting the chain.
@@ -63,6 +63,11 @@ fn sorted_bootstrap_entries(
 }
 
 impl BootstrapSource {
+    /// Credential-free provider text for prompts and diagnostics.
+    pub(crate) fn display_provider(&self) -> String {
+        crate::audit::redact_uri_strict(&self.provider)
+    }
+
     /// The store location this source reads and writes: the pinned `ref`, or
     /// the convention path for the active project and profile. The single
     /// derivation both [`Secrets::resolve_bootstrap_overlay`] (read) and
@@ -81,11 +86,69 @@ impl BootstrapSource {
     /// (`onepassword+token://tok@Vault`), and this string reaches stderr and
     /// the `config provider login` output.
     fn location(&self, project: &str, profile: &str, var: &str) -> String {
-        let provider = crate::audit::redact_uri_strict(&self.provider);
+        let provider = self.display_provider();
         match &self.reference {
             Some(reference) => format!("{provider} at {}", reference.render()),
             None => format!("{provider} at {project}/{profile}/{var}"),
         }
+    }
+}
+
+type BootstrapOverlayKey = (String, String);
+type BootstrapOverlaySlot = Arc<Mutex<Option<BootstrapEnv>>>;
+
+/// Memoized bootstrap overlays with single-flight population per key.
+///
+/// The outer mutex protects only the key-to-slot map. Resolution runs while
+/// holding the selected slot, so callers for the same alias/profile wait for
+/// its first fetch while unrelated keys can populate concurrently.
+#[derive(Default)]
+struct BootstrapOverlayCache {
+    entries: Mutex<HashMap<BootstrapOverlayKey, BootstrapOverlaySlot>>,
+}
+
+impl BootstrapOverlayCache {
+    fn get_or_try_init<F>(&self, key: BootstrapOverlayKey, resolve: F) -> Result<BootstrapEnv>
+    where
+        F: FnOnce() -> Result<BootstrapEnv>,
+    {
+        let slot = {
+            let mut entries = self.entries.lock().unwrap();
+            Arc::clone(
+                entries
+                    .entry(key.clone())
+                    .or_insert_with(|| Arc::new(Mutex::new(None))),
+            )
+        };
+
+        let mut cached = slot.lock().unwrap();
+        if let Some(overlay) = cached.as_ref() {
+            return Ok(overlay.clone());
+        }
+
+        match resolve() {
+            Ok(overlay) => {
+                *cached = Some(overlay.clone());
+                Ok(overlay)
+            }
+            Err(err) => {
+                // Do not memoize failures: a later operation may succeed after
+                // credentials or provider availability change.
+                drop(cached);
+                let mut entries = self.entries.lock().unwrap();
+                if entries
+                    .get(&key)
+                    .is_some_and(|current| Arc::ptr_eq(current, &slot))
+                {
+                    entries.remove(&key);
+                }
+                Err(err)
+            }
+        }
+    }
+
+    fn clear(&self) {
+        self.entries.lock().unwrap().clear();
     }
 }
 
@@ -194,7 +257,7 @@ pub struct Secrets {
     /// not reuse the other profile's credential. Cleared by
     /// [`Secrets::store_bootstrap_credential`] so a freshly stored credential
     /// is re-read.
-    bootstrap_overlays: Mutex<HashMap<(String, String), BootstrapEnv>>,
+    bootstrap_overlays: BootstrapOverlayCache,
 }
 
 /// secretspec's own opt-in for marking the current process as an agent. Lets any
@@ -363,7 +426,7 @@ impl Secrets {
             reason: None,
             require_reason: RequireReason::Never,
             audit: None,
-            bootstrap_overlays: Mutex::new(HashMap::new()),
+            bootstrap_overlays: BootstrapOverlayCache::default(),
         }
     }
 
@@ -439,7 +502,7 @@ impl Secrets {
             profile: None,
             reason: env_reason(),
             audit,
-            bootstrap_overlays: Mutex::new(HashMap::new()),
+            bootstrap_overlays: BootstrapOverlayCache::default(),
         })
     }
 
@@ -553,25 +616,16 @@ impl Secrets {
     ) -> Result<Box<dyn ProviderTrait>> {
         // When `spec` names an alias with a bootstrap `env` map, resolve those
         // credentials from their source providers into an overlay the built
-        // provider reads before the process environment. Memoized per
-        // (profile, spec) so rebuilding a provider (per-secret chain walks,
+        // provider uses when the process environment has no non-empty value.
+        // Memoized per (profile, spec) so rebuilding a provider (per-secret chain walks,
         // interactive prompting) does not refetch the same credentials from
         // the source store, while a profile switch on this instance does not
         // reuse the other profile's credentials.
         let profile = self.resolve_profile_name(profile);
         let key = (profile.clone(), spec.clone());
-        let cached = self.bootstrap_overlays.lock().unwrap().get(&key).cloned();
-        let overlay = match cached {
-            Some(overlay) => overlay,
-            None => {
-                let overlay = self.resolve_bootstrap_overlay(&spec, &profile)?;
-                self.bootstrap_overlays
-                    .lock()
-                    .unwrap()
-                    .insert(key, overlay.clone());
-                overlay
-            }
-        };
+        let overlay = self
+            .bootstrap_overlays
+            .get_or_try_init(key, || self.resolve_bootstrap_overlay(&spec, &profile))?;
         self.build_provider_with_overlay(&spec, overlay)
     }
 
@@ -605,7 +659,7 @@ impl Secrets {
 
     /// Resolves the bootstrap overlay for a provider spec: for each `(VAR, source)`
     /// its alias declares in `env`, fetch the credential from the source provider
-    /// and collect it, so the built provider reads it before the environment.
+    /// and collect it as a fallback for a missing or empty environment value.
     ///
     /// `profile` scopes the convention path a bare-string source reads from.
     /// Returns an empty overlay for a spec that is not an alias, or an alias with
@@ -724,12 +778,17 @@ impl Secrets {
     }
 
     /// The bootstrap credentials a provider alias declares, sorted by variable
-    /// name, for the `config provider login` flow. Errors if the alias is not
-    /// defined; returns an empty list for an alias with no `env`.
+    /// name, for the `config provider login` flow. Validates every source before
+    /// returning any credentials. Errors if the alias is not defined; returns
+    /// an empty list for an alias with no `env`.
     pub(crate) fn bootstrap_credentials(
         &self,
         alias: &str,
     ) -> Result<Vec<(String, BootstrapSource)>> {
+        // Validate the complete map before returning any entry. The login CLI
+        // prompts and writes only after this method succeeds, so a later-sorted
+        // invalid source cannot leave earlier credentials partially stored.
+        self.validate_bootstrap_sources(alias)?;
         let entry = self
             .lookup_provider_alias_entry(alias)
             .ok_or_else(|| SecretSpecError::ProviderNotFound(alias.to_string()))?;
@@ -774,7 +833,7 @@ impl Secrets {
         result?;
         // The stored credential replaces whatever an earlier resolution
         // memoized; drop the memo so the next build re-reads it.
-        self.bootstrap_overlays.lock().unwrap().clear();
+        self.bootstrap_overlays.clear();
         Ok(source.location(&project, &profile, var))
     }
 
@@ -3249,6 +3308,54 @@ mod policy_tests {
             Some(&OsString::from("secret_wins"))
         );
         assert_eq!(env.len(), 4);
+    }
+}
+
+#[cfg(test)]
+mod bootstrap_overlay_cache_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn concurrent_population_for_one_key_is_single_flight() {
+        const CALLERS: usize = 8;
+        let cache = Arc::new(BootstrapOverlayCache::default());
+        let start = Arc::new(Barrier::new(CALLERS));
+        let fetches = Arc::new(AtomicUsize::new(0));
+
+        let threads: Vec<_> = (0..CALLERS)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let start = Arc::clone(&start);
+                let fetches = Arc::clone(&fetches);
+                thread::spawn(move || {
+                    start.wait();
+                    cache
+                        .get_or_try_init(("default".into(), "target".into()), || {
+                            fetches.fetch_add(1, Ordering::SeqCst);
+                            // Keep the first population in flight long enough for
+                            // every caller to contend on the same key.
+                            thread::sleep(Duration::from_millis(50));
+                            let mut overlay = BootstrapEnv::new();
+                            overlay.insert("TOKEN".into(), SecretString::new("value".into()));
+                            Ok(overlay)
+                        })
+                        .unwrap()
+                })
+            })
+            .collect();
+
+        for thread in threads {
+            let overlay = thread.join().unwrap();
+            assert_eq!(
+                overlay.get("TOKEN").map(|value| value.expose_secret()),
+                Some("value")
+            );
+        }
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
     }
 }
 

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::config::{
-    BootstrapSource, Config, GlobalConfig, GlobalDefaults, NativeAddress, ParseError, Profile,
+    Config, CredentialSource, GlobalConfig, GlobalDefaults, NativeAddress, ParseError, Profile,
     Project, ProviderAlias, RequireReason, Resolved, Secret,
 };
 use crate::error::{Result, SecretSpecError};
@@ -5057,7 +5057,7 @@ fn test_override_skips_read_chain() {
         .expect("override resolution should succeed");
 
     // The read walks the raw override spec only (the alias is expanded at build
-    // time, where its bootstrap `env` is still reachable); the resolved URI is
+    // time, where its `credentials` is still reachable); the resolved URI is
     // carried for display.
     assert_eq!(
         route.specs(),
@@ -6077,66 +6077,66 @@ fn test_resolve_profile_unknown_returns_invalid_profile() {
     }
 }
 
-// --- Provider bootstrap: overlay resolution and validation ---
+// --- Provider credential resolution and validation ---
 
 /// Builds a `Secrets` whose only project provider alias is `target`, carrying
-/// the given bootstrap `env` map.
-fn secrets_with_bootstrap_alias(
+/// the given semantic credential-source map.
+fn secrets_with_credential_alias(
     target_uri: &str,
-    env: HashMap<String, BootstrapSource>,
+    credentials: HashMap<String, CredentialSource>,
 ) -> Secrets {
     let mut config = resolve_test_config(HashMap::new());
     config.providers = Some(HashMap::from([(
         "target".to_string(),
         ProviderAlias {
             uri: target_uri.to_string(),
-            env,
+            credentials,
         },
     )]));
     Secrets::new(config, None, None, None)
 }
 
 #[test]
-fn bootstrap_overlay_reads_convention_credential_from_source() {
+fn provider_credentials_read_convention_credential_from_source() {
     let _guard = scrub_resolution_env();
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.env");
     // dotenv addresses a convention secret by the flat key name.
-    std::fs::write(&source, "BOOTSTRAP_READ_VAR=secret-abc\n").unwrap();
+    std::fs::write(&source, "access_token=secret-abc\n").unwrap();
 
-    let secrets = secrets_with_bootstrap_alias(
-        "env://",
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
         HashMap::from([(
-            "BOOTSTRAP_READ_VAR".to_string(),
-            BootstrapSource::from(format!("dotenv://{}", source.display())),
+            "access_token".to_string(),
+            CredentialSource::from(format!("dotenv://{}", source.display())),
         )]),
     );
 
-    let overlay = secrets
-        .resolve_bootstrap_overlay("target", "default")
+    let credentials = secrets
+        .resolve_provider_credentials("target", "default")
         .unwrap();
     assert_eq!(
-        overlay
-            .get("BOOTSTRAP_READ_VAR")
+        credentials
+            .get("access_token")
             .map(|value| value.expose_secret().to_string()),
         Some("secret-abc".to_string()),
     );
 }
 
 #[test]
-fn bootstrap_source_credential_reaches_target_provider_end_to_end() {
+fn sourced_credential_reaches_target_provider_end_to_end() {
     let _guard = scrub_resolution_env();
     let _token = EnvVarGuard::remove("OP_SERVICE_ACCOUNT_TOKEN");
     let temp = TempDir::new().unwrap();
 
     let target_scope = |filename: &str, token: &str| {
         let source = temp.path().join(filename);
-        std::fs::write(&source, format!("OP_SERVICE_ACCOUNT_TOKEN={token}\n")).unwrap();
-        let secrets = secrets_with_bootstrap_alias(
+        std::fs::write(&source, format!("service_account_token={token}\n")).unwrap();
+        let secrets = secrets_with_credential_alias(
             "onepassword://Private",
             HashMap::from([(
-                "OP_SERVICE_ACCOUNT_TOKEN".to_string(),
-                BootstrapSource::from(format!("dotenv://{}", source.display())),
+                "service_account_token".to_string(),
+                CredentialSource::from(format!("dotenv://{}", source.display())),
             )]),
         );
 
@@ -6164,19 +6164,19 @@ fn bootstrap_source_credential_reaches_target_provider_end_to_end() {
 }
 
 #[test]
-fn bootstrap_overlay_reads_ref_addressed_credential() {
+fn provider_credentials_read_ref_addressed_credential() {
     let _guard = scrub_resolution_env();
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.env");
     std::fs::write(&source, "SOURCE_KEY=secret-xyz\n").unwrap();
 
-    // The env variable name (MY_TOKEN) and the source key (SOURCE_KEY) differ;
+    // The semantic credential name and the source key differ;
     // `ref` pins the exact location.
-    let secrets = secrets_with_bootstrap_alias(
-        "env://",
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
         HashMap::from([(
-            "MY_TOKEN".to_string(),
-            BootstrapSource {
+            "access_token".to_string(),
+            CredentialSource {
                 provider: format!("dotenv://{}", source.display()),
                 reference: Some(NativeAddress {
                     item: "SOURCE_KEY".to_string(),
@@ -6186,78 +6186,80 @@ fn bootstrap_overlay_reads_ref_addressed_credential() {
         )]),
     );
 
-    let overlay = secrets
-        .resolve_bootstrap_overlay("target", "default")
+    let credentials = secrets
+        .resolve_provider_credentials("target", "default")
         .unwrap();
     assert_eq!(
-        overlay
-            .get("MY_TOKEN")
+        credentials
+            .get("access_token")
             .map(|value| value.expose_secret().to_string()),
         Some("secret-xyz".to_string()),
     );
 }
 
 #[test]
-fn bootstrap_overlay_lets_the_environment_win() {
+fn configured_credential_is_resolved_even_when_provider_env_is_set() {
     let _guard = scrub_resolution_env();
-    const VAR: &str = "BOOTSTRAP_ENVWINS_VAR";
-    let _var = EnvVarGuard::set(VAR, "from-env");
+    let _var = EnvVarGuard::set("BWS_ACCESS_TOKEN", "from-env");
 
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.env");
-    std::fs::write(&source, format!("{VAR}=from-source\n")).unwrap();
+    std::fs::write(&source, "access_token=from-source\n").unwrap();
 
-    let secrets = secrets_with_bootstrap_alias(
-        "env://",
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
         HashMap::from([(
-            VAR.to_string(),
-            BootstrapSource::from(format!("dotenv://{}", source.display())),
+            "access_token".to_string(),
+            CredentialSource::from(format!("dotenv://{}", source.display())),
         )]),
     );
 
-    let overlay = secrets
-        .resolve_bootstrap_overlay("target", "default")
+    let credentials = secrets
+        .resolve_provider_credentials("target", "default")
         .unwrap();
-    // The environment satisfies the variable, so the chain is not consulted and
-    // the overlay carries nothing for it (the provider reads the env directly).
-    assert!(!overlay.contains_key(VAR));
+    assert_eq!(
+        credentials
+            .get("access_token")
+            .map(|value| value.expose_secret()),
+        Some("from-source")
+    );
 }
 
 #[test]
-fn bootstrap_overlay_missing_credential_is_an_actionable_error() {
+fn missing_provider_credential_is_an_actionable_error() {
     let _guard = scrub_resolution_env();
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.env");
     std::fs::write(&source, "").unwrap();
 
-    let secrets = secrets_with_bootstrap_alias(
-        "env://",
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
         HashMap::from([(
-            "BOOTSTRAP_MISSING_VAR".to_string(),
-            BootstrapSource::from(format!("dotenv://{}", source.display())),
+            "access_token".to_string(),
+            CredentialSource::from(format!("dotenv://{}", source.display())),
         )]),
     );
 
     let error = secrets
-        .resolve_bootstrap_overlay("target", "default")
+        .resolve_provider_credentials("target", "default")
         .unwrap_err();
     let message = error.to_string();
     assert!(
-        message.contains("BOOTSTRAP_MISSING_VAR") && message.contains("not found"),
-        "error should name the variable and say it was not found: {message}"
+        message.contains("access_token") && message.contains("not found"),
+        "error should name the credential and say it was not found: {message}"
     );
 }
 
 #[test]
-fn bootstrap_source_must_name_a_known_provider() {
-    let secrets = secrets_with_bootstrap_alias(
-        "bws://project",
+fn credential_source_must_name_a_known_provider() {
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
         HashMap::from([(
-            "TOKEN".to_string(),
-            BootstrapSource::from("not_a_real_provider"),
+            "access_token".to_string(),
+            CredentialSource::from("not_a_real_provider"),
         )]),
     );
-    let error = secrets.validate_bootstrap_sources("target").unwrap_err();
+    let error = secrets.validate_credential_sources("target").unwrap_err();
     assert!(
         error.to_string().contains("not_a_real_provider"),
         "error should name the unknown source: {error}"
@@ -6265,28 +6267,44 @@ fn bootstrap_source_must_name_a_known_provider() {
 }
 
 #[test]
-fn bootstrap_credentials_validates_every_source_before_login() {
-    let secrets = secrets_with_bootstrap_alias(
-        "bws://project",
+fn credential_name_must_be_supported_by_target_provider() {
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
+        HashMap::from([(
+            "BWS_ACCESS_TOKEN".to_string(),
+            CredentialSource::from("keyring"),
+        )]),
+    );
+
+    let error = secrets.validate_credential_sources("target").unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains("BWS_ACCESS_TOKEN"), "{message}");
+    assert!(message.contains("access_token"), "{message}");
+}
+
+#[test]
+fn declared_provider_credentials_validates_every_source_before_login() {
+    let secrets = secrets_with_credential_alias(
+        "vault://secret/app?auth=approle",
         HashMap::from([
             (
-                "A_VALID_FIRST".to_string(),
-                BootstrapSource::from("dotenv://source.env"),
+                "role_id".to_string(),
+                CredentialSource::from("dotenv://source.env"),
             ),
             (
-                "Z_INVALID_LAST".to_string(),
-                BootstrapSource::from("not_a_real_provider"),
+                "secret_id".to_string(),
+                CredentialSource::from("not_a_real_provider"),
             ),
         ]),
     );
 
-    let error = secrets.bootstrap_credentials("target").unwrap_err();
-    assert!(error.to_string().contains("Z_INVALID_LAST"));
+    let error = secrets.declared_provider_credentials("target").unwrap_err();
+    assert!(error.to_string().contains("secret_id"));
 }
 
 #[test]
-fn bootstrap_source_display_redacts_inline_credentials() {
-    let source = BootstrapSource::from("onepassword+token://ops_secret@Vault");
+fn credential_source_display_redacts_inline_credentials() {
+    let source = CredentialSource::from("onepassword+token://ops_secret@Vault");
     let displayed = source.display_provider();
 
     assert_eq!(displayed, "onepassword+token://Vault");
@@ -6294,27 +6312,33 @@ fn bootstrap_source_display_redacts_inline_credentials() {
 }
 
 #[test]
-fn bootstrap_chain_is_limited_to_one_hop() {
+fn credential_chain_is_limited_to_one_hop() {
     let mut config = resolve_test_config(HashMap::new());
     config.providers = Some(HashMap::from([
-        // `chained` itself declares bootstrap env, so it may not be a source.
+        // `chained` itself declares credentials, so it may not be a source.
         (
             "chained".to_string(),
             ProviderAlias {
                 uri: "keyring://".to_string(),
-                env: HashMap::from([("INNER".to_string(), BootstrapSource::from("keyring"))]),
+                credentials: HashMap::from([(
+                    "access_token".to_string(),
+                    CredentialSource::from("keyring"),
+                )]),
             },
         ),
         (
             "target".to_string(),
             ProviderAlias {
-                uri: "bws://project".to_string(),
-                env: HashMap::from([("TOKEN".to_string(), BootstrapSource::from("chained"))]),
+                uri: "bws://00000000-0000-0000-0000-000000000000".to_string(),
+                credentials: HashMap::from([(
+                    "access_token".to_string(),
+                    CredentialSource::from("chained"),
+                )]),
             },
         ),
     ]));
     let secrets = Secrets::new(config, None, None, None);
-    let error = secrets.validate_bootstrap_sources("target").unwrap_err();
+    let error = secrets.validate_credential_sources("target").unwrap_err();
     assert!(
         error.to_string().contains("one hop"),
         "error should explain the one-hop limit: {error}"
@@ -6322,26 +6346,26 @@ fn bootstrap_chain_is_limited_to_one_hop() {
 }
 
 #[test]
-fn bootstrap_credential_round_trips_through_its_source() {
+fn provider_credential_round_trips_through_its_source() {
     let _guard = scrub_resolution_env();
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.env");
     std::fs::write(&source, "").unwrap();
 
-    let secrets = secrets_with_bootstrap_alias(
-        "env://",
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
         HashMap::from([(
-            "ROUND_TRIP_VAR".to_string(),
-            BootstrapSource::from(format!("dotenv://{}", source.display())),
+            "access_token".to_string(),
+            CredentialSource::from(format!("dotenv://{}", source.display())),
         )]),
     );
 
-    let credentials = secrets.bootstrap_credentials("target").unwrap();
+    let credentials = secrets.declared_provider_credentials("target").unwrap();
     assert_eq!(credentials.len(), 1);
     let (var, source_spec) = &credentials[0];
 
     secrets
-        .store_bootstrap_credential(
+        .store_provider_credential(
             source_spec,
             var,
             &secrecy::SecretString::new("stored-value".into()),
@@ -6349,32 +6373,32 @@ fn bootstrap_credential_round_trips_through_its_source() {
         .unwrap();
 
     // Stored and read back through the same address the resolver uses.
-    let overlay = secrets
-        .resolve_bootstrap_overlay("target", "default")
+    let resolved = secrets
+        .resolve_provider_credentials("target", "default")
         .unwrap();
     assert_eq!(
-        overlay
-            .get("ROUND_TRIP_VAR")
+        resolved
+            .get("access_token")
             .map(|value| value.expose_secret().to_string()),
         Some("stored-value".to_string()),
     );
 }
 
-/// The overlay memo is keyed by profile: building the target for one profile
+/// The credential memo is keyed by profile: building the target for one profile
 /// memoizes only that profile's credentials, and another profile re-fetches
 /// from the source instead of reusing them.
 #[test]
-fn bootstrap_overlay_memoizes_per_profile() {
+fn provider_credentials_memoize_per_profile() {
     let _guard = scrub_resolution_env();
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.env");
-    std::fs::write(&source, "SECRETSPEC_TEST_PROFILE_SCOPED_VAR=v1\n").unwrap();
+    std::fs::write(&source, "access_token=v1\n").unwrap();
 
-    let secrets = secrets_with_bootstrap_alias(
-        "env://",
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
         HashMap::from([(
-            "SECRETSPEC_TEST_PROFILE_SCOPED_VAR".to_string(),
-            BootstrapSource::from(format!("dotenv://{}", source.display())),
+            "access_token".to_string(),
+            CredentialSource::from(format!("dotenv://{}", source.display())),
         )]),
     );
 
@@ -6399,20 +6423,20 @@ fn bootstrap_overlay_memoizes_per_profile() {
 }
 
 /// Storing a credential through its source (the `login` flow) clears the
-/// overlay memo, so the next build re-reads the store instead of resolving to
+/// credential memo, so the next build re-reads the store instead of resolving to
 /// the stale cached value.
 #[test]
-fn storing_a_bootstrap_credential_invalidates_the_memo() {
+fn storing_a_provider_credential_invalidates_the_memo() {
     let _guard = scrub_resolution_env();
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.env");
-    std::fs::write(&source, "SECRETSPEC_TEST_ROTATED_VAR=old\n").unwrap();
+    std::fs::write(&source, "access_token=old\n").unwrap();
 
-    let secrets = secrets_with_bootstrap_alias(
-        "env://",
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
         HashMap::from([(
-            "SECRETSPEC_TEST_ROTATED_VAR".to_string(),
-            BootstrapSource::from(format!("dotenv://{}", source.display())),
+            "access_token".to_string(),
+            CredentialSource::from(format!("dotenv://{}", source.display())),
         )]),
     );
 
@@ -6421,10 +6445,10 @@ fn storing_a_bootstrap_credential_invalidates_the_memo() {
         .get_provider(Some("target"), Some("default"))
         .expect("the source supplies the credential");
 
-    let credentials = secrets.bootstrap_credentials("target").unwrap();
+    let credentials = secrets.declared_provider_credentials("target").unwrap();
     let (var, source_spec) = &credentials[0];
     secrets
-        .store_bootstrap_credential(source_spec, var, &secrecy::SecretString::new("new".into()))
+        .store_provider_credential(source_spec, var, &secrecy::SecretString::new("new".into()))
         .unwrap();
 
     // Empty the source: only a memo hit could satisfy the next build, so a
@@ -6439,31 +6463,36 @@ fn storing_a_bootstrap_credential_invalidates_the_memo() {
 }
 
 #[test]
-fn bootstrap_credentials_errors_for_an_unknown_alias() {
+fn declared_provider_credentials_errors_for_an_unknown_alias() {
     let secrets = Secrets::new(resolve_test_config(HashMap::new()), None, None, None);
-    assert!(secrets.bootstrap_credentials("nope").is_err());
+    assert!(secrets.declared_provider_credentials("nope").is_err());
 }
 
 #[test]
-fn bootstrap_credentials_is_empty_for_an_alias_without_env() {
+fn declared_provider_credentials_is_empty_for_an_alias_without_credentials() {
     let mut config = resolve_test_config(HashMap::new());
     config.providers = Some(HashMap::from([(
         "plain".to_string(),
         ProviderAlias::from("keyring://"),
     )]));
     let secrets = Secrets::new(config, None, None, None);
-    assert!(secrets.bootstrap_credentials("plain").unwrap().is_empty());
+    assert!(
+        secrets
+            .declared_provider_credentials("plain")
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
-fn store_bootstrap_credential_rejects_a_read_only_source() {
-    let secrets = secrets_with_bootstrap_alias(
-        "env://",
-        HashMap::from([("V".to_string(), BootstrapSource::from("env://"))]),
+fn store_provider_credential_rejects_a_read_only_source() {
+    let secrets = secrets_with_credential_alias(
+        "bws://00000000-0000-0000-0000-000000000000",
+        HashMap::from([("access_token".to_string(), CredentialSource::from("env://"))]),
     );
-    let credentials = secrets.bootstrap_credentials("target").unwrap();
+    let credentials = secrets.declared_provider_credentials("target").unwrap();
     let (var, source_spec) = &credentials[0];
-    let result = secrets.store_bootstrap_credential(
+    let result = secrets.store_provider_credential(
         source_spec,
         var,
         &secrecy::SecretString::new("x".into()),

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6124,6 +6124,46 @@ fn bootstrap_overlay_reads_convention_credential_from_source() {
 }
 
 #[test]
+fn bootstrap_source_credential_reaches_target_provider_end_to_end() {
+    let _guard = scrub_resolution_env();
+    let _token = EnvVarGuard::remove("OP_SERVICE_ACCOUNT_TOKEN");
+    let temp = TempDir::new().unwrap();
+
+    let target_scope = |filename: &str, token: &str| {
+        let source = temp.path().join(filename);
+        std::fs::write(&source, format!("OP_SERVICE_ACCOUNT_TOKEN={token}\n")).unwrap();
+        let secrets = secrets_with_bootstrap_alias(
+            "onepassword://Private",
+            HashMap::from([(
+                "OP_SERVICE_ACCOUNT_TOKEN".to_string(),
+                BootstrapSource::from(format!("dotenv://{}", source.display())),
+            )]),
+        );
+
+        secrets
+            .get_provider(Some("target"), Some("default"))
+            .expect("the source credential should build the target provider")
+            .auth_scope_key()
+            .expect("onepassword should identify its effective authentication scope")
+    };
+
+    let first = target_scope("first.env", "source-token-a");
+    let same = target_scope("same.env", "source-token-a");
+    let different = target_scope("different.env", "source-token-b");
+
+    assert_eq!(
+        first, same,
+        "the same fetched credential yields the same scope"
+    );
+    assert_ne!(
+        first, different,
+        "changing the source credential must change the target's effective auth scope"
+    );
+    assert!(!first.contains("source-token-a"));
+    assert!(!different.contains("source-token-b"));
+}
+
+#[test]
 fn bootstrap_overlay_reads_ref_addressed_credential() {
     let _guard = scrub_resolution_env();
     let temp = TempDir::new().unwrap();
@@ -6222,6 +6262,35 @@ fn bootstrap_source_must_name_a_known_provider() {
         error.to_string().contains("not_a_real_provider"),
         "error should name the unknown source: {error}"
     );
+}
+
+#[test]
+fn bootstrap_credentials_validates_every_source_before_login() {
+    let secrets = secrets_with_bootstrap_alias(
+        "bws://project",
+        HashMap::from([
+            (
+                "A_VALID_FIRST".to_string(),
+                BootstrapSource::from("dotenv://source.env"),
+            ),
+            (
+                "Z_INVALID_LAST".to_string(),
+                BootstrapSource::from("not_a_real_provider"),
+            ),
+        ]),
+    );
+
+    let error = secrets.bootstrap_credentials("target").unwrap_err();
+    assert!(error.to_string().contains("Z_INVALID_LAST"));
+}
+
+#[test]
+fn bootstrap_source_display_redacts_inline_credentials() {
+    let source = BootstrapSource::from("onepassword+token://ops_secret@Vault");
+    let displayed = source.display_provider();
+
+    assert_eq!(displayed, "onepassword+token://Vault");
+    assert!(!displayed.contains("ops_secret"));
 }
 
 #[test]

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -3082,19 +3082,13 @@ fn test_per_secret_provider_configuration() {
     };
 
     // Create global config with provider aliases
-    let mut providers_map = HashMap::new();
-    providers_map.insert("shared".to_string(), "keyring://".to_string());
+    let providers_map = aliases_map(&[("shared", "keyring://")]);
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: Some("env".to_string()),
             profile: None,
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -3116,20 +3110,16 @@ fn test_per_secret_provider_configuration() {
 
 #[test]
 fn test_provider_alias_resolution() {
-    let mut providers_map = HashMap::new();
-    providers_map.insert("dev".to_string(), "dotenv://.env.development".to_string());
-    providers_map.insert("prod".to_string(), "onepassword://Production".to_string());
+    let providers_map = aliases_map(&[
+        ("dev", "dotenv://.env.development"),
+        ("prod", "onepassword://Production"),
+    ]);
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: None,
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -3163,19 +3153,13 @@ fn test_provider_alias_resolution() {
 
 #[test]
 fn test_provider_alias_not_found() {
-    let mut providers_map = HashMap::new();
-    providers_map.insert("existing".to_string(), "dotenv://.env".to_string());
+    let providers_map = aliases_map(&[("existing", "dotenv://.env")]);
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: None,
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -3263,26 +3247,16 @@ fn test_per_secret_provider_with_fallback_chain() {
         providers: None,
     };
 
-    let mut providers_map = HashMap::new();
-    providers_map.insert(
-        "primary".to_string(),
-        format!("dotenv://{}", env_file.display()),
-    );
-    providers_map.insert(
-        "fallback".to_string(),
-        format!("dotenv://{}", keyring_file.display()),
-    );
+    let providers_map = aliases_map(&[
+        ("primary", &format!("dotenv://{}", env_file.display())),
+        ("fallback", &format!("dotenv://{}", keyring_file.display())),
+    ]);
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: None,
             profile: None,
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -3366,26 +3340,16 @@ fn test_get_secret_with_fallback_chain() {
         providers: None,
     };
 
-    let mut providers_map = HashMap::new();
-    providers_map.insert(
-        "primary".to_string(),
-        format!("dotenv://{}", primary_file.display()),
-    );
-    providers_map.insert(
-        "fallback".to_string(),
-        format!("dotenv://{}", fallback_file.display()),
-    );
+    let providers_map = aliases_map(&[
+        ("primary", &format!("dotenv://{}", primary_file.display())),
+        ("fallback", &format!("dotenv://{}", fallback_file.display())),
+    ]);
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()), // Default fallback provider
             profile: None,
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -3454,26 +3418,16 @@ fn test_validate_falls_back_on_primary_provider_error() {
         providers: None,
     };
 
-    let mut providers_map = HashMap::new();
-    providers_map.insert(
-        "primary".to_string(),
-        format!("dotenv://{}", primary_dir.display()),
-    );
-    providers_map.insert(
-        "fallback".to_string(),
-        format!("dotenv://{}", fallback_file.display()),
-    );
+    let providers_map = aliases_map(&[
+        ("primary", &format!("dotenv://{}", primary_dir.display())),
+        ("fallback", &format!("dotenv://{}", fallback_file.display())),
+    ]);
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: None,
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -3533,20 +3487,16 @@ fn test_validate_surfaces_error_when_all_providers_fail() {
         providers: None,
     };
 
-    let mut providers_map = HashMap::new();
-    providers_map.insert("a".to_string(), format!("dotenv://{}", broken_a.display()));
-    providers_map.insert("b".to_string(), format!("dotenv://{}", broken_b.display()));
+    let providers_map = aliases_map(&[
+        ("a", &format!("dotenv://{}", broken_a.display())),
+        ("b", &format!("dotenv://{}", broken_b.display())),
+    ]);
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: None,
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -3631,26 +3581,19 @@ fn test_validate_with_per_secret_providers() {
         providers: None,
     };
 
-    let mut providers_map = HashMap::new();
-    providers_map.insert(
-        "env_provider".to_string(),
-        format!("dotenv://{}", env_file.display()),
-    );
-    providers_map.insert(
-        "keyring_provider".to_string(),
-        format!("dotenv://{}", keyring_file.display()),
-    );
+    let providers_map = aliases_map(&[
+        ("env_provider", &format!("dotenv://{}", env_file.display())),
+        (
+            "keyring_provider",
+            &format!("dotenv://{}", keyring_file.display()),
+        ),
+    ]);
 
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: Some("env".to_string()),
             profile: None,
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -4772,25 +4715,15 @@ fn build_chain_scenario(
         providers: None,
     };
 
-    let mut providers_map = HashMap::new();
-    providers_map.insert(
-        "personal".to_string(),
-        format!("dotenv://{}", personal_path.display()),
-    );
-    providers_map.insert(
-        "team".to_string(),
-        format!("dotenv://{}", team_path.display()),
-    );
+    let providers_map = aliases_map(&[
+        ("personal", &format!("dotenv://{}", personal_path.display())),
+        ("team", &format!("dotenv://{}", team_path.display())),
+    ]);
     let global_config = GlobalConfig {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: Some("development".to_string()),
-            providers: Some(
-                providers_map
-                    .into_iter()
-                    .map(|(k, v)| (k, ProviderAlias::from(v)))
-                    .collect(),
-            ),
+            providers: Some(providers_map),
         },
         audit: None,
     };
@@ -5082,19 +5015,23 @@ fn test_override_skips_read_chain() {
 
     let spec = Secrets::new(config, Some(global_config), Some("team".to_string()), None);
     let secret_config = spec.resolve_secret_config("MY_SECRET", None).unwrap();
-    let override_uri = spec.resolve_provider_override(None);
-    let uris = spec
-        .route_for(&secret_config, &override_uri)
-        .expect("override resolution should succeed")
-        .specs()
-        .expect("override should produce a URI list");
+    let override_spec = spec.explicit_provider_spec(None);
+    let route = spec
+        .route_for(&secret_config, &override_spec)
+        .expect("override resolution should succeed");
 
+    // The read walks the raw override spec only (the alias is expanded at build
+    // time, where its bootstrap `env` is still reachable); the resolved URI is
+    // carried for display.
     assert_eq!(
-        uris.len(),
-        1,
-        "override must collapse the chain to a single URI"
+        route.specs(),
+        Some(vec!["team".to_string()]),
+        "override must collapse the chain to the single override spec"
     );
-    assert_eq!(uris[0], format!("dotenv://{}", team_path.display()));
+    assert_eq!(
+        route.primary(),
+        Some(format!("dotenv://{}", team_path.display()).as_str())
+    );
 }
 
 /// `get` must accept the same provider specs `--provider` accepts everywhere
@@ -5424,7 +5361,8 @@ fn test_provider_override_expands_project_alias() {
     spec.set_provider("op_infra");
 
     let resolved = spec
-        .resolve_provider_override(None)
+        .explicit_provider_spec(None)
+        .map(|spec_str| spec.resolve_provider_spec(spec_str))
         .expect("override should resolve to a URI");
 
     assert_eq!(resolved, "onepassword://Infra");
@@ -5494,7 +5432,8 @@ fn test_provider_override_resolves_global_alias_when_project_providers_present()
     spec.set_provider("team");
 
     let resolved = spec
-        .resolve_provider_override(None)
+        .explicit_provider_spec(None)
+        .map(|spec_str| spec.resolve_provider_spec(spec_str))
         .expect("override should resolve to a URI");
 
     assert_eq!(resolved, "onepassword://Team");
@@ -6241,7 +6180,7 @@ fn bootstrap_source_must_name_a_known_provider() {
             BootstrapSource::from("not_a_real_provider"),
         )]),
     );
-    let error = secrets.validate_primary_bootstrap("target").unwrap_err();
+    let error = secrets.validate_bootstrap_sources("target").unwrap_err();
     assert!(
         error.to_string().contains("not_a_real_provider"),
         "error should name the unknown source: {error}"
@@ -6275,7 +6214,7 @@ fn bootstrap_chain_is_limited_to_one_hop() {
         ),
     ]));
     let secrets = Secrets::new(config, None, None, None);
-    let error = secrets.validate_primary_bootstrap("target").unwrap_err();
+    let error = secrets.validate_bootstrap_sources("target").unwrap_err();
     assert!(
         error.to_string().contains("one hop"),
         "error should explain the one-hop limit: {error}"

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6090,7 +6090,7 @@ fn secrets_with_bootstrap_alias(
         "target".to_string(),
         ProviderAlias {
             uri: target_uri.to_string(),
-            env: Some(env),
+            env,
         },
     )]));
     Secrets::new(config, None, None, None)
@@ -6161,9 +6161,7 @@ fn bootstrap_overlay_reads_ref_addressed_credential() {
 fn bootstrap_overlay_lets_the_environment_win() {
     let _guard = scrub_resolution_env();
     const VAR: &str = "BOOTSTRAP_ENVWINS_VAR";
-    let previous = std::env::var_os(VAR);
-    // SAFETY: serialized by the `scrub_resolution_env` guard held above.
-    unsafe { std::env::set_var(VAR, "from-env") };
+    let _var = EnvVarGuard::set(VAR, "from-env");
 
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.env");
@@ -6183,11 +6181,6 @@ fn bootstrap_overlay_lets_the_environment_win() {
     // The environment satisfies the variable, so the chain is not consulted and
     // the overlay carries nothing for it (the provider reads the env directly).
     assert!(!overlay.contains_key(VAR));
-
-    match previous {
-        Some(value) => unsafe { std::env::set_var(VAR, value) },
-        None => unsafe { std::env::remove_var(VAR) },
-    }
 }
 
 #[test]
@@ -6240,20 +6233,14 @@ fn bootstrap_chain_is_limited_to_one_hop() {
             "chained".to_string(),
             ProviderAlias {
                 uri: "keyring://".to_string(),
-                env: Some(HashMap::from([(
-                    "INNER".to_string(),
-                    BootstrapSource::from("keyring"),
-                )])),
+                env: HashMap::from([("INNER".to_string(), BootstrapSource::from("keyring"))]),
             },
         ),
         (
             "target".to_string(),
             ProviderAlias {
                 uri: "bws://project".to_string(),
-                env: Some(HashMap::from([(
-                    "TOKEN".to_string(),
-                    BootstrapSource::from("chained"),
-                )])),
+                env: HashMap::from([("TOKEN".to_string(), BootstrapSource::from("chained"))]),
             },
         ),
     ]));

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6281,3 +6281,73 @@ fn bootstrap_chain_is_limited_to_one_hop() {
         "error should explain the one-hop limit: {error}"
     );
 }
+
+#[test]
+fn bootstrap_credential_round_trips_through_its_source() {
+    let _guard = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    std::fs::write(&source, "").unwrap();
+
+    let secrets = secrets_with_bootstrap_alias(
+        "env://",
+        HashMap::from([(
+            "ROUND_TRIP_VAR".to_string(),
+            BootstrapSource::from(format!("dotenv://{}", source.display())),
+        )]),
+    );
+
+    let credentials = secrets.bootstrap_credentials("target").unwrap();
+    assert_eq!(credentials.len(), 1);
+    let (var, source_spec) = &credentials[0];
+
+    secrets
+        .store_bootstrap_credential(
+            source_spec,
+            var,
+            &secrecy::SecretString::new("stored-value".into()),
+        )
+        .unwrap();
+
+    // Stored and read back through the same address the resolver uses.
+    let overlay = secrets.resolve_bootstrap_overlay("target").unwrap();
+    assert_eq!(
+        overlay
+            .get("ROUND_TRIP_VAR")
+            .map(|value| value.expose_secret().to_string()),
+        Some("stored-value".to_string()),
+    );
+}
+
+#[test]
+fn bootstrap_credentials_errors_for_an_unknown_alias() {
+    let secrets = Secrets::new(resolve_test_config(HashMap::new()), None, None, None);
+    assert!(secrets.bootstrap_credentials("nope").is_err());
+}
+
+#[test]
+fn bootstrap_credentials_is_empty_for_an_alias_without_env() {
+    let mut config = resolve_test_config(HashMap::new());
+    config.providers = Some(HashMap::from([(
+        "plain".to_string(),
+        ProviderAlias::from("keyring://"),
+    )]));
+    let secrets = Secrets::new(config, None, None, None);
+    assert!(secrets.bootstrap_credentials("plain").unwrap().is_empty());
+}
+
+#[test]
+fn store_bootstrap_credential_rejects_a_read_only_source() {
+    let secrets = secrets_with_bootstrap_alias(
+        "env://",
+        HashMap::from([("V".to_string(), BootstrapSource::from("env://"))]),
+    );
+    let credentials = secrets.bootstrap_credentials("target").unwrap();
+    let (var, source_spec) = &credentials[0];
+    let result = secrets.store_bootstrap_credential(
+        source_spec,
+        var,
+        &secrecy::SecretString::new("x".into()),
+    );
+    assert!(result.is_err(), "the env provider is read-only");
+}

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    Config, GlobalConfig, GlobalDefaults, ParseError, Profile, Project, RequireReason, Resolved,
-    Secret,
+    Config, GlobalConfig, GlobalDefaults, ParseError, Profile, Project, ProviderAlias,
+    RequireReason, Resolved, Secret,
 };
 use crate::error::{Result, SecretSpecError};
 use crate::secrets::Secrets;
@@ -822,10 +822,13 @@ fn test_chain_primary_error_surfaces_instead_of_missing() {
     // Primary alias resolves to an unbuildable provider (the "outage"); fallback
     // is a healthy dotenv that simply lacks the key.
     let mut provider_aliases = HashMap::new();
-    provider_aliases.insert("primary".to_string(), "bogus://unreachable".to_string());
+    provider_aliases.insert(
+        "primary".to_string(),
+        ProviderAlias::from("bogus://unreachable"),
+    );
     provider_aliases.insert(
         "fallback".to_string(),
-        format!("dotenv://{}", env_path.display()),
+        ProviderAlias::from(format!("dotenv://{}", env_path.display())),
     );
 
     let mut config = resolve_test_config(secrets);
@@ -3086,7 +3089,12 @@ fn test_per_secret_provider_configuration() {
         defaults: GlobalDefaults {
             provider: Some("env".to_string()),
             profile: None,
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -3116,7 +3124,12 @@ fn test_provider_alias_resolution() {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: None,
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -3157,7 +3170,12 @@ fn test_provider_alias_not_found() {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: None,
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -3259,7 +3277,12 @@ fn test_per_secret_provider_with_fallback_chain() {
         defaults: GlobalDefaults {
             provider: None,
             profile: None,
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -3357,7 +3380,12 @@ fn test_get_secret_with_fallback_chain() {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()), // Default fallback provider
             profile: None,
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -3440,7 +3468,12 @@ fn test_validate_falls_back_on_primary_provider_error() {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: None,
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -3508,7 +3541,12 @@ fn test_validate_surfaces_error_when_all_providers_fail() {
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: None,
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -3607,7 +3645,12 @@ fn test_validate_with_per_secret_providers() {
         defaults: GlobalDefaults {
             provider: Some("env".to_string()),
             profile: None,
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -3868,15 +3911,21 @@ provider = "keyring"
         config.defaults.providers = Some(HashMap::new());
     }
     if let Some(providers) = &mut config.defaults.providers {
-        providers.insert("shared".to_string(), "onepassword://Shared".to_string());
-        providers.insert("prod".to_string(), "onepassword://Production".to_string());
+        providers.insert(
+            "shared".to_string(),
+            ProviderAlias::from("onepassword://Shared"),
+        );
+        providers.insert(
+            "prod".to_string(),
+            ProviderAlias::from("onepassword://Production"),
+        );
     }
 
     // Verify providers were added
     assert_eq!(config.defaults.providers.as_ref().unwrap().len(), 2);
     assert_eq!(
         config.defaults.providers.as_ref().unwrap().get("shared"),
-        Some(&"onepassword://Shared".to_string())
+        Some(&ProviderAlias::from("onepassword://Shared"))
     );
 
     // Simulate removing a provider alias
@@ -4736,7 +4785,12 @@ fn build_chain_scenario(
         defaults: GlobalDefaults {
             provider: Some("keyring".to_string()),
             profile: Some("development".to_string()),
-            providers: Some(providers_map),
+            providers: Some(
+                providers_map
+                    .into_iter()
+                    .map(|(k, v)| (k, ProviderAlias::from(v)))
+                    .collect(),
+            ),
         },
         audit: None,
     };
@@ -5190,10 +5244,10 @@ OPTIONAL_MISSING = { description = "optional, not set", required = false }
     );
 }
 
-pub(crate) fn aliases_map(aliases: &[(&str, &str)]) -> HashMap<String, String> {
+pub(crate) fn aliases_map(aliases: &[(&str, &str)]) -> HashMap<String, ProviderAlias> {
     aliases
         .iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .map(|(k, v)| (k.to_string(), ProviderAlias::from(*v)))
         .collect()
 }
 
@@ -5348,12 +5402,14 @@ APP_SECRET = { description = "App", required = true }
         .expect("merged config should carry [providers]");
 
     assert_eq!(
-        providers.get("op_infra").map(String::as_str),
+        providers.get("op_infra").map(|alias| alias.uri.as_str()),
         Some("onepassword://Shared"),
         "alias defined only in extended config should be inherited"
     );
     assert_eq!(
-        providers.get("op_overridden").map(String::as_str),
+        providers
+            .get("op_overridden")
+            .map(|alias| alias.uri.as_str()),
         Some("onepassword://NewVault"),
         "alias defined in both should resolve to the current (extending) config's value"
     );

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -499,6 +499,42 @@ impl Drop for ResolutionEnvGuard {
     }
 }
 
+/// Sets or removes one environment variable and restores its previous value on
+/// drop, so a failing assertion cannot leak the mutation. The caller must hold
+/// the crate-wide env lock (via [`scrub_resolution_env`]) for the guard's
+/// lifetime: `set_var`/`remove_var` mutate the shared process environment and
+/// are only sound while no other thread touches it.
+pub(crate) struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    pub(crate) fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: serialized by the env lock the caller holds.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+
+    pub(crate) fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: serialized by the env lock the caller holds.
+        unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            // SAFETY: serialized by the env lock the caller holds.
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
 #[test]
 fn test_resolve_carries_values_and_provenance() {
     use crate::resolve::ResolvedSource;
@@ -1035,7 +1071,7 @@ fn test_get_provider_error_cases() {
     );
 
     // Test with no provider configured
-    let result = spec.get_provider(None);
+    let result = spec.get_provider(None, None);
     assert!(matches!(result, Err(SecretSpecError::NoProviderConfigured)));
 }
 
@@ -1065,7 +1101,7 @@ fn test_get_provider_with_global_config() {
     );
 
     // Should not error with global config
-    let result = spec.get_provider(None);
+    let result = spec.get_provider(None, None);
     assert!(result.is_ok());
 }
 
@@ -6076,7 +6112,9 @@ fn bootstrap_overlay_reads_convention_credential_from_source() {
         )]),
     );
 
-    let overlay = secrets.resolve_bootstrap_overlay("target").unwrap();
+    let overlay = secrets
+        .resolve_bootstrap_overlay("target", "default")
+        .unwrap();
     assert_eq!(
         overlay
             .get("BOOTSTRAP_READ_VAR")
@@ -6108,7 +6146,9 @@ fn bootstrap_overlay_reads_ref_addressed_credential() {
         )]),
     );
 
-    let overlay = secrets.resolve_bootstrap_overlay("target").unwrap();
+    let overlay = secrets
+        .resolve_bootstrap_overlay("target", "default")
+        .unwrap();
     assert_eq!(
         overlay
             .get("MY_TOKEN")
@@ -6137,7 +6177,9 @@ fn bootstrap_overlay_lets_the_environment_win() {
         )]),
     );
 
-    let overlay = secrets.resolve_bootstrap_overlay("target").unwrap();
+    let overlay = secrets
+        .resolve_bootstrap_overlay("target", "default")
+        .unwrap();
     // The environment satisfies the variable, so the chain is not consulted and
     // the overlay carries nothing for it (the provider reads the env directly).
     assert!(!overlay.contains_key(VAR));
@@ -6163,7 +6205,9 @@ fn bootstrap_overlay_missing_credential_is_an_actionable_error() {
         )]),
     );
 
-    let error = secrets.resolve_bootstrap_overlay("target").unwrap_err();
+    let error = secrets
+        .resolve_bootstrap_overlay("target", "default")
+        .unwrap_err();
     let message = error.to_string();
     assert!(
         message.contains("BOOTSTRAP_MISSING_VAR") && message.contains("not found"),
@@ -6249,12 +6293,92 @@ fn bootstrap_credential_round_trips_through_its_source() {
         .unwrap();
 
     // Stored and read back through the same address the resolver uses.
-    let overlay = secrets.resolve_bootstrap_overlay("target").unwrap();
+    let overlay = secrets
+        .resolve_bootstrap_overlay("target", "default")
+        .unwrap();
     assert_eq!(
         overlay
             .get("ROUND_TRIP_VAR")
             .map(|value| value.expose_secret().to_string()),
         Some("stored-value".to_string()),
+    );
+}
+
+/// The overlay memo is keyed by profile: building the target for one profile
+/// memoizes only that profile's credentials, and another profile re-fetches
+/// from the source instead of reusing them.
+#[test]
+fn bootstrap_overlay_memoizes_per_profile() {
+    let _guard = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    std::fs::write(&source, "SECRETSPEC_TEST_PROFILE_SCOPED_VAR=v1\n").unwrap();
+
+    let secrets = secrets_with_bootstrap_alias(
+        "env://",
+        HashMap::from([(
+            "SECRETSPEC_TEST_PROFILE_SCOPED_VAR".to_string(),
+            BootstrapSource::from(format!("dotenv://{}", source.display())),
+        )]),
+    );
+
+    // First build fetches the credential and memoizes it for this profile.
+    secrets
+        .get_provider(Some("target"), Some("default"))
+        .expect("the source supplies the credential");
+
+    // Empty the source: a fresh fetch can no longer succeed.
+    std::fs::write(&source, "").unwrap();
+
+    // Same profile: served from the memo, so the emptied source is not read.
+    secrets
+        .get_provider(Some("target"), Some("default"))
+        .expect("the memoized credential must be reused for the same profile");
+
+    // Another profile must not reuse the memo: it re-fetches and hard-misses.
+    assert!(
+        secrets.get_provider(Some("target"), Some("other")).is_err(),
+        "another profile must re-fetch rather than reuse the memoized credential"
+    );
+}
+
+/// Storing a credential through its source (the `login` flow) clears the
+/// overlay memo, so the next build re-reads the store instead of resolving to
+/// the stale cached value.
+#[test]
+fn storing_a_bootstrap_credential_invalidates_the_memo() {
+    let _guard = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    std::fs::write(&source, "SECRETSPEC_TEST_ROTATED_VAR=old\n").unwrap();
+
+    let secrets = secrets_with_bootstrap_alias(
+        "env://",
+        HashMap::from([(
+            "SECRETSPEC_TEST_ROTATED_VAR".to_string(),
+            BootstrapSource::from(format!("dotenv://{}", source.display())),
+        )]),
+    );
+
+    // Memoize the old credential.
+    secrets
+        .get_provider(Some("target"), Some("default"))
+        .expect("the source supplies the credential");
+
+    let credentials = secrets.bootstrap_credentials("target").unwrap();
+    let (var, source_spec) = &credentials[0];
+    secrets
+        .store_bootstrap_credential(source_spec, var, &secrecy::SecretString::new("new".into()))
+        .unwrap();
+
+    // Empty the source: only a memo hit could satisfy the next build, so a
+    // success here would prove the store had NOT invalidated it.
+    std::fs::write(&source, "").unwrap();
+    assert!(
+        secrets
+            .get_provider(Some("target"), Some("default"))
+            .is_err(),
+        "the store must clear the memo so the credential is re-read"
     );
 }
 

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    Config, GlobalConfig, GlobalDefaults, ParseError, Profile, Project, ProviderAlias,
-    RequireReason, Resolved, Secret,
+    BootstrapSource, Config, GlobalConfig, GlobalDefaults, NativeAddress, ParseError, Profile,
+    Project, ProviderAlias, RequireReason, Resolved, Secret,
 };
 use crate::error::{Result, SecretSpecError};
 use crate::secrets::Secrets;
@@ -6100,4 +6100,184 @@ fn test_resolve_profile_unknown_returns_invalid_profile() {
         }
         other => panic!("expected InvalidProfile, got {other:?}"),
     }
+}
+
+// --- Provider bootstrap: overlay resolution and validation ---
+
+/// Builds a `Secrets` whose only project provider alias is `target`, carrying
+/// the given bootstrap `env` map.
+fn secrets_with_bootstrap_alias(
+    target_uri: &str,
+    env: HashMap<String, BootstrapSource>,
+) -> Secrets {
+    let mut config = resolve_test_config(HashMap::new());
+    config.providers = Some(HashMap::from([(
+        "target".to_string(),
+        ProviderAlias {
+            uri: target_uri.to_string(),
+            env: Some(env),
+        },
+    )]));
+    Secrets::new(config, None, None, None)
+}
+
+#[test]
+fn bootstrap_overlay_reads_convention_credential_from_source() {
+    let _guard = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    // dotenv addresses a convention secret by the flat key name.
+    std::fs::write(&source, "BOOTSTRAP_READ_VAR=secret-abc\n").unwrap();
+
+    let secrets = secrets_with_bootstrap_alias(
+        "env://",
+        HashMap::from([(
+            "BOOTSTRAP_READ_VAR".to_string(),
+            BootstrapSource::from(format!("dotenv://{}", source.display())),
+        )]),
+    );
+
+    let overlay = secrets.resolve_bootstrap_overlay("target").unwrap();
+    assert_eq!(
+        overlay
+            .get("BOOTSTRAP_READ_VAR")
+            .map(|value| value.expose_secret().to_string()),
+        Some("secret-abc".to_string()),
+    );
+}
+
+#[test]
+fn bootstrap_overlay_reads_ref_addressed_credential() {
+    let _guard = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    std::fs::write(&source, "SOURCE_KEY=secret-xyz\n").unwrap();
+
+    // The env variable name (MY_TOKEN) and the source key (SOURCE_KEY) differ;
+    // `ref` pins the exact location.
+    let secrets = secrets_with_bootstrap_alias(
+        "env://",
+        HashMap::from([(
+            "MY_TOKEN".to_string(),
+            BootstrapSource {
+                provider: format!("dotenv://{}", source.display()),
+                reference: Some(NativeAddress {
+                    item: "SOURCE_KEY".to_string(),
+                    ..Default::default()
+                }),
+            },
+        )]),
+    );
+
+    let overlay = secrets.resolve_bootstrap_overlay("target").unwrap();
+    assert_eq!(
+        overlay
+            .get("MY_TOKEN")
+            .map(|value| value.expose_secret().to_string()),
+        Some("secret-xyz".to_string()),
+    );
+}
+
+#[test]
+fn bootstrap_overlay_lets_the_environment_win() {
+    let _guard = scrub_resolution_env();
+    const VAR: &str = "BOOTSTRAP_ENVWINS_VAR";
+    let previous = std::env::var_os(VAR);
+    // SAFETY: serialized by the `scrub_resolution_env` guard held above.
+    unsafe { std::env::set_var(VAR, "from-env") };
+
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    std::fs::write(&source, format!("{VAR}=from-source\n")).unwrap();
+
+    let secrets = secrets_with_bootstrap_alias(
+        "env://",
+        HashMap::from([(
+            VAR.to_string(),
+            BootstrapSource::from(format!("dotenv://{}", source.display())),
+        )]),
+    );
+
+    let overlay = secrets.resolve_bootstrap_overlay("target").unwrap();
+    // The environment satisfies the variable, so the chain is not consulted and
+    // the overlay carries nothing for it (the provider reads the env directly).
+    assert!(!overlay.contains_key(VAR));
+
+    match previous {
+        Some(value) => unsafe { std::env::set_var(VAR, value) },
+        None => unsafe { std::env::remove_var(VAR) },
+    }
+}
+
+#[test]
+fn bootstrap_overlay_missing_credential_is_an_actionable_error() {
+    let _guard = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    std::fs::write(&source, "").unwrap();
+
+    let secrets = secrets_with_bootstrap_alias(
+        "env://",
+        HashMap::from([(
+            "BOOTSTRAP_MISSING_VAR".to_string(),
+            BootstrapSource::from(format!("dotenv://{}", source.display())),
+        )]),
+    );
+
+    let error = secrets.resolve_bootstrap_overlay("target").unwrap_err();
+    let message = error.to_string();
+    assert!(
+        message.contains("BOOTSTRAP_MISSING_VAR") && message.contains("not found"),
+        "error should name the variable and say it was not found: {message}"
+    );
+}
+
+#[test]
+fn bootstrap_source_must_name_a_known_provider() {
+    let secrets = secrets_with_bootstrap_alias(
+        "bws://project",
+        HashMap::from([(
+            "TOKEN".to_string(),
+            BootstrapSource::from("not_a_real_provider"),
+        )]),
+    );
+    let error = secrets.validate_primary_bootstrap("target").unwrap_err();
+    assert!(
+        error.to_string().contains("not_a_real_provider"),
+        "error should name the unknown source: {error}"
+    );
+}
+
+#[test]
+fn bootstrap_chain_is_limited_to_one_hop() {
+    let mut config = resolve_test_config(HashMap::new());
+    config.providers = Some(HashMap::from([
+        // `chained` itself declares bootstrap env, so it may not be a source.
+        (
+            "chained".to_string(),
+            ProviderAlias {
+                uri: "keyring://".to_string(),
+                env: Some(HashMap::from([(
+                    "INNER".to_string(),
+                    BootstrapSource::from("keyring"),
+                )])),
+            },
+        ),
+        (
+            "target".to_string(),
+            ProviderAlias {
+                uri: "bws://project".to_string(),
+                env: Some(HashMap::from([(
+                    "TOKEN".to_string(),
+                    BootstrapSource::from("chained"),
+                )])),
+            },
+        ),
+    ]));
+    let secrets = Secrets::new(config, None, None, None);
+    let error = secrets.validate_primary_bootstrap("target").unwrap_err();
+    assert!(
+        error.to_string().contains("one hop"),
+        "error should explain the one-hop limit: {error}"
+    );
 }


### PR DESCRIPTION
## Summary

Provider aliases can now source their own credentials from another provider. An alias in `[providers]` may declare an `env` map binding an environment variable the provider needs (such as `BWS_ACCESS_TOKEN` or `VAULT_TOKEN`) to a source: a bare provider spec, which reads the value at the convention path, or a table with a `ref` giving exact coordinates. The credential is fetched from the source and handed to the store, so a machine token can live in the OS keyring instead of a plaintext environment variable, and it is never written into the environment of processes started by `secretspec run`.

```toml
[providers]
bws = { uri = "bws://project-uuid", env = { BWS_ACCESS_TOKEN = "keyring" } }
vault = { uri = "vault://kv/app?auth=approle", credentials = {
  VAULT_ROLE_ID   = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "role_id" } },
  VAULT_SECRET_ID = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "secret_id" } },
} }
```

## Behavior

- An environment variable that is already set (non empty) wins, so CI keeps working with no extra configuration.
- Bootstrap chains are limited to one hop, enforced on every path the alias can appear on: chain primary, chain fallback, explicit `--provider`/`SECRETSPEC_PROVIDER`, and the default provider.
- Credentials are fetched once per invocation and profile, then reused across all secrets routed at the alias; convention path credentials are scoped per profile.
- Every source read, and every credential stored through `login`, is audited with a `bootstrap` marker naming the variable and the source store.
- Declaring an `env` variable the target provider never reads prints a warning naming the variables it does read.

## CLI

- `secretspec config provider login <alias>` prompts for each declared bootstrap credential and stores it at its source, at exactly the location resolution later reads it from.
- `secretspec config provider add` gains a repeatable `--env VAR=PROVIDER` flag.

## Also in this PR

- Docs for the feature (concepts, provider pages, CLI and configuration reference).
- A cleanup pass over the branch (reuse/simplification/efficiency review): `ProviderAlias::env` is a plain map instead of an `Option`, single registry scheme lookup, one ordering rule for bootstrap entries, bootstrap writes audit through the shared write audit helper, per provider bootstrap variable consts, and deduplicated CI release/build scripts.

## Testing

- `cargo test --package secretspec`: 424 tests pass, including new coverage for overlay resolution, env wins, one hop validation, profile scoping, round trips through `login`, and plan grouping.
- PHP extension build script smoke tested (stages `lib/secretspec.so`, loads in PHP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)