### PR TITLE
docs(ffi): document the request `mode` field, and test it

### DIFF
--- a/secretspec-ffi/include/secretspec.h
+++ b/secretspec-ffi/include/secretspec.h
@@ -7,14 +7,37 @@
  *
  * Request JSON (all fields optional):
  *   { "path": ".../secretspec.toml", "provider": "keyring://",
- *     "profile": "production", "reason": "boot", "no_values": false }
+ *     "profile": "production", "reason": "boot", "no_values": false,
+ *     "mode": "resolve" }
+ *
+ * "mode" selects the response shape and defaults to "resolve":
+ *
+ *   "resolve"  the value-carrying resolve response. Set "no_values" to strip
+ *              the values from it.
+ *   "report"   the value-free resolution report: the inventory/preflight view
+ *              the CLI exposes as `check --json`.
+ *
+ * Any other value is rejected with an "invalid_request" error.
+ *
+ * "no_values" is NOT the same as "mode": "report". A "no_values" resolve blanks
+ * the values but keeps the resolve shape: its "secrets" is an object keyed by
+ * name, it never says whether a secret is *declared* required, and when a
+ * required secret is missing that object is empty. A report's "secrets" is an
+ * ARRAY of per-secret entries carrying "name", "required", "status"
+ * ("resolved" / "missing_required" / "missing_optional") and provenance, and
+ * lists every declared secret whether or not it resolved. "required" is
+ * reachable only via "report".
  *
  * Response envelope:
- *   { "ok": true,  "response": { ...resolve response... } }
+ *   { "ok": true,  "response": { ...resolve response | resolution report... } }
  *   { "ok": false, "error": { "kind": "io", "message": "..." } }
  *
- * The response (when ok) carries secret values unless "no_values" was set.
- * Treat returned strings as sensitive and free them promptly.
+ * "ok": false means the call itself failed (bad manifest, provider error,
+ * unknown "mode"); a missing required secret is a domain result reported inside
+ * an "ok": true response.
+ *
+ * A resolve response carries secret values unless "no_values" was set; a report
+ * never does. Treat returned strings as sensitive and free them promptly.
  */
 #ifndef SECRETSPEC_H
 #define SECRETSPEC_H

--- a/secretspec-ffi/src/lib.rs
+++ b/secretspec-ffi/src/lib.rs
@@ -20,24 +20,50 @@
 //!
 //! ```json
 //! { "path": "…/secretspec.toml", "provider": "keyring://",
-//!   "profile": "production", "reason": "boot", "no_values": false }
+//!   "profile": "production", "reason": "boot", "no_values": false,
+//!   "mode": "resolve" }
 //! ```
 //!
 //! All fields are optional. `path` omitted means "walk up from the working
-//! directory" like the CLI. `no_values` strips secret values from the response.
+//! directory" like the CLI.
+//!
+//! `mode` selects which shape comes back, and defaults to `"resolve"`:
+//!
+//! - `"resolve"` — the value-carrying [`secretspec::ResolveResponse`]. Set
+//!   `no_values` to strip the values from it.
+//! - `"report"` — the value-free [`secretspec::ResolutionReport`]: the
+//!   inventory/preflight view the CLI exposes as `check --json`.
+//!
+//! Any other value is rejected with an `invalid_request` error.
+//!
+//! ### `no_values` is not `mode: "report"`
+//!
+//! They are different shapes, and a consumer that wants an inventory wants
+//! `report`:
+//!
+//! - `no_values` returns a `ResolveResponse` with the values blanked. Its
+//!   `secrets` is an object keyed by name, it never reports whether a secret is
+//!   *declared* required, and when a required secret is missing that object is
+//!   **empty** — so the one case a preflight check exists to describe is the case
+//!   it tells you least about.
+//! - `report` returns a `ResolutionReport`, whose `secrets` is an **array** of
+//!   per-secret entries carrying `name`, `required`, `status`
+//!   (`resolved` / `missing_required` / `missing_optional`) and provenance. Every
+//!   declared secret is listed whether or not it resolved. `required` is
+//!   reachable *only* here.
 //!
 //! ## Response envelope
 //!
 //! ```json
-//! { "ok": true,  "response": { …ResolveResponse… } }
+//! { "ok": true,  "response": { …ResolveResponse | ResolutionReport… } }
 //! { "ok": false, "error": { "kind": "io", "message": "…" } }
 //! ```
 //!
-//! `ok: true` carries the value-carrying [`secretspec::ResolveResponse`] (which
-//! still reports domain failures like `missing_required` in its own fields).
-//! `ok: false` means the call itself failed (bad manifest, provider error,
-//! reason policy). This separates transport failure from "a required secret is
-//! missing", which the SDK surfaces differently.
+//! `ok: true` carries whichever shape `mode` selected. `ok: false` means the call
+//! itself failed (bad manifest, provider error, reason policy, unknown `mode`).
+//! This separates transport failure from "a required secret is missing", which is
+//! a domain result reported inside an `ok: true` response and which the SDK
+//! surfaces differently.
 //!
 //! # Safety
 //!

--- a/secretspec-ffi/tests/c_abi.rs
+++ b/secretspec-ffi/tests/c_abi.rs
@@ -31,6 +31,14 @@ fn write_project(dir: &TempDir, manifest: &str, dotenv: &str) -> (String, String
     )
 }
 
+/// Find one secret entry by name in a `report` response's `secrets` array.
+fn secret<'a>(secrets: &'a [Value], name: &str) -> &'a Value {
+    secrets
+        .iter()
+        .find(|s| s["name"] == name)
+        .unwrap_or_else(|| panic!("no secret named {name} in report"))
+}
+
 const MANIFEST: &str = r#"
 [project]
 name = "ffi-test"
@@ -119,6 +127,90 @@ fn resolve_missing_required_is_ok_envelope_with_error_list() {
     assert_eq!(env["ok"], true, "envelope: {env}");
     assert_eq!(env["response"]["missing_required"][0], "DATABASE_URL");
     assert!(env["response"]["secrets"].as_object().unwrap().is_empty());
+}
+
+#[test]
+fn report_mode_returns_requiredness_and_status() {
+    let dir = TempDir::new().unwrap();
+    let (manifest_path, provider) = write_project(&dir, MANIFEST, "DATABASE_URL=postgres://db\n");
+
+    let request = serde_json::json!({
+        "path": manifest_path,
+        "provider": provider,
+        "reason": "ffi test",
+        "mode": "report",
+    })
+    .to_string();
+
+    let env = resolve(&request);
+    assert_eq!(env["ok"], true, "envelope: {env}");
+    let response = &env["response"];
+    assert_eq!(response["schema_version"], 1);
+    assert_eq!(response["profile"], "default");
+
+    // `report` answers with a list, not the name-keyed map `resolve` returns.
+    let secrets = response["secrets"].as_array().unwrap();
+    assert_eq!(secrets.len(), 3);
+
+    // Requiredness is reachable only here: `resolve` never reports it.
+    let db = secret(secrets, "DATABASE_URL");
+    assert_eq!(db["required"], true);
+    assert_eq!(db["status"], "resolved");
+    assert!(db.get("value").is_none(), "report must not carry a value");
+
+    let log = secret(secrets, "LOG_LEVEL");
+    assert_eq!(log["required"], false);
+    assert_eq!(log["default_applied"], true);
+
+    let sentry = secret(secrets, "SENTRY_DSN");
+    assert_eq!(sentry["status"], "missing_optional");
+}
+
+#[test]
+fn report_mode_keeps_the_inventory_when_a_required_secret_is_missing() {
+    let dir = TempDir::new().unwrap();
+    // DATABASE_URL is required but absent from the backend.
+    let (manifest_path, provider) = write_project(&dir, MANIFEST, "");
+
+    let request = serde_json::json!({
+        "path": manifest_path,
+        "provider": provider,
+        "reason": "ffi test",
+        "mode": "report",
+    })
+    .to_string();
+
+    let env = resolve(&request);
+    assert_eq!(env["ok"], true, "envelope: {env}");
+
+    // The contrast with `resolve`, which empties `secrets` in this situation
+    // (see `resolve_missing_required_is_ok_envelope_with_error_list`): a report
+    // still describes every declared secret, so a preflight consumer can say
+    // which one is missing and whether anything else resolved.
+    let secrets = env["response"]["secrets"].as_array().unwrap();
+    assert_eq!(secrets.len(), 3);
+    let db = secret(secrets, "DATABASE_URL");
+    assert_eq!(db["status"], "missing_required");
+    assert_eq!(db["required"], true);
+    let log = secret(secrets, "LOG_LEVEL");
+    assert_eq!(log["status"], "resolved");
+}
+
+#[test]
+fn unknown_mode_yields_error_envelope() {
+    let dir = TempDir::new().unwrap();
+    let (manifest_path, provider) = write_project(&dir, MANIFEST, "");
+
+    let request = serde_json::json!({
+        "path": manifest_path,
+        "provider": provider,
+        "mode": "inventory",
+    })
+    .to_string();
+
+    let env = resolve(&request);
+    assert_eq!(env["ok"], false, "envelope: {env}");
+    assert_eq!(env["error"]["kind"], "invalid_request");
 }
 
 #[test]


### PR DESCRIPTION
`secretspec-ffi` is the only place in the repo that doesn't know its own request contract has a `mode` field. Both the module docs and the shipped C header document the request as exactly five fields:

```c
 * Request JSON (all fields optional):
 *   { "path": ".../secretspec.toml", "provider": "keyring://",
 *     "profile": "production", "reason": "boot", "no_values": false }
```

But `secretspec_resolve` hands its request straight to `secretspec::resolve_json`, which has accepted `mode` since `report()` landed — and every SDK already relies on it, including the four that reach it through this very ABI (`secretspec-hs`, `-go`, `-rb`, `-php`):

```haskell
-- secretspec-hs/src/SecretSpec.hs
report b = do
  resp <- callNative (requestBytes b (Just "report"))
```

The header isn't incidental — `stage-staticlib.sh` copies it into the Go SDK's `include/`, so it's the artifact a native consumer actually reads. Someone binding this ABI from C has no way to discover the report mode at all.

`tests/c_abi.rs` had the same blind spot: it covered `resolve`, `no_values`, missing-required, bad JSON and a missing manifest, but never `report`. So the one documented-contract gap was also the one untested path. This adds both halves.

### The part worth naming

`no_values` looks like it does the same job as `mode: "report"`. It doesn't, and the difference bites exactly when it matters:

| | `no_values: true` | `mode: "report"` |
|---|---|---|
| Shape | `ResolveResponse`, values blanked | `ResolutionReport` |
| `secrets` | object keyed by name | **array** of entries |
| `required` per secret | absent | **present** |
| `status` per secret | absent | `resolved` / `missing_required` / `missing_optional` |
| When a required secret is missing | `secrets` is **empty** | full inventory retained |

A preflight consumer reaching for `no_values` gets a response that goes empty precisely in the situation it was written to describe, and can never see requiredness.

### Tests

Three added to `tests/c_abi.rs`, all through the real `extern "C"` entry points:

- `report_mode_returns_requiredness_and_status` — pins the array shape, `required`, `status`, provenance, and that no value is carried.
- `report_mode_keeps_the_inventory_when_a_required_secret_is_missing` — pins the contrast with `resolve_missing_required_is_ok_envelope_with_error_list`, which asserts the opposite for `resolve`.
- `unknown_mode_yields_error_envelope` — pins that an unknown `mode` is `invalid_request` rather than a silent fallback to `resolve`.

I mutation-tested the two report tests by dropping the `mode` field: both fail, so they depend on report mode rather than passing incidentally.

Locally: 9/9 in `secretspec-ffi` (was 6), `cargo fmt --check` clean, `cargo clippy` clean for this crate, `RUSTDOCFLAGS="-D warnings" cargo doc` clean for the new intra-doc links.

### One judgement call for you

**No CHANGELOG entry.** `CLAUDE.md` says Rust commits get one, but also says to keep entries user-facing and leave out development and testing notes — and nothing here changes behaviour, so there's no user-facing change to report (`mode` already worked). Happy to add one if you'd rather; I'd rather ask than guess.

Documentation and tests only; no behaviour change.
