### PR TITLE
feat: add secretspec export command

### DIFF
--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -301,6 +301,33 @@ $ secretspec run -- node app.js  # app.js reads process.env.DATABASE_URL
 ```
 :::
 
+### export
+Resolve every secret for the active profile and write it to stdout in a chosen format, without running a command. Unlike `run`, it never prompts and exits non-zero when a required secret is missing, so CI can gate on it.
+
+```bash
+secretspec export [OPTIONS]
+```
+
+Options are `-p, --provider <PROVIDER>`, `-P, --profile <PROFILE>`, and `--format <FORMAT>` (default `shell`).
+
+| Format | Output |
+|--------|--------|
+| `shell` | `export KEY='value'` lines, ready for `eval "$(secretspec export)"` |
+| `dotenv` | `KEY=value` lines in dotenv syntax |
+| `json` | a single JSON object mapping each secret name to its value |
+| `gha` | appends `KEY=value` to the file named by `$GITHUB_ENV` and prints an `::add-mask::` command per value to stdout, so later workflow steps and third-party actions see the secrets |
+
+```bash
+# Load secrets into the current shell
+$ eval "$(secretspec export --profile production)"
+
+# Emit JSON for another tool to consume
+$ secretspec export --profile production --format json
+{ "DATABASE_URL": "postgresql://prod.example.com/mydb" }
+```
+
+The `gha` format targets a `secretspec export --format gha` step in a GitHub or Forgejo Actions job: it masks the values in the runner log and persists them to the job environment for the steps that follow.
+
 ### import
 Import secrets from one provider to another.
 
@@ -344,7 +371,7 @@ secretspec audit [--project <NAME>] [--action <ACTION>] [-n <N>] [--json]
 
 **Options:**
 - `--project <NAME>` - Only show entries for this project
-- `--action <ACTION>` - Only show entries for this action (`get`, `set`, `check`, `run`, `import`)
+- `--action <ACTION>` - Only show entries for this action (`get`, `set`, `check`, `run`, `import`, `export`)
 - `-n, --tail <N>` - Show only the last N entries
 - `--json` - Output raw JSON Lines instead of the formatted summary
 

--- a/secretspec/src/audit.rs
+++ b/secretspec/src/audit.rs
@@ -51,6 +51,8 @@ pub(crate) enum AuditAction {
     Run,
     /// Copy secrets from one provider to another (`secretspec import`).
     Import,
+    /// Resolve all secrets and emit them for another tool (`secretspec export`)
+    Export,
 }
 
 /// The result of an audited operation.

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1,5 +1,5 @@
 use crate::provider::{Provider, providers};
-use crate::{Config, GlobalConfig, GlobalDefaults, Profile, Project, Secrets};
+use crate::{Config, ExportFormat, GlobalConfig, GlobalDefaults, Profile, Project, Secrets};
 use clap::{Parser, Subcommand};
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
 use std::collections::HashMap;
@@ -83,6 +83,18 @@ enum Commands {
         #[arg(trailing_var_arg = true)]
         command: Vec<String>,
     },
+    /// Resolve secrets and print them for another tool to consume
+    Export {
+        /// Provider backend to use
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        provider: Option<String>,
+        /// Profile to use
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        profile: Option<String>,
+        /// Output format
+        #[arg(long, value_enum, default_value = "shell")]
+        format: ExportFormat,
+    },
     /// Check if all required secrets are in the provider, if not set them
     Check {
         /// Provider backend to use
@@ -135,7 +147,7 @@ enum Commands {
         /// Only show entries for this project
         #[arg(long)]
         project: Option<String>,
-        /// Only show entries for this action (get, set, check, run, import)
+        /// Only show entries for this action (get, set, check, run, import, export)
         #[arg(long)]
         action: Option<String>,
         /// Show only the last N entries
@@ -633,6 +645,24 @@ pub fn main() -> Result<()> {
             app.run(command)
                 .into_diagnostic()
                 .wrap_err("Failed to run command")?;
+            Ok(())
+        }
+        // Resolve secrets and print them without running a command
+        Commands::Export {
+            provider,
+            profile,
+            format,
+        } => {
+            let mut app = load_secrets(&cli.file, &cli.reason)?;
+            if let Some(p) = provider {
+                app.set_provider(p);
+            }
+            if let Some(p) = profile {
+                app.set_profile(p);
+            }
+            app.export(format)
+                .into_diagnostic()
+                .wrap_err("Failed to export secrets")?;
             Ok(())
         }
         // Verify all required secrets are available

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -80,6 +80,7 @@ pub use report::{
 pub use resolve::{
     RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource, resolve_json,
 };
+pub use secrets::ExportFormat;
 pub use secrets::Secrets;
 pub use validation::ValidatedSecrets;
 

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 /// `\$` (suppresses variable substitution), and `\n` (literal
 /// newlines folded onto a single line). Keys are sorted for stable
 /// output.
-fn serialize_dotenv(vars: &HashMap<String, String>) -> String {
+pub(crate) fn serialize_dotenv(vars: &HashMap<String, String>) -> String {
     let sorted: BTreeMap<&str, &str> = vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
     let mut out = String::new();
     for (key, value) in sorted {

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -2761,6 +2761,235 @@ impl Secrets {
         let status = child?.wait()?;
         Ok(status.code().unwrap_or(1))
     }
+
+    /// Resolves every secret for the active profile and emits them in `format`,
+    /// without executing a command. This is the non-interactive, scripting
+    /// counterpart to [`Secrets::run`]: it never prompts and errors when a
+    /// required secret is missing, so CI can gate on it.
+    ///
+    /// `as_path` secrets keep their backing temp files, like [`Secrets::check`],
+    /// so the emitted paths stay valid for whatever consumes the output.
+    pub fn export(&self, format: ExportFormat) -> Result<()> {
+        self.ensure_reason_for(AuditAction::Export, None)?;
+        let profile = self.resolve_profile_name(None);
+
+        let mut validated = match self.ensure_secrets(None, None, false) {
+            Ok(v) => v,
+            Err(e) => {
+                self.record(
+                    AuditAction::Export,
+                    &profile,
+                    AuditOutcome::Error,
+                    AuditFields {
+                        error_kind: Some(e.kind()),
+                        ..Default::default()
+                    },
+                );
+                return Err(e);
+            }
+        };
+
+        // Deterministic key order regardless of HashMap iteration
+        let mut entries: Vec<(String, String)> = validated
+            .resolved
+            .secrets
+            .iter()
+            .map(|(key, value)| (key.clone(), value.expose_secret().to_string()))
+            .collect();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let keys: Vec<String> = if self.audit.is_some() {
+            entries.iter().map(|(key, _)| key.clone()).collect()
+        } else {
+            Vec::new()
+        };
+
+        let result = write_export(format, &entries);
+        self.record(
+            AuditAction::Export,
+            &validated.resolved.profile,
+            if result.is_ok() {
+                AuditOutcome::Found
+            } else {
+                AuditOutcome::Error
+            },
+            AuditFields {
+                keys: &keys,
+                error_kind: result.as_ref().err().map(|e| e.kind()),
+                ..Default::default()
+            },
+        );
+        result?;
+
+        // Persist as_path temp files so emitted paths outlive this process
+        validated.keep_temp_files().map_err(SecretSpecError::Io)?;
+
+        Ok(())
+    }
+}
+
+/// Output format for [`Secrets::export`]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+pub enum ExportFormat {
+    /// `export KEY='value'` lines for `eval "$(secretspec export)"`
+    #[default]
+    Shell,
+    /// `KEY=value` lines in dotenv syntax
+    Dotenv,
+    /// A single JSON object mapping each secret name to its value
+    Json,
+    /// GitHub/Forgejo Actions `$GITHUB_ENV` file plus `::add-mask::` on stdout
+    Gha,
+}
+
+/// Write entries (pre-sorted by key) to stdout in the given format
+fn write_export(format: ExportFormat, entries: &[(String, String)]) -> Result<()> {
+    match format {
+        ExportFormat::Shell => {
+            let mut out = String::new();
+            for (key, value) in entries {
+                out.push_str("export ");
+                out.push_str(key);
+                out.push('=');
+                out.push_str(&shell_single_quote(value));
+                out.push('\n');
+            }
+            print!("{out}");
+        }
+        ExportFormat::Dotenv => {
+            let vars: HashMap<String, String> = entries.iter().cloned().collect();
+            print!("{}", crate::provider::dotenv::serialize_dotenv(&vars));
+        }
+        ExportFormat::Json => {
+            let map: BTreeMap<&str, &str> = entries
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str()))
+                .collect();
+            let json = serde_json::to_string_pretty(&map)
+                .map_err(|e| SecretSpecError::Io(io::Error::other(e)))?;
+            println!("{json}");
+        }
+        ExportFormat::Gha => write_gha(entries)?,
+    }
+
+    Ok(())
+}
+
+/// POSIX single-quote escaping so the value survives `eval` verbatim
+fn shell_single_quote(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('\'');
+    for ch in value.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// GitHub/Forgejo Actions writer that masks every value line on stdout and
+/// appends the assignments to `$GITHUB_ENV`. Multi-line values use the heredoc
+/// form so they survive. Errors when `$GITHUB_ENV` is unset.
+fn write_gha(entries: &[(String, String)]) -> Result<()> {
+    use std::io::Write;
+
+    let github_env = env::var("GITHUB_ENV").map_err(|_| {
+        SecretSpecError::Io(io::Error::new(
+            io::ErrorKind::NotFound,
+            "GITHUB_ENV is not set; `--format gha` only works inside a GitHub/Forgejo Actions runner",
+        ))
+    })?;
+
+    // Mask every value line so the runner scrubs accidental echoes
+    let mut masks = String::new();
+    for (_, value) in entries {
+        for line in value.split('\n') {
+            if !line.is_empty() {
+                masks.push_str("::add-mask::");
+                masks.push_str(line);
+                masks.push('\n');
+            }
+        }
+    }
+    print!("{masks}");
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&github_env)
+        .map_err(SecretSpecError::Io)?;
+
+    let mut block = String::new();
+    for (key, value) in entries {
+        if value.contains('\n') {
+            let delimiter = gha_heredoc_delimiter(value);
+            block.push_str(key);
+            block.push_str("<<");
+            block.push_str(&delimiter);
+            block.push('\n');
+            block.push_str(value);
+            block.push('\n');
+            block.push_str(&delimiter);
+            block.push('\n');
+        } else {
+            block.push_str(key);
+            block.push('=');
+            block.push_str(value);
+            block.push('\n');
+        }
+    }
+
+    file.write_all(block.as_bytes())
+        .map_err(SecretSpecError::Io)?;
+
+    Ok(())
+}
+
+/// A heredoc delimiter that does not collide with any line of `value`
+fn gha_heredoc_delimiter(value: &str) -> String {
+    loop {
+        let delimiter = format!("ghadelimiter_{}", uuid::Uuid::new_v4().simple());
+        if !value.lines().any(|line| line == delimiter) {
+            return delimiter;
+        }
+    }
+}
+
+#[cfg(test)]
+mod export_tests {
+    use super::*;
+
+    /// A POSIX shell evaluating `export K=<quoted>` must read the variable back
+    /// as exactly the original value. This round-trip is the real contract that
+    /// `shell_single_quote` defends, across quotes, spaces, `$`, `"`, and empty.
+    #[cfg(unix)]
+    #[test]
+    fn shell_single_quote_round_trips_through_sh() {
+        let cases = ["abc'123", "a b c", "pa$$word", "he said \"hi\"", "", "'"];
+
+        for value in cases {
+            let script = format!("export K={}; printf '%s' \"$K\"", shell_single_quote(value));
+
+            let output = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(&script)
+                .output()
+                .expect("sh should be available in the test environment");
+
+            assert!(
+                output.status.success(),
+                "sh failed for {value:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            let read_back = String::from_utf8(output.stdout).expect("sh stdout is utf-8");
+            assert_eq!(read_back, value, "round-trip mismatch for {value:?}");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -361,6 +361,10 @@ impl Secrets {
     /// Sets the provider to use for secret operations
     ///
     /// This overrides the provider from global configuration.
+    /// Blank input (empty or whitespace-only) is ignored, so a blank
+    /// `--provider` or `SECRETSPEC_PROVIDER` cannot shadow the configured
+    /// fallback chain. CI templates and workflow `env:` maps routinely
+    /// materialize unset values as empty strings.
     ///
     /// # Arguments
     ///
@@ -376,12 +380,16 @@ impl Secrets {
     /// spec.check(false).unwrap();
     /// ```
     pub fn set_provider(&mut self, provider: impl Into<String>) {
-        self.provider = Some(provider.into());
+        let provider = provider.into();
+        if !provider.trim().is_empty() {
+            self.provider = Some(provider);
+        }
     }
 
     /// Sets the profile to use for secret operations
     ///
     /// This overrides the profile from global configuration.
+    /// Blank input is ignored, matching [`Secrets::set_provider`].
     ///
     /// # Arguments
     ///
@@ -397,7 +405,10 @@ impl Secrets {
     /// spec.check(false).unwrap();
     /// ```
     pub fn set_profile(&mut self, profile: impl Into<String>) {
-        self.profile = Some(profile.into());
+        let profile = profile.into();
+        if !profile.trim().is_empty() {
+            self.profile = Some(profile);
+        }
     }
 
     /// Sets a human-readable reason for this session's secret access.
@@ -670,7 +681,11 @@ impl Secrets {
         profile
             .map(|p| p.to_string())
             .or_else(|| self.profile.clone())
-            .or_else(|| env::var("SECRETSPEC_PROFILE").ok())
+            .or_else(|| {
+                env::var("SECRETSPEC_PROFILE")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            })
             .or_else(|| {
                 self.global_config
                     .as_ref()
@@ -911,7 +926,11 @@ impl Secrets {
         override_arg
             .map(|spec| spec.to_string())
             .or_else(|| self.provider.clone())
-            .or_else(|| env::var("SECRETSPEC_PROVIDER").ok())
+            .or_else(|| {
+                env::var("SECRETSPEC_PROVIDER")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            })
     }
 
     /// Returns the explicit provider override resolved to a URI, if one is set.


### PR DESCRIPTION
Closes https://github.com/cachix/secretspec/issues/94

Formats are `shell` (default, `export KEY='value'` for `eval "$(secretspec export)"`), `dotenv` (via the existing `serialize_dotenv`), `json`, and `gha`. Resolution reuses the non-interactive `ensure_secrets` path, so a missing required secret exits non-zero and CI can gate on it, and access is recorded under a new `export` audit action.

`--format gha` appends `KEY=value` (heredoc for multi-line values) to the file named by `$GITHUB_ENV` and prints an `::add-mask::` per value, which makes it usable directly for `cachix/secretspec-action` in #97.

I verified the four formats against a dotenv provider, including eval round-trip, the missing-required exit code, and the unset-`$GITHUB_ENV` error.

The second commit treats blank provider and profile overrides (`SECRETSPEC_PROVIDER=`, `--provider ""`) as unset, matching the existing normalization of blank `SECRETSPEC_REASON`. CI env maps materialize omitted values as empty strings, which previously overrode the config fallback and failed with Provider backend '' not found.