### PR TITLE
feat: add gopass provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 
 # PHP (Composer) — manifest at repo root, vendor-dir points into secretspec-php/
 /composer.lock
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Gopass provider (`gopass://`) for GPG-based password manager with git-synced password store.
 - Azure Key Vault provider (`akv://`). Authenticates via a service principal
   whose `tenant_id`, `client_id`, and `client_secret` can be sourced as provider
   credentials (with `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -109,7 +109,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault / OpenBao, Bitwarden Secrets Manager, or Azure Key Vault.`,
+Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, Gopass, LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault / OpenBao, Bitwarden Secrets Manager, or Azure Key Vault.`,
         }),
       ],
       title: "SecretSpec",
@@ -170,6 +170,7 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
             { label: "Proton Pass", slug: "providers/protonpass" },
             { label: "LastPass", slug: "providers/lastpass" },
             { label: "1Password", slug: "providers/onepassword" },
+            { label: "Gopass", slug: "providers/gopass" },
             {
               label: "Google Cloud Secret Manager",
               slug: "providers/gcsm",

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -43,6 +43,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ |
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ |
 | [pass](/providers/pass/) | Unix `pass` password store | ✓ | ✓ | ✓ |
+| [gopass](/providers/gopass/) | `gopass` password store (git-synced, GPG-encrypted) | ✓ | ✓ | ✓ |
 | [protonpass](/providers/protonpass/) | Proton Pass | ✓ | ✓ | ✓ |
 | [onepassword](/providers/onepassword/) | 1Password | ✓ | ✓ | ✓ |
 | [lastpass](/providers/lastpass/) | LastPass | ✓ | ✓ | ✓ |

--- a/docs/src/content/docs/providers/gopass.md
+++ b/docs/src/content/docs/providers/gopass.md
@@ -1,0 +1,99 @@
+---
+title: Gopass Provider
+description: GPG-encrypted, git-synced password store integration
+---
+
+The Gopass provider integrates with [gopass](https://www.gopass.pw/), a multi-user, multi-store abstraction layer on top of `pass` that keeps secrets GPG-encrypted and syncs them via git.
+
+## Prerequisites
+
+Install the `gopass` CLI and initialize a password store:
+```bash
+# macOS
+brew install gopass
+
+# Debian/Ubuntu
+sudo apt install gopass
+
+# NixOS
+nix-env -iA nixpkgs.gopass
+```
+
+## Configuration
+
+### URI Format
+
+```
+gopass://[folder_prefix]
+```
+
+- `folder_prefix`: Optional path prefix supporting `{project}`, `{profile}`, and `{key}` placeholders. Defaults to `secretspec/{project}/{profile}/{key}`.
+
+### Examples
+
+```bash
+# Use default gopass storage
+$ secretspec set DATABASE_URL --provider gopass
+
+# Custom folder prefix (e.g., to share secrets across projects — see below)
+$ secretspec set DATABASE_URL --provider "gopass://secretspec/shared/{profile}/{key}"
+```
+
+## Secret References
+
+By default each secret is stored under `secretspec/{project}/{profile}/{key}`.
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing entry instead: `item` is the full entry path, including any mount-point
+prefix for multi-store setups (`field` is not supported). Reads and writes
+target that entry in place.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "Production DB", ref = { item = "work-store/infra/postgres" }, providers = ["gopass"] }
+```
+
+## Usage
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret DATABASE_URL saved to gopass
+
+# Get a secret
+$ secretspec get DATABASE_URL
+postgresql://localhost/mydb
+
+# Run with secrets
+$ secretspec run -- npm start
+
+# Use with profiles
+$ secretspec set API_KEY --profile production
+$ secretspec run --profile production -- npm start
+```
+
+## Shared Secrets
+
+By default, secrets are stored under `secretspec/{project}/{profile}/{key}`, which isolates them per project. To share secrets across projects, use a custom folder prefix via the URI:
+
+```toml
+# ~/.config/secretspec/config.toml
+[defaults.providers]
+shared = "gopass://secretspec/shared/{profile}/{key}"
+```
+
+The URI supports `{project}`, `{profile}`, and `{key}` placeholders. By omitting `{project}`, multiple projects can read and write the same store entry:
+
+```toml
+# secretspec.toml (in project-A and project-B)
+[profiles.default]
+ARTIFACTORY_USER = { description = "Artifactory user", providers = ["shared"] }
+```
+
+Both projects will resolve `ARTIFACTORY_USER` from `secretspec/shared/default/ARTIFACTORY_USER`.
+
+## Limitations
+
+Only the first line of an entry is read back — if an entry was written outside
+of `secretspec` and contains multiple lines, everything after the first line is
+discarded on `get`.

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -94,6 +94,7 @@ $ secretspec config init
   dotenv: Traditional .env files
   env: Read-only environment variables
   pass: Unix password manager with GPG encryption
+  gopass: Gopass CLI password manager with GPG encryption
   protonpass: Proton Pass via official pass-cli
   lastpass: LastPass password manager
   gcsm: Google Cloud Secret Manager

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -27,6 +27,21 @@ env://                       # Current process environment
 
 **Features**: Read-only, no setup required, no persistence
 
+## GoPass Provider
+
+**URI**: `gopass://[host][path]` - Uses `gopass`, a multi-user and multi-store abstraction layer over `pass`, with GPG encryption
+
+```bash
+gopass://                                    # Default folder prefix
+gopass://secretspec/shared/{profile}/{key}   # Custom folder prefix with placeholders
+```
+
+**Features**: Read/write, GPG encryption, git-backed sync, profiles, local storage
+**Prerequisites**: `gopass` CLI, initialized password store
+**Storage**: Path `secretspec/{project}/{profile}/{key}` by default; the URI host and path override the folder prefix and support `{project}`, `{profile}`, and `{key}` placeholders
+
+Gopass entries store a single line; multiline secrets are truncated to their first line when read.
+
 ## Keyring Provider
 
 **URI**: `keyring://` - Uses system keychain/keyring for secure storage
@@ -204,6 +219,7 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Environment | ❌ Plain text | Process memory | ❌ No |
 | Keyring | ✅ System encryption | System keychain | ❌ No |
 | Pass | ✅ GPG encryption | Local filesystem | ❌ No |
+| GoPass | ✅ GPG encryption | Local filesystem | ❌ No |
 | Proton Pass | ✅ End-to-end | Cloud (Proton) | ✅ Yes |
 | LastPass | ✅ End-to-end | Cloud (LastPass) | ✅ Yes |
 | OnePassword | ✅ End-to-end | Cloud (OnePassword) | ✅ Yes |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -37,6 +37,7 @@ const providerMetadata: ProviderMetadata[] = [
   { slug: 'awssm', label: 'AWS Secrets Manager' },
   { icon: 'googlecloud', slug: 'gcsm', label: 'Google Cloud Secret Manager' },
   { icon: 'microsoftazure', slug: 'akv', label: 'Azure Key Vault' },
+  { slug: 'gopass', label: 'Gopass' },
   { slug: 'protonpass', label: 'Proton Pass' },
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -22,6 +22,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [OnePassword](https://secretspec.dev/providers/onepassword)
   - [LastPass](https://secretspec.dev/providers/lastpass)
   - [Pass](https://secretspec.dev/providers/pass)
+  - [Gopass](https://secretspec.dev/providers/gopass)
   - [Proton Pass](https://secretspec.dev/providers/protonpass)
   - [environment variables](https://secretspec.dev/providers/env)
   - [Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)
@@ -56,6 +57,7 @@ $ secretspec config init
   dotenv: Traditional .env files
   env: Read-only environment variables
   pass: Unix password manager with GPG encryption
+  gopass: Gopass CLI password manager with GPG encryption
   protonpass: Proton Pass via official pass-cli
   lastpass: LastPass password manager
   gcsm: Google Cloud Secret Manager
@@ -138,6 +140,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[.env files](https://secretspec.dev/providers/dotenv)** - Traditional dotenv files
 - **[Environment variables](https://secretspec.dev/providers/env)** - Read-only for CI/CD
 - **[Pass](https://secretspec.dev/providers/pass)** - Unix password manager with GPG encryption
+- **[Gopass](https://secretspec.dev/providers/gopass)** - GPG-based password manager with git-synced password store
 - **[Proton Pass](https://secretspec.dev/providers/protonpass)** - End-to-end encrypted via Proton's official pass-cli
 - **[OnePassword](https://secretspec.dev/providers/onepassword)** - Team secret management
 - **[LastPass](https://secretspec.dev/providers/lastpass)** - Cloud password manager

--- a/secretspec/src/provider/gopass.rs
+++ b/secretspec/src/provider/gopass.rs
@@ -1,0 +1,344 @@
+use crate::config::NativeAddress;
+use crate::provider::{Address, ProviderUrl};
+use crate::{Provider, SecretSpecError};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+/// Configuration for the gopass (gopass.pw) provider.
+///
+/// Gopass is a multi-user, multi-store abstraction layer on top of
+/// `pass`.
+/// This struct holds configuration options for the gopass provider
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct GoPassConfig {
+    /// Optional folder prefix format string for organizing secrets in pass.
+    ///
+    /// Supports placeholders: {project}, {profile}, and {key}.
+    /// Defaults to "secretspec/{project}/{profile}/{key}" if not specified.
+    pub folder_prefix: Option<String>,
+}
+
+impl TryFrom<&ProviderUrl> for GoPassConfig {
+    type Error = SecretSpecError;
+
+    /// Creates a GoPassConfig from a URL.
+    ///
+    /// The URL must have the scheme "gopass" (e.g., "gopass://" or
+    /// "gopass://secretspec/shared/{profile}/{key}").
+    fn try_from(url: &ProviderUrl) -> Result<Self, Self::Error> {
+        if url.scheme() != "gopass" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for gopass provider",
+                url.scheme(),
+            )));
+        }
+
+        let mut config = Self::default();
+
+        if let Some(host) = url.host() {
+            let path = url.path();
+            config.folder_prefix = Some(format!("{}{}", host, path));
+        }
+
+        Ok(config)
+    }
+}
+
+pub struct GoPassProvider {
+    config: GoPassConfig,
+}
+
+crate::register_provider! {
+    struct: GoPassProvider,
+    config: GoPassConfig,
+    name: "gopass",
+    description: "Multi-user and multi-store abstraction layer over pass",
+    schemes: ["gopass"],
+    examples: ["gopass://", "gopass://secretspec/shared/{profile}/{key}"],
+}
+
+impl GoPassProvider {
+    /// Creates a new GoPassProvider with the given configuration.
+    pub fn new(config: GoPassConfig) -> Self {
+        Self { config }
+    }
+
+    /// Formats the entry name for a secret.
+    ///
+    /// Uses folder_prefix as a format string with {project}, {profile}, and {key} placeholders.
+    /// Defaults to "secretspec/{project}/{profile}/{key}" if not configured.
+    fn format_entry_name(&self, project: &str, profile: &str, key: &str) -> String {
+        let format_string = self
+            .config
+            .folder_prefix
+            .as_deref()
+            .unwrap_or("secretspec/{project}/{profile}/{key}");
+
+        format_string
+            .replace("{project}", project)
+            .replace("{profile}", profile)
+            .replace("{key}", key)
+    }
+
+    /// Creates a `gopass` command
+    fn command(&self) -> Command {
+        Command::new("gopass")
+    }
+}
+
+impl Provider for GoPassProvider {
+    /// Convention entries live under the folder-prefix format string,
+    /// `secretspec/{project}/{profile}/{key}` by default.
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> crate::Result<NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: self.format_entry_name(project, profile, key),
+            ..Default::default()
+        })
+    }
+
+    /// Retrieves a secret from the password store.
+    ///
+    /// # Arguments
+    ///
+    /// * `project` - The project name
+    /// * `key` - The secret key to retrieve
+    /// * `profile` - The profile name
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(SecretString))` - The secret value if found
+    /// * `Ok(None)` - If the secret doesn't exist in the password store
+    /// * `Err` - If there was an error executing `gopass` or reading the output
+    fn get(&self, addr: Address<'_>) -> crate::Result<Option<SecretString>> {
+        let entry_name = super::flat_item(self, addr)?;
+
+        let output = self
+            .command()
+            .arg("show")
+            // auto-confirm any yes/no prompt, in case the entry doesn't exist
+            .arg("-y")
+            // only show the password
+            // ponytail: first line only — multiline secrets truncate; switch to -n/--noparsing if that bites
+            .arg("-o")
+            .arg(&*entry_name)
+            .output()
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to execute 'gopass' command: {}. Is gopass installed?",
+                    e
+                ))
+            })?;
+
+        if output.status.success() {
+            let content = String::from_utf8(output.stdout)
+                .map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to parse gopass output as UTF-8: {}",
+                        e
+                    ))
+                })?
+                .trim()
+                .to_string();
+
+            Ok(Some(SecretString::new(content.into())))
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            // Entry doesn't exist. gopass exits 11 here; the message is
+            // "is not in the password store" when piped.
+            if output.status.code() == Some(11) && stderr.contains("is not in the password store") {
+                Ok(None)
+            } else {
+                Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "gopass command failed: {}",
+                    stderr
+                )))
+            }
+        }
+    }
+
+    /// Sets a secret value in the password store.
+    ///
+    /// # Arguments
+    ///
+    /// * `project` - The project name
+    /// * `key` - The secret key to set
+    /// * `value` - The value to store
+    /// * `profile` - The profile name
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the value was successfully written
+    /// * `Err(SecretSpecError)` - If writing the gopass entry fails
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> crate::Result<()> {
+        let entry_name = super::flat_item(self, addr)?;
+
+        let mut child = self
+            .command()
+            .args(["insert", "-m", "-f", &entry_name])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to execute gopass command: {}",
+                    e
+                ))
+            })?;
+
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(
+                "Failed to obtain stdin for gopass command".to_string(),
+            )
+        })?;
+
+        use std::io::Write;
+        stdin
+            .write_all(value.expose_secret().as_bytes())
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to write to gopass stdin: {}",
+                    e
+                ))
+            })?;
+
+        // Drop stdin to close the pipe so gopass process receives EOF
+        drop(stdin);
+
+        let output = child.wait_with_output().map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to wait for gopass command: {}",
+                e
+            ))
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "gopass command failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let prefix = self
+            .config
+            .folder_prefix
+            .as_deref()
+            .map(ProviderUrl::encode)
+            .unwrap_or_default();
+
+        if prefix.is_empty() {
+            "gopass".to_string()
+        } else {
+            format!("gopass://{}", prefix)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    fn provider_url(s: &str) -> ProviderUrl {
+        ProviderUrl::new(Url::parse(s).unwrap())
+    }
+
+    #[test]
+    fn format_entry_name_default_pattern() {
+        let provider = GoPassProvider::new(GoPassConfig::default());
+        assert_eq!(
+            provider.format_entry_name("myproj", "prod", "API_KEY"),
+            "secretspec/myproj/prod/API_KEY"
+        );
+    }
+
+    #[test]
+    fn format_entry_name_custom_prefix() {
+        let provider = GoPassProvider::new(GoPassConfig {
+            folder_prefix: Some("team-store/{profile}/{key}".to_string()),
+        });
+        assert_eq!(
+            provider.format_entry_name("myproj", "prod", "API_KEY"),
+            "team-store/prod/API_KEY"
+        );
+    }
+
+    #[test]
+    fn try_from_sets_folder_prefix_from_host_and_path() {
+        let config =
+            GoPassConfig::try_from(&provider_url("gopass://secretspec/shared/{profile}/{key}"))
+                .unwrap();
+        assert_eq!(
+            config.folder_prefix.as_deref(),
+            Some("secretspec/shared/{profile}/{key}")
+        );
+    }
+
+    #[test]
+    fn try_from_bare_url_leaves_prefix_unset() {
+        let config = GoPassConfig::try_from(&provider_url("gopass://")).unwrap();
+        assert_eq!(config.folder_prefix, None);
+    }
+
+    #[test]
+    fn try_from_rejects_wrong_scheme() {
+        let err = GoPassConfig::try_from(&provider_url("pass://x")).unwrap_err();
+        assert!(err.to_string().contains("Invalid scheme"));
+    }
+
+    #[test]
+    fn uri_round_trips_default_and_prefix() {
+        assert_eq!(GoPassProvider::new(GoPassConfig::default()).uri(), "gopass");
+        let provider = GoPassProvider::new(GoPassConfig {
+            folder_prefix: Some("my store/{key}".to_string()),
+        });
+        assert_eq!(provider.uri(), "gopass://my%20store/{key}");
+    }
+
+    /// A native address names the store entry directly via `item`, bypassing
+    /// the folder-prefix format string. This is what gopass logical paths
+    /// (including mount-point prefixes for multi-store setups) map onto.
+    #[test]
+    fn native_address_names_the_entry() {
+        let p = GoPassProvider::new(GoPassConfig {
+            folder_prefix: Some("team-store/{profile}/{key}".to_string()),
+        });
+        let addr = crate::config::NativeAddress {
+            item: "work-store/email/work".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            crate::provider::flat_item(&p, Address::Native(&addr)).unwrap(),
+            "work-store/email/work"
+        );
+    }
+
+    /// Store entries have no sub-components; a `field` coordinate is rejected.
+    #[test]
+    fn native_address_rejects_field() {
+        let p = GoPassProvider::new(GoPassConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "email/work".into(),
+            field: Some("password".into()),
+            ..Default::default()
+        };
+        let err = crate::provider::flat_item(&p, Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -229,6 +229,7 @@ pub mod dotenv;
 pub mod env;
 #[cfg(feature = "gcsm")]
 pub mod gcsm;
+pub mod gopass;
 #[cfg(feature = "keyring")]
 pub mod keyring;
 pub mod lastpass;

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -313,6 +313,9 @@ fn test_create_from_string_with_plain_names() {
     let provider = Box::<dyn Provider>::try_from("lastpass").unwrap();
     assert_eq!(provider.name(), "lastpass");
 
+    let provider = Box::<dyn Provider>::try_from("gopass").unwrap();
+    assert_eq!(provider.name(), "gopass");
+
     let provider = Box::<dyn Provider>::try_from("pass").unwrap();
     assert_eq!(provider.name(), "pass");
 


### PR DESCRIPTION
Adds a [gopass](https://www.gopass.pw/) provider backed by the `gopass` CLI (GPG-encrypted, git-synced password store).

- URI scheme `gopass://`, default entry path `secretspec/{project}/{profile}/{key}`; host+path override the folder prefix with `{project}`/`{profile}`/`{key}` placeholders (e.g. `gopass://secretspec/shared/{profile}/{key}`)
- `get` via `gopass show -y -o` (missing entry resolves to not-found, not an error), `set` via `gopass insert -m -f` over stdin
- Docs added everywhere providers are listed (provider page, sidebar, concepts/reference tables, landing page, quick-start, README) plus a CHANGELOG entry
- Unit tests for URI parsing/entry formatting/round-tripping; wired into the generic provider test suite (`SECRETSPEC_TEST_PROVIDERS=gopass`)

Known limitation: `gopass show -o` returns only the first line, so multiline secrets truncate on read (flagged in code and docs; `--noparsing` is the likely follow-up if needed).