### PR TITLE
feat: add Infisical provider (infisical://)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,27 @@ jobs:
     - name: Run tests
       run: devenv shell -- cargo test --all
 
+  # Each optional provider must compile on its own, not just in the default
+  # feature set. `cargo test` above cannot catch a missing feature gate: it
+  # builds with every provider enabled and with `cfg(test)` on, and shared
+  # helpers gated on `any(feature = "...", test)` are reachable under either.
+  # A provider that forgets to add itself to such a gate only breaks for the
+  # user who builds it standalone, which is precisely who `--features` is for.
+  features:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install Rust
+      run: rustup toolchain install stable --profile minimal
+    - name: Check each provider feature standalone
+      run: |
+        set -euo pipefail
+        for feature in cli keyring gcsm awssm vault infisical bws akv; do
+          echo "::group::$feature"
+          cargo check --package secretspec --no-default-features --features "$feature"
+          echo "::endgroup::"
+        done
+
   # Windows runners can't run Nix/devenv, so the suite runs here natively via
   # rustup + cargo. This exists specifically to catch Windows-only path handling
   # regressions (e.g. config discovery and relative `-f` paths, issue #59), which

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,10 @@ jobs:
     - uses: actions/checkout@v5
     - name: Install Rust
       run: rustup toolchain install stable --profile minimal
+    # `keyring` links libdbus for its secret-service transport on Linux. The
+    # devenv job above gets it from the shell; a bare runner does not.
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
     - name: Check each provider feature standalone
       run: |
         set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `?env=`, and profiles stay separate either way. Secrets live at
   `/secretspec/{project}/{profile}` (`?path=` overrides the prefix), with keys
   stored verbatim, and secrets sharing a folder are fetched in one request. A
+  folder's imported secrets resolve too, with Infisical's own precedence. A
   secret's `ref` can name an Infisical secret by folder, key and `version`.
+  Self-hosted and EU instances are named by the URI host, `INFISICAL_DOMAIN`, or
+  Infisical's legacy `INFISICAL_API_URL`.
 
 ## [0.15.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Infisical provider (`infisical://`), for Infisical Cloud and self-hosted
+  instances. Authenticates as a machine identity via Universal Auth, whose
+  `client_id` and `client_secret` can be sourced as provider credentials (with
+  `INFISICAL_CLIENT_ID`/`INFISICAL_CLIENT_SECRET` fallbacks), or with a
+  ready-made `token`/`INFISICAL_TOKEN`. A profile names the Infisical
+  environment, so a `production` profile reads the `production` environment;
+  projects whose environments do not correspond to profiles pin one with
+  `?env=`, and profiles stay separate either way. Secrets live at
+  `/secretspec/{project}/{profile}` (`?path=` overrides the prefix), with keys
+  stored verbatim, and secrets sharing a folder are fetched in one request. A
+  secret's `ref` can name an Infisical secret by folder, key and `version`.
+
 ## [0.15.0] - 2026-07-16
 
 ### Added

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -109,7 +109,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault / OpenBao, Bitwarden Secrets Manager, or Azure Key Vault.`,
+Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault / OpenBao, Bitwarden Secrets Manager, Azure Key Vault, or Infisical (0.16+).`,
         }),
       ],
       title: "SecretSpec",
@@ -190,6 +190,10 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
             {
               label: "Azure Key Vault",
               slug: "providers/akv",
+            },
+            {
+              label: "Infisical (0.16+)",
+              slug: "providers/infisical",
             },
           ],
         },

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -52,6 +52,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [vault](/providers/vault/) | HashiCorp Vault or OpenBao (requires the `vault` build feature) | ✓ | ✓ | ✓ |
 | [bws](/providers/bws/) | Bitwarden Secrets Manager (requires the `bws` build feature) | ✓ | ✓ | ✓ |
 | [akv](/providers/akv/) | Azure Key Vault (requires the `akv` build feature) | ✓ | ✓ | ✓ |
+| [infisical](/providers/infisical/) (0.16+) | Infisical (requires the `infisical` build feature) | ✓ | ✓ | ✓ |
 
 See each provider's page for its URI format, authentication requirements, and
 storage conventions.

--- a/docs/src/content/docs/providers/infisical.md
+++ b/docs/src/content/docs/providers/infisical.md
@@ -1,0 +1,211 @@
+---
+title: Infisical Provider
+description: Infisical integration
+---
+
+The Infisical provider integrates with [Infisical](https://infisical.com) over its REST API, for
+both Infisical Cloud and self-hosted instances.
+
+:::note[Version compatibility]
+The Infisical provider is an upcoming SecretSpec 0.16 feature and is not available
+in SecretSpec 0.15.
+:::
+
+## Prerequisites
+
+- An Infisical project
+- A machine identity with access to it (see [Authentication](#authentication))
+- Build with `--features infisical`
+
+## Configuration
+
+### URI Format
+
+```
+infisical://[host]/{project-id}[?env=slug&path=/prefix&tls=false]
+```
+
+- `host`: the Infisical instance (falls back to `INFISICAL_DOMAIN`, then `app.infisical.com`)
+- `{project-id}`: the project's **UUID**, from Project Settings → Project ID
+- `?env=`: environment slug. Without it, the SecretSpec profile names the environment
+- `?path=`: folder prefix holding SecretSpec's secrets (default: `/secretspec`)
+- `?tls=false`: disable TLS, for self-hosted instances served over plain HTTP
+
+Infisical's API addresses a project by UUID, not by the slug shown in its UI.
+
+### Examples
+
+```bash
+# Infisical Cloud (US, and the default host)
+secretspec set DATABASE_URL --provider infisical://app.infisical.com/7e2f1a4c-...
+
+# Infisical Cloud (EU)
+secretspec check --provider infisical://eu.infisical.com/7e2f1a4c-...
+
+# Self-hosted
+secretspec run --provider infisical://vault.example.com/7e2f1a4c-... -- npm start
+
+# Self-hosted over plain HTTP
+secretspec run --provider "infisical://localhost:8080/7e2f1a4c-...?tls=false" -- npm start
+```
+
+## Profiles and environments
+
+By default a SecretSpec profile names the Infisical environment: a `production` profile reads the
+`production` environment, and `dev` reads `dev`. New Infisical projects come with `dev`, `staging`
+and `prod`, so this works out of the box for profiles named after them.
+
+A project whose environments do not correspond to profiles pins one with `?env=`:
+
+```bash
+# Every profile reads Infisical's "dev" environment
+secretspec run --provider "infisical://app.infisical.com/7e2f1a4c-...?env=dev" -- npm start
+```
+
+Profiles stay separate either way: the profile names the folder as well as the environment, so
+pinning `?env=` cannot make two profiles share a secret.
+
+To route each profile to a different environment, give each one its own alias:
+
+```toml
+[providers]
+infisical_dev = "infisical://app.infisical.com/7e2f1a4c-...?env=dev"
+infisical_prod = "infisical://app.infisical.com/7e2f1a4c-...?env=prod"
+
+[profiles.production]
+DATABASE_URL = { description = "Production database", providers = ["infisical_prod"] }
+```
+
+### Secret Naming
+
+Secrets are stored under the folder `{path}/{project}/{profile}`, in the environment named by the
+profile (or by `?env=`):
+
+```
+project "myapp", profile "prod", key "DATABASE_URL"
+  -> environment prod
+     folder      /secretspec/myapp/prod
+     key         DATABASE_URL
+```
+
+Keys are stored exactly as written: Infisical accepts any non-empty key, so nothing is rewritten
+and two keys can never collide. Folder names are narrower — letters, digits, dashes and
+underscores — so a project or profile Infisical cannot spell is refused rather than quietly
+renamed.
+
+Folders are created as needed when writing a secret.
+
+## Secret References
+
+A secret can name one Infisical secret by its own coordinates, instead of SecretSpec's layout:
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "Postgres DSN", ref = { item = "/infra/shared/DB_PASSWORD" } }
+API_KEY = { description = "Pinned key", ref = { item = "/infra/API_KEY", version = "3" } }
+```
+
+- `item`: the folder and key. A leading slash names the environment's root — `/infra/shared/DB_PASSWORD`
+  is read from `/infra/shared`. Without one, the folder is read under the configured prefix, so
+  `team/DB_PASSWORD` means `/secretspec/team/DB_PASSWORD` and a bare `DB_PASSWORD` sits at
+  `/secretspec` itself
+- `version`: an Infisical secret version. Version-pinned refs are read-only, since a past version cannot be rewritten
+
+A ref has no profile to name an environment with, so the provider URI must pin one with `?env=`.
+Infisical secrets are single values with no sub-components, so `field`, `section` and `vault` are
+rejected.
+
+## Secret references inside values
+
+Values are read with Infisical's own `${...}` references expanded, matching its CLI, so a value of
+`postgres://${DB_USER}@host` arrives resolved.
+
+## Authentication
+
+### Universal Auth (machine identity)
+
+Create a machine identity in Infisical, grant it access to the project, and set:
+
+```bash
+export INFISICAL_CLIENT_ID=...
+export INFISICAL_CLIENT_SECRET=...
+```
+
+The provider exchanges these for a short-lived access token once per run.
+
+### Token
+
+A token minted elsewhere is used as it stands, which is what CI often has to hand:
+
+```bash
+export INFISICAL_TOKEN=...
+```
+
+Service tokens are not supported: Infisical deprecated them in favour of machine identities.
+
+### Sourcing credentials from another provider
+
+A machine identity's credentials can live in another store rather than in the environment, declared
+as [provider credentials](/concepts/providers/#provider-credentials):
+
+```toml title="secretspec.toml"
+[providers]
+infisical = { uri = "infisical://app.infisical.com/7e2f1a4c-...", credentials = {
+  client_id = "keyring",
+  client_secret = "keyring",
+} }
+```
+
+The provider declares three credentials: `client_id` and `client_secret` for Universal Auth, and
+`token` for a ready-made access token. Each falls back to its environment variable
+(`INFISICAL_CLIENT_ID`, `INFISICAL_CLIENT_SECRET`, `INFISICAL_TOKEN`) when not declared here.
+
+`secretspec config provider login infisical` prompts for each and stores it where resolution later
+reads it from.
+
+## Usage
+
+```bash
+# Store a secret
+secretspec set DATABASE_URL --provider infisical://app.infisical.com/7e2f1a4c-...
+
+# Verify every secret is set
+secretspec check --provider infisical://app.infisical.com/7e2f1a4c-...
+
+# Run with secrets injected
+secretspec run --provider infisical://app.infisical.com/7e2f1a4c-... -- npm start
+```
+
+Secrets sharing a folder are fetched in one request, so a run costs one call per folder rather than
+one per secret.
+
+## Self-hosting
+
+Point the URI at the instance, or set `INFISICAL_DOMAIN`:
+
+```bash
+export INFISICAL_DOMAIN=https://vault.example.com
+secretspec run --provider "infisical:///7e2f1a4c-..." -- npm start
+```
+
+## Approval policies
+
+A project under an approval policy turns a write into a change request: Infisical stores nothing
+until a human merges it. `secretspec set` reports that rather than claiming the secret was stored,
+so the value is written once the request is approved.
+
+## Limitations
+
+- The project is addressed by UUID; Infisical's API does not accept a project slug
+- A project or profile whose name is not spellable as an Infisical folder (letters, digits, dashes,
+  underscores) is refused rather than rewritten
+- Refs need `?env=`, having no profile to name an environment with
+- `secretspec import infisical://…` is not supported: the provider does not enumerate existing
+  secrets, so import has nothing to discover
+- `INFISICAL_DOMAIN` names a host, not a path: an instance served under a sub-path
+  (`https://example.com/infisical`) is not addressable. A trailing `/api` is the exception and is
+  accepted, since Infisical's own CLI takes the domain in that form
+- An environment or project that does not exist reads as an unset secret rather than an error:
+  Infisical answers a missing secret, folder, environment and project with the same bare 404.
+  Writing one reports the environment by name. If a profile does not match an environment slug —
+  Infisical's own default projects use `dev`, `staging` and `prod` — pin the right one with `?env=`

--- a/docs/src/content/docs/providers/infisical.md
+++ b/docs/src/content/docs/providers/infisical.md
@@ -25,7 +25,8 @@ in SecretSpec 0.15.
 infisical://[host]/{project-id}[?env=slug&path=/prefix&tls=false]
 ```
 
-- `host`: the Infisical instance (falls back to `INFISICAL_DOMAIN`, then `app.infisical.com`)
+- `host`: the Infisical instance (falls back to `INFISICAL_DOMAIN`, then the legacy
+  `INFISICAL_API_URL`, then `app.infisical.com`)
 - `{project-id}`: the project's **UUID**, from Project Settings → Project ID
 - `?env=`: environment slug. Without it, the SecretSpec profile names the environment
 - `?path=`: folder prefix holding SecretSpec's secrets (default: `/secretspec`)
@@ -115,6 +116,12 @@ A ref has no profile to name an environment with, so the provider URI must pin o
 Infisical secrets are single values with no sub-components, so `field`, `section` and `vault` are
 rejected.
 
+## Imported folders
+
+A folder that imports another resolves the imported keys too, with Infisical's own precedence: a
+secret defined directly in the folder wins over an imported one, and a later import wins over an
+earlier one. This matches their CLI, so a value reads the same way through either tool.
+
 ## Secret references inside values
 
 Values are read with Infisical's own `${...}` references expanded, matching its CLI, so a value of
@@ -188,6 +195,9 @@ export INFISICAL_DOMAIN=https://vault.example.com
 secretspec run --provider "infisical:///7e2f1a4c-..." -- npm start
 ```
 
+Infisical's legacy `INFISICAL_API_URL` is honoured too, so an instance already configured for
+their CLI works unchanged. `INFISICAL_DOMAIN` wins when both are set, matching the CLI.
+
 ## Approval policies
 
 A project under an approval policy turns a write into a change request: Infisical stores nothing
@@ -202,7 +212,7 @@ so the value is written once the request is approved.
 - Refs need `?env=`, having no profile to name an environment with
 - `secretspec import infisical://…` is not supported: the provider does not enumerate existing
   secrets, so import has nothing to discover
-- `INFISICAL_DOMAIN` names a host, not a path: an instance served under a sub-path
+- The domain variables name a host, not a path: an instance served under a sub-path
   (`https://example.com/infisical`) is not addressable. A trailing `/api` is the exception and is
   accepted, since Infisical's own CLI takes the domain in that form
 - An environment or project that does not exist reads as an unset secret rather than an error:

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -102,6 +102,7 @@ $ secretspec config init
   vault: HashiCorp Vault / OpenBao secret management
   bws: Bitwarden Secrets Manager
   akv: Azure Key Vault
+  infisical: Infisical secret management (0.16+)
 ? Select your default profile:
 > development
   default

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -191,6 +191,33 @@ akv://myvault?suffix=vault.azure.cn      # Sovereign cloud (explicit suffix, bar
 **Prerequisites**: An Azure Key Vault instance, authenticated via one of the methods above, build with `--features akv`
 **Storage**: Secret name `secretspec--{base32(project)}--{base32(profile)}--{base32(key)}` (lowercase, unpadded Base32 preserves case and punctuation distinctions within Azure's case-insensitive secret-name namespace)
 
+## Infisical Provider (0.16+)
+
+**URI**: `infisical://[HOST]/PROJECT_ID[?env=SLUG][&path=/PREFIX][&tls=false]` - Stores secrets in Infisical
+
+```bash
+infisical://app.infisical.com/7e2f1a4c-...            # Infisical Cloud (US)
+infisical://eu.infisical.com/7e2f1a4c-...             # Infisical Cloud (EU)
+infisical://vault.example.com/7e2f1a4c-...?env=prod   # Read every profile from one environment
+infisical://localhost:8080/7e2f1a4c-...?tls=false     # Self-hosted over plain HTTP
+```
+
+The project is Infisical's project **UUID** (Project Settings → Project ID); its API does not
+accept the project slug. Without a host, the provider reads `INFISICAL_DOMAIN`, then defaults to
+Infisical Cloud.
+
+**Features**: Read/write, cloud sync, profiles, machine-identity (Universal Auth) or token auth, secret references, version-pinned refs
+**Prerequisites**: An Infisical project, a machine identity with access to it, build with `--features infisical`
+**Authentication**: `INFISICAL_CLIENT_ID` + `INFISICAL_CLIENT_SECRET` (Universal Auth), or a ready-made `INFISICAL_TOKEN`. Service tokens are not supported; Infisical deprecated them in favour of machine identities.
+**Storage**: Secret `{key}` in folder `/secretspec/{project}/{profile}`, in the environment named by the profile (or by `?env=`). Keys are stored verbatim.
+
+By default the SecretSpec profile names the Infisical environment, so a `production` profile reads
+the `production` environment. Projects whose environments do not correspond to profiles pin one with
+`?env=`; the profile still names the folder, so profiles never share a secret.
+
+Values are read with Infisical's secret references expanded, matching its own CLI, so a value of
+`postgres://${DB_USER}@host` arrives resolved.
+
 ## Provider Selection
 
 ### Command Line
@@ -230,3 +257,4 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Vault/OpenBao | ✅ Vault encryption | Vault/OpenBao server | ✅ Yes |
 | BWS | ✅ End-to-end | Cloud (Bitwarden) | ✅ Yes |
 | AKV | ✅ Azure-managed | Cloud (Azure) | ✅ Yes |
+| Infisical (0.16+) | ✅ Infisical-managed | Cloud (Infisical) or self-hosted | ✅ Yes |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -203,8 +203,8 @@ infisical://localhost:8080/7e2f1a4c-...?tls=false     # Self-hosted over plain H
 ```
 
 The project is Infisical's project **UUID** (Project Settings → Project ID); its API does not
-accept the project slug. Without a host, the provider reads `INFISICAL_DOMAIN`, then defaults to
-Infisical Cloud.
+accept the project slug. Without a host, the provider reads `INFISICAL_DOMAIN`, then Infisical's
+legacy `INFISICAL_API_URL`, then defaults to Infisical Cloud.
 
 **Features**: Read/write, cloud sync, profiles, machine-identity (Universal Auth) or token auth, secret references, version-pinned refs
 **Prerequisites**: An Infisical project, a machine identity with access to it, build with `--features infisical`

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -53,7 +53,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
 <StarlightPage
   frontmatter={{
     title: 'Declare secrets once. Store them anywhere.',
-    description: 'Declare what your application needs in secretspec.toml — resolve the values through any of 14 providers. No secrets in git. Same code, every environment.',
+    description: 'Declare what your application needs in secretspec.toml — resolve the values through any of 13 providers. No secrets in git. Same code, every environment.',
     template: 'splash',
     hero: { tagline: '' },
   }}
@@ -85,7 +85,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
       <p class="landing-badge">Declarative secrets manager</p>
       <h1 id="_top" class="landing-hero-title">Declare secrets once.<br>Store them anywhere.</h1>
       <p class="landing-hero-subtitle">
-        Stop leaking <code class="inline-code">.env</code> files. Define what your application needs in <code class="inline-code">secretspec.toml</code>, then plug in keyring, 1Password, Vault, AWS, Azure, Gopass, Infisical, or any of 14 providers — same code, every environment.
+        Stop leaking <code class="inline-code">.env</code> files. Define what your application needs in <code class="inline-code">secretspec.toml</code>, then plug in keyring, 1Password, Vault, AWS, Azure, Gopass, or any of 13 providers — same code, every environment.
       </p>
       <div class="landing-hero-actions">
         <a href="/quick-start/" class="landing-btn landing-btn-primary">Get Started</a>
@@ -189,7 +189,7 @@ $ secretspec run --profile production -- npm start
       <div class="landing-step">
         <span class="landing-step-num">2</span>
         <p class="landing-step-title">Configure</p>
-        <p class="landing-step-desc">Pick from 14 providers: system keyring, password managers, cloud secret stores, Gopass, dotenv, or environment variables.</p>
+        <p class="landing-step-desc">Pick from 13 providers: system keyring, password managers, cloud secret stores, Gopass, dotenv, or environment variables.</p>
         <pre is:raw class="landing-step-code"><code>$ secretspec config init
 ? Default provider: keyring</code></pre>
       </div>
@@ -216,9 +216,9 @@ $ secretspec run --profile production -- npm start
 
     <div class="landing-bento">
       <a href="/concepts/providers/" class="landing-bento-card is-link landing-bento-2">
-        <div class="landing-bento-big-num">14</div>
+        <div class="landing-bento-big-num">13</div>
         <p class="landing-bento-title">Providers</p>
-        <p class="landing-bento-desc">Keyring · 1Password · LastPass · Bitwarden · Vault · AWS · GCP · Azure · Infisical · Gopass · Pass · Proton Pass · dotenv · env.</p>
+        <p class="landing-bento-desc">Keyring · 1Password · LastPass · Bitwarden · Vault · AWS · GCP · Azure · Gopass · Pass · Proton Pass · dotenv · env.</p>
       </a>
 
       <a href="/concepts/profiles/" class="landing-bento-card is-link landing-bento-2">
@@ -279,7 +279,7 @@ println!("{}", s.secrets.database_url);</code></pre>
       <span class="landing-showcase-eyebrow">Declaration vs storage</span>
       <h2 class="landing-section-title">Declare a secret. Swap the source.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        Your <code class="inline-code">secretspec.toml</code> never changes. The same code reads from Keychain, 1Password, Vault, AWS, Azure, or any of 14 providers.
+        Your <code class="inline-code">secretspec.toml</code> never changes. The same code reads from Keychain, 1Password, Vault, AWS, Azure, or any of 13 providers.
       </p>
     </div>
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -37,6 +37,7 @@ const providerMetadata: ProviderMetadata[] = [
   { slug: 'awssm', label: 'AWS Secrets Manager' },
   { icon: 'googlecloud', slug: 'gcsm', label: 'Google Cloud Secret Manager' },
   { icon: 'microsoftazure', slug: 'akv', label: 'Azure Key Vault' },
+  { slug: 'infisical', label: 'Infisical (0.16+)' },
   { slug: 'gopass', label: 'Gopass' },
   { slug: 'protonpass', label: 'Proton Pass' },
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
@@ -52,7 +53,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
 <StarlightPage
   frontmatter={{
     title: 'Declare secrets once. Store them anywhere.',
-    description: 'Declare what your application needs in secretspec.toml — resolve the values through any of 13 providers. No secrets in git. Same code, every environment.',
+    description: 'Declare what your application needs in secretspec.toml — resolve the values through any of 14 providers. No secrets in git. Same code, every environment.',
     template: 'splash',
     hero: { tagline: '' },
   }}
@@ -84,7 +85,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
       <p class="landing-badge">Declarative secrets manager</p>
       <h1 id="_top" class="landing-hero-title">Declare secrets once.<br>Store them anywhere.</h1>
       <p class="landing-hero-subtitle">
-        Stop leaking <code class="inline-code">.env</code> files. Define what your application needs in <code class="inline-code">secretspec.toml</code>, then plug in keyring, 1Password, Vault, AWS, Azure, Gopass, or any of 13 providers — same code, every environment.
+        Stop leaking <code class="inline-code">.env</code> files. Define what your application needs in <code class="inline-code">secretspec.toml</code>, then plug in keyring, 1Password, Vault, AWS, Azure, Gopass, Infisical, or any of 14 providers — same code, every environment.
       </p>
       <div class="landing-hero-actions">
         <a href="/quick-start/" class="landing-btn landing-btn-primary">Get Started</a>
@@ -188,7 +189,7 @@ $ secretspec run --profile production -- npm start
       <div class="landing-step">
         <span class="landing-step-num">2</span>
         <p class="landing-step-title">Configure</p>
-        <p class="landing-step-desc">Pick from 13 providers: system keyring, password managers, cloud secret stores, Gopass, dotenv, or environment variables.</p>
+        <p class="landing-step-desc">Pick from 14 providers: system keyring, password managers, cloud secret stores, Gopass, dotenv, or environment variables.</p>
         <pre is:raw class="landing-step-code"><code>$ secretspec config init
 ? Default provider: keyring</code></pre>
       </div>
@@ -215,9 +216,9 @@ $ secretspec run --profile production -- npm start
 
     <div class="landing-bento">
       <a href="/concepts/providers/" class="landing-bento-card is-link landing-bento-2">
-        <div class="landing-bento-big-num">13</div>
+        <div class="landing-bento-big-num">14</div>
         <p class="landing-bento-title">Providers</p>
-        <p class="landing-bento-desc">Keyring · 1Password · LastPass · Bitwarden · Vault · AWS · GCP · Azure · Gopass · Pass · Proton Pass · dotenv · env.</p>
+        <p class="landing-bento-desc">Keyring · 1Password · LastPass · Bitwarden · Vault · AWS · GCP · Azure · Infisical · Gopass · Pass · Proton Pass · dotenv · env.</p>
       </a>
 
       <a href="/concepts/profiles/" class="landing-bento-card is-link landing-bento-2">
@@ -278,7 +279,7 @@ println!("{}", s.secrets.database_url);</code></pre>
       <span class="landing-showcase-eyebrow">Declaration vs storage</span>
       <h2 class="landing-section-title">Declare a secret. Swap the source.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        Your <code class="inline-code">secretspec.toml</code> never changes. The same code reads from Keychain, 1Password, Vault, AWS, Azure, or any of 13 providers.
+        Your <code class="inline-code">secretspec.toml</code> never changes. The same code reads from Keychain, 1Password, Vault, AWS, Azure, or any of 14 providers.
       </p>
     </div>
 

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -52,7 +52,7 @@ data-encoding.workspace = true
 detect-coding-agent.workspace = true
 
 [features]
-default = ["cli", "keyring", "gcsm", "awssm", "vault", "bws", "akv"]
+default = ["cli", "keyring", "gcsm", "awssm", "vault", "bws", "akv", "infisical"]
 cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 # Compile libdbus from source into the binary instead of linking the system
@@ -62,5 +62,6 @@ vendored-dbus = ["keyring?/vendored"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 vault = ["dep:reqwest"]
+infisical = ["dep:reqwest"]
 bws = ["dep:bitwarden", "dep:rustls"]
 akv = ["dep:azure_core", "dep:azure_identity", "dep:azure_security_keyvault_secrets"]

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -62,6 +62,9 @@ vendored-dbus = ["keyring?/vendored"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 vault = ["dep:reqwest"]
-infisical = ["dep:reqwest"]
+# `tokio/sync` for the async `OnceCell` that serializes the Universal Auth
+# exchange. It is already on transitively via reqwest, but a provider should
+# name the features it uses rather than inherit them from a sibling.
+infisical = ["dep:reqwest", "tokio/sync"]
 bws = ["dep:bitwarden", "dep:rustls"]
 akv = ["dep:azure_core", "dep:azure_identity", "dep:azure_security_keyvault_secrets"]

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -30,6 +30,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [Vault/OpenBao](https://secretspec.dev/providers/vault)
   - [Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)
   - [Azure Key Vault](https://secretspec.dev/providers/akv)
+  - [Infisical](https://secretspec.dev/providers/infisical) (0.16+)
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
 - **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
@@ -65,6 +66,7 @@ $ secretspec config init
   vault: HashiCorp Vault / OpenBao secret management
   bws: Bitwarden Secrets Manager
   akv: Azure Key Vault
+  infisical: Infisical secret management (0.16+)
 ? Select your default profile:
 > development
   default
@@ -149,6 +151,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Vault / OpenBao](https://secretspec.dev/providers/vault)** - HashiCorp Vault and OpenBao KV engine
 - **[Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)** - Bitwarden Secrets Manager integration
 - **[Azure Key Vault](https://secretspec.dev/providers/akv)** - Azure secret management
+- **[Infisical](https://secretspec.dev/providers/infisical)** (0.16+) - Infisical secret management
 
 ```bash
 $ secretspec run --provider keyring -- npm start

--- a/secretspec/src/provider/infisical.rs
+++ b/secretspec/src/provider/infisical.rs
@@ -31,8 +31,8 @@
 //! - `tls` -- enable TLS: `true` (default) or `false`, for self-hosted
 //!   instances served over plain HTTP.
 //!
-//! When no host is given, falls back to `INFISICAL_DOMAIN`, then to
-//! `app.infisical.com`.
+//! When no host is given, falls back to `INFISICAL_DOMAIN`, then to Infisical's
+//! legacy `INFISICAL_API_URL`, then to `app.infisical.com`.
 //!
 //! # Examples
 //!
@@ -61,6 +61,10 @@
 //! rewriting is needed and distinct keys cannot collide. Folder names are
 //! narrower, so a project or profile Infisical cannot spell is refused rather
 //! than rewritten.
+//!
+//! A folder that imports another resolves the imported keys too, with
+//! Infisical's own precedence: a secret defined directly in the folder wins
+//! over an imported one, and a later import wins over an earlier one.
 
 use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
 use crate::config::NativeAddress;
@@ -83,7 +87,12 @@ const TOKEN: &str = "token";
 const INFISICAL_CLIENT_ID_ENV: &str = "INFISICAL_CLIENT_ID";
 const INFISICAL_CLIENT_SECRET_ENV: &str = "INFISICAL_CLIENT_SECRET";
 const INFISICAL_TOKEN_ENV: &str = "INFISICAL_TOKEN";
-const INFISICAL_DOMAIN_ENV: &str = "INFISICAL_DOMAIN";
+/// The environment variables naming the instance, in the Infisical CLI's own
+/// precedence order: `INFISICAL_DOMAIN` first, then the legacy
+/// `INFISICAL_API_URL` it superseded but still honours (`util.GetEnvDomain`).
+/// Reading only the current name would silently send an existing EU or
+/// self-hosted setup, configured with the legacy one, to US Cloud.
+const INFISICAL_DOMAIN_ENVS: [&str; 2] = ["INFISICAL_DOMAIN", "INFISICAL_API_URL"];
 
 /// Configuration for the Infisical provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -120,7 +129,7 @@ impl InfisicalConfig {
     /// Infisical's own CLI appends `/api` to the domain unless it is already
     /// there, so the suffix is common in a working configuration -- one that
     /// SecretSpec should read the same way, since it appends `/api` too.
-    fn endpoint_from_domain(domain: &str, http_scheme: &str) -> Result<String> {
+    fn endpoint_from_domain(var: &str, domain: &str, http_scheme: &str) -> Result<String> {
         let domain = domain.trim_end_matches('/');
         let domain = domain.strip_suffix("/api").unwrap_or(domain);
         let absolute = if domain.starts_with("http://") || domain.starts_with("https://") {
@@ -130,17 +139,35 @@ impl InfisicalConfig {
         };
 
         let parsed = url::Url::parse(&absolute).map_err(|e| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "Invalid {INFISICAL_DOMAIN_ENV} '{domain}': {e}"
-            ))
+            SecretSpecError::ProviderOperationFailed(format!("Invalid {var} '{domain}': {e}"))
         })?;
         if !parsed.path().trim_matches('/').is_empty() {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "Invalid {INFISICAL_DOMAIN_ENV} '{domain}': it names a path. Infisical's \
+                "Invalid {var} '{domain}': it names a path. Infisical's \
                  API is addressed at the host, e.g. https://vault.example.com."
             )));
         }
         Ok(absolute)
+    }
+
+    /// The instance named by the environment, with the variable that named it
+    /// so an error can report the one the user actually set.
+    fn env_domain() -> Option<(&'static str, String)> {
+        Self::pick_domain(|var| std::env::var(var).ok())
+    }
+
+    /// The first variable in [`INFISICAL_DOMAIN_ENVS`] that names an instance.
+    ///
+    /// Trimmed and empty-filtered to match the CLI's `GetEnvDomain`, so a blank
+    /// variable falls through to the next rather than being taken as a domain.
+    /// Split from [`env_domain`](Self::env_domain) so the precedence is
+    /// testable without mutating the process environment.
+    fn pick_domain(lookup: impl Fn(&str) -> Option<String>) -> Option<(&'static str, String)> {
+        INFISICAL_DOMAIN_ENVS.iter().find_map(|var| {
+            let value = lookup(var)?;
+            let value = value.trim().to_string();
+            (!value.is_empty()).then_some((*var, value))
+        })
     }
 }
 
@@ -171,18 +198,15 @@ impl TryFrom<&ProviderUrl> for InfisicalConfig {
             .unwrap_or(true);
         let http_scheme = if use_tls { "https" } else { "http" };
 
-        // Host from the URI, else INFISICAL_DOMAIN, else Infisical Cloud.
+        // Host from the URI, else the environment, else Infisical Cloud.
         let endpoint = match url.host().filter(|s| !s.is_empty()) {
             Some(host) => match url.port() {
                 Some(port) => format!("{http_scheme}://{host}:{port}"),
                 None => format!("{http_scheme}://{host}"),
             },
-            None => match std::env::var(INFISICAL_DOMAIN_ENV)
-                .ok()
-                .filter(|s| !s.is_empty())
-            {
-                // INFISICAL_DOMAIN is a full URL in Infisical's own CLI.
-                Some(domain) => Self::endpoint_from_domain(&domain, http_scheme)?,
+            // The domain is a full URL in Infisical's own CLI.
+            None => match Self::env_domain() {
+                Some((var, domain)) => Self::endpoint_from_domain(var, &domain, http_scheme)?,
                 None => format!("{http_scheme}://{DEFAULT_HOST}"),
             },
         };
@@ -242,7 +266,14 @@ pub struct InfisicalProvider {
     /// The Universal Auth access token, fetched once per process. Infisical's
     /// tokens are short-lived (7200s by default), which outlives any single
     /// SecretSpec invocation.
-    token: OnceLock<SecretString>,
+    ///
+    /// Async, because the exchange itself must be serialized rather than merely
+    /// its result: a batch read fetches distinct addresses concurrently, and a
+    /// cell that only guards the completed token lets every caller log in and
+    /// then discard all but one. Infisical supports client secrets with a
+    /// one-use limit, for which the surplus exchanges are not just waste but a
+    /// hard failure.
+    token: tokio::sync::OnceCell<SecretString>,
     /// One HTTP client for every request, so a run of secrets reuses the
     /// connection rather than building a pool per call.
     http: OnceLock<reqwest::Client>,
@@ -264,7 +295,7 @@ impl InfisicalProvider {
         Self {
             config,
             credentials: ProviderCredentials::new(),
-            token: OnceLock::new(),
+            token: tokio::sync::OnceCell::new(),
             http: OnceLock::new(),
         }
     }
@@ -342,17 +373,20 @@ impl InfisicalProvider {
     /// runtime that [`block_on`](super::block_on) already entered for the
     /// request, and blocking there would panic.
     async fn resolve_token(&self) -> Result<&SecretString> {
-        if let Some(token) = self.token.get() {
-            return Ok(token);
-        }
-        // `credential_or_env` never yields an empty value, so a blank
-        // INFISICAL_TOKEN reads as absent rather than as a broken token.
-        let token = match credential_or_env(&self.credentials, TOKEN, INFISICAL_TOKEN_ENV) {
-            Some(token) => SecretString::new(token.into()),
-            None => self.login().await?,
-        };
-        // A concurrent login would have produced an equivalent token.
-        Ok(self.token.get_or_init(|| token))
+        // `get_or_try_init` runs one initializer at a time: a concurrent caller
+        // waits for the in-flight exchange and takes its token rather than
+        // starting a second one. On failure the cell stays empty, so a later
+        // call retries instead of caching the error.
+        self.token
+            .get_or_try_init(|| async {
+                // `credential_or_env` never yields an empty value, so a blank
+                // INFISICAL_TOKEN reads as absent rather than as a broken token.
+                match credential_or_env(&self.credentials, TOKEN, INFISICAL_TOKEN_ENV) {
+                    Some(token) => Ok(SecretString::new(token.into())),
+                    None => self.login().await,
+                }
+            })
+            .await
     }
 
     /// Exchanges the machine identity's credentials for an access token.
@@ -544,6 +578,55 @@ impl InfisicalProvider {
         }
     }
 
+    /// Folds a list response's imported secrets into the keys read directly
+    /// from the folder.
+    ///
+    /// A folder can import others, and the list endpoint answers with those in
+    /// a separate `imports` array rather than merged into `secrets` (it sets
+    /// `includeImports` by default, so they arrive whether or not they are
+    /// asked for). Ignoring them would make a batch read disagree with a
+    /// single read of the same key, which does resolve imports: `check` and
+    /// `run` would call an imported secret missing while `get` returned it.
+    ///
+    /// The precedence mirrors the Infisical CLI's `InjectRawImportedSecret`, so
+    /// a value resolves the same way here as it does through their own tool: a
+    /// secret defined directly in the folder wins over any import, and among
+    /// imports a later entry wins over an earlier one (the CLI walks the array
+    /// in reverse, taking the first value it finds for a key).
+    fn merge_imports(
+        parsed: &serde_json::Value,
+        listed: &mut HashMap<String, SecretString>,
+    ) -> Result<()> {
+        // Absent rather than empty on an instance that predates imports, or on
+        // a folder that imports nothing.
+        let Some(imports) = parsed["imports"].as_array() else {
+            return Ok(());
+        };
+
+        for import in imports.iter().rev() {
+            let Some(secrets) = import["secrets"].as_array() else {
+                continue;
+            };
+            for secret in secrets {
+                let Some(key) = secret["secretKey"].as_str() else {
+                    continue;
+                };
+                // A direct secret, or a higher-precedence import, already
+                // claimed this key.
+                if listed.contains_key(key) {
+                    continue;
+                }
+                // Withheld values are refused here exactly as for a direct
+                // secret: an imported key the identity may not read must not
+                // arrive as the literal placeholder.
+                if let Some(value) = Self::secret_value(secret, key)? {
+                    listed.insert(key.to_string(), value);
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Lists every secret in one folder, indexed by key. Infisical has no
     /// fetch-these-N-names endpoint, so a batch read lists the folder once.
     async fn list_async(
@@ -581,6 +664,7 @@ impl InfisicalProvider {
                         listed.insert(key.to_string(), value);
                     }
                 }
+                Self::merge_imports(&parsed, &mut listed)?;
                 Ok(listed)
             }
             // An absent folder holds no secrets, exactly like an empty one.
@@ -1154,6 +1238,109 @@ mod tests {
         assert_eq!(value.expose_secret(), "s3cret");
     }
 
+    /// Builds a list-response import entry holding one key.
+    fn import(path: &str, key: &str, value: &str) -> serde_json::Value {
+        serde_json::json!({
+            "secretPath": path,
+            "environment": "prod",
+            "secrets": [{
+                "secretKey": key,
+                "secretValue": value,
+                "secretValueHidden": false,
+            }],
+        })
+    }
+
+    fn merged(parsed: &serde_json::Value, direct: &[(&str, &str)]) -> HashMap<String, String> {
+        let mut listed: HashMap<String, SecretString> = direct
+            .iter()
+            .map(|(k, v)| (k.to_string(), SecretString::new((*v).into())))
+            .collect();
+        InfisicalProvider::merge_imports(parsed, &mut listed).expect("merge");
+        listed
+            .into_iter()
+            .map(|(k, v)| (k, v.expose_secret().to_string()))
+            .collect()
+    }
+
+    /// An imported secret is readable in a batch read.
+    ///
+    /// Infisical answers a folder's imports separately from its own secrets. A
+    /// batch read that ignored them would call an imported secret missing while
+    /// a single read of the same key returned it.
+    #[test]
+    fn imported_secrets_are_merged_into_a_listing() {
+        let parsed = serde_json::json!({
+            "secrets": [],
+            "imports": [import("/shared", "DB_HOST", "db.internal")],
+        });
+        let merged = merged(&parsed, &[]);
+        assert_eq!(
+            merged.get("DB_HOST").map(String::as_str),
+            Some("db.internal")
+        );
+    }
+
+    /// A folder's own secret wins over an imported one, as in Infisical's CLI.
+    #[test]
+    fn a_direct_secret_beats_an_import() {
+        let parsed = serde_json::json!({
+            "secrets": [],
+            "imports": [import("/shared", "DB_HOST", "imported")],
+        });
+        let merged = merged(&parsed, &[("DB_HOST", "direct")]);
+        assert_eq!(merged.get("DB_HOST").map(String::as_str), Some("direct"));
+    }
+
+    /// Among imports the later entry wins: the CLI walks `imports` in reverse
+    /// and keeps the first value it finds for a key.
+    #[test]
+    fn a_later_import_beats_an_earlier_one() {
+        let parsed = serde_json::json!({
+            "secrets": [],
+            "imports": [
+                import("/base", "DB_HOST", "from-base"),
+                import("/override", "DB_HOST", "from-override"),
+            ],
+        });
+        let merged = merged(&parsed, &[]);
+        assert_eq!(
+            merged.get("DB_HOST").map(String::as_str),
+            Some("from-override"),
+        );
+    }
+
+    /// A withheld imported value is refused, exactly as a direct one is.
+    #[test]
+    fn a_withheld_imported_value_is_refused() {
+        let parsed = serde_json::json!({
+            "secrets": [],
+            "imports": [serde_json::json!({
+                "secretPath": "/shared",
+                "environment": "prod",
+                "secrets": [{
+                    "secretKey": "DB_HOST",
+                    "secretValue": "<hidden-by-infisical>",
+                    "secretValueHidden": true,
+                }],
+            })],
+        });
+        let mut listed = HashMap::new();
+        let err = InfisicalProvider::merge_imports(&parsed, &mut listed)
+            .expect_err("a withheld import must not pass through");
+        assert!(err.to_string().contains("DB_HOST"), "{err}");
+    }
+
+    /// A response without `imports` is not an error: an instance predating
+    /// imports, or a folder importing nothing, simply has none.
+    #[test]
+    fn a_listing_without_imports_is_unchanged() {
+        let parsed = serde_json::json!({ "secrets": [] });
+        let merged = merged(&parsed, &[("API_KEY", "kept")]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged.get("API_KEY").map(String::as_str), Some("kept"));
+    }
+
     /// A write held for approval does not report success.
     ///
     /// A project under an approval policy answers a write with 200 and an
@@ -1280,17 +1467,95 @@ mod tests {
     /// mistake. A domain naming any other path still is one.
     #[test]
     fn a_domain_may_carry_the_api_suffix() {
+        let var = INFISICAL_DOMAIN_ENVS[0];
         assert_eq!(
-            InfisicalConfig::endpoint_from_domain("https://vault.example.com/api", "https")
+            InfisicalConfig::endpoint_from_domain(var, "https://vault.example.com/api", "https")
                 .unwrap(),
             "https://vault.example.com"
         );
         assert_eq!(
-            InfisicalConfig::endpoint_from_domain("vault.example.com:8080", "https").unwrap(),
+            InfisicalConfig::endpoint_from_domain(var, "vault.example.com:8080", "https").unwrap(),
             "https://vault.example.com:8080"
         );
-        let err = InfisicalConfig::endpoint_from_domain("https://example.com/infisical", "https")
-            .unwrap_err();
+        let err =
+            InfisicalConfig::endpoint_from_domain(var, "https://example.com/infisical", "https")
+                .unwrap_err();
         assert!(err.to_string().contains("names a path"), "{err}");
+    }
+
+    /// An invalid domain is reported against the variable that actually set it,
+    /// not against whichever name the provider happens to prefer.
+    #[test]
+    fn an_invalid_domain_names_the_variable_that_set_it() {
+        let err =
+            InfisicalConfig::endpoint_from_domain("INFISICAL_API_URL", "https://e.com/x", "https")
+                .unwrap_err();
+        assert!(err.to_string().contains("INFISICAL_API_URL"), "{err}");
+    }
+
+    /// The legacy variable still names an instance.
+    ///
+    /// Infisical superseded `INFISICAL_API_URL` with `INFISICAL_DOMAIN` but
+    /// still honours it, so an existing EU or self-hosted setup configured with
+    /// the old name must not be silently redirected to US Cloud.
+    #[test]
+    fn the_legacy_domain_variable_is_honoured() {
+        let picked = InfisicalConfig::pick_domain(|var| {
+            (var == "INFISICAL_API_URL").then(|| "https://eu.infisical.com".to_string())
+        });
+        assert_eq!(
+            picked,
+            Some(("INFISICAL_API_URL", "https://eu.infisical.com".to_string()))
+        );
+    }
+
+    /// `INFISICAL_DOMAIN` wins when both are set, matching the CLI's
+    /// `GetEnvDomain` precedence.
+    #[test]
+    fn the_current_domain_variable_supersedes_the_legacy_one() {
+        let picked = InfisicalConfig::pick_domain(|var| {
+            Some(
+                match var {
+                    "INFISICAL_DOMAIN" => "https://current.example.com",
+                    _ => "https://legacy.example.com",
+                }
+                .to_string(),
+            )
+        });
+        assert_eq!(
+            picked,
+            Some((
+                "INFISICAL_DOMAIN",
+                "https://current.example.com".to_string()
+            ))
+        );
+    }
+
+    /// A blank variable falls through rather than being taken as a domain, so
+    /// `INFISICAL_DOMAIN=""` still lets the legacy name apply.
+    #[test]
+    fn a_blank_domain_variable_falls_through() {
+        let picked = InfisicalConfig::pick_domain(|var| {
+            Some(
+                match var {
+                    "INFISICAL_DOMAIN" => "   ",
+                    _ => "https://legacy.example.com",
+                }
+                .to_string(),
+            )
+        });
+        assert_eq!(
+            picked,
+            Some((
+                "INFISICAL_API_URL",
+                "https://legacy.example.com".to_string()
+            ))
+        );
+    }
+
+    /// Neither set means Infisical Cloud, not an error.
+    #[test]
+    fn no_domain_variable_is_not_an_error() {
+        assert_eq!(InfisicalConfig::pick_domain(|_| None), None);
     }
 }

--- a/secretspec/src/provider/infisical.rs
+++ b/secretspec/src/provider/infisical.rs
@@ -1,0 +1,1296 @@
+//! Infisical provider
+//!
+//! This provider integrates with [Infisical](https://infisical.com) to store and
+//! retrieve secrets over its REST API, against both Infisical Cloud and
+//! self-hosted instances.
+//!
+//! # Authentication
+//!
+//! A machine identity's `client_id` and `client_secret` are exchanged for a
+//! short-lived access token via Universal Auth, cached for the life of the
+//! process. A `token` minted elsewhere is used directly instead, which is what
+//! CI usually has to hand. Credentials come from the provider alias or from
+//! `INFISICAL_CLIENT_ID` / `INFISICAL_CLIENT_SECRET` / `INFISICAL_TOKEN`.
+//!
+//! Service tokens are not supported: Infisical deprecated them in favour of
+//! machine identities.
+//!
+//! # URI Format
+//!
+//! `infisical://[host]/{project-id}[?env=slug&path=/prefix&tls=false]`
+//!
+//! The project is Infisical's own project UUID; its v4 API does not accept a
+//! project slug. Query parameters:
+//!
+//! - `env` -- environment slug. When omitted, the SecretSpec profile names the
+//!   environment, so a `production` profile reads Infisical's `production`
+//!   environment. Set it to read every profile from one environment, e.g. an
+//!   instance whose environments do not correspond to profiles.
+//! - `path` -- folder prefix holding SecretSpec's secrets (default:
+//!   `/secretspec`).
+//! - `tls` -- enable TLS: `true` (default) or `false`, for self-hosted
+//!   instances served over plain HTTP.
+//!
+//! When no host is given, falls back to `INFISICAL_DOMAIN`, then to
+//! `app.infisical.com`.
+//!
+//! # Examples
+//!
+//! - `infisical://app.infisical.com/7e2f...` -- Infisical Cloud (US)
+//! - `infisical://eu.infisical.com/7e2f...` -- Infisical Cloud (EU)
+//! - `infisical://vault.example.com/7e2f...?env=prod` -- pin one environment
+//! - `infisical://localhost:8080/7e2f...?tls=false` -- self-hosted, plain HTTP
+//!
+//! # Secret Naming
+//!
+//! A secret lives at the folder `{path}/{project}/{profile}` in the
+//! environment named by the profile, under the key itself:
+//!
+//! ```text
+//! project "myapp", profile "prod", key "DATABASE_URL"
+//!   -> environment prod
+//!      secretPath  /secretspec/myapp/prod
+//!      secretKey   DATABASE_URL
+//! ```
+//!
+//! The profile names the folder as well as the environment, so that pinning
+//! `?env=` moves every profile into one environment without two of them
+//! landing on the same secret.
+//!
+//! Keys are stored verbatim: Infisical imposes no charset of its own, so no
+//! rewriting is needed and distinct keys cannot collide. Folder names are
+//! narrower, so a project or profile Infisical cannot spell is refused rather
+//! than rewritten.
+
+use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
+use crate::config::NativeAddress;
+use crate::{Result, SecretSpecError};
+use reqwest::StatusCode;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// Default folder prefix holding SecretSpec's secrets.
+const DEFAULT_PATH: &str = "/secretspec";
+/// Infisical Cloud's US host, used when neither the URI nor the environment
+/// names one.
+const DEFAULT_HOST: &str = "app.infisical.com";
+
+const CLIENT_ID: &str = "client_id";
+const CLIENT_SECRET: &str = "client_secret";
+const TOKEN: &str = "token";
+const INFISICAL_CLIENT_ID_ENV: &str = "INFISICAL_CLIENT_ID";
+const INFISICAL_CLIENT_SECRET_ENV: &str = "INFISICAL_CLIENT_SECRET";
+const INFISICAL_TOKEN_ENV: &str = "INFISICAL_TOKEN";
+const INFISICAL_DOMAIN_ENV: &str = "INFISICAL_DOMAIN";
+
+/// Configuration for the Infisical provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InfisicalConfig {
+    /// The Infisical API endpoint (e.g. `https://app.infisical.com`).
+    pub endpoint: String,
+    /// The Infisical project UUID.
+    pub project_id: String,
+    /// Environment slug. When `None`, the profile names the environment.
+    pub environment: Option<String>,
+    /// Folder prefix holding SecretSpec's secrets.
+    pub path: String,
+}
+
+impl Default for InfisicalConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: format!("https://{DEFAULT_HOST}"),
+            project_id: String::new(),
+            environment: None,
+            path: DEFAULT_PATH.to_string(),
+        }
+    }
+}
+
+impl InfisicalConfig {
+    /// Reads `INFISICAL_DOMAIN` into an endpoint.
+    ///
+    /// The URI names a host, so the endpoint is a host too: a domain carrying
+    /// a path is refused rather than accepted into a config that
+    /// [`uri`](Provider::uri) could not render back.
+    ///
+    /// A trailing `/api` is the exception, and is dropped rather than refused.
+    /// Infisical's own CLI appends `/api` to the domain unless it is already
+    /// there, so the suffix is common in a working configuration -- one that
+    /// SecretSpec should read the same way, since it appends `/api` too.
+    fn endpoint_from_domain(domain: &str, http_scheme: &str) -> Result<String> {
+        let domain = domain.trim_end_matches('/');
+        let domain = domain.strip_suffix("/api").unwrap_or(domain);
+        let absolute = if domain.starts_with("http://") || domain.starts_with("https://") {
+            domain.to_string()
+        } else {
+            format!("{http_scheme}://{domain}")
+        };
+
+        let parsed = url::Url::parse(&absolute).map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid {INFISICAL_DOMAIN_ENV} '{domain}': {e}"
+            ))
+        })?;
+        if !parsed.path().trim_matches('/').is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid {INFISICAL_DOMAIN_ENV} '{domain}': it names a path. Infisical's \
+                 API is addressed at the host, e.g. https://vault.example.com."
+            )));
+        }
+        Ok(absolute)
+    }
+}
+
+impl TryFrom<&ProviderUrl> for InfisicalConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        let scheme = url.scheme();
+        if scheme != "infisical" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{scheme}' for infisical provider. Expected 'infisical'."
+            )));
+        }
+
+        // An unreadable `tls` is refused rather than read as one of its two
+        // meanings: the knob is explicit, so a typo in it should be too.
+        let use_tls = url
+            .query_pairs()
+            .find(|(k, _)| k == "tls")
+            .map(|(_, v)| match v.as_ref() {
+                "true" | "1" => Ok(true),
+                "false" | "0" => Ok(false),
+                other => Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Unknown tls value '{other}'. Expected 'true' or 'false'."
+                ))),
+            })
+            .transpose()?
+            .unwrap_or(true);
+        let http_scheme = if use_tls { "https" } else { "http" };
+
+        // Host from the URI, else INFISICAL_DOMAIN, else Infisical Cloud.
+        let endpoint = match url.host().filter(|s| !s.is_empty()) {
+            Some(host) => match url.port() {
+                Some(port) => format!("{http_scheme}://{host}:{port}"),
+                None => format!("{http_scheme}://{host}"),
+            },
+            None => match std::env::var(INFISICAL_DOMAIN_ENV)
+                .ok()
+                .filter(|s| !s.is_empty())
+            {
+                // INFISICAL_DOMAIN is a full URL in Infisical's own CLI.
+                Some(domain) => Self::endpoint_from_domain(&domain, http_scheme)?,
+                None => format!("{http_scheme}://{DEFAULT_HOST}"),
+            },
+        };
+
+        // The project UUID is the URI path; Infisical's v4 API has no slug form.
+        let project_id = url.path().trim_matches('/').to_string();
+        if project_id.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "No Infisical project given. Name the project UUID in the URI, e.g. \
+                 infisical://app.infisical.com/7e2f1a4c-....  Infisical's API takes the \
+                 project's UUID (Project Settings -> Project ID), not its slug."
+                    .to_string(),
+            ));
+        }
+        if project_id.contains('/') {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid Infisical project '{project_id}': expected a single project UUID. \
+                 The folder holding the secrets is set with `?path=` instead."
+            )));
+        }
+
+        let environment = url.query_value("env").filter(|s| !s.is_empty());
+
+        let path = match url.query_value("path").filter(|s| !s.is_empty()) {
+            Some(p) => {
+                let trimmed = p.trim_end_matches('/');
+                if trimmed.starts_with('/') {
+                    trimmed.to_string()
+                } else {
+                    format!("/{trimmed}")
+                }
+            }
+            None => DEFAULT_PATH.to_string(),
+        };
+
+        Ok(Self {
+            endpoint,
+            project_id,
+            environment,
+            path,
+        })
+    }
+}
+
+/// One secret's location in Infisical's own terms.
+struct Location {
+    environment: String,
+    secret_path: String,
+    key: String,
+}
+
+/// Infisical provider.
+pub struct InfisicalProvider {
+    config: InfisicalConfig,
+    /// Credentials supplied by the provider alias.
+    credentials: ProviderCredentials,
+    /// The Universal Auth access token, fetched once per process. Infisical's
+    /// tokens are short-lived (7200s by default), which outlives any single
+    /// SecretSpec invocation.
+    token: OnceLock<SecretString>,
+    /// One HTTP client for every request, so a run of secrets reuses the
+    /// connection rather than building a pool per call.
+    http: OnceLock<reqwest::Client>,
+}
+
+crate::register_provider! {
+    struct: InfisicalProvider,
+    config: InfisicalConfig,
+    name: "infisical",
+    description: "Infisical secret management",
+    schemes: ["infisical"],
+    examples: ["infisical://app.infisical.com/{project-id}"],
+    credential_names: [CLIENT_ID, CLIENT_SECRET, TOKEN],
+}
+
+impl InfisicalProvider {
+    /// Creates a new InfisicalProvider with the given configuration.
+    pub fn new(config: InfisicalConfig) -> Self {
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+            token: OnceLock::new(),
+            http: OnceLock::new(),
+        }
+    }
+
+    /// The shared HTTP client.
+    fn http(&self) -> &reqwest::Client {
+        self.http.get_or_init(reqwest::Client::new)
+    }
+
+    /// Resolves an address to one secret's Infisical location.
+    ///
+    /// `item` carries the folder and the key together, so convention and `ref`
+    /// addresses share one spelling of the layout. The environment comes from
+    /// the address itself, since the profile names it when `?env=` does not.
+    fn locate(&self, addr: Address<'_>) -> Result<Location> {
+        let coords = self.resolve_coords(addr)?;
+
+        let environment = match (&self.config.environment, addr) {
+            (Some(env), _) => env.clone(),
+            (None, Address::Convention { profile, .. }) => profile.to_string(),
+            (None, Address::Native(_)) => {
+                return Err(SecretSpecError::ProviderOperationFailed(
+                    "No Infisical environment for this ref. Name one in the provider URI, \
+                     e.g. infisical://app.infisical.com/{project-id}?env=prod."
+                        .to_string(),
+                ));
+            }
+        };
+
+        // A leading slash distinguishes the two forms a ref can take: `/DB`
+        // names the environment's root, while `DB` and `team/DB` alike are read
+        // under the configured prefix. Trimming the slash first would move a
+        // root secret under the prefix, where reading it finds nothing; reading
+        // a relative folder from the root instead would put the prefix out of
+        // reach of every ref that names a folder.
+        let (secret_path, key) = match coords.item.rsplit_once('/') {
+            Some((folder, key)) => {
+                let folder = folder.trim_end_matches('/');
+                let secret_path = match folder {
+                    "" => "/".to_string(),
+                    relative if !relative.starts_with('/') => {
+                        // The prefix is `/` at the root, where a naive join
+                        // would double the separator.
+                        format!("{}/{relative}", self.config.path.trim_end_matches('/'))
+                    }
+                    absolute => absolute.to_string(),
+                };
+                (secret_path, key.to_string())
+            }
+            // A bare name sits at the folder prefix itself.
+            None => (self.config.path.clone(), coords.item.clone()),
+        };
+        if key.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid Infisical ref '{}': it names a folder, not a secret.",
+                coords.item
+            )));
+        }
+
+        Ok(Location {
+            environment,
+            secret_path,
+            key,
+        })
+    }
+
+    /// Resolves the access token, logging in at most once.
+    ///
+    /// An already-minted token is used directly; otherwise a machine
+    /// identity's credentials are exchanged for one. Infisical's tokens are
+    /// short-lived (7200s by default), which outlives any single SecretSpec
+    /// invocation, so the token is fetched once and never renewed.
+    ///
+    /// The login is awaited rather than blocked on: this runs inside the
+    /// runtime that [`block_on`](super::block_on) already entered for the
+    /// request, and blocking there would panic.
+    async fn resolve_token(&self) -> Result<&SecretString> {
+        if let Some(token) = self.token.get() {
+            return Ok(token);
+        }
+        // `credential_or_env` never yields an empty value, so a blank
+        // INFISICAL_TOKEN reads as absent rather than as a broken token.
+        let token = match credential_or_env(&self.credentials, TOKEN, INFISICAL_TOKEN_ENV) {
+            Some(token) => SecretString::new(token.into()),
+            None => self.login().await?,
+        };
+        // A concurrent login would have produced an equivalent token.
+        Ok(self.token.get_or_init(|| token))
+    }
+
+    /// Exchanges the machine identity's credentials for an access token.
+    async fn login(&self) -> Result<SecretString> {
+        let client_id = credential_or_env(&self.credentials, CLIENT_ID, INFISICAL_CLIENT_ID_ENV);
+        let client_secret = credential_or_env(
+            &self.credentials,
+            CLIENT_SECRET,
+            INFISICAL_CLIENT_SECRET_ENV,
+        );
+
+        // A half-specified identity is an error: falling back to an anonymous
+        // request would fail later with an opaque 401 instead.
+        let (client_id, client_secret) = match (client_id, client_secret) {
+            (Some(id), Some(secret)) => (id, secret),
+            (None, None) => {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "No Infisical credentials found. Configure the {CLIENT_ID} and \
+                     {CLIENT_SECRET} provider credentials (or a ready-made {TOKEN}), or set \
+                     {INFISICAL_CLIENT_ID_ENV} and {INFISICAL_CLIENT_SECRET_ENV} (or \
+                     {INFISICAL_TOKEN_ENV})."
+                )));
+            }
+            (Some(_), None) => {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Infisical {CLIENT_SECRET} is missing. Configure the {CLIENT_SECRET} \
+                     provider credential, or set {INFISICAL_CLIENT_SECRET_ENV}."
+                )));
+            }
+            (None, Some(_)) => {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Infisical {CLIENT_ID} is missing. Configure the {CLIENT_ID} provider \
+                     credential, or set {INFISICAL_CLIENT_ID_ENV}."
+                )));
+            }
+        };
+
+        let url = format!("{}/api/v1/auth/universal-auth/login", self.config.endpoint);
+        let body = serde_json::json!({
+            "clientId": client_id,
+            "clientSecret": client_secret,
+        });
+
+        let response = self
+            .http()
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to connect to Infisical at {}: {e}",
+                    self.config.endpoint
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Infisical login returned HTTP {status}: {}",
+                Self::error_message(&body)
+            )));
+        }
+
+        let parsed: serde_json::Value = response.json().await.map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to parse Infisical login response: {e}"
+            ))
+        })?;
+
+        let token = parsed["accessToken"].as_str().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(
+                "Infisical login response missing accessToken".to_string(),
+            )
+        })?;
+
+        Ok(SecretString::new(token.to_string().into()))
+    }
+
+    /// Infisical's error envelope carries a human-readable `message`; the
+    /// status code, not this text, decides control flow.
+    fn error_message(body: &str) -> String {
+        serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .and_then(|v| v["message"].as_str().map(str::to_string))
+            .unwrap_or_else(|| body.to_string())
+    }
+
+    /// The query shared by every read: which project, environment and folder.
+    ///
+    /// `expandSecretReferences` follows Infisical's own default and CLI: a
+    /// `${...}` reference is a feature its users configure deliberately, so the
+    /// value SecretSpec hands over is the resolved one.
+    ///
+    /// `viewSecretValue` is set explicitly rather than left to its default,
+    /// since Infisical can withhold a value from an identity that may only see
+    /// that a secret exists. Requesting the value does not guarantee it, so
+    /// every read is checked with [`secret_value`](Self::secret_value).
+    fn read_query<'q>(
+        &'q self,
+        environment: &'q str,
+        secret_path: &'q str,
+    ) -> Vec<(&'static str, &'q str)> {
+        vec![
+            ("projectId", self.config.project_id.as_str()),
+            ("environment", environment),
+            ("secretPath", secret_path),
+            ("expandSecretReferences", "true"),
+            ("viewSecretValue", "true"),
+        ]
+    }
+
+    /// Reads one secret's value from its JSON, rejecting a value Infisical
+    /// withheld.
+    ///
+    /// An identity allowed to see that a secret exists, but not to read it,
+    /// still gets HTTP 200: the value is replaced with a placeholder and
+    /// `secretValueHidden` is set. Passing that placeholder on would export a
+    /// literal `<hidden-by-infisical>` to the process SecretSpec runs, so it is
+    /// reported as the refusal it is.
+    fn secret_value(secret: &serde_json::Value, key: &str) -> Result<Option<SecretString>> {
+        if secret["secretValueHidden"].as_bool() == Some(true) {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Infisical withheld the value of '{key}': this identity may see that the \
+                 secret exists but not read it. Grant it permission to read secret values."
+            )));
+        }
+        Ok(secret["secretValue"]
+            .as_str()
+            .map(|v| SecretString::new(v.to_string().into())))
+    }
+
+    /// The URL naming one secret.
+    ///
+    /// Infisical accepts any non-empty key -- spaces and non-ASCII included --
+    /// so the key is escaped as a path segment rather than interpolated.
+    fn secret_url(&self, key: &str) -> Result<String> {
+        let mut url = url::Url::parse(&self.config.endpoint).map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid Infisical endpoint '{}': {e}",
+                self.config.endpoint
+            ))
+        })?;
+        url.path_segments_mut()
+            .map_err(|_| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Invalid Infisical endpoint '{}': not a base URL",
+                    self.config.endpoint
+                ))
+            })?
+            .extend(["api", "v4", "secrets", key]);
+        Ok(url.into())
+    }
+
+    /// Reads one secret, by version when the ref pins one.
+    async fn get_async(
+        &self,
+        loc: &Location,
+        version: Option<&str>,
+    ) -> Result<Option<SecretString>> {
+        let url = self.secret_url(&loc.key)?;
+        let mut query = self.read_query(&loc.environment, &loc.secret_path);
+        if let Some(version) = version {
+            query.push(("version", version));
+        }
+
+        let response = self.send(reqwest::Method::GET, &url, &query, None).await?;
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+
+        match status {
+            StatusCode::OK => {
+                let parsed: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to parse Infisical response: {e}"
+                    ))
+                })?;
+                Self::secret_value(&parsed["secret"], &loc.key)
+            }
+            // A 404 covers a missing secret, folder, environment and project
+            // alike, and only the message text tells them apart. Reading it
+            // would make control flow turn on prose, so all four are taken as
+            // "nothing stored here", which `check` and provider fallback read
+            // as "not set". A misspelled `?env=` therefore looks like an unset
+            // secret until a write reports it.
+            StatusCode::NOT_FOUND => Ok(None),
+            _ => Err(self.http_error(status, &body, "reading a secret")),
+        }
+    }
+
+    /// Lists every secret in one folder, indexed by key. Infisical has no
+    /// fetch-these-N-names endpoint, so a batch read lists the folder once.
+    async fn list_async(
+        &self,
+        environment: &str,
+        secret_path: &str,
+    ) -> Result<HashMap<String, SecretString>> {
+        let url = format!("{}/api/v4/secrets", self.config.endpoint);
+        let query = self.read_query(environment, secret_path);
+
+        let response = self.send(reqwest::Method::GET, &url, &query, None).await?;
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+
+        match status {
+            StatusCode::OK => {
+                let parsed: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to parse Infisical response: {e}"
+                    ))
+                })?;
+                let secrets = parsed["secrets"].as_array().ok_or_else(|| {
+                    SecretSpecError::ProviderOperationFailed(
+                        "Infisical list response missing `secrets`".to_string(),
+                    )
+                })?;
+                let mut listed = HashMap::new();
+                for secret in secrets {
+                    let Some(key) = secret["secretKey"].as_str() else {
+                        continue;
+                    };
+                    // A withheld value is refused here rather than dropped:
+                    // omitting it would read as a secret that is simply unset.
+                    if let Some(value) = Self::secret_value(secret, key)? {
+                        listed.insert(key.to_string(), value);
+                    }
+                }
+                Ok(listed)
+            }
+            // An absent folder holds no secrets, exactly like an empty one.
+            StatusCode::NOT_FOUND => Ok(HashMap::new()),
+            _ => Err(self.http_error(status, &body, "listing secrets")),
+        }
+    }
+
+    /// Writes a secret, creating its folder when Infisical requires one.
+    ///
+    /// Infisical separates creating a secret from updating one, and does not
+    /// create a folder implicitly: writing into a folder that does not exist
+    /// fails and stores nothing, not even part of the path. Each request is
+    /// chosen from the status of the one before it, so updating an existing
+    /// secret costs a single call, and only a new secret costs more.
+    async fn set_async(&self, loc: &Location, value: &SecretString) -> Result<()> {
+        // A secret that is merely absent, and a folder that is absent, both
+        // answer 404 here.
+        if self
+            .write_secret(reqwest::Method::PATCH, loc, value)
+            .await?
+        {
+            return Ok(());
+        }
+        if self.write_secret(reqwest::Method::POST, loc, value).await? {
+            return Ok(());
+        }
+
+        // The folder is what is missing, unless the secret lives at the root,
+        // which always exists -- then the 404 is the environment's.
+        if loc.secret_path == "/" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Infisical has no environment '{}' in project {}. Environments are \
+                 SecretSpec profiles here unless the provider URI pins one with `?env=`.",
+                loc.environment, self.config.project_id
+            )));
+        }
+        let refused = self.create_folder(loc).await?;
+
+        if self.write_secret(reqwest::Method::POST, loc, value).await? {
+            return Ok(());
+        }
+        Err(SecretSpecError::ProviderOperationFailed(format!(
+            "Infisical could not find the folder '{}' in environment '{}' even after \
+             creating it{}",
+            loc.secret_path,
+            loc.environment,
+            match refused {
+                Some(reason) => format!(", which reported: {reason}"),
+                None => ".".to_string(),
+            }
+        )))
+    }
+
+    /// Creates or updates one secret. `Ok(false)` reports the 404 that means
+    /// the secret, its folder or its environment is absent; the caller decides
+    /// which, since Infisical answers all three alike.
+    async fn write_secret(
+        &self,
+        method: reqwest::Method,
+        loc: &Location,
+        value: &SecretString,
+    ) -> Result<bool> {
+        let url = self.secret_url(&loc.key)?;
+        let body = serde_json::json!({
+            "projectId": self.config.project_id,
+            "environment": loc.environment,
+            "secretPath": loc.secret_path,
+            "secretValue": value.expose_secret(),
+        });
+
+        let response = self.send(method, &url, &[], Some(body)).await?;
+        let status = response.status();
+        if status == StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+        let body = response.text().await.unwrap_or_default();
+        if status.is_success() {
+            Self::written(&body, &loc.key)?;
+            return Ok(true);
+        }
+        Err(self.http_error(status, &body, "writing a secret"))
+    }
+
+    /// Confirms a write that answered 200 actually stored the value.
+    ///
+    /// A project can carry an approval policy, under which a write is not a
+    /// write but a change request: Infisical still answers 200, with an
+    /// `approval` in place of the `secret`, and the value lands only once a
+    /// human merges it. Reading that as success would have `set` report a
+    /// secret stored that nobody can read back.
+    fn written(body: &str, key: &str) -> Result<()> {
+        let parsed: serde_json::Value = match serde_json::from_str(body) {
+            Ok(parsed) => parsed,
+            // A 200 whose body will not parse is left alone: the write is the
+            // server's word, and the shape is only consulted to catch the
+            // approval case.
+            Err(_) => return Ok(()),
+        };
+        let Some(approval) = parsed.get("approval") else {
+            return Ok(());
+        };
+        let status = approval["status"].as_str().unwrap_or("open");
+        Err(SecretSpecError::ProviderOperationFailed(format!(
+            "Infisical did not store '{key}': this project has an approval policy, so the \
+             write opened a change request ({status}) instead. The value lands once the \
+             request is approved in Infisical."
+        )))
+    }
+
+    /// Creates the folder holding a secret, and any parent it still needs:
+    /// Infisical creates the intermediate levels of a nested path in the one
+    /// call.
+    /// Returns whatever a refused creation said, for the caller to quote if
+    /// the write that follows still fails.
+    async fn create_folder(&self, loc: &Location) -> Result<Option<String>> {
+        let (parent, name) = loc
+            .secret_path
+            .rsplit_once('/')
+            .map(|(parent, name)| {
+                let parent = if parent.is_empty() { "/" } else { parent };
+                (parent.to_string(), name.to_string())
+            })
+            .ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Invalid Infisical folder '{}': paths are absolute, e.g. /secretspec.",
+                    loc.secret_path
+                ))
+            })?;
+
+        let url = format!("{}/api/v2/folders", self.config.endpoint);
+        let body = serde_json::json!({
+            "projectId": self.config.project_id,
+            "environment": loc.environment,
+            "path": parent,
+            "name": name,
+        });
+
+        let response = self
+            .send(reqwest::Method::POST, &url, &[], Some(body))
+            .await?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(None);
+        }
+        let body = response.text().await.unwrap_or_default();
+        // A folder that already exists answers 400, and so does a folder a
+        // concurrent SecretSpec run created. Telling those apart would mean
+        // reading the message, so the write that follows decides instead: it
+        // succeeds if the folder is present, whichever run created it. The
+        // refusal's message is returned so a write that still fails can name
+        // the reason rather than discard it.
+        if status == StatusCode::BAD_REQUEST {
+            return Ok(Some(Self::error_message(&body)));
+        }
+        Err(self.http_error(status, &body, "creating a folder"))
+    }
+
+    /// Sends an authenticated request.
+    async fn send(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        query: &[(&str, &str)],
+        body: Option<serde_json::Value>,
+    ) -> Result<reqwest::Response> {
+        let token = self.resolve_token().await?;
+        let mut request = self
+            .http()
+            .request(method, url)
+            .bearer_auth(token.expose_secret())
+            .query(query);
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        request.send().await.map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to connect to Infisical at {}: {e}",
+                self.config.endpoint
+            ))
+        })
+    }
+
+    /// Renders a failed response, naming the likely cause for the statuses a
+    /// user actually hits.
+    fn http_error(&self, status: StatusCode, body: &str, action: &str) -> SecretSpecError {
+        let message = Self::error_message(body);
+        match status {
+            StatusCode::UNAUTHORIZED => SecretSpecError::ProviderOperationFailed(format!(
+                "Infisical authentication failed (401) while {action}: {message}. \
+                 Check the machine identity's {CLIENT_ID}/{CLIENT_SECRET}."
+            )),
+            StatusCode::FORBIDDEN => SecretSpecError::ProviderOperationFailed(format!(
+                "Infisical denied access (403) while {action}: {message}. Check the machine \
+                 identity's permissions on project {}.",
+                self.config.project_id
+            )),
+            StatusCode::TOO_MANY_REQUESTS => SecretSpecError::ProviderOperationFailed(format!(
+                "Infisical rate limit exceeded (429) while {action}: {message}."
+            )),
+            _ => SecretSpecError::ProviderOperationFailed(format!(
+                "Infisical returned HTTP {status} while {action}: {message}"
+            )),
+        }
+    }
+}
+
+impl Provider for InfisicalProvider {
+    /// A profile's secrets share one folder under the configured prefix, each
+    /// under its own key. `item` carries the folder and the key together; the
+    /// environment is resolved separately in [`locate`](Self::locate), since
+    /// SecretSpec's `ref` table has no coordinate for it.
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        for (label, value) in [("project", project), ("profile", profile), ("key", key)] {
+            if value.is_empty() {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "{label} cannot be empty"
+                )));
+            }
+        }
+        // Infisical addresses folders like a filesystem, so a key carrying a
+        // separator would silently move the secret to another folder. The key
+        // is otherwise unconstrained -- spaces and non-ASCII included -- so it
+        // is stored exactly as written, and two distinct keys can never land
+        // on one name.
+        if key.contains('/') {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid key '{key}': Infisical addresses folders by path, so a '/' would \
+                 move the secret to another folder."
+            )));
+        }
+        // The project and profile each name a folder, and Infisical spells
+        // folder names in a narrower alphabet than keys. Rewriting a name to
+        // fit would let two projects share a folder, so an unspellable one is
+        // refused instead.
+        for (label, value) in [("Project", project), ("Profile", profile)] {
+            if !value
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+            {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "{label} '{value}' cannot name an Infisical folder: only letters, digits, \
+                     dashes and underscores are allowed. Rename it in secretspec.toml, or \
+                     address these secrets by their own coordinates with \
+                     ref = {{ item = \"/folder/KEY\" }}."
+                )));
+            }
+        }
+
+        Ok(NativeAddress {
+            item: format!("{}/{project}/{profile}/{key}", self.config.path),
+            ..Default::default()
+        })
+    }
+
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    /// The inverse of parsing: every knob the config holds is rendered, so the
+    /// URI naming this store in an audit record or a warning is one that reads
+    /// back as the same store. `tls` is the one that bites -- a plain-HTTP
+    /// endpoint rendered without it comes back as HTTPS.
+    fn uri(&self) -> String {
+        let plain_http = self.config.endpoint.starts_with("http://");
+        let host = self
+            .config
+            .endpoint
+            .trim_start_matches("https://")
+            .trim_start_matches("http://");
+        let mut uri = format!("infisical://{host}/{}", self.config.project_id);
+        let mut query = Vec::new();
+        if let Some(env) = &self.config.environment {
+            query.push(format!("env={}", ProviderUrl::encode_query(env)));
+        }
+        if self.config.path != DEFAULT_PATH {
+            query.push(format!(
+                "path={}",
+                ProviderUrl::encode_query(&self.config.path)
+            ));
+        }
+        if plain_http {
+            query.push("tls=false".to_string());
+        }
+        if !query.is_empty() {
+            uri.push('?');
+            uri.push_str(&query.join("&"));
+        }
+        uri
+    }
+
+    /// Infisical versions its secrets, so a `ref` may pin one. Its values are
+    /// single strings with no sub-components, so `field`, `section` and
+    /// `vault` are rejected.
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["version"]
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let loc = self.locate(addr)?;
+        let version = match addr {
+            Address::Native(native) => native.version.as_deref(),
+            Address::Convention { .. } => None,
+        };
+        super::block_on(self.get_async(&loc, version))
+    }
+
+    /// Secrets sharing a folder and environment are read with one list call
+    /// each, rather than one round trip per secret: Infisical's cloud rate
+    /// limits are per-minute, and a fan-out of single reads burns them.
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        // A pinned version names one historical value, which the folder
+        // listing (always latest) cannot answer.
+        let (versioned, listable): (Vec<_>, Vec<_>) = requests.iter().partition(
+            |(_, addr)| matches!(addr, Address::Native(native) if native.version.is_some()),
+        );
+
+        // Nothing about a versioned read is Infisical-specific, so it keeps the
+        // shared fetch, which already fetches one address once however many
+        // secrets name it, and fetches distinct ones concurrently.
+        let versioned: Vec<(&str, Address<'_>)> = versioned.into_iter().copied().collect();
+        let mut resolved = if versioned.is_empty() {
+            HashMap::new()
+        } else {
+            super::get_each(self, &versioned)?
+        };
+
+        super::block_on(async {
+            // One list call per distinct folder and environment.
+            let mut folders: HashMap<(String, String), Vec<(&str, String)>> = HashMap::new();
+            for (name, addr) in &listable {
+                let loc = self.locate(*addr)?;
+                folders
+                    .entry((loc.environment, loc.secret_path))
+                    .or_default()
+                    .push((name, loc.key));
+            }
+
+            for ((environment, secret_path), wanted) in folders {
+                let listed = self.list_async(&environment, &secret_path).await?;
+                for (name, key) in wanted {
+                    if let Some(value) = listed.get(&key) {
+                        resolved.insert(name.to_string(), value.clone());
+                    }
+                }
+            }
+
+            Ok(resolved)
+        })
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let loc = self.locate(addr)?;
+        super::block_on(self.set_async(&loc, value))
+    }
+
+    /// A pinned version names a value that already exists; writing one would
+    /// mean rewriting history, which Infisical does not offer.
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Native(native) if native.version.is_some() => {
+                Err(SecretSpecError::ProviderOperationFailed(
+                    "infisical refs pinning a `version` are read-only: a past version cannot \
+                     be rewritten. Drop `version` to write the secret's latest value."
+                        .to_string(),
+                ))
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    const PROJECT: &str = "7e2f1a4c-0000-0000-0000-000000000000";
+
+    fn config(s: &str) -> InfisicalConfig {
+        InfisicalConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap()
+    }
+
+    fn provider(s: &str) -> InfisicalProvider {
+        InfisicalProvider::new(config(s))
+    }
+
+    #[test]
+    fn uri_defaults_to_infisical_cloud() {
+        let c = config(&format!("infisical:///{PROJECT}"));
+        assert_eq!(c.endpoint, "https://app.infisical.com");
+        assert_eq!(c.project_id, PROJECT);
+        assert_eq!(c.path, DEFAULT_PATH);
+        assert_eq!(c.environment, None);
+    }
+
+    #[test]
+    fn uri_carries_host_environment_and_path() {
+        let c = config(&format!(
+            "infisical://localhost:8080/{PROJECT}?env=prod&path=/team&tls=false"
+        ));
+        assert_eq!(c.endpoint, "http://localhost:8080");
+        assert_eq!(c.environment.as_deref(), Some("prod"));
+        assert_eq!(c.path, "/team");
+    }
+
+    /// A project is required, and its absence names the UUID that v4 wants:
+    /// the slug the Infisical UI shows is not addressable.
+    #[test]
+    fn uri_without_a_project_is_rejected() {
+        let err = InfisicalConfig::try_from(&ProviderUrl::new(
+            Url::parse("infisical://app.infisical.com").unwrap(),
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("UUID"), "{err}");
+    }
+
+    /// The profile names the folder as well as the environment, so pinning
+    /// `?env=` cannot make two profiles share one secret.
+    #[test]
+    fn every_profile_gets_its_own_folder() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}?env=dev"));
+        let dev = p.convention_address("myapp", "dev", "API_KEY").unwrap();
+        let prod = p.convention_address("myapp", "prod", "API_KEY").unwrap();
+        assert_eq!(dev.item, "/secretspec/myapp/dev/API_KEY");
+        assert_ne!(dev.item, prod.item);
+    }
+
+    /// The profile names the environment when the URI pins none.
+    #[test]
+    fn profile_names_the_environment() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+        let loc = p
+            .locate(Address::convention("myapp", "prod", "API_KEY"))
+            .unwrap();
+        assert_eq!(loc.environment, "prod");
+        assert_eq!(loc.secret_path, "/secretspec/myapp/prod");
+        assert_eq!(loc.key, "API_KEY");
+
+        let pinned = provider(&format!("infisical://app.infisical.com/{PROJECT}?env=dev"));
+        let loc = pinned
+            .locate(Address::convention("myapp", "prod", "API_KEY"))
+            .unwrap();
+        assert_eq!(loc.environment, "dev");
+        // The folder still keeps the profile apart.
+        assert_eq!(loc.secret_path, "/secretspec/myapp/prod");
+    }
+
+    /// Keys are stored exactly as written: Infisical constrains them no
+    /// further than being non-empty, so nothing needs rewriting.
+    #[test]
+    fn keys_are_stored_verbatim() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+        for key in ["lower_case", "SECTION__KEY", "with.dot", "with-dash"] {
+            let addr = p.convention_address("myapp", "dev", key).unwrap();
+            assert_eq!(addr.item, format!("/secretspec/myapp/dev/{key}"));
+        }
+    }
+
+    /// A folder name Infisical cannot spell is refused, not rewritten: a
+    /// rewrite could land two projects on one folder.
+    #[test]
+    fn unspellable_folder_names_are_refused() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+        let err = p.convention_address("my.app", "dev", "KEY").unwrap_err();
+        assert!(
+            err.to_string().contains("cannot name an Infisical folder"),
+            "{err}"
+        );
+        let err = p
+            .convention_address("myapp", "my.profile", "KEY")
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("cannot name an Infisical folder"),
+            "{err}"
+        );
+    }
+
+    /// A ref names a folder and key; Infisical values have no components, so
+    /// `field` has no meaning and is rejected rather than ignored.
+    #[test]
+    fn native_address_rejects_field() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}?env=dev"));
+        let addr = NativeAddress {
+            item: "/infra/DB_PASSWORD".into(),
+            field: Some("password".into()),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`field`"), "{err}");
+    }
+
+    /// A ref has no profile to name an environment with, so the URI must.
+    #[test]
+    fn native_address_needs_an_environment() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+        let addr = NativeAddress {
+            item: "/infra/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("?env="), "{err}");
+    }
+
+    /// A ref splits into the folder holding it and the key itself.
+    #[test]
+    fn native_address_splits_folder_from_key() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}?env=dev"));
+        let addr = NativeAddress {
+            item: "/infra/shared/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        let loc = p.locate(Address::Native(&addr)).unwrap();
+        assert_eq!(loc.secret_path, "/infra/shared");
+        assert_eq!(loc.key, "DB_PASSWORD");
+    }
+
+    /// A past version cannot be rewritten, so those refs refuse writes with
+    /// the same reason the pre-check gives.
+    #[test]
+    fn versioned_refs_are_read_only() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}?env=dev"));
+        let addr = NativeAddress {
+            item: "/infra/DB_PASSWORD".into(),
+            version: Some("3".into()),
+            ..Default::default()
+        };
+        let refusal = p.check_writable(Address::Native(&addr)).unwrap_err();
+        assert!(refusal.to_string().contains("read-only"), "{refusal}");
+        let err = p
+            .set(Address::Native(&addr), &SecretString::new("v".into()))
+            .unwrap_err();
+        assert_eq!(err.to_string(), refusal.to_string());
+    }
+
+    /// A value Infisical withheld is refused, not handed on.
+    ///
+    /// An identity that may see a secret exists but not read it still gets
+    /// HTTP 200, with a placeholder where the value should be. Passing that on
+    /// would export a literal `<hidden-by-infisical>` to the process
+    /// SecretSpec runs, and reporting it as absent would read as an unset
+    /// secret; both are worse than saying what happened.
+    #[test]
+    fn a_withheld_value_is_refused() {
+        let hidden = serde_json::json!({
+            "secretKey": "API_KEY",
+            "secretValue": "<hidden-by-infisical>",
+            "secretValueHidden": true,
+        });
+        let err = InfisicalProvider::secret_value(&hidden, "API_KEY").unwrap_err();
+        assert!(err.to_string().contains("withheld"), "{err}");
+        assert!(err.to_string().contains("API_KEY"), "{err}");
+    }
+
+    /// A readable value is returned unchanged.
+    #[test]
+    fn a_readable_value_is_returned() {
+        let visible = serde_json::json!({
+            "secretKey": "API_KEY",
+            "secretValue": "s3cret",
+            "secretValueHidden": false,
+        });
+        let value = InfisicalProvider::secret_value(&visible, "API_KEY")
+            .unwrap()
+            .expect("a readable value");
+        assert_eq!(value.expose_secret(), "s3cret");
+    }
+
+    /// A write held for approval does not report success.
+    ///
+    /// A project under an approval policy answers a write with 200 and an
+    /// `approval` where the `secret` would be, storing nothing until a human
+    /// merges it. Reporting that as success would claim a secret was stored
+    /// that cannot be read back.
+    #[test]
+    fn a_write_held_for_approval_is_not_a_write() {
+        let held = serde_json::json!({
+            "approval": { "id": "8f2c", "status": "open", "hasMerged": false },
+        });
+        let err = InfisicalProvider::written(&held.to_string(), "API_KEY").unwrap_err();
+        assert!(err.to_string().contains("approval policy"), "{err}");
+        assert!(err.to_string().contains("API_KEY"), "{err}");
+    }
+
+    /// An ordinary write answers with the secret it stored, and reports success.
+    #[test]
+    fn an_ordinary_write_reports_success() {
+        let stored = serde_json::json!({
+            "secret": { "id": "1a2b", "secretKey": "API_KEY", "version": 1 },
+        });
+        InfisicalProvider::written(&stored.to_string(), "API_KEY")
+            .expect("a stored secret is not an approval");
+        // A body that will not parse is the server's word, taken as given.
+        InfisicalProvider::written("", "API_KEY").expect("an unparseable 200 stays a success");
+    }
+
+    /// The rendered URI round-trips through parsing.
+    ///
+    /// `uri()` names this store in audit records and warnings, so it has to
+    /// read back as the same store -- including a self-hosted instance on
+    /// plain HTTP, which without `tls` would come back as HTTPS.
+    #[test]
+    fn uri_round_trips() {
+        for spec in [
+            format!("infisical://app.infisical.com/{PROJECT}"),
+            format!("infisical://app.infisical.com/{PROJECT}?env=prod"),
+            format!("infisical://app.infisical.com/{PROJECT}?env=prod&path=/team"),
+            format!("infisical://localhost:8080/{PROJECT}?tls=false"),
+            format!("infisical://localhost:8080/{PROJECT}?env=dev&tls=false"),
+        ] {
+            let rendered = provider(&spec).uri();
+            assert_eq!(rendered, spec, "uri() must render what parsing read");
+            // ... and the rendering must parse back to the same endpoint.
+            assert_eq!(
+                config(&rendered).endpoint,
+                config(&spec).endpoint,
+                "re-reading uri() must reach the same instance"
+            );
+        }
+    }
+
+    /// An unreadable `tls` is refused rather than silently meaning one of its
+    /// two values.
+    #[test]
+    fn unreadable_tls_is_rejected() {
+        let err = InfisicalConfig::try_from(&ProviderUrl::new(
+            Url::parse(&format!("infisical://host/{PROJECT}?tls=banana")).unwrap(),
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("tls value 'banana'"), "{err}");
+    }
+
+    /// A ref names the environment's root with a leading slash, and the
+    /// configured prefix without one. Trimming the slash away would move a
+    /// root secret under the prefix, where it reads as unset.
+    #[test]
+    fn a_root_ref_stays_at_the_root() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}?env=dev"));
+
+        let root = NativeAddress {
+            item: "/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        let loc = p.locate(Address::Native(&root)).unwrap();
+        assert_eq!(loc.secret_path, "/");
+        assert_eq!(loc.key, "DB_PASSWORD");
+
+        // A bare name still means "in the configured prefix".
+        let bare = NativeAddress {
+            item: "DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        let loc = p.locate(Address::Native(&bare)).unwrap();
+        assert_eq!(loc.secret_path, DEFAULT_PATH);
+        assert_eq!(loc.key, "DB_PASSWORD");
+    }
+
+    /// A ref that names a folder without a leading slash is read under the
+    /// prefix, exactly as a bare name is. Reading it from the root instead
+    /// would put the prefix out of reach of every ref naming a folder, and
+    /// make `team/DB` mean what `/team/DB` already means.
+    #[test]
+    fn a_relative_ref_is_read_under_the_prefix() {
+        let p = provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}?env=dev&path=/myapp"
+        ));
+        let relative = NativeAddress {
+            item: "team/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        let loc = p.locate(Address::Native(&relative)).unwrap();
+        assert_eq!(loc.secret_path, "/myapp/team");
+
+        // ... while the absolute form still names the root, unprefixed.
+        let absolute = NativeAddress {
+            item: "/team/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        let loc = p.locate(Address::Native(&absolute)).unwrap();
+        assert_eq!(loc.secret_path, "/team");
+
+        // A prefix of `/` joins without doubling the separator.
+        let rooted = provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}?env=dev&path=/"
+        ));
+        let loc = rooted.locate(Address::Native(&relative)).unwrap();
+        assert_eq!(loc.secret_path, "/team");
+    }
+
+    /// Infisical's own CLI appends `/api` to the domain unless it is already
+    /// there, so a domain carrying it is a working configuration, not a
+    /// mistake. A domain naming any other path still is one.
+    #[test]
+    fn a_domain_may_carry_the_api_suffix() {
+        assert_eq!(
+            InfisicalConfig::endpoint_from_domain("https://vault.example.com/api", "https")
+                .unwrap(),
+            "https://vault.example.com"
+        );
+        assert_eq!(
+            InfisicalConfig::endpoint_from_domain("vault.example.com:8080", "https").unwrap(),
+            "https://vault.example.com:8080"
+        );
+        let err = InfisicalConfig::endpoint_from_domain("https://example.com/infisical", "https")
+            .unwrap_err();
+        assert!(err.to_string().contains("names a path"), "{err}");
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -168,12 +168,12 @@ impl ProviderUrl {
             .into_owned()
     }
 
-    #[cfg(any(feature = "vault", test))]
+    #[cfg(any(feature = "infisical", feature = "vault", test))]
     pub fn port(&self) -> Option<u16> {
         self.0.port()
     }
 
-    #[cfg(any(feature = "awssm", feature = "vault", test))]
+    #[cfg(any(feature = "awssm", feature = "infisical", feature = "vault", test))]
     pub fn query_pairs(&self) -> url::form_urlencoded::Parse<'_> {
         self.0.query_pairs()
     }

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -232,6 +232,8 @@ pub mod env;
 #[cfg(feature = "gcsm")]
 pub mod gcsm;
 pub mod gopass;
+#[cfg(feature = "infisical")]
+pub mod infisical;
 #[cfg(feature = "keyring")]
 pub mod keyring;
 pub mod lastpass;

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -557,6 +557,36 @@ mod integration_tests {
                     .expect("Should create vault provider");
                 (provider, None)
             }
+            #[cfg(feature = "infisical")]
+            // Bare "infisical" names no project, so route it through a real
+            // one instead of failing to parse in the generic `_` branch below.
+            // Set INFISICAL_TEST_PROJECT to a project UUID, INFISICAL_TEST_HOST
+            // to reach a self-hosted instance (default: Infisical Cloud), and
+            // authenticate with INFISICAL_CLIENT_ID/INFISICAL_CLIENT_SECRET or
+            // INFISICAL_TOKEN. Prefer the former, and exercise both: only the
+            // client_id/client_secret path logs in, so a token alone leaves
+            // that request untested. The environment is pinned (INFISICAL_TEST_ENV,
+            // default `dev`, which every new project has) because these tests
+            // run under profiles no Infisical environment is named after;
+            // profiles still separate, by folder.
+            "infisical" => {
+                let project = std::env::var("INFISICAL_TEST_PROJECT").expect(
+                    "Testing the infisical provider requires a real project: set INFISICAL_TEST_PROJECT to a project UUID (and authenticate via INFISICAL_CLIENT_ID/INFISICAL_CLIENT_SECRET or INFISICAL_TOKEN).",
+                );
+                let host = std::env::var("INFISICAL_TEST_HOST")
+                    .unwrap_or_else(|_| "app.infisical.com".to_string());
+                let env = std::env::var("INFISICAL_TEST_ENV").unwrap_or_else(|_| "dev".to_string());
+                // A self-hosted instance is commonly served over plain HTTP.
+                let tls = if host.starts_with("localhost") || host.starts_with("127.0.0.1") {
+                    "&tls=false"
+                } else {
+                    ""
+                };
+                let provider_spec = format!("infisical://{host}/{project}?env={env}{tls}");
+                let provider = Box::<dyn Provider>::try_from(provider_spec.as_str())
+                    .expect("Should create infisical provider");
+                (provider, None)
+            }
             #[cfg(feature = "akv")]
             // Bare "akv" has no vault name, so route it through a real
             // AKV_TEST_VAULT instead of falling into the generic `_` branch
@@ -686,6 +716,147 @@ mod integration_tests {
             println!("Testing provider: {}", provider_name);
             let (provider, _temp_dir) = create_provider_with_temp_path(&provider_name);
             test_provider_basic_workflow(provider.as_ref(), &provider_name);
+        }
+    }
+
+    /// A value Infisical withholds surfaces as a refusal, never as a secret.
+    ///
+    /// An identity permitted to see that a secret exists, but not to read it,
+    /// still gets HTTP 200: the value is replaced with a placeholder and
+    /// `secretValueHidden` is set. Handing that on would export a literal
+    /// `<hidden-by-infisical>` to the process SecretSpec runs, and reporting it
+    /// absent would read as an unset secret.
+    ///
+    /// Telling those identities apart needs a custom role, which Infisical
+    /// gates behind a paid tier, so this runs only where one exists: set
+    /// `INFISICAL_TEST_NOREAD_CLIENT_ID` and `INFISICAL_TEST_NOREAD_CLIENT_SECRET`
+    /// to an identity holding that role, alongside the usual
+    /// `INFISICAL_TEST_PROJECT` and a writable identity to plant the secret
+    /// with. The refusal itself is covered without any of that by
+    /// `provider::infisical::tests::a_withheld_value_is_refused`; this test is
+    /// what proves the placeholder still looks like Infisical says it does.
+    #[cfg(feature = "infisical")]
+    #[test]
+    fn test_infisical_refuses_a_withheld_value() {
+        let (Ok(client_id), Ok(client_secret)) = (
+            std::env::var("INFISICAL_TEST_NOREAD_CLIENT_ID"),
+            std::env::var("INFISICAL_TEST_NOREAD_CLIENT_SECRET"),
+        ) else {
+            eprintln!(
+                "skipping: set INFISICAL_TEST_NOREAD_CLIENT_ID/SECRET to an identity that may \
+                 see a secret exists but not read it (needs an Infisical custom role)"
+            );
+            return;
+        };
+        if !get_test_providers().iter().any(|p| p == "infisical") {
+            eprintln!("skipping: SECRETSPEC_TEST_PROVIDERS does not name infisical");
+            return;
+        }
+        // A ready-made token outranks the credentials below, so the reader
+        // would authenticate as whoever minted it -- read the value, and fail
+        // for the wrong reason. The restricted identity has to be the only way
+        // in.
+        if std::env::var("INFISICAL_TOKEN").is_ok() {
+            eprintln!(
+                "skipping: INFISICAL_TOKEN outranks the restricted identity's credentials. \
+                 Unset it and authenticate with INFISICAL_CLIENT_ID/INFISICAL_CLIENT_SECRET \
+                 to exercise a withheld value."
+            );
+            return;
+        }
+
+        // Plant a secret the restricted identity is allowed to know about.
+        let project_name = generate_test_project_name();
+        let (writer, _t) = create_provider_with_temp_path("infisical");
+        writer
+            .set(
+                Address::convention(&project_name, "default", "HIDDEN_KEY"),
+                &SecretString::new("plaintext".into()),
+            )
+            .expect("the writing identity should store a secret");
+
+        // The same store, read by an identity that may not see values.
+        let (mut restricted, _t) = create_provider_with_temp_path("infisical");
+        let mut credentials = crate::provider::ProviderCredentials::new();
+        credentials.insert("client_id".to_string(), SecretString::new(client_id.into()));
+        credentials.insert(
+            "client_secret".to_string(),
+            SecretString::new(client_secret.into()),
+        );
+        restricted.with_credentials(credentials);
+
+        let err = restricted
+            .get(Address::convention(&project_name, "default", "HIDDEN_KEY"))
+            .expect_err("a withheld value must not read as a secret");
+        assert!(
+            err.to_string().contains("withheld"),
+            "the refusal should say the value was withheld, got: {err}"
+        );
+        // The placeholder must never reach the caller.
+        assert!(
+            !err.to_string().contains("plaintext"),
+            "the error must not carry the value"
+        );
+    }
+
+    /// One key, many profiles: each profile keeps its own value.
+    ///
+    /// A store that folds the profile into its naming can map two profiles
+    /// onto one secret, where a write under one profile silently overwrites
+    /// another's. That is invisible to a single-profile test, so every store
+    /// is asked to keep the profiles apart.
+    #[test]
+    fn test_all_providers_isolate_profiles() {
+        let mock = MockProvider::new();
+        test_provider_profile_isolation(&mock, "mock");
+
+        for provider_name in get_test_providers() {
+            println!("Testing provider: {}", provider_name);
+            let (provider, _temp_dir) = create_provider_with_temp_path(&provider_name);
+            test_provider_profile_isolation(provider.as_ref(), &provider_name);
+        }
+    }
+
+    /// Stores that hold one flat namespace, where every profile reads the same
+    /// value by design. Named rather than detected: a store that has collapsed
+    /// its profiles by accident looks exactly like one that never had them,
+    /// which is the bug this test exists to catch.
+    const FLAT_PROVIDERS: &[&str] = &["dotenv", "env"];
+
+    fn test_provider_profile_isolation(provider: &dyn Provider, provider_name: &str) {
+        if FLAT_PROVIDERS.contains(&provider_name)
+            || provider
+                .check_writable(Address::convention("proj", "default", "KEY"))
+                .is_err()
+        {
+            return;
+        }
+
+        let project_name = generate_test_project_name();
+        let profiles = ["dev", "staging", "prod"];
+
+        for profile in profiles {
+            let value = SecretString::new(format!("value_for_{profile}").into());
+            provider
+                .set(
+                    Address::convention(&project_name, profile, "API_KEY"),
+                    &value,
+                )
+                .unwrap_or_else(|e| panic!("[{provider_name}] set under '{profile}': {e}"));
+        }
+
+        // Written last, so a store that collapses the profiles hands "prod"
+        // back for every one of them.
+        for profile in profiles {
+            let found = provider
+                .get(Address::convention(&project_name, profile, "API_KEY"))
+                .unwrap_or_else(|e| panic!("[{provider_name}] get under '{profile}': {e}"))
+                .unwrap_or_else(|| panic!("[{provider_name}] '{profile}' lost its secret"));
+            assert_eq!(
+                found.expose_secret(),
+                format!("value_for_{profile}"),
+                "[{provider_name}] profile '{profile}' reads another profile's value"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Adds an `infisical` provider for [Infisical](https://infisical.com) — Cloud and self-hosted — gated behind an `infisical` Cargo feature (in the default set alongside gcsm/awssm/vault/bws/akv).

It speaks Infisical's **v4** REST API directly over `reqwest`, which the vault provider already depends on, so the feature adds **no new dependency and leaves `Cargo.lock` untouched**. (The official `infisical` Rust SDK is 0.0.3, last released Sep 2025, and hardcodes the deprecated `/api/v3/secrets/raw` endpoints in all five secrets operations, so it isn't used.)

Closes #17

## URI format

```
infisical://[host]/{project-id}[?env=slug&path=/prefix&tls=false]
```

```bash
infisical://app.infisical.com/7e2f1a4c-...            # Infisical Cloud (US), the default host
infisical://eu.infisical.com/7e2f1a4c-...             # Infisical Cloud (EU)
infisical://vault.example.com/7e2f1a4c-...?env=prod   # read every profile from one environment
infisical://localhost:8080/7e2f1a4c-...?tls=false     # self-hosted over plain HTTP
```

The project is Infisical's project **UUID**; its v4 API takes no project slug (a slug in `projectId` 404s — verified). Without a host, the provider reads `INFISICAL_DOMAIN`, then defaults to `app.infisical.com`.

## Profiles map to environments

A SecretSpec profile names the Infisical environment, so a `production` profile reads the `production` environment — Infisical's environments are what profiles already mean. A project whose environments don't correspond to profiles pins one with `?env=`.

The profile names the **folder as well as** the environment, so pinning `?env=` cannot make two profiles resolve to the same secret. It looks redundant in the default layout and is load-bearing: without it, `?env=` makes `(project, "dev", KEY)` and `(project, "prod", KEY)` collide.

**Storage:** secret `{key}` in folder `{path}/{project}/{profile}` (default prefix `/secretspec`, overridable with `?path=`), in the environment named by the profile or `?env=`.

Keys are stored **verbatim** — Infisical constrains a key no further than being non-empty (lowercase, dots, `__`, spaces and Unicode all verified accepted), so nothing is rewritten and two keys cannot collide. Folder names are narrower (`[A-Za-z0-9_-]`), so a project or profile Infisical can't spell is **refused rather than rewritten**, which would let two projects share a folder.

## Authentication

Universal Auth (machine identity) via `client_id` + `client_secret`, exchanged once per run for a short-lived token; or a ready-made `token`, which is what CI usually has. Credentials come from the provider alias (so they can live in the keyring via `[providers]` `env`) or from `INFISICAL_CLIENT_ID` / `INFISICAL_CLIENT_SECRET` / `INFISICAL_TOKEN`. A half-specified identity errors naming the missing half rather than falling back to an anonymous request.

Service tokens are not supported: Infisical deprecated them in favour of machine identities.

## Refs

`ref = { item = "/infra/shared/DB_PASSWORD" }` names a secret by its own coordinates; `version` pins a version (read-only — a past version can't be rewritten). A leading slash names the environment's root, without one the folder is read under the configured prefix. Infisical values have no sub-components, so `field`, `section` and `vault` are rejected.

## Decisions worth flagging for review

- **Not-found is read from the status, never the message.** Infisical answers a missing secret, folder, environment and project with an indistinguishable bare 404, so all four are taken as "nothing stored here". A misspelled `?env=` therefore reads as an unset secret until a write reports it by name. Documented as a limitation; the alternative was matching error prose.
- **`expandSecretReferences=true`**, matching Infisical's own default and CLI — a `${...}` reference is a feature its users configure deliberately, so passing `false` would hand back a literal `${DB_USER}`.
- **A withheld value is refused, not passed on.** An identity that may see a secret exists but not read it still gets **HTTP 200**, carrying the literal string `<hidden-by-infisical>` with `secretValueHidden` set. Exporting that into the process `secretspec run` starts would be worse than failing, so it's reported as the refusal it is. (`viewSecretValue=true` alone does not prevent this.)
- **A write held for approval doesn't report success.** A project under an approval policy answers a write with 200 and an `approval` object, storing nothing until a human merges it.
- **`get_many` lists each folder once** rather than one round trip per secret — Infisical has no fetch-these-N-names endpoint, and its cloud rate limits are per-minute. Versioned refs fall back to the shared `get_each`, which already dedupes and parallelises.
- **Folders are created, not assumed.** Writing into a folder that doesn't exist 404s and stores nothing, so `set` creates the chain (one call creates every level) and lets the retry decide, rather than reading messages to tell "already exists" from a real fault.

## Testing

`cargo test --all --all-features`: **504 pass**, including provider integration tests run against **both** Infisical Cloud and self-hosted `v0.162.7`, which agreed on every behaviour tested.

```bash
export INFISICAL_CLIENT_ID=... INFISICAL_CLIENT_SECRET=...   # or INFISICAL_TOKEN
export INFISICAL_TEST_PROJECT=<project-uuid>
export INFISICAL_TEST_HOST=app.infisical.com                 # or localhost:8080 for self-hosted
export INFISICAL_TEST_ENV=dev                                # tests pin an env; profiles still separate by folder
SECRETSPEC_TEST_PROVIDERS=infisical cargo test --package secretspec --all-features
```

Also adds `test_all_providers_isolate_profiles` to the generic suite: one key written under three profiles, each asserted to keep its own value. It fails if a provider collapses profiles onto one secret — a class of bug that is invisible to a single-profile test. `dotenv`/`env` are named as flat stores rather than detected, since a store that collapsed its profiles by accident looks exactly like one that never had them.

## Known limitations

- The project is addressed by UUID; the v4 API accepts no slug
- A project or profile not spellable as an Infisical folder is refused rather than rewritten
- Refs need `?env=`, having no profile to name an environment with
- `secretspec import infisical://…` is unsupported: the provider doesn't enumerate secrets, so there's nothing for import to discover (`reflect()` follows the vault provider in not being implemented)
- `INFISICAL_DOMAIN` names a host, not a sub-path; a trailing `/api` is accepted, since Infisical's CLI takes the domain in that form
- **The withheld-value and approval-policy paths are implemented and unit-tested, but not verified against a live paid tier.** Custom roles are Pro-gated and approval workflows are Enterprise-gated; both guards are built against response shapes observed from the real API and the documented schema respectively. The restricted-role case ships as a *gated* integration test (`INFISICAL_TEST_NOREAD_CLIENT_ID`/`_SECRET`) rather than an absent one, so it runs wherever such a role exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
