### PR TITLE
Validate secrets on their merged effective config; manylinux node addons

### DIFF
--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -91,15 +91,14 @@ jobs:
         if: matrix.container
         shell: bash
         run: |
-          addon=secretspec-node/secretspec.node
           # Read the version-reference table (objdump -p), not per-symbol
           # version tags (objdump -T): file-level ABI markers such as
           # GLIBC_ABI_DT_RELR (needs glibc >= 2.36) are attached to no symbol,
           # so a symbol scan stays green on a binary older loaders reject.
           # Numeric needs above GLIBC_2.28 fail, and so does any GLIBC_*
           # version need that is not plain numeric.
-          too_new=$(objdump -p "$addon" \
-            | grep -oE 'GLIBC_[A-Za-z0-9_.]+' \
+          headers=$(objdump -p secretspec-node/secretspec.node)
+          too_new=$(grep -oE 'GLIBC_[A-Za-z0-9_.]+' <<<"$headers" \
             | sort -u \
             | awk -F. '/^GLIBC_2\.[0-9]+(\.[0-9]+)?$/ { if ($2 + 0 > 28) print; next } { print }')
           if [ -n "$too_new" ]; then
@@ -107,9 +106,9 @@ jobs:
             echo "$too_new" >&2
             exit 1
           fi
-          if objdump -p "$addon" | grep NEEDED | grep -q dbus; then
+          if grep NEEDED <<<"$headers" | grep -q dbus; then
             echo "addon links libdbus dynamically; vendored-dbus regressed:" >&2
-            objdump -p "$addon" | grep NEEDED >&2
+            grep NEEDED <<<"$headers" >&2
             exit 1
           fi
 

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -5,6 +5,18 @@ name: "Node addon"
 # (secretspec-<platform>, referenced via the main `secretspec` package's
 # optionalDependencies) using @napi-rs/cli, authenticated via npm Trusted
 # Publishing (OIDC) -- no NPM_TOKEN stored in CI.
+#
+# The Linux builds run inside manylinux_2_28 containers (AlmaLinux 8, glibc
+# 2.28) with libdbus compiled from source and linked statically (the
+# vendored-dbus cargo feature), so the published addon loads on any distro
+# with glibc >= 2.28 (RHEL 8/9, Amazon Linux 2023, Debian 10+, Ubuntu 18.10+)
+# and needs no system libdbus at runtime. Building on the bare runner instead
+# links the runner's glibc (2.39 on ubuntu-24.04), which broke RHEL 9-family
+# distros (issue #136). A post-build step fails the job if the addon's
+# glibc floor or NEEDED libraries regress. The container additionally gets
+# dbus-devel because the SDK test suite rebuilds the CLI with default (non
+# vendored) features, which links system libdbus; the published addon itself
+# is built with vendored-dbus and stays independent of it.
 
 on:
   workflow_dispatch:
@@ -24,6 +36,7 @@ jobs:
   addon:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,8 +44,16 @@ jobs:
           # `platform` is napi-rs's platformArchABI naming (see
           # secretspec-node/npm/<platform>/), used to name the artifact that
           # feeds the publish job below.
-          - { target: linux-x64, platform: linux-x64-gnu, runner: ubuntu-latest }
-          - { target: linux-arm64, platform: linux-arm64-gnu, runner: ubuntu-24.04-arm }
+          - target: linux-x64
+            platform: linux-x64-gnu
+            runner: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            build_args: --features vendored-dbus
+          - target: linux-arm64
+            platform: linux-arm64-gnu
+            runner: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            build_args: --features vendored-dbus
           - { target: darwin-arm64, platform: darwin-arm64, runner: macos-latest }
           - { target: win32-x64, platform: win32-x64-msvc, runner: windows-latest }
 
@@ -41,9 +62,15 @@ jobs:
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
 
-      - name: Install Linux system dependencies (dbus for keyring)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Install rustup (the manylinux container ships none)
+        if: matrix.container
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Install dbus headers (the SDK tests rebuild the CLI against system dbus)
+        if: matrix.container
+        run: yum install -y dbus-devel
 
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
@@ -57,8 +84,34 @@ jobs:
       - name: Build the addon and run the SDK tests
         shell: bash
         run: |
-          bash secretspec-node/scripts/build-addon.sh
+          bash secretspec-node/scripts/build-addon.sh ${{ matrix.build_args }}
           ( cd secretspec-node && node --test )
+
+      - name: Verify addon portability (glibc <= 2.28, libdbus linked in)
+        if: matrix.container
+        shell: bash
+        run: |
+          addon=secretspec-node/secretspec.node
+          # Read the version-reference table (objdump -p), not per-symbol
+          # version tags (objdump -T): file-level ABI markers such as
+          # GLIBC_ABI_DT_RELR (needs glibc >= 2.36) are attached to no symbol,
+          # so a symbol scan stays green on a binary older loaders reject.
+          # Numeric needs above GLIBC_2.28 fail, and so does any GLIBC_*
+          # version need that is not plain numeric.
+          too_new=$(objdump -p "$addon" \
+            | grep -oE 'GLIBC_[A-Za-z0-9_.]+' \
+            | sort -u \
+            | awk -F. '/^GLIBC_2\.[0-9]+(\.[0-9]+)?$/ { if ($2 + 0 > 28) print; next } { print }')
+          if [ -n "$too_new" ]; then
+            echo "addon requires glibc version needs newer than the 2.28 baseline:" >&2
+            echo "$too_new" >&2
+            exit 1
+          fi
+          if objdump -p "$addon" | grep NEEDED | grep -q dbus; then
+            echo "addon links libdbus dynamically; vendored-dbus regressed:" >&2
+            objdump -p "$addon" | grep NEEDED >&2
+            exit 1
+          fi
 
       - name: Copy the addon to its platform-specific filename for publishing
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+    # The full devenv shell includes every SDK toolchain plus the musl static
+    # dependencies. It no longer fits alongside the preinstalled software on
+    # GitHub's Ubuntu image, so reclaim that space before populating /nix.
+    - name: Free up disk space
+      if: runner.os == 'Linux'
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android \
+          /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /opt/ghc \
+          /usr/local/share/boost /usr/local/share/powershell
+        sudo docker image prune --all --force
+        df -h /
     - uses: cachix/install-nix-action@v31
     - uses: cachix/cachix-action@v17
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `run` no longer aborts when the environment contains a non-UTF-8 variable.
   Such variables are now passed through to the child process untouched, with
   resolved secrets overlaid on top.
+- The prebuilt Linux addons of the Node SDK are now built against glibc 2.28
+  (manylinux_2_28) with libdbus compiled in statically, so `npm install
+  secretspec` works on Amazon Linux 2023, RHEL 8/9, and other distros with an
+  older glibc, instead of the addon failing to load with "version `GLIBC_2.38'
+  not found". ([#136](https://github.com/cachix/secretspec/issues/136))
 
 ## [0.14.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fallback entry it is still skipped with a warning, like any broken link.
 
 ### Fixed
+- Profile overrides no longer need to repeat the secret's `description`:
+  validation now checks each secret's effective, merged configuration, so a
+  partial override like `[profiles.development] DATABASE_URL = { default =
+  "sqlite:///dev.db" }` inherits the description (and `type`, for `generate`)
+  from the default profile instead of failing with "missing description".
+  The merged view is also validated for real conflicts, so a `generate`
+  secret in the default profile combined with a `default` value from an
+  override or a profile `[defaults]` table is now rejected at load instead of
+  silently generating a random value and ignoring the default. Validation
+  errors are reported deterministically, attributed to the profile that
+  declares the offending field, and `check` and `run` list secrets in stable
+  name-sorted order.
 - Provider fallback chains (`providers = [...]`) are now tried strictly in
   order: each link is resolved only when a read actually reaches it, and a
   broken link (an undefined alias, an unreachable store) is skipped with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "dbus",
+ "openssl",
  "zeroize",
 ]
 
@@ -2934,6 +2935,7 @@ dependencies = [
  "byteorder",
  "dbus-secret-service",
  "log",
+ "openssl",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
@@ -2973,6 +2975,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -3380,6 +3383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,6 +3399,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/docs/src/content/docs/concepts/declarative.md
+++ b/docs/src/content/docs/concepts/declarative.md
@@ -32,7 +32,7 @@ SECRET_NAME = {
 ```
 
 **Options:**
-- `description`: Explains the secret's purpose (required)
+- `description`: Explains the secret's purpose (required in the `default` profile; profile overrides inherit it when omitted)
 - `required`: Whether the secret must be provided (default: `true`)
 - `default`: Fallback value for optional secrets
 - `type`: Secret type for auto-generation (`password`, `hex`, `base64`, `uuid`, `command`)

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -85,21 +85,24 @@ Each secret variable is defined as a table with the following fields:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `description` | string | Yes* | Human-readable description of the secret |
-| `required` | boolean | No** | Whether the value must be provided (default: true) |
-| `default` | string | No*** | Default value if not provided |
+| `description` | string | Yes (see notes) | Human-readable description of the secret |
+| `required` | boolean | No | Whether the value must be provided (default: true) |
+| `default` | string | No | Default value if not provided |
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
 | `ref` | table | No | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
-| `type` | string | No**** | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
-| `generate` | boolean or table | No**** | Enable auto-generation when secret is missing |
+| `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
+| `generate` | boolean or table | No | Enable auto-generation when secret is missing |
 
-*Required in the `default` profile. A secret overriding one that the default
-profile already declares inherits its `description` (and other omitted fields)
-and may leave it out.
-**If `default` is provided, `required` defaults to false
-***Only valid when `required = false`
-****`type` is required when `generate` is enabled; `generate` and `default` cannot both be set
+Field notes:
+
+- `description` is required in the `default` profile. A secret overriding one
+  that the default profile already declares inherits its `description` (and
+  other omitted fields) and may leave it out.
+- `required` defaults to false when `default` is provided.
+- `default` is only valid when `required = false`.
+- `type` is required when `generate` is enabled.
+- `generate` and `default` cannot both be set.
 
 ## Complete Example
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -85,18 +85,21 @@ Each secret variable is defined as a table with the following fields:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `description` | string | Yes | Human-readable description of the secret |
-| `required` | boolean | No* | Whether the value must be provided (default: true) |
-| `default` | string | No** | Default value if not provided |
+| `description` | string | Yes* | Human-readable description of the secret |
+| `required` | boolean | No** | Whether the value must be provided (default: true) |
+| `default` | string | No*** | Default value if not provided |
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
 | `ref` | table | No | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
-| `type` | string | No*** | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
-| `generate` | boolean or table | No*** | Enable auto-generation when secret is missing |
+| `type` | string | No**** | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
+| `generate` | boolean or table | No**** | Enable auto-generation when secret is missing |
 
-*If `default` is provided, `required` defaults to false
-**Only valid when `required = false`
-***`type` is required when `generate` is enabled; `generate` and `default` cannot both be set
+*Required in the `default` profile. A secret overriding one that the default
+profile already declares inherits its `description` (and other omitted fields)
+and may leave it out.
+**If `default` is provided, `required` defaults to false
+***Only valid when `required = false`
+****`type` is required when `generate` is enabled; `generate` and `default` cannot both be set
 
 ## Complete Example
 

--- a/secretspec-node/Cargo.toml
+++ b/secretspec-node/Cargo.toml
@@ -14,5 +14,10 @@ napi = { version = "2.16", default-features = false, features = ["napi8"] }
 napi-derive = "2.16"
 secretspec = { workspace = true }
 
+[features]
+# Statically link a from-source libdbus so the prebuilt Linux addon has no
+# runtime dependency beyond glibc (enabled by the node-addon release CI).
+vendored-dbus = ["secretspec/vendored-dbus"]
+
 [build-dependencies]
 napi-build = "2.1"

--- a/secretspec-node/scripts/build-addon.sh
+++ b/secretspec-node/scripts/build-addon.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Build the napi-rs addon (release) via `napi build` and place it as
-# secretspec.node next to index.js.
+# secretspec.node next to index.js. Extra arguments are forwarded to
+# `napi build` (e.g. `--features vendored-dbus` for the Linux release CI).
 set -euo pipefail
 
 pkg_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -11,7 +12,7 @@ napi_bin="$pkg_dir/node_modules/.bin/napi"
 # clobber the hand-maintained index.d.ts) out of pkg_dir entirely.
 tmp_out="$(mktemp -d)"
 trap 'rm -rf "$tmp_out"' EXIT
-( cd "$pkg_dir" && "$napi_bin" build --release --output-dir "$tmp_out" )
+( cd "$pkg_dir" && "$napi_bin" build --release --output-dir "$tmp_out" "$@" )
 
 # Install atomically: node --test runs test files in parallel processes that
 # may build concurrently, and overwriting in place SIGBUSes a process that has

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -52,6 +52,10 @@ detect-coding-agent.workspace = true
 default = ["cli", "keyring", "gcsm", "awssm", "vault", "bws"]
 cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
+# Compile libdbus from source into the binary instead of linking the system
+# library at runtime (keyring's secret-service transport on Linux). Used by
+# prebuilt release artifacts that must run on distros we don't build on.
+vendored-dbus = ["keyring?/vendored"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 vault = ["dep:reqwest"]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -529,7 +529,10 @@ impl Profile {
     /// Pass `None` when this profile has nothing to inherit from (it is the
     /// default profile itself).
     fn validate_with_default(&self, default_profile: Option<&Profile>) -> Result<(), String> {
-        if self.secrets.is_empty() {
+        // A non-default profile may be an empty marker that inherits every
+        // secret from `default`. Profiles with nothing to inherit still need
+        // to declare at least one secret.
+        if self.secrets.is_empty() && default_profile.is_none() {
             return Err("Profile must define at least one secret".into());
         }
 
@@ -1697,6 +1700,39 @@ mod validation_tests {
             .validate()
             .unwrap_err();
         assert!(err.to_string().contains("at least one secret"));
+    }
+
+    /// Regression for https://github.com/cachix/secretspec/issues/144: an
+    /// explicitly declared empty profile inherits the complete default
+    /// profile and is therefore not empty from the resolver's perspective.
+    #[test]
+    fn config_validate_allows_empty_profile_to_inherit_default_secrets() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "lm04-stats"
+revision = "1.0"
+
+[profiles.default]
+ADMIN_PASSWORD = { description = "Password securing the admin page", required = true, type = "password" }
+
+[profiles.production]
+"#,
+        )
+        .unwrap();
+
+        config.validate().unwrap();
+
+        let spec = crate::Secrets::new(config, None, None, Some("production".to_string()));
+        let resolved = spec
+            .resolve_secret_config("ADMIN_PASSWORD", Some("production"))
+            .expect("production should inherit ADMIN_PASSWORD from default");
+        assert_eq!(
+            resolved.description.as_deref(),
+            Some("Password securing the admin page")
+        );
+        assert_eq!(resolved.required, Some(true));
+        assert_eq!(resolved.secret_type.as_deref(), Some("password"));
     }
 
     #[test]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -86,12 +86,25 @@ impl Config {
 
         let default_profile = self.profiles.get("default");
 
-        // Validate each profile. Non-default profiles are partial overrides, so
-        // their secrets may inherit descriptions from the default profile. The
-        // default profile inheriting from itself is a no-op.
-        for (profile_name, profile) in &self.profiles {
-            profile
-                .validate_with_default(default_profile)
+        // Validate each profile against the same effective view resolution
+        // uses: non-default profiles are partial overrides whose secrets merge
+        // field by field with the default profile's entries. The default
+        // profile is validated first and profiles are ordered, so an error
+        // (e.g. an empty description in the default profile) is always
+        // attributed to the profile that declares it, deterministically.
+        let mut profile_names: Vec<&String> = self.profiles.keys().collect();
+        profile_names.sort_by(|a, b| {
+            (a.as_str() != "default", a.as_str()).cmp(&(b.as_str() != "default", b.as_str()))
+        });
+
+        for profile_name in profile_names {
+            let inherit_from = if profile_name == "default" {
+                None
+            } else {
+                default_profile
+            };
+            self.profiles[profile_name]
+                .validate_with_default(inherit_from)
                 .map_err(|e| {
                     ParseError::Validation(format!("Profile '{}': {}", profile_name, e))
                 })?;
@@ -518,21 +531,51 @@ impl Profile {
             return Err("Profile must define at least one secret".into());
         }
 
-        for (name, secret) in &self.secrets {
-            // Validate secret name is a valid identifier
-            if !is_valid_identifier(name) {
-                return Err(format!(
-                    "Invalid secret name '{}': must be a valid identifier (alphanumeric and underscores, not starting with a number)",
-                    name
-                ));
+        // Resolution acts on the union of this profile's secrets and the
+        // default profile's, merged field by field together with this
+        // profile's `[defaults]` table. Validate that same effective view so
+        // validation and resolution cannot disagree. Names are sorted so
+        // error attribution is deterministic.
+        let mut names: Vec<&String> = self.secrets.keys().collect();
+        if let Some(default_profile) = default_profile {
+            names.extend(
+                default_profile
+                    .secrets
+                    .keys()
+                    .filter(|name| !self.secrets.contains_key(*name)),
+            );
+        }
+        names.sort();
+
+        for name in names {
+            let secret = self.secrets.get(name);
+
+            if let Some(secret) = secret {
+                // Validate secret name is a valid identifier
+                if !is_valid_identifier(name) {
+                    return Err(format!(
+                        "Invalid secret name '{}': must be a valid identifier (alphanumeric and underscores, not starting with a number)",
+                        name
+                    ));
+                }
+
+                // Raw-entry rule: `required = true` plus an inline `default`
+                // contradicts itself within one entry. Across profiles the
+                // same combination is the override mechanism working as
+                // intended (e.g. dev supplies a default for a secret the
+                // default profile requires), so it is not checked on the
+                // merged view below.
+                secret
+                    .validate_required_default()
+                    .map_err(|e| format!("Secret '{}': {}", name, e))?;
             }
 
-            let inherited_description = default_profile
-                .and_then(|profile| profile.secrets.get(name))
-                .and_then(|secret| secret.description.as_deref());
+            let inherited = default_profile.and_then(|profile| profile.secrets.get(name));
+            let merged = Secret::resolved(secret, inherited, self.defaults.as_ref())
+                .expect("every validated name comes from one of the two secret maps");
 
-            secret
-                .validate_with_description(inherited_description)
+            merged
+                .validate_effective()
                 .map_err(|e| format!("Secret '{}': {}", name, e))?;
         }
 
@@ -903,21 +946,39 @@ impl Secret {
     /// Ensures that required secrets don't have default values,
     /// and that generation config is consistent with type.
     pub fn validate(&self) -> Result<(), String> {
-        self.validate_with_description(None)
+        self.validate_description()?;
+        self.validate_required_default()?;
+        self.validate_semantics()
     }
 
-    fn validate_with_description(&self, inherited_description: Option<&str>) -> Result<(), String> {
-        match self.description.as_deref().or(inherited_description) {
-            Some("") => return Err("description cannot be empty".into()),
-            None => return Err("missing description".into()),
-            Some(_) => {}
-        }
+    /// Rules that apply to the effective (merged) configuration of a secret,
+    /// i.e. what a resolver actually acts on. `Config::validate` calls this on
+    /// the merged view so overrides may inherit fields (description, type,
+    /// generate, ...) from the default profile.
+    fn validate_effective(&self) -> Result<(), String> {
+        self.validate_description()?;
+        self.validate_semantics()
+    }
 
-        // If required is explicitly true and default is set, that's an error
+    fn validate_description(&self) -> Result<(), String> {
+        match self.description.as_deref() {
+            Some("") => Err("description cannot be empty".into()),
+            None => Err("missing description".into()),
+            Some(_) => Ok(()),
+        }
+    }
+
+    /// If required is explicitly true and default is set, that's an error.
+    /// Checked on raw entries only, not on merged views (see
+    /// `Profile::validate_with_default`).
+    fn validate_required_default(&self) -> Result<(), String> {
         if self.required == Some(true) && self.default.is_some() {
             return Err("Required secrets cannot have default values".into());
         }
+        Ok(())
+    }
 
+    fn validate_semantics(&self) -> Result<(), String> {
         // A `ref` supplies naming only: it composes with `providers` routing
         // and with `generate` (a missing referenced secret is minted and
         // written to its coordinates, like any other generated value).
@@ -993,6 +1054,73 @@ impl Secret {
         }
 
         Ok(())
+    }
+
+    /// Field-level merge producing the effective configuration a resolver
+    /// acts on.
+    ///
+    /// Precedence (highest to lowest): the current profile's entry, the
+    /// default profile's entry, then the current profile's `[defaults]` table
+    /// (for the fields it can supply). Shared by secret resolution
+    /// (`Secrets::resolve_secret_config`) and `Config::validate` so the two
+    /// can never disagree about what a merged secret looks like.
+    pub(crate) fn resolved(
+        current: Option<&Secret>,
+        default: Option<&Secret>,
+        defaults: Option<&ProfileDefaults>,
+    ) -> Option<Secret> {
+        match (current, default) {
+            (Some(current), Some(default)) => Some(Secret {
+                description: current
+                    .description
+                    .clone()
+                    .or_else(|| default.description.clone()),
+                required: current
+                    .required
+                    .or(default.required)
+                    .or(defaults.and_then(|d| d.required)),
+                default: current
+                    .default
+                    .clone()
+                    .or_else(|| default.default.clone())
+                    .or_else(|| defaults.and_then(|d| d.default.clone())),
+                providers: current
+                    .providers
+                    .clone()
+                    .or_else(|| default.providers.clone())
+                    .or_else(|| defaults.and_then(|d| d.providers.clone())),
+                reference: current
+                    .reference
+                    .clone()
+                    .or_else(|| default.reference.clone()),
+                as_path: current.as_path.or(default.as_path),
+                secret_type: current
+                    .secret_type
+                    .clone()
+                    .or_else(|| default.secret_type.clone()),
+                generate: current
+                    .generate
+                    .clone()
+                    .or_else(|| default.generate.clone()),
+            }),
+            (Some(secret), None) | (None, Some(secret)) => Some(Secret {
+                description: secret.description.clone(),
+                required: secret.required.or(defaults.and_then(|d| d.required)),
+                default: secret
+                    .default
+                    .clone()
+                    .or_else(|| defaults.and_then(|d| d.default.clone())),
+                providers: secret
+                    .providers
+                    .clone()
+                    .or_else(|| defaults.and_then(|d| d.providers.clone())),
+                reference: secret.reference.clone(),
+                as_path: secret.as_path,
+                secret_type: secret.secret_type.clone(),
+                generate: secret.generate.clone(),
+            }),
+            (None, None) => None,
+        }
     }
 }
 
@@ -1624,7 +1752,7 @@ DATABASE_URL = { default = "sqlite:///dev.db" }
 
         config.validate().unwrap();
 
-        let spec = crate::Secrets::new(config, None, Some("development".to_string()), None);
+        let spec = crate::Secrets::new(config, None, None, Some("development".to_string()));
         let resolved = spec
             .resolve_secret_config("DATABASE_URL", Some("development"))
             .unwrap();
@@ -1647,6 +1775,130 @@ DATABASE_URL = { default = "sqlite:///dev.db" }
 
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("missing description"));
+    }
+
+    #[test]
+    fn config_validate_rejects_generate_and_default_split_across_profiles() {
+        // The merged production config carries generate (inherited) plus an
+        // inline default; the executor would generate and silently ignore the
+        // default, so validation must reject the combination.
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "tmp"
+revision = "1.0"
+
+[profiles.default]
+API_TOKEN = { description = "t", type = "password", generate = true }
+
+[profiles.production]
+API_TOKEN = { default = "placeholder" }
+"#,
+        )
+        .unwrap();
+
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("Profile 'production'"), "{err}");
+        assert!(
+            err.contains("'generate' and 'default' cannot both be set"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn config_validate_allows_generate_with_type_inherited_from_default_profile() {
+        // Resolution merges `type` from the default profile, so the override
+        // only enabling `generate` is a coherent effective config.
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "tmp"
+revision = "1.0"
+
+[profiles.default]
+TOKEN = { description = "t", type = "password" }
+
+[profiles.production]
+TOKEN = { generate = true }
+"#,
+        )
+        .unwrap();
+
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn config_validate_allows_required_in_default_with_override_default() {
+        // required=true in the default profile plus a default value supplied
+        // by an override is the override mechanism working as intended; only
+        // the same combination within a single raw entry is a contradiction.
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "tmp"
+revision = "1.0"
+
+[profiles.default]
+DATABASE_URL = { description = "db", required = true }
+
+[profiles.development]
+DATABASE_URL = { default = "sqlite:///dev.db" }
+"#,
+        )
+        .unwrap();
+
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn config_validate_blames_default_profile_for_empty_inherited_description() {
+        // The empty description lives in the default profile; the error must
+        // name that profile deterministically, not the override that inherits
+        // the empty value.
+        let config = config_with(
+            "proj",
+            vec![
+                ("default", vec![("DB", secret(Some("")))]),
+                ("development", vec![("DB", secret(None))]),
+            ],
+        );
+
+        for _ in 0..8 {
+            let err = config.validate().unwrap_err().to_string();
+            assert!(err.contains("Profile 'default'"), "{err}");
+            assert!(err.contains("description cannot be empty"), "{err}");
+        }
+    }
+
+    #[test]
+    fn config_validate_checks_profile_defaults_in_merged_config() {
+        // A [defaults] table participates in resolution, so a default value it
+        // injects next to an inherited generate must fail validation too, even
+        // though the production profile never declares the secret itself.
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "tmp"
+revision = "1.0"
+
+[profiles.default]
+API_TOKEN = { description = "t", type = "password", generate = true }
+
+[profiles.production]
+OTHER = { description = "o" }
+
+[profiles.production.defaults]
+default = "placeholder"
+"#,
+        )
+        .unwrap();
+
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("Profile 'production'"), "{err}");
+        assert!(
+            err.contains("'generate' and 'default' cannot both be set"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -84,11 +84,17 @@ impl Config {
             ));
         }
 
-        // Validate each profile
+        let default_profile = self.profiles.get("default");
+
+        // Validate each profile. Non-default profiles are partial overrides, so
+        // their secrets may inherit descriptions from the default profile. The
+        // default profile inheriting from itself is a no-op.
         for (profile_name, profile) in &self.profiles {
-            profile.validate().map_err(|e| {
-                ParseError::Validation(format!("Profile '{}': {}", profile_name, e))
-            })?;
+            profile
+                .validate_with_default(default_profile)
+                .map_err(|e| {
+                    ParseError::Validation(format!("Profile '{}': {}", profile_name, e))
+                })?;
         }
 
         Ok(())
@@ -504,6 +510,10 @@ impl Profile {
     ///
     /// Ensures all secrets have valid names and configurations.
     pub fn validate(&self) -> Result<(), String> {
+        self.validate_with_default(None)
+    }
+
+    fn validate_with_default(&self, default_profile: Option<&Profile>) -> Result<(), String> {
         if self.secrets.is_empty() {
             return Err("Profile must define at least one secret".into());
         }
@@ -517,8 +527,12 @@ impl Profile {
                 ));
             }
 
+            let inherited_description = default_profile
+                .and_then(|profile| profile.secrets.get(name))
+                .and_then(|secret| secret.description.as_deref());
+
             secret
-                .validate()
+                .validate_with_description(inherited_description)
                 .map_err(|e| format!("Secret '{}': {}", name, e))?;
         }
 
@@ -889,12 +903,14 @@ impl Secret {
     /// Ensures that required secrets don't have default values,
     /// and that generation config is consistent with type.
     pub fn validate(&self) -> Result<(), String> {
-        if let Some(desc) = &self.description {
-            if desc.is_empty() {
-                return Err("description cannot be empty".into());
-            }
-        } else {
-            return Err("missing description".into());
+        self.validate_with_description(None)
+    }
+
+    fn validate_with_description(&self, inherited_description: Option<&str>) -> Result<(), String> {
+        match self.description.as_deref().or(inherited_description) {
+            Some("") => return Err("description cannot be empty".into()),
+            None => return Err("missing description".into()),
+            Some(_) => {}
         }
 
         // If required is explicitly true and default is set, that's an error
@@ -1587,6 +1603,50 @@ mod validation_tests {
             .validate()
             .is_ok()
         );
+    }
+
+    #[test]
+    fn config_validate_allows_profile_override_to_inherit_description() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "tmp"
+revision = "1.0"
+
+[profiles.default]
+DATABASE_URL = { description = "Database connection string", required = true }
+
+[profiles.development]
+DATABASE_URL = { default = "sqlite:///dev.db" }
+"#,
+        )
+        .unwrap();
+
+        config.validate().unwrap();
+
+        let spec = crate::Secrets::new(config, None, Some("development".to_string()), None);
+        let resolved = spec
+            .resolve_secret_config("DATABASE_URL", Some("development"))
+            .unwrap();
+        assert_eq!(
+            resolved.description.as_deref(),
+            Some("Database connection string")
+        );
+        assert_eq!(resolved.default.as_deref(), Some("sqlite:///dev.db"));
+    }
+
+    #[test]
+    fn config_validate_requires_description_for_profile_only_secret() {
+        let config = config_with(
+            "proj",
+            vec![
+                ("default", vec![("API_KEY", secret(Some("API key")))]),
+                ("development", vec![("DATABASE_URL", secret(None))]),
+            ],
+        );
+
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("missing description"));
     }
 
     #[test]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -84,27 +84,30 @@ impl Config {
             ));
         }
 
-        let default_profile = self.profiles.get("default");
-
         // Validate each profile against the same effective view resolution
         // uses: non-default profiles are partial overrides whose secrets merge
         // field by field with the default profile's entries. The default
-        // profile is validated first and profiles are ordered, so an error
-        // (e.g. an empty description in the default profile) is always
-        // attributed to the profile that declares it, deterministically.
-        let mut profile_names: Vec<&String> = self.profiles.keys().collect();
-        profile_names.sort_by(|a, b| {
-            (a.as_str() != "default", a.as_str()).cmp(&(b.as_str() != "default", b.as_str()))
-        });
+        // profile is validated first, so an error it declares (e.g. an empty
+        // description) is attributed to it rather than to an override that
+        // inherits the broken value; the remaining profiles follow in name
+        // order so attribution stays deterministic.
+        let default_profile = self.profiles.get("default");
+        if let Some(default_profile) = default_profile {
+            default_profile
+                .validate_with_default(None)
+                .map_err(|e| ParseError::Validation(format!("Profile 'default': {}", e)))?;
+        }
+
+        let mut profile_names: Vec<&String> = self
+            .profiles
+            .keys()
+            .filter(|name| name.as_str() != "default")
+            .collect();
+        profile_names.sort();
 
         for profile_name in profile_names {
-            let inherit_from = if profile_name == "default" {
-                None
-            } else {
-                default_profile
-            };
             self.profiles[profile_name]
-                .validate_with_default(inherit_from)
+                .validate_with_default(default_profile)
                 .map_err(|e| {
                     ParseError::Validation(format!("Profile '{}': {}", profile_name, e))
                 })?;
@@ -519,35 +522,18 @@ impl Profile {
         }
     }
 
-    /// Validate the profile configuration.
-    ///
-    /// Ensures all secrets have valid names and configurations.
-    pub fn validate(&self) -> Result<(), String> {
-        self.validate_with_default(None)
-    }
-
+    /// Validate the profile configuration against the effective view
+    /// resolution uses: the union of this profile's secrets and the default
+    /// profile's, merged field by field together with this profile's
+    /// `[defaults]` table, so validation and resolution cannot disagree.
+    /// Pass `None` when this profile has nothing to inherit from (it is the
+    /// default profile itself).
     fn validate_with_default(&self, default_profile: Option<&Profile>) -> Result<(), String> {
         if self.secrets.is_empty() {
             return Err("Profile must define at least one secret".into());
         }
 
-        // Resolution acts on the union of this profile's secrets and the
-        // default profile's, merged field by field together with this
-        // profile's `[defaults]` table. Validate that same effective view so
-        // validation and resolution cannot disagree. Names are sorted so
-        // error attribution is deterministic.
-        let mut names: Vec<&String> = self.secrets.keys().collect();
-        if let Some(default_profile) = default_profile {
-            names.extend(
-                default_profile
-                    .secrets
-                    .keys()
-                    .filter(|name| !self.secrets.contains_key(*name)),
-            );
-        }
-        names.sort();
-
-        for name in names {
+        for name in self.sorted_secret_names_with(default_profile) {
             let secret = self.secrets.get(name);
 
             if let Some(secret) = secret {
@@ -604,6 +590,27 @@ impl Profile {
     /// ordering (grouping, missing lists) instead of the map's hash order.
     pub(crate) fn sorted_secret_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self.secrets.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Sorted union of this profile's secret names and the default profile's:
+    /// the name set resolution acts on when this profile overrides
+    /// `default_profile`, with the same deterministic ordering as
+    /// [`Profile::sorted_secret_names`].
+    pub(crate) fn sorted_secret_names_with<'a>(
+        &'a self,
+        default_profile: Option<&'a Profile>,
+    ) -> Vec<&'a String> {
+        let mut names: Vec<&String> = self.secrets.keys().collect();
+        if let Some(default_profile) = default_profile {
+            names.extend(
+                default_profile
+                    .secrets
+                    .keys()
+                    .filter(|name| !self.secrets.contains_key(*name)),
+            );
+        }
         names.sort();
         names
     }
@@ -1069,58 +1076,37 @@ impl Secret {
         default: Option<&Secret>,
         defaults: Option<&ProfileDefaults>,
     ) -> Option<Secret> {
-        match (current, default) {
-            (Some(current), Some(default)) => Some(Secret {
-                description: current
-                    .description
-                    .clone()
-                    .or_else(|| default.description.clone()),
-                required: current
-                    .required
-                    .or(default.required)
-                    .or(defaults.and_then(|d| d.required)),
-                default: current
-                    .default
-                    .clone()
-                    .or_else(|| default.default.clone())
-                    .or_else(|| defaults.and_then(|d| d.default.clone())),
-                providers: current
-                    .providers
-                    .clone()
-                    .or_else(|| default.providers.clone())
-                    .or_else(|| defaults.and_then(|d| d.providers.clone())),
-                reference: current
-                    .reference
-                    .clone()
-                    .or_else(|| default.reference.clone()),
-                as_path: current.as_path.or(default.as_path),
-                secret_type: current
-                    .secret_type
-                    .clone()
-                    .or_else(|| default.secret_type.clone()),
-                generate: current
-                    .generate
-                    .clone()
-                    .or_else(|| default.generate.clone()),
-            }),
-            (Some(secret), None) | (None, Some(secret)) => Some(Secret {
-                description: secret.description.clone(),
-                required: secret.required.or(defaults.and_then(|d| d.required)),
-                default: secret
-                    .default
-                    .clone()
-                    .or_else(|| defaults.and_then(|d| d.default.clone())),
-                providers: secret
-                    .providers
-                    .clone()
-                    .or_else(|| defaults.and_then(|d| d.providers.clone())),
-                reference: secret.reference.clone(),
-                as_path: secret.as_path,
-                secret_type: secret.secret_type.clone(),
-                generate: secret.generate.clone(),
-            }),
-            (None, None) => None,
+        if current.is_none() && default.is_none() {
+            return None;
         }
+
+        // One field's value from the profile entries in precedence order: the
+        // current profile's entry, then the default profile's. A missing
+        // entry simply contributes nothing. The `[defaults]` table tail is
+        // appended per field below, for the fields it can supply.
+        fn inherit<T>(
+            current: Option<&Secret>,
+            default: Option<&Secret>,
+            field: impl Fn(&Secret) -> Option<T>,
+        ) -> Option<T> {
+            current
+                .and_then(&field)
+                .or_else(|| default.and_then(&field))
+        }
+
+        Some(Secret {
+            description: inherit(current, default, |s| s.description.clone()),
+            required: inherit(current, default, |s| s.required)
+                .or(defaults.and_then(|d| d.required)),
+            default: inherit(current, default, |s| s.default.clone())
+                .or_else(|| defaults.and_then(|d| d.default.clone())),
+            providers: inherit(current, default, |s| s.providers.clone())
+                .or_else(|| defaults.and_then(|d| d.providers.clone())),
+            reference: inherit(current, default, |s| s.reference.clone()),
+            as_path: inherit(current, default, |s| s.as_path),
+            secret_type: inherit(current, default, |s| s.secret_type.clone()),
+            generate: inherit(current, default, |s| s.generate.clone()),
+        })
     }
 }
 
@@ -1735,6 +1721,9 @@ mod validation_tests {
 
     #[test]
     fn config_validate_allows_profile_override_to_inherit_description() {
+        // required = true in the default profile plus a default value from
+        // the override is also fine: only that combination within a single
+        // raw entry is a contradiction.
         let config: Config = toml::from_str(
             r#"
 [project]
@@ -1828,42 +1817,20 @@ TOKEN = { generate = true }
     }
 
     #[test]
-    fn config_validate_allows_required_in_default_with_override_default() {
-        // required=true in the default profile plus a default value supplied
-        // by an override is the override mechanism working as intended; only
-        // the same combination within a single raw entry is a contradiction.
-        let config: Config = toml::from_str(
-            r#"
-[project]
-name = "tmp"
-revision = "1.0"
-
-[profiles.default]
-DATABASE_URL = { description = "db", required = true }
-
-[profiles.development]
-DATABASE_URL = { default = "sqlite:///dev.db" }
-"#,
-        )
-        .unwrap();
-
-        config.validate().unwrap();
-    }
-
-    #[test]
     fn config_validate_blames_default_profile_for_empty_inherited_description() {
         // The empty description lives in the default profile; the error must
         // name that profile deterministically, not the override that inherits
-        // the empty value.
-        let config = config_with(
-            "proj",
-            vec![
-                ("default", vec![("DB", secret(Some("")))]),
-                ("development", vec![("DB", secret(None))]),
-            ],
-        );
-
+        // the empty value. The config is rebuilt each iteration so every
+        // HashMap gets a fresh hash seed and seed-dependent iteration order
+        // would surface here.
         for _ in 0..8 {
+            let config = config_with(
+                "proj",
+                vec![
+                    ("default", vec![("DB", secret(Some("")))]),
+                    ("development", vec![("DB", secret(None))]),
+                ],
+            );
             let err = config.validate().unwrap_err().to_string();
             assert!(err.contains("Profile 'default'"), "{err}");
             assert!(err.contains("description cannot be empty"), "{err}");

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -180,9 +180,7 @@ impl Secrets {
 
         let mut secrets = Vec::with_capacity(names.len());
         for name in names {
-            let config = self
-                .resolve_secret_config(&name, Some(&profile_name))
-                .expect("secret resolved from the merged profile always has a config");
+            let config = self.effective_secret_config(&name, &profile_name);
             secrets.push(self.plan_one_secret(name, config, &override_uri)?);
         }
 

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -845,6 +845,14 @@ impl Secrets {
         }
     }
 
+    /// Resolve the effective (merged) config for a secret that is known to
+    /// belong to `profile`. Any secret yielded by iterating that profile is
+    /// guaranteed to have an effective config, so a missing one is a bug.
+    fn effective_secret_config(&self, name: &str, profile: &str) -> crate::config::Secret {
+        self.resolve_secret_config(name, Some(profile))
+            .expect("secret from the resolved profile must have an effective config")
+    }
+
     /// Provider-alias maps in lookup order: project `secretspec.toml` first,
     /// then user-global config. Project entries win on conflict so teams can
     /// pin shareable mappings in version control while still allowing per-user
@@ -1636,7 +1644,8 @@ impl Secrets {
             .collect::<HashSet<_>>();
         let missing_optional: HashSet<&String> = valid.missing_optional.iter().collect();
 
-        for (name, config) in profile.iter() {
+        for (name, _) in profile.iter() {
+            let config = self.effective_secret_config(name, &valid.resolved.profile);
             if missing_optional.contains(&name) {
                 optional_count += 1;
                 eprintln!(
@@ -1683,7 +1692,8 @@ impl Secrets {
             .map(|(name, _)| name)
             .collect::<HashSet<_>>();
 
-        for (name, config) in &profile {
+        for (name, _) in &profile {
+            let config = self.effective_secret_config(name, &errors.profile);
             if errors.missing_required.contains(name) {
                 missing_count += 1;
                 eprintln!(

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -791,9 +791,38 @@ impl Secrets {
     /// Resolve the effective (merged) config for a secret that is known to
     /// belong to `profile`. Any secret yielded by iterating that profile is
     /// guaranteed to have an effective config, so a missing one is a bug.
-    fn effective_secret_config(&self, name: &str, profile: &str) -> crate::config::Secret {
+    pub(crate) fn effective_secret_config(
+        &self,
+        name: &str,
+        profile: &str,
+    ) -> crate::config::Secret {
         self.resolve_secret_config(name, Some(profile))
             .expect("secret from the resolved profile must have an effective config")
+    }
+
+    /// The effective (field-level merged) secrets of `profile_name` in
+    /// name-sorted order: the union of the profile's and the default
+    /// profile's names, each resolved via [`Secrets::resolve_secret_config`].
+    /// This is the view `check`/`run` list, matching what resolution acts on.
+    fn effective_secrets(&self, profile_name: &str) -> Vec<(String, crate::config::Secret)> {
+        let Some(current) = self.config.profiles.get(profile_name) else {
+            return Vec::new();
+        };
+        let default_profile = if profile_name != "default" {
+            self.config.profiles.get("default")
+        } else {
+            None
+        };
+        current
+            .sorted_secret_names_with(default_profile)
+            .into_iter()
+            .map(|name| {
+                (
+                    name.clone(),
+                    self.effective_secret_config(name, profile_name),
+                )
+            })
+            .collect()
     }
 
     /// Provider-alias maps in lookup order: project `secretspec.toml` first,
@@ -1577,7 +1606,6 @@ impl Secrets {
 
     /// Display validation success results
     fn display_validation_success(&self, valid: &ValidatedSecrets) -> Result<()> {
-        let profile = self.resolve_profile(Some(&valid.resolved.profile))?;
         let mut found_count = 0;
         let mut optional_count = 0;
         let default_names = valid
@@ -1587,8 +1615,7 @@ impl Secrets {
             .collect::<HashSet<_>>();
         let missing_optional: HashSet<&String> = valid.missing_optional.iter().collect();
 
-        for name in &profile.sorted_secret_names() {
-            let config = self.effective_secret_config(name, &valid.resolved.profile);
+        for (name, config) in &self.effective_secrets(&valid.resolved.profile) {
             if missing_optional.contains(&name) {
                 optional_count += 1;
                 eprintln!(
@@ -1625,7 +1652,6 @@ impl Secrets {
 
     /// Display validation error results
     fn display_validation_errors(&self, errors: &ValidationErrors) -> Result<()> {
-        let profile = self.resolve_profile(Some(&errors.profile))?;
         let mut found_count = 0;
         let mut missing_count = 0;
         let mut optional_count = 0;
@@ -1635,8 +1661,7 @@ impl Secrets {
             .map(|(name, _)| name)
             .collect::<HashSet<_>>();
 
-        for name in &profile.sorted_secret_names() {
-            let config = self.effective_secret_config(name, &errors.profile);
+        for (name, config) in &self.effective_secrets(&errors.profile) {
             if errors.missing_required.contains(name) {
                 missing_count += 1;
                 eprintln!(

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -783,66 +783,9 @@ impl Secrets {
             None
         };
 
-        match (current_secret, default_secret) {
-            (Some(current), Some(default)) => {
-                // Merge: current profile takes precedence, then default profile, then profile defaults
-                Some(crate::config::Secret {
-                    description: current
-                        .description
-                        .clone()
-                        .or_else(|| default.description.clone()),
-                    required: current
-                        .required
-                        .or(default.required)
-                        .or(current_defaults.and_then(|d| d.required)),
-                    default: current
-                        .default
-                        .clone()
-                        .or_else(|| default.default.clone())
-                        .or_else(|| current_defaults.and_then(|d| d.default.clone())),
-                    providers: current
-                        .providers
-                        .clone()
-                        .or_else(|| default.providers.clone())
-                        .or_else(|| current_defaults.and_then(|d| d.providers.clone())),
-                    reference: current
-                        .reference
-                        .clone()
-                        .or_else(|| default.reference.clone()),
-                    as_path: current.as_path.or(default.as_path),
-                    secret_type: current
-                        .secret_type
-                        .clone()
-                        .or_else(|| default.secret_type.clone()),
-                    generate: current
-                        .generate
-                        .clone()
-                        .or_else(|| default.generate.clone()),
-                })
-            }
-            (Some(secret), None) | (None, Some(secret)) => {
-                // Apply profile defaults to the found secret
-                Some(crate::config::Secret {
-                    description: secret.description.clone(),
-                    required: secret
-                        .required
-                        .or(current_defaults.and_then(|d| d.required)),
-                    default: secret
-                        .default
-                        .clone()
-                        .or_else(|| current_defaults.and_then(|d| d.default.clone())),
-                    providers: secret
-                        .providers
-                        .clone()
-                        .or_else(|| current_defaults.and_then(|d| d.providers.clone())),
-                    reference: secret.reference.clone(),
-                    as_path: secret.as_path,
-                    secret_type: secret.secret_type.clone(),
-                    generate: secret.generate.clone(),
-                })
-            }
-            (None, None) => None,
-        }
+        // The field-level merge lives on `Secret` so `Config::validate`
+        // checks exactly the effective config this method produces.
+        crate::config::Secret::resolved(current_secret, default_secret, current_defaults)
     }
 
     /// Resolve the effective (merged) config for a secret that is known to
@@ -1644,7 +1587,7 @@ impl Secrets {
             .collect::<HashSet<_>>();
         let missing_optional: HashSet<&String> = valid.missing_optional.iter().collect();
 
-        for (name, _) in profile.iter() {
+        for name in &profile.sorted_secret_names() {
             let config = self.effective_secret_config(name, &valid.resolved.profile);
             if missing_optional.contains(&name) {
                 optional_count += 1;
@@ -1692,7 +1635,7 @@ impl Secrets {
             .map(|(name, _)| name)
             .collect::<HashSet<_>>();
 
-        for (name, _) in &profile {
+        for name in &profile.sorted_secret_names() {
             let config = self.effective_secret_config(name, &errors.profile);
             if errors.missing_required.contains(name) {
                 missing_count += 1;


### PR DESCRIPTION
## Profile overrides inherit from the default profile during validation

Fixes #135

Validation now checks each secret's effective, merged configuration, the same view resolution acts on. A partial override like:

```toml
[profiles.default]
DATABASE_URL = { description = "Database connection string", required = true }

[profiles.development]
DATABASE_URL = { default = "sqlite:///dev.db" }
```

no longer fails with "missing description": the override inherits `description` (and `type`, for `generate`) from the default profile. The merged view is also validated for real conflicts, so `generate` in the default profile combined with a `default` value from an override or a profile `[defaults]` table is rejected at load instead of silently generating a value and ignoring the default. Validation errors are attributed deterministically to the profile that declares the offending field, and `check`/`run` list secrets in stable name sorted order.

The field level merge now lives in one place (`Secret::resolved`), shared by resolution, validation, planning, and the `check`/`run` listings, so they cannot disagree about what a merged secret looks like.

## Node SDK: portable Linux addons (fixes #136)

The prebuilt Linux addons are now built in manylinux_2_28 containers with libdbus compiled from source and linked statically (new `vendored-dbus` cargo feature). `npm install secretspec` works on any distro with glibc >= 2.28 (RHEL 8/9, Amazon Linux 2023, Debian 10+) instead of failing to load with ``version `GLIBC_2.38' not found``. A post build CI step fails the job if the addon's glibc floor or NEEDED libraries regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)