### PR TITLE
test: property tests for the naming and encoding invariants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -712,6 +721,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -2001,7 +2016,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex-automata",
  "regex-syntax",
 ]
@@ -3837,6 +3852,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,6 +3937,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -4056,6 +4096,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -4430,6 +4479,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4547,6 +4608,7 @@ dependencies = [
  "linkme",
  "miette",
  "percent-encoding",
+ "proptest",
  "rand 0.9.2",
  "reqwest 0.12.28",
  "rsa",
@@ -5574,6 +5636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5734,6 +5802,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ dotenvy = "0.15"
 inquire = { version = "0.9.4", features = ["experimental-multiline-input"] }
 miette = { version = "7.6", features = ["fancy"] }
 serde_json = "1.0"
+proptest = "1"
 tempfile = "3.0"
 http = "1.0"
 url = "2.5.4"

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -51,6 +51,9 @@ uuid.workspace = true
 data-encoding.workspace = true
 detect-coding-agent.workspace = true
 
+[dev-dependencies]
+proptest.workspace = true
+
 [features]
 default = ["cli", "keyring", "gcsm", "awssm", "vault", "bws", "akv"]
 cli = ["dep:toml_edit"]

--- a/secretspec/src/provider/akv.rs
+++ b/secretspec/src/provider/akv.rs
@@ -861,3 +861,124 @@ mod tests {
         assert!(err.to_string().contains("ref"), "{err}");
     }
 }
+
+/// Property tests for the invariants `format_secret_name` is built on.
+///
+/// The example-based tests above pin the counterexamples already found --
+/// `b__c`/`c__d`, `b-`/`_C`, `API_KEY`/`api_key`. These quantify over the whole
+/// component domain, so the *next* collision fails a test rather than a user's
+/// `get`.
+#[cfg(test)]
+mod name_properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// A component Azure will accept: non-empty, alphanumeric/`_`/`-` only --
+    /// exactly the domain `validate_name_component` admits. Kept short so a
+    /// failure shrinks to a minimal, readable counterexample.
+    ///
+    /// The second arm is deliberate. Every collision this scheme has ever had
+    /// lived in `_`/`-` against the `--` delimiter, and a uniform alphanumeric
+    /// generator reaches that region far too rarely to find one: sampled against
+    /// the old `_`->`-` mapping, an unbiased generator reports no collision at
+    /// all. Weighting short delimiter-only components finds one immediately.
+    fn component() -> impl Strategy<Value = String> {
+        prop_oneof!["[A-Za-z0-9_-]{1,8}", "[_-]{1,3}"]
+    }
+
+    fn triple() -> impl Strategy<Value = (String, String, String)> {
+        (component(), component(), component())
+    }
+
+    /// Recovers the triple a name was built from.
+    ///
+    /// Injectivity is stated over pairs, but sampling pairs is a poor way to
+    /// look for a collision: two independently generated triples almost never
+    /// collide by chance, so such a test passes happily against a scheme that is
+    /// provably not injective. A left inverse is the stronger and cheaper claim
+    /// -- if every name decodes back to exactly one triple, no two triples can
+    /// share a name -- and every generated case exercises it.
+    fn decode_secret_name(name: &str) -> Option<(String, String, String)> {
+        let body = name.strip_prefix("secretspec--")?;
+        let parts: Vec<&str> = body.split("--").collect();
+        let [project, profile, key] = parts.as_slice() else {
+            return None;
+        };
+        let decode = |part: &str| {
+            let bytes = BASE32_NOPAD
+                .decode(part.to_ascii_uppercase().as_bytes())
+                .ok()?;
+            String::from_utf8(bytes).ok()
+        };
+        Some((decode(project)?, decode(profile)?, decode(key)?))
+    }
+
+    proptest! {
+        /// A name decodes back to the exact triple that built it.
+        ///
+        /// This is injectivity with teeth: it fails on the first generated case
+        /// under a lossy scheme. The `_`->`-` mapping this replaced fails here
+        /// immediately -- `-` and `_` both encode to `-`, so the original is
+        /// unrecoverable and two triples can reach one name.
+        #[test]
+        fn a_name_decodes_to_the_triple_that_built_it((project, profile, key) in triple()) {
+            let name = AkvProvider::format_secret_name(&project, &profile, &key)
+                .expect("a valid component must format");
+            prop_assert_eq!(
+                decode_secret_name(&name),
+                Some((project, profile, key)),
+                "name {:?} did not decode back to its triple",
+                name,
+            );
+        }
+
+        /// No two triples in a batch share a name.
+        ///
+        /// Weaker than the left inverse above and kept deliberately: it states
+        /// the guarantee in the form the module claims it ("injective"), and it
+        /// would catch a collision introduced somewhere other than the encoding
+        /// -- a changed delimiter, say, which decoding alone would not notice.
+        #[test]
+        fn distinct_triples_never_collide(triples in prop::collection::vec(triple(), 2..24)) {
+            let mut seen: std::collections::HashMap<String, (String, String, String)> =
+                std::collections::HashMap::new();
+            for triple in triples {
+                let name = AkvProvider::format_secret_name(&triple.0, &triple.1, &triple.2)
+                    .expect("a valid component must format");
+                if let Some(previous) = seen.insert(name.clone(), triple.clone()) {
+                    prop_assert_eq!(
+                        &previous,
+                        &triple,
+                        "distinct triples {:?} and {:?} both produced {:?}",
+                        previous,
+                        triple,
+                        name,
+                    );
+                }
+            }
+        }
+
+        /// Every formatted name is one Azure will accept: Key Vault permits
+        /// alphanumerics and hyphens only.
+        #[test]
+        fn formatted_names_are_azure_legal((project, profile, key) in triple()) {
+            let name = AkvProvider::format_secret_name(&project, &profile, &key)
+                .expect("a valid component must format");
+            prop_assert!(
+                name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+                "name {name:?} contains a character Azure rejects",
+            );
+        }
+
+        /// Names are already lowercase, so Azure's case-insensitive comparison
+        /// changes nothing. Case distinctions survive in the encoded bytes
+        /// rather than in the name's case, which is what lets `API_KEY` and
+        /// `api_key` coexist.
+        #[test]
+        fn formatted_names_are_lowercase((project, profile, key) in triple()) {
+            let name = AkvProvider::format_secret_name(&project, &profile, &key)
+                .expect("a valid component must format");
+            prop_assert_eq!(name.clone(), name.to_ascii_lowercase());
+        }
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -1363,3 +1363,67 @@ mod provider_credentials_tests {
         );
     }
 }
+
+/// Property tests for the URI encoding every provider's `uri()` runs through.
+///
+/// `QUERY_ENCODE_SET` states its own contract: it "makes `ProviderUrl::encode_query`
+/// a true inverse of that parsing, so query values round-trip". That is a claim
+/// about every string, checked today against one hand-written value in one
+/// provider's tests. These quantify it.
+#[cfg(test)]
+mod encoding_properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Reads a query value back the way a provider's `TryFrom` does.
+    fn query_value_of(uri: &str, key: &str) -> Option<String> {
+        let url = ProviderUrl::new(Url::parse(uri).ok()?);
+        url.query_pairs()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.into_owned())
+    }
+
+    proptest! {
+        /// A query value survives `encode_query` -> parse unchanged.
+        ///
+        /// The characters that break this are the ones form-urlencoded parsing
+        /// claims: `&` splits a pair, `+` becomes a space, `%` starts an escape,
+        /// `#` ends the query. Each silently truncates or mangles a value rather
+        /// than failing, so the store a provider ends up talking to is not the
+        /// one the URI named.
+        #[test]
+        fn encode_query_round_trips(value in ".*") {
+            let uri = format!("keyring://?v={}", ProviderUrl::encode_query(&value));
+            let decoded = query_value_of(&uri, "v");
+            prop_assert_eq!(
+                decoded.as_deref(),
+                Some(value.as_str()),
+                "value {:?} did not survive the round-trip through {:?}",
+                value,
+                uri,
+            );
+        }
+
+        /// Encoding is deterministic: the same value always encodes the same
+        /// way, so a `uri()` rendering is stable across runs (it lands in audit
+        /// records, which are compared).
+        #[test]
+        fn encode_query_is_deterministic(value in ".*") {
+            prop_assert_eq!(
+                ProviderUrl::encode_query(&value),
+                ProviderUrl::encode_query(&value),
+            );
+        }
+
+        /// An encoded value never carries a character that would end the query
+        /// or start a new pair, whatever went in.
+        #[test]
+        fn encoded_values_are_query_safe(value in ".*") {
+            let encoded = ProviderUrl::encode_query(&value);
+            prop_assert!(
+                !encoded.contains('&') && !encoded.contains('#') && !encoded.contains('+'),
+                "encoded {encoded:?} still carries a query-structural character",
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #156.

Adds `proptest` as a dev-dependency and quantifies the two invariants from the issue: akv name injectivity, and the `encode_query` inverse. Seven properties, 0.59s.

I checked both against the **real pre-fix implementations** rather than trusting that they work. That turned out to matter — see the second section.

## What they catch

**akv name injectivity.** Restoring the old `_`→`-` mapping in `encode_name_component`:

```
Test failed: name "secretspec--A--A--a" did not decode back to its triple
minimal failing input: (project, profile, key) = ("A", "A", "a")
```

**Query encoding.** Restoring the plain URI encoder that `QUERY_ENCODE_SET` replaced:

```
Test failed: value "#" did not survive the round-trip through "keyring://?v=#"
minimal failing input: value = "#"
```

Both fail on essentially the first case and shrink to something minimal.

## The design bit worth reviewing

**Injectivity stated over pairs is the honest phrasing, but a bad test.** My first attempt was the obvious one:

```rust
fn distinct_triples_never_collide(a in triple(), b in triple()) {
    prop_assume!(a != b);
    prop_assert_ne!(format_secret_name(&a.0, ..)?, format_secret_name(&b.0, ..)?);
}
```

Run against the old `_`→`-` scheme, **it passes.** Two independently generated triples essentially never collide by chance — finding `("a","b__c","d")` vs `("a","b","c__d")` that way is a needle in a haystack. It looks like a test of injectivity and is close to vacuous.

So the load-bearing property here is a **left inverse** instead: a name decodes back to exactly the triple that built it. If every name decodes to one triple, no two triples can share a name — same guarantee, but every single generated case exercises it, and it's linear rather than quadratic to sample.

I kept the pairwise form too, because it states the guarantee in the shape the module actually claims ("injective") and would catch a collision introduced somewhere other than the encoding. But it only earns its place with a generator biased toward the `_`/`-` region where every historical collision has lived:

```rust
prop_oneof!["[A-Za-z0-9_-]{1,8}", "[_-]{1,3}"]
```

So biased, against the old scheme it finds one immediately:

```
distinct triples ("_", "-", "---") and ("_", "_-_", "-")
  both produced "secretspec-----------"
```

That bias is commented in the source, since it looks arbitrary otherwise and is the difference between a real test and a decorative one.

## Cost

- **8 new lockfile entries**, all dev-only: `proptest`, `bit-set`, `bit-vec`, `quick-error`, `rand_xorshift`, `rusty-fork`, `unarray`, `wait-timeout`. Nothing reaches anyone depending on `secretspec`.
- **0.59s** for the seven properties. Default 256 cases; happy to lower it.
- No `proptest-regressions` files yet. If you'd rather those weren't committed when a failure is found, that's a one-line `.gitignore` — tell me which you prefer.

## Not included

The third item from #156 — `parse(uri(cfg)) == parse(spec)` across every provider — isn't here. The trait object only exposes `uri()`, so what's reachable generically is idempotence (`uri(parse(uri(parse(s)))) == uri(parse(s))`), which is strictly weaker: it wouldn't catch a *dropped* field, because the loss happens in the first render and is stable after. Doing it properly needs per-provider config generators and `PartialEq` on the config types. Worth its own PR if you want it; I didn't want to smuggle that scope in here.

No CHANGELOG entry: test-only, no behaviour change, and the CHANGELOG asks for user-facing entries.
