### PR TITLE
Add C# SDK

### DIFF
--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -1,0 +1,195 @@
+name: ".NET SDK"
+
+# Builds the C# client and the runtime-specific secretspec-ffi libraries packed
+# into Cachix.SecretSpec. Linux uses a manylinux_2_28 baseline and vendors dbus,
+# so the NuGet asset works on older supported glibc distributions without a
+# system libdbus dependency.
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: Publish the built package to NuGet
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the built package to NuGet
+        required: false
+        type: boolean
+        default: false
+  push:
+    tags:
+      - v**
+  pull_request:
+    paths:
+      - "secretspec-dotnet/**"
+      - "secretspec-ffi/**"
+      - ".github/workflows/dotnet-package.yml"
+      - "scripts/sync-sdk-versions.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  native:
+    name: ${{ matrix.rid }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container || null }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-x64
+            target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            library: libsecretspec_ffi.so
+            cargo_features: --features vendored-dbus
+          - rid: linux-arm64
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            library: libsecretspec_ffi.so
+            cargo_features: --features vendored-dbus
+          - rid: osx-arm64
+            target: aarch64-apple-darwin
+            runner: macos-latest
+            library: libsecretspec_ffi.dylib
+          - rid: win-x64
+            target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            library: secretspec_ffi.dll
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Sync SDK package versions
+        shell: bash
+        run: bash scripts/sync-sdk-versions.sh
+
+      - name: Install ICU in manylinux (the .NET runtime needs it)
+        if: matrix.container
+        shell: bash
+        run: yum install -y libicu
+
+      - name: Install rustup in manylinux
+        if: matrix.container
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+            sh -s -- -y --default-toolchain none
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Install Rust
+        run: rustup toolchain install
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Build native resolver
+        shell: bash
+        run: >-
+          cargo build -p secretspec-ffi --release
+          --target ${{ matrix.target }} ${{ matrix.cargo_features }}
+
+      - name: Verify library portability (glibc <= 2.28, libdbus linked in)
+        if: matrix.container
+        shell: bash
+        run: >-
+          bash scripts/check-linux-portability.sh
+          "target/${{ matrix.target }}/release/${{ matrix.library }}"
+
+      - name: Run C# SDK tests against native resolver
+        shell: bash
+        env:
+          SECRETSPEC_FFI_LIB: ${{ github.workspace }}/target/${{ matrix.target }}/release/${{ matrix.library }}
+        run: >-
+          dotnet run
+          --project secretspec-dotnet/tests/SecretSpec.Tests
+          --configuration Release
+
+      - name: Stage native NuGet asset
+        shell: bash
+        run: |
+          mkdir -p "staged/${{ matrix.rid }}/native"
+          cp "target/${{ matrix.target }}/release/${{ matrix.library }}" \
+             "staged/${{ matrix.rid }}/native/"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-native-${{ matrix.rid }}
+          path: staged/${{ matrix.rid }}
+
+  package:
+    name: NuGet package
+    needs: [native]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Sync SDK package versions
+        run: bash scripts/sync-sdk-versions.sh
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dotnet-native-*
+          path: staged
+      - name: Place runtime assets
+        shell: bash
+        run: |
+          for artifact in staged/dotnet-native-*; do
+            rid="${artifact##*/dotnet-native-}"
+            mkdir -p "secretspec-dotnet/src/SecretSpec/runtimes/$rid"
+            cp -R "$artifact/"* "secretspec-dotnet/src/SecretSpec/runtimes/$rid/"
+          done
+      - name: Pack
+        run: >-
+          dotnet pack secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
+          --configuration Release --output artifacts
+      - name: Verify runtime assets are present
+        shell: bash
+        run: |
+          # The staged directories come from the same matrix that builds the
+          # native libraries, so this check cannot drift from the matrix.
+          package="$(find artifacts -name '*.nupkg' ! -name '*.symbols.nupkg' -print -quit)"
+          shopt -s nullglob
+          staged=(staged/dotnet-native-*)
+          if [ "${#staged[@]}" -eq 0 ]; then
+            echo "no staged native artifacts were downloaded" >&2
+            exit 1
+          fi
+          for artifact in "${staged[@]}"; do
+            rid="${artifact##*/dotnet-native-}"
+            unzip -l "$package" | grep -q "runtimes/$rid/native/"
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-nuget
+          path: artifacts/*.nupkg
+
+  publish:
+    name: publish to NuGet
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish
+    needs: [package]
+    runs-on: ubuntu-latest
+    environment: nuget
+    steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+      - uses: actions/download-artifact@v4
+        with:
+          name: dotnet-nuget
+          path: artifacts
+      - name: Publish package
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: >-
+          dotnet nuget push "artifacts/*.nupkg"
+          --api-key "$NUGET_API_KEY"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -176,7 +176,13 @@ jobs:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish
     needs: [package]
     runs-on: ubuntu-latest
+    # Must match the "Environment" on nuget.org's trusted publishing policy
+    # for Cachix.SecretSpec (see RELEASE.md); nuget.org matches policies by
+    # repo + workflow filename + environment.
     environment: nuget
+    permissions:
+      id-token: write # NuGet Trusted Publishing (OIDC), no long-lived key
+      contents: read
     steps:
       - uses: actions/setup-dotnet@v4
         with:
@@ -185,11 +191,16 @@ jobs:
         with:
           name: dotnet-nuget
           path: artifacts
+      # Trades the job's OIDC token for an API key that expires in about an
+      # hour, so it must stay immediately before the push.
+      - name: NuGet login (OIDC trusted publishing)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Publish package
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: >-
           dotnet nuget push "artifacts/*.nupkg"
-          --api-key "$NUGET_API_KEY"
+          --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
           --source https://api.nuget.org/v3/index.json
           --skip-duplicate

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -103,27 +103,7 @@ jobs:
       - name: Verify addon portability (glibc <= 2.28, libdbus linked in)
         if: matrix.container
         shell: bash
-        run: |
-          # Read the version-reference table (objdump -p), not per-symbol
-          # version tags (objdump -T): file-level ABI markers such as
-          # GLIBC_ABI_DT_RELR (needs glibc >= 2.36) are attached to no symbol,
-          # so a symbol scan stays green on a binary older loaders reject.
-          # Numeric needs above GLIBC_2.28 fail, and so does any GLIBC_*
-          # version need that is not plain numeric.
-          headers=$(objdump -p secretspec-node/secretspec.node)
-          too_new=$(grep -oE 'GLIBC_[A-Za-z0-9_.]+' <<<"$headers" \
-            | sort -u \
-            | awk -F. '/^GLIBC_2\.[0-9]+(\.[0-9]+)?$/ { if ($2 + 0 > 28) print; next } { print }')
-          if [ -n "$too_new" ]; then
-            echo "addon requires glibc version needs newer than the 2.28 baseline:" >&2
-            echo "$too_new" >&2
-            exit 1
-          fi
-          if grep NEEDED <<<"$headers" | grep -q dbus; then
-            echo "addon links libdbus dynamically; vendored-dbus regressed:" >&2
-            grep NEEDED <<<"$headers" >&2
-            exit 1
-          fi
+        run: bash scripts/check-linux-portability.sh secretspec-node/secretspec.node
 
       - name: Copy the addon to its platform-specific filename for publishing
         shell: bash

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -111,6 +111,9 @@ jobs:
   dotnet:
     name: .NET package
     needs: authorize
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/dotnet-package.yml
 
   release-artifacts:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,6 +18,7 @@ on:
       - "secretspec-node/package.json"
       - "secretspec-py/pyproject.toml"
       - "secretspec-rb/secretspec.gemspec"
+      - "secretspec-dotnet/src/SecretSpec/SecretSpec.csproj"
 
 permissions:
   contents: read
@@ -106,6 +107,11 @@ jobs:
     name: Haskell static-link build
     needs: authorize
     uses: ./.github/workflows/haskell-build.yml
+
+  dotnet:
+    name: .NET package
+    needs: authorize
+    uses: ./.github/workflows/dotnet-package.yml
 
   release-artifacts:
     name: CLI release artifacts

--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -2,7 +2,7 @@ name: "SDKs"
 
 # Runs every language SDK's full test suite (unit + cross-language conformance +
 # the schema/quicktype codegen pipeline) against a freshly built cdylib, so the
-# Python/Go/Ruby/Node/Haskell/PHP bindings cannot silently rot.
+# Python/Go/Ruby/Node/Haskell/C#/PHP bindings cannot silently rot.
 
 on:
   workflow_call:
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v5
       # The full workspace debug build (AWS/GCP/Bitwarden providers) plus the
       # Nix store overflows the ~14GB free on a hosted runner.
+      # /usr/share/dotnet is safe to purge: the C# suite uses devenv's dotnet.
       - name: Free up disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android \

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,9 @@ target
 
 # PHP (Composer) — manifest at repo root, vendor-dir points into secretspec-php/
 /composer.lock
+
+# .NET
+/secretspec-dotnet/**/bin/
+/secretspec-dotnet/**/obj/
+
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- C# SDK (`Cachix.SecretSpec`, available in 0.16): resolve secrets from .NET
+  through the shared native resolver, with fluent builder and one-shot APIs,
+  typed failure exceptions, value-free preflight reports, provenance,
+  environment export, typed-codegen input, and deterministic cleanup of
+  `as_path` files. The NuGet package includes native resolver builds for Linux
+  x64/Arm64, macOS Arm64, and Windows x64.
 - Infisical provider (`infisical://`), for Infisical Cloud and self-hosted
   instances. Authenticates as a machine identity via Universal Auth, whose
   `client_id` and `client_secret` can be sourced as provider credentials (with

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -95,11 +95,20 @@ No CI workflow or token is involved — Packagist pulls from the tag on push.
 
 ### NuGet (.NET) — not yet set up
 
-The `Cachix.SecretSpec` package is built by `dotnet-package.yml`. Before its
-first release, reserve the package ID on nuget.org and add an
-`NUGET_API_KEY` secret to the repository's `nuget` environment, scoped to push
-only `Cachix.SecretSpec`. Version tags then build all native runtime assets,
-pack them into one `.nupkg`, and publish it automatically.
+The `Cachix.SecretSpec` package is built by `dotnet-package.yml` and published
+with NuGet Trusted Publishing (OIDC), so no long-lived API key is stored.
+Before the first release:
+
+1. On nuget.org, create a trusted publishing policy: repository owner
+   `cachix`, repository `secretspec`, workflow file `dotnet-package.yml`
+   (file name only), environment `nuget`.
+2. Set a `NUGET_USER` secret in the repository's `nuget` GitHub environment
+   to the nuget.org profile name (not email) that owns the policy.
+
+Version tags then build all native runtime assets, pack them into one
+`.nupkg`, and publish it automatically with a short-lived OIDC-issued API
+key. The first successful publish claims the `Cachix.SecretSpec` package ID
+and permanently activates the policy.
 
 ## Python (PyPI) — `python-wheels.yml`
 
@@ -253,6 +262,6 @@ In order:
   `osx-arm64`, and `win-x64`. Linux builds use a manylinux 2.28 baseline and
   the resolver's vendored-dbus feature.
 - **Publish:** `dotnet-package.yml` tests every native asset on its target,
-  assembles `Cachix.SecretSpec.<version>.nupkg`, and pushes it with the
-  `NUGET_API_KEY` stored in the `nuget` GitHub environment. One-time setup is
-  described above.
+  assembles `Cachix.SecretSpec.<version>.nupkg`, and pushes it with a
+  short-lived API key from NuGet Trusted Publishing (OIDC), running in the
+  `nuget` GitHub environment. One-time setup is described above.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -93,6 +93,14 @@ the monorepo — the manifest lives at the repository root (`/composer.json`, wi
 
 No CI workflow or token is involved — Packagist pulls from the tag on push.
 
+### NuGet (.NET) — not yet set up
+
+The `Cachix.SecretSpec` package is built by `dotnet-package.yml`. Before its
+first release, reserve the package ID on nuget.org and add an
+`NUGET_API_KEY` secret to the repository's `nuget` environment, scoped to push
+only `Cachix.SecretSpec`. Version tags then build all native runtime assets,
+pack them into one `.nupkg`, and publish it automatically.
+
 ## Python (PyPI) — `python-wheels.yml`
 
 - **Build:** the Rust resolver is statically linked into a pyo3 extension
@@ -234,3 +242,17 @@ In order:
    `vendor/bin/secretspec-install-lib` for the ext-ffi path, and a downloaded
    `secretspec-php-native` `.so` (`extension=…`) for the extension path — and
    confirm a resolve works under each.
+
+## .NET (NuGet) — `dotnet-package.yml`
+
+- **Client:** a .NET 8 assembly with no managed package dependencies. It invokes
+  the stable JSON C ABI through P/Invoke and exposes the same builder, resolved
+  value, report, and typed-error vocabulary as the other SDKs.
+- **Native assets:** one NuGet package carries `secretspec-ffi` under the
+  standard `runtimes/<rid>/native/` layout for `linux-x64`, `linux-arm64`,
+  `osx-arm64`, and `win-x64`. Linux builds use a manylinux 2.28 baseline and
+  the resolver's vendored-dbus feature.
+- **Publish:** `dotnet-package.yml` tests every native asset on its target,
+  assembles `Cachix.SecretSpec.<version>.nupkg`, and pushes it with the
+  `NUGET_API_KEY` stored in the `nuget` GitHub environment. One-time setup is
+  described above.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,8 +1,8 @@
 # Cross-language conformance suite
 
-Every SecretSpec SDK (Python, Go, Ruby, Node.js, Haskell) is a thin client over
-the same `secretspec-ffi` C ABI. This suite proves they agree: each SDK resolves
-the same fixtures and must produce the identical **canonical** result.
+Every SecretSpec SDK (Python, Go, Ruby, Node.js, Haskell, C#, and PHP) is a thin
+client over the same resolver contract. This suite proves they agree: each SDK
+resolves the same fixtures and must produce the identical **canonical** result.
 
 ## Fixtures
 
@@ -58,3 +58,5 @@ relative to the repo root:
 - Node: `cd secretspec-node && node --test`
 - Haskell: `cd secretspec-hs && cabal test` (needs the `secretspec-ffi`
   staticlib staged on `--extra-lib-dirs`; see the Haskell SDK build steps)
+- C#: `cd secretspec-dotnet && dotnet run --project tests/SecretSpec.Tests`
+- PHP: `cd secretspec-php && ./vendor/bin/phpunit tests/ConformanceTest.php`

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -4,7 +4,7 @@
 #
 # Builds the secretspec-ffi cdylib once, then runs every SDK's conformance suite
 # against the shared fixtures and reports a combined result. Run inside the
-# project devenv shell (which provides cargo, python, go, ruby, node):
+# project devenv shell (which provides cargo, python, go, ruby, node, dotnet):
 #
 #     devenv shell -- bash conformance/run.sh
 #
@@ -80,12 +80,17 @@ run_php() { (
   [ -d secretspec-php/vendor ] || composer install --no-interaction --no-progress >/dev/null
   cd secretspec-php && ./vendor/bin/phpunit tests/ConformanceTest.php
 ); }
+run_dotnet() { (
+  cd secretspec-dotnet
+  dotnet run --project tests/SecretSpec.Tests --configuration Release
+); }
 
 run "Python"  python run_python
 run "Go"      go     run_go
 run "Ruby"    ruby   run_ruby
 run "Node"    node   run_node
 run "Haskell" cabal  run_haskell
+run "C#"      dotnet run_dotnet
 run "PHP"     php    run_php
 
 echo

--- a/devenv.nix
+++ b/devenv.nix
@@ -39,6 +39,10 @@
   languages.ruby.enable = true;
   # Haskell SDK (secretspec-hs) links the C ABI at build time via the FFI.
   languages.haskell.enable = true;
+  # C# SDK (secretspec-dotnet) loads the C ABI through P/Invoke. The NuGet
+  # package carries runtime-specific cdylibs; local tests use
+  # SECRETSPEC_FFI_LIB from scripts/ci-sdks.sh.
+  languages.dotnet.enable = true;
   # PHP SDK (secretspec-php) has two native backends over the same resolver:
   #   * secretspec-php-native, an ext-php-rs extension that embeds the resolver
   #     (the production path: no ffi.enable, works in FPM like ext-redis); and

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -208,6 +208,7 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
             { label: "Node.js SDK", slug: "sdk/nodejs" },
             { label: "Haskell SDK", slug: "sdk/haskell" },
             { label: "PHP SDK", slug: "sdk/php" },
+            { label: "C# SDK (0.16+)", slug: "sdk/csharp" },
           ],
         },
         {

--- a/docs/src/content/docs/sdk/csharp.md
+++ b/docs/src/content/docs/sdk/csharp.md
@@ -1,0 +1,134 @@
+---
+title: C# SDK
+description: Resolve SecretSpec secrets from C# and .NET
+---
+
+> **Version compatibility:** The C# SDK targets SecretSpec 0.16 and is
+> unavailable in the current 0.15 release. With 0.15, use the CLI integration:
+> `secretspec run -- dotnet run`. The `Cachix.SecretSpec` package and API below
+> become available with 0.16.
+
+The C# SDK (`Cachix.SecretSpec`) is a thin client over the same Rust resolver as
+the CLI. Every provider, fallback chain, profile, generator, reference, and
+`as_path` secret therefore works without C#-side resolution logic.
+
+## Install (0.16+)
+
+```bash
+dotnet add package Cachix.SecretSpec
+```
+
+The package targets .NET 8 and includes the native resolver for Linux x64 and
+Arm64, macOS Arm64, and Windows x64. No separate SecretSpec CLI or native
+library installation is needed at runtime.
+
+## Quick start
+
+```csharp
+using Cachix.SecretSpec;
+
+using var resolved = SecretSpec.Builder()
+    .WithProvider("keyring://")
+    .WithProfile("production")
+    .WithReason("boot web app")
+    .Load();
+
+Console.WriteLine($"{resolved.Provider} {resolved.Profile}");
+Console.WriteLine(resolved.Secrets["DATABASE_URL"].Get());
+resolved.SetAsEnv();
+```
+
+`Get()` returns the inline value, or the readable file path for an `as_path`
+secret. A missing required secret throws `MissingRequiredException`; its
+`Missing` property contains the secret names. Other failures throw
+`SecretSpecException`, whose `Kind` property is a stable error category.
+
+A one-shot form is also available:
+
+```csharp
+using var resolved = SecretSpec.Resolve(
+    provider: "keyring://",
+    profile: "production",
+    reason: "boot web app");
+```
+
+## ASP.NET Core
+
+Resolve and export secrets before creating the application builder, so normal
+environment-variable configuration sees them:
+
+```csharp
+using Cachix.SecretSpec;
+
+using var secrets = SecretSpec.Builder()
+    .WithProfile(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"))
+    .WithReason("ASP.NET Core boot")
+    .Load();
+
+secrets.SetAsEnv();
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.Run();
+```
+
+For longer-lived services, you can instead register `resolved` in dependency
+injection and read `ResolvedSecret` objects directly. Keep the result alive for
+as long as consumers need any `as_path` file.
+
+## Value-free preflight
+
+`Report()` returns the inventory view exposed by `secretspec check --json`.
+It never carries values. Missing required secrets appear with
+`Status == "missing_required"` rather than throwing, so incomplete deployments
+can still be inspected.
+
+```csharp
+var report = SecretSpec.Builder()
+    .WithProfile("production")
+    .WithReason("deployment preflight")
+    .Report();
+
+foreach (var secret in report.Secrets)
+    Console.WriteLine($"{secret.Name}: {secret.Status}");
+```
+
+## Typed access
+
+Generate an idiomatic C# model from the manifest schema:
+
+```bash
+secretspec schema |
+  quicktype -s schema --top-level AppSecrets --lang csharp -o AppSecrets.cs
+```
+
+Then deserialize the SDK's flat field map:
+
+```csharp
+var typed = AppSecrets.FromJson(resolved.FieldsJson());
+Console.WriteLine(typed.DatabaseURL);
+```
+
+The schema models successful resolution: required, defaulted, and generated
+secrets are non-nullable, and profile-specific schemas include inherited
+default-profile fields.
+
+## Files (`as_path`)
+
+File-shaped secrets are materialized as mode-0400 temporary files. The returned
+path must remain valid after `Load()`, so the caller owns its lifetime.
+`Resolved` implements `IDisposable`; use a `using` declaration or call `Close()`
+to remove these files deterministically:
+
+```csharp
+using var resolved = SecretSpec.Builder().WithReason("TLS boot").Load();
+var certificatePath = resolved.Secrets["TLS_CERT"].Get();
+// Use the certificate before resolved is disposed.
+```
+
+## Native loading
+
+The NuGet runtime asset is selected automatically. For local SDK development,
+`SECRETSPEC_FFI_LIB` can point to a particular `libsecretspec_ffi` build. From
+a SecretSpec source checkout, the SDK also searches an ancestor Cargo
+`target/debug` or `target/release` directory.

--- a/docs/src/content/docs/sdk/overview.md
+++ b/docs/src/content/docs/sdk/overview.md
@@ -4,8 +4,14 @@ description: How the SecretSpec language SDKs work
 ---
 
 SecretSpec ships SDKs for Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell,
-and PHP. They all resolve secrets from the same declarative `secretspec.toml`,
-and they all behave identically, because they share one resolver.
+PHP, and C# (0.16+). They all resolve secrets from the same declarative
+`secretspec.toml`, and they all behave identically, because they share one
+resolver.
+
+> **C# compatibility:** The C# SDK targets SecretSpec 0.16 and is unavailable
+> in the current 0.15 release. With 0.15, run a .NET application through
+> `secretspec run -- dotnet run`; the `Cachix.SecretSpec` NuGet API shown in the
+> C# guide becomes available in 0.16.
 
 ## One resolver, thin clients
 
@@ -19,6 +25,8 @@ that core rather than a reimplementation:
   at build time; **Go** (purego) loads it at runtime with no cgo. Both exchange
   a small JSON request/response with the core.
 - **Haskell** links the same C ABI at build time via the GHC FFI.
+- **C# (0.16+)** loads the same C ABI with P/Invoke from a runtime-specific
+  native asset in the NuGet package.
 - **Python** uses a [pyo3](https://pyo3.rs/) native extension, and
   **Node.js/TypeScript** uses a [napi-rs](https://napi.rs/) native addon; both
   embed the same resolver directly and exchange the same JSON request/response
@@ -50,7 +58,8 @@ print(resolved.secrets["DATABASE_URL"].get)
 
 See each language's page for the idiomatic spelling: [Rust](/sdk/rust),
 [Python](/sdk/python), [Go](/sdk/go), [Ruby](/sdk/ruby),
-[Node.js](/sdk/nodejs), [Haskell](/sdk/haskell), and [PHP](/sdk/php).
+[Node.js](/sdk/nodejs), [Haskell](/sdk/haskell), [PHP](/sdk/php), and
+[C# (0.16+)](/sdk/csharp).
 
 ## Typed access
 
@@ -80,6 +89,8 @@ no runtime library path to set:
   wheel, and **Ruby** statically links the `secretspec-ffi` archive into a
   native C extension in the gem.
 - **Haskell** statically links the same archive at build time via the GHC FFI.
+- **C# (0.16+)** ships the `cdylib` as runtime-specific native assets in one
+  NuGet package and loads the matching asset through P/Invoke.
 - **Go** embeds the `cdylib` in the module and loads it at runtime via purego
   (no cgo); an opt-in `-tags static` build links it statically instead.
 - **Node.js** builds the resolver into a napi-rs addon.

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -626,7 +626,7 @@ $ secretspec export --format json
       <span class="landing-showcase-eyebrow">Language SDKs</span>
       <h2 class="landing-section-title">Use it from any language.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell, and PHP all resolve from the same <code class="inline-code">secretspec.toml</code> through one Rust core — every provider, chain, and profile behaves identically, with no per-language logic. <a href="/sdk/overview/" class="landing-link">How the SDKs work →</a>
+        Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell, PHP, and C# (0.16+) all resolve from the same <code class="inline-code">secretspec.toml</code> through one Rust core — every provider, chain, and profile behaves identically, with no per-language logic. <a href="/sdk/overview/" class="landing-link">How the SDKs work →</a>
       </p>
     </div>
 
@@ -711,6 +711,22 @@ print (S.get <span class="tok-pun">=&lt;&lt;</span> Map.lookup <span class="tok-
     <span class="tok-pun">-&gt;</span>withProvider<span class="tok-pun">(</span><span class="tok-str">'keyring://'</span><span class="tok-pun">)</span>
     <span class="tok-pun">-&gt;</span>withReason<span class="tok-pun">(</span><span class="tok-str">'boot web app'</span><span class="tok-pun">)-&gt;</span>load<span class="tok-pun">();</span>
 <span class="tok-key">$s</span><span class="tok-pun">-&gt;</span>setAsEnv<span class="tok-pun">();</span></code></pre>
+      </div>
+    </div>
+
+    <div class="landing-fallback" style="margin-top: 1.5rem;">
+      <!-- C# -->
+      <div class="landing-terminal">
+        <div class="landing-terminal-header">
+          <div class="landing-terminal-dots"><span></span><span></span><span></span></div>
+          <span class="landing-terminal-title">C# / .NET (0.16+)</span>
+        </div>
+        <pre is:raw class="landing-terminal-body"><code><span class="tok-key">using</span> Cachix.SecretSpec<span class="tok-pun">;</span>
+
+<span class="tok-key">using var</span> s <span class="tok-pun">=</span> SecretSpec.Builder()
+    .WithProvider(<span class="tok-str">"keyring://"</span>)
+    .WithReason(<span class="tok-str">"boot"</span>).Load();
+Console.WriteLine(s.Secrets[<span class="tok-str">"DATABASE_URL"</span>].Get());</code></pre>
       </div>
     </div>
 

--- a/scripts/check-linux-portability.sh
+++ b/scripts/check-linux-portability.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Verify a Linux native library built in the manylinux_2_28 container stays
+# loadable on older supported glibc distributions with no system libdbus
+# dependency (issue #136: an unverified build once shipped a broken addon).
+#
+#     check-linux-portability.sh <library>
+#
+# Read the version-reference table (objdump -p), not per-symbol version tags
+# (objdump -T): file-level ABI markers such as GLIBC_ABI_DT_RELR (needs
+# glibc >= 2.36) are attached to no symbol, so a symbol scan stays green on a
+# binary older loaders reject. Numeric needs above GLIBC_2.28 fail, and so
+# does any GLIBC_* version need that is not plain numeric.
+set -euo pipefail
+
+library="${1:?usage: check-linux-portability.sh <library>}"
+
+headers=$(objdump -p "$library")
+too_new=$(grep -oE 'GLIBC_[A-Za-z0-9_.]+' <<<"$headers" \
+  | sort -u \
+  | awk -F. '/^GLIBC_2\.[0-9]+(\.[0-9]+)?$/ { if ($2 + 0 > 28) print; next } { print }')
+if [ -n "$too_new" ]; then
+  echo "$library requires glibc version needs newer than the 2.28 baseline:" >&2
+  echo "$too_new" >&2
+  exit 1
+fi
+if grep NEEDED <<<"$headers" | grep -q dbus; then
+  echo "$library links libdbus dynamically; vendored-dbus regressed:" >&2
+  grep NEEDED <<<"$headers" >&2
+  exit 1
+fi

--- a/scripts/ci-sdks.sh
+++ b/scripts/ci-sdks.sh
@@ -85,6 +85,9 @@ echo "==> Haskell"
     --write-ghc-environment-files=always
 )
 
+echo "==> C# / .NET"
+( cd secretspec-dotnet && dotnet run --project tests/SecretSpec.Tests --configuration Release )
+
 echo "==> PHP"
 # The PHP SDK has two native backends over the same resolver; exercise both.
 # The Composer manifest is at the repo root (so Packagist can read it from the

--- a/scripts/sync-sdk-versions.sh
+++ b/scripts/sync-sdk-versions.sh
@@ -104,6 +104,16 @@ update_file() {
         END { if (!changed) exit 1 }
       ' "$file" > "$tmp"
       ;;
+    csproj)
+      awk -v version="$workspace_version" '
+        !changed && /<Version>[^<]+<\/Version>/ {
+          sub(/<Version>[^<]+<\/Version>/, "<Version>" version "</Version>")
+          changed = 1
+        }
+        { print }
+        END { if (!changed) exit 1 }
+      ' "$file" > "$tmp"
+      ;;
     *)
       echo "unknown manifest kind: $kind" >&2
       rm -f "$tmp"
@@ -118,5 +128,6 @@ update_file secretspec-py/pyproject.toml pyproject
 update_file secretspec-rb/secretspec.gemspec gemspec
 update_file secretspec-hs/secretspec.cabal cabal
 update_file secretspec-node/package.json package-json
+update_file secretspec-dotnet/src/SecretSpec/SecretSpec.csproj csproj
 
 echo "synced SDK package versions to $workspace_version"

--- a/secretspec-dotnet/README.md
+++ b/secretspec-dotnet/README.md
@@ -1,0 +1,73 @@
+# SecretSpec for .NET
+
+> Requires SecretSpec 0.16 or newer. The C# SDK is targeted for SecretSpec 0.16
+> and is not available in the current 0.15 release.
+
+`Cachix.SecretSpec` is the C# SDK for
+[SecretSpec](https://secretspec.dev/), the declarative secrets manager. It is a
+thin client over the shared Rust resolver, so every provider, fallback chain,
+profile, generator, and `as_path` secret behaves exactly like the CLI and the
+other language SDKs.
+
+```bash
+dotnet add package Cachix.SecretSpec
+```
+
+```csharp
+using Cachix.SecretSpec;
+
+using var resolved = SecretSpec.Builder()
+    .WithProvider("keyring://")
+    .WithProfile("production")
+    .WithReason("boot web app")
+    .Load();
+
+Console.WriteLine(resolved.Secrets["DATABASE_URL"].Get());
+resolved.SetAsEnv();
+```
+
+A missing required secret throws `MissingRequiredException`, whose `Missing`
+property contains the names. Other failures throw `SecretSpecException`, with a
+stable `Kind`.
+
+## Value-free reports
+
+`Report()` returns the same inventory/preflight view as
+`secretspec check --json`. It never exposes values, and a missing required
+secret is an entry with `Status == "missing_required"` rather than an exception.
+
+```csharp
+var report = SecretSpec.Builder()
+    .WithProfile("production")
+    .WithReason("deployment preflight")
+    .Report();
+
+foreach (var secret in report.Secrets)
+    Console.WriteLine($"{secret.Name}: {secret.Status}");
+```
+
+## Typed access
+
+Generate a C# type from the manifest, then deserialize `FieldsJson()`:
+
+```bash
+secretspec schema |
+  quicktype -s schema --top-level AppSecrets --lang csharp -o AppSecrets.cs
+```
+
+```csharp
+var secrets = AppSecrets.FromJson(resolved.FieldsJson());
+```
+
+## Files and cleanup
+
+An `as_path` secret is materialized as a mode-0400 temporary file, and `Get()`
+returns its path. `Resolved` implements `IDisposable`; keep the result in a
+`using` declaration or call `Close()` to remove those files when finished.
+
+## Native resolver
+
+The NuGet package carries the resolver for Linux x64/Arm64, macOS Arm64, and
+Windows x64. During local SDK development, `SECRETSPEC_FFI_LIB` can point to an
+explicit `libsecretspec_ffi` build; the SDK also discovers a Cargo `target`
+directory when used from a SecretSpec source checkout.

--- a/secretspec-dotnet/src/SecretSpec/Exceptions.cs
+++ b/secretspec-dotnet/src/SecretSpec/Exceptions.cs
@@ -1,0 +1,36 @@
+namespace Cachix.SecretSpec;
+
+/// <summary>A manifest, provider, policy, native-loading, or wire-format failure.</summary>
+public class SecretSpecException : Exception
+{
+    public SecretSpecException(string kind, string message)
+        : base($"{message} (kind: {kind})")
+    {
+        Kind = kind;
+    }
+
+    public SecretSpecException(string kind, string message, Exception innerException)
+        : base($"{message} (kind: {kind})", innerException)
+    {
+        Kind = kind;
+    }
+
+    /// <summary>A stable machine-readable error category.</summary>
+    public string Kind { get; }
+}
+
+/// <summary>Required secrets that could not be resolved.</summary>
+public sealed class MissingRequiredException : SecretSpecException
+{
+    internal MissingRequiredException(IEnumerable<string> missing)
+        : base("missing_required", BuildMessage(missing))
+    {
+        Missing = Array.AsReadOnly(missing.ToArray());
+    }
+
+    /// <summary>The unresolved required secret names.</summary>
+    public IReadOnlyList<string> Missing { get; }
+
+    private static string BuildMessage(IEnumerable<string> missing) =>
+        $"missing required secret(s): {string.Join(", ", missing)}";
+}

--- a/secretspec-dotnet/src/SecretSpec/JsonContracts.cs
+++ b/secretspec-dotnet/src/SecretSpec/JsonContracts.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cachix.SecretSpec;
+
+internal static class JsonContracts
+{
+    internal const int ResolveSchemaVersion = 1;
+    internal const int ReportSchemaVersion = 1;
+
+    internal static readonly JsonSerializerOptions Options = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}
+
+internal sealed record ResolveRequest
+{
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
+
+    [JsonPropertyName("provider")]
+    public string? Provider { get; set; }
+
+    [JsonPropertyName("profile")]
+    public string? Profile { get; set; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+
+    [JsonPropertyName("no_values")]
+    public bool? NoValues { get; set; }
+
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+}
+
+internal sealed class Envelope<T>
+{
+    [JsonPropertyName("ok")]
+    public bool Ok { get; set; }
+
+    [JsonPropertyName("response")]
+    public T? Response { get; set; }
+
+    [JsonPropertyName("error")]
+    public ErrorContract? Error { get; set; }
+}
+
+internal sealed class ErrorContract
+{
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}
+
+internal sealed class ResolveResponseContract
+{
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; set; }
+
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = "";
+
+    [JsonPropertyName("profile")]
+    public string Profile { get; set; } = "";
+
+    [JsonPropertyName("secrets")]
+    public Dictionary<string, ResolvedSecret> Secrets { get; set; } = [];
+
+    [JsonPropertyName("missing_required")]
+    public List<string> MissingRequired { get; set; } = [];
+
+    [JsonPropertyName("missing_optional")]
+    public List<string> MissingOptional { get; set; } = [];
+}
+
+internal sealed class ReportResponseContract
+{
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; set; }
+
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = "";
+
+    [JsonPropertyName("profile")]
+    public string Profile { get; set; } = "";
+
+    [JsonPropertyName("secrets")]
+    public List<SecretReport> Secrets { get; set; } = [];
+}

--- a/secretspec-dotnet/src/SecretSpec/Models.cs
+++ b/secretspec-dotnet/src/SecretSpec/Models.cs
@@ -1,0 +1,153 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cachix.SecretSpec;
+
+/// <summary>One resolved secret and its provenance.</summary>
+public sealed class ResolvedSecret
+{
+    /// <summary>The inline value, or null for an <c>as_path</c> secret.</summary>
+    [JsonPropertyName("value")]
+    public string? Value { get; init; }
+
+    /// <summary>The materialized file path, or null for an inline secret.</summary>
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+
+    [JsonPropertyName("as_path")]
+    public bool AsPath { get; init; }
+
+    [JsonPropertyName("source")]
+    public string Source { get; init; } = "";
+
+    [JsonPropertyName("source_provider")]
+    public string? SourceProvider { get; init; }
+
+    /// <summary>
+    /// Returns the usable string: the file path for an <c>as_path</c> secret,
+    /// otherwise its inline value. A value-less resolution returns null.
+    /// </summary>
+    public string? Get() => AsPath ? Path : Value;
+}
+
+/// <summary>A successful, value-carrying resolution.</summary>
+public sealed class Resolved : IDisposable
+{
+    private bool _disposed;
+
+    internal Resolved(
+        string provider,
+        string profile,
+        Dictionary<string, ResolvedSecret> secrets,
+        IEnumerable<string> missingOptional)
+    {
+        Provider = provider;
+        Profile = profile;
+        Secrets = new ReadOnlyDictionary<string, ResolvedSecret>(secrets);
+        MissingOptional = Array.AsReadOnly(missingOptional.ToArray());
+    }
+
+    public string Provider { get; }
+    public string Profile { get; }
+    public IReadOnlyDictionary<string, ResolvedSecret> Secrets { get; }
+    public IReadOnlyList<string> MissingOptional { get; }
+
+    /// <summary>Exports every present secret into the current process environment.</summary>
+    public void SetAsEnv()
+    {
+        foreach (var (name, secret) in Secrets)
+        {
+            var value = secret.Get();
+            if (value is not null)
+                Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    /// <summary>
+    /// Returns a flat secret-name-to-value map suitable for a generated typed
+    /// deserializer. File-shaped secrets map to their paths; stripped values map to null.
+    /// </summary>
+    public IReadOnlyDictionary<string, string?> Fields() =>
+        new ReadOnlyDictionary<string, string?>(
+            Secrets.ToDictionary(
+                pair => pair.Key,
+                pair => pair.Value.Get(),
+                StringComparer.Ordinal));
+
+    /// <summary>Serializes <see cref="Fields"/> for a generated deserializer.</summary>
+    public string FieldsJson() => JsonSerializer.Serialize(Fields(), JsonContracts.Options);
+
+    /// <summary>Removes temporary files backing <c>as_path</c> secrets.</summary>
+    public void Close()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        Exception? firstError = null;
+        foreach (var secret in Secrets.Values)
+        {
+            if (!secret.AsPath || secret.Path is null)
+                continue;
+
+            try
+            {
+                File.Delete(secret.Path);
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException)
+            {
+                firstError ??= error;
+            }
+        }
+
+        if (firstError is not null)
+            throw firstError;
+    }
+
+    public void Dispose()
+    {
+        Close();
+        GC.SuppressFinalize(this);
+    }
+}
+
+/// <summary>The value-free resolution outcome for one declared secret.</summary>
+public sealed class SecretReport
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = "";
+
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = "";
+
+    [JsonPropertyName("required")]
+    public bool Required { get; init; }
+
+    [JsonPropertyName("source_provider")]
+    public string? SourceProvider { get; init; }
+
+    [JsonPropertyName("default_applied")]
+    public bool DefaultApplied { get; init; }
+
+    [JsonPropertyName("generated")]
+    public bool Generated { get; init; }
+
+    [JsonPropertyName("as_path")]
+    public bool AsPath { get; init; }
+}
+
+/// <summary>A value-free inventory/preflight snapshot.</summary>
+public sealed class ResolutionReport
+{
+    internal ResolutionReport(string provider, string profile, IEnumerable<SecretReport> secrets)
+    {
+        Provider = provider;
+        Profile = profile;
+        Secrets = Array.AsReadOnly(secrets.ToArray());
+    }
+
+    public string Provider { get; }
+    public string Profile { get; }
+    public IReadOnlyList<SecretReport> Secrets { get; }
+}

--- a/secretspec-dotnet/src/SecretSpec/Native.cs
+++ b/secretspec-dotnet/src/SecretSpec/Native.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Cachix.SecretSpec;
+
+internal static class Native
+{
+    private const string LibraryName = "secretspec_ffi";
+
+    static Native()
+    {
+        NativeLibrary.SetDllImportResolver(typeof(Native).Assembly, ResolveLibrary);
+    }
+
+    internal static string Resolve(string requestJson)
+    {
+        IntPtr response = IntPtr.Zero;
+        try
+        {
+            response = secretspec_resolve(requestJson);
+            if (response == IntPtr.Zero)
+                throw new SecretSpecException("ffi", "secretspec_resolve returned null");
+            return Marshal.PtrToStringUTF8(response)
+                ?? throw new SecretSpecException("ffi", "secretspec_resolve returned invalid UTF-8");
+        }
+        catch (Exception error) when (
+            error is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
+        {
+            throw new SecretSpecException("load", error.Message, error);
+        }
+        finally
+        {
+            if (response != IntPtr.Zero)
+                secretspec_free(response);
+        }
+    }
+
+    internal static string AbiVersion()
+    {
+        try
+        {
+            var pointer = secretspec_abi_version();
+            return Marshal.PtrToStringUTF8(pointer)
+                ?? throw new SecretSpecException("ffi", "secretspec_abi_version returned null");
+        }
+        catch (Exception error) when (
+            error is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
+        {
+            throw new SecretSpecException("load", error.Message, error);
+        }
+    }
+
+    private static IntPtr ResolveLibrary(
+        string libraryName,
+        Assembly assembly,
+        DllImportSearchPath? searchPath)
+    {
+        if (libraryName != LibraryName)
+            return IntPtr.Zero;
+
+        var explicitPath = Environment.GetEnvironmentVariable("SECRETSPEC_FFI_LIB");
+        if (!string.IsNullOrWhiteSpace(explicitPath))
+            return NativeLibrary.Load(explicitPath);
+
+        // Prefer the runtime-specific NuGet asset (or a library on the platform's
+        // normal loader search path); the source-checkout scan below is a
+        // development fallback that must not stat ancestor directories, or shadow
+        // the packaged asset, in a deployed application.
+        if (NativeLibrary.TryLoad(libraryName, assembly, searchPath, out var packaged))
+            return packaged;
+
+        var fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "secretspec_ffi.dll"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? "libsecretspec_ffi.dylib"
+                : "libsecretspec_ffi.so";
+
+        foreach (var start in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            for (var directory = new DirectoryInfo(start); directory is not null; directory = directory.Parent)
+            {
+                // Within the nearest ancestor target/, pick the most recently
+                // built library rather than always preferring one profile: a
+                // stale build must not shadow the one the developer just
+                // produced. Mirrors the Go and PHP SDK discovery rule.
+                string? newest = null;
+                var newestTime = DateTime.MinValue;
+                foreach (var profile in new[] { "release", "debug" })
+                {
+                    var candidate = new FileInfo(
+                        Path.Combine(directory.FullName, "target", profile, fileName));
+                    if (candidate.Exists && candidate.LastWriteTimeUtc >= newestTime)
+                    {
+                        newest = candidate.FullName;
+                        newestTime = candidate.LastWriteTimeUtc;
+                    }
+                }
+                if (newest is not null)
+                    return NativeLibrary.Load(newest);
+            }
+        }
+
+        return IntPtr.Zero;
+    }
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr secretspec_resolve(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string requestJson);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    private static extern void secretspec_free(IntPtr pointer);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr secretspec_abi_version();
+}

--- a/secretspec-dotnet/src/SecretSpec/SecretSpec.cs
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpec.cs
@@ -1,0 +1,38 @@
+namespace Cachix.SecretSpec;
+
+/// <summary>Entry point for the SecretSpec C# SDK.</summary>
+public static class SecretSpec
+{
+    /// <summary>Starts a fluent resolution builder.</summary>
+    public static SecretSpecBuilder Builder() => new();
+
+    /// <summary>Resolves secrets in one call.</summary>
+    public static Resolved Resolve(
+        string? path = null,
+        string? provider = null,
+        string? profile = null,
+        string? reason = null) =>
+        Configured(path, provider, profile, reason).Load();
+
+    /// <summary>Builds a value-free inventory report in one call.</summary>
+    public static ResolutionReport Report(
+        string? path = null,
+        string? provider = null,
+        string? profile = null,
+        string? reason = null) =>
+        Configured(path, provider, profile, reason).Report();
+
+    /// <summary>The ABI version reported by the loaded native resolver.</summary>
+    public static string AbiVersion() => Native.AbiVersion();
+
+    private static SecretSpecBuilder Configured(
+        string? path,
+        string? provider,
+        string? profile,
+        string? reason) =>
+        Builder()
+            .WithPath(path)
+            .WithProvider(provider)
+            .WithProfile(profile)
+            .WithReason(reason);
+}

--- a/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <PackageId>Cachix.SecretSpec</PackageId>
+    <Version>0.15.0</Version>
+    <Authors>Cachix</Authors>
+    <Description>C# SDK for SecretSpec, the declarative secrets manager.</Description>
+    <PackageTags>secrets;configuration;security;dotnet</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://secretspec.dev/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/cachix/secretspec</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="README.md" />
+    <None Include="../../../LICENSE" Pack="true" PackagePath="" />
+    <None Include="runtimes/**" Pack="true"
+          PackagePath="runtimes/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+</Project>

--- a/secretspec-dotnet/src/SecretSpec/SecretSpecBuilder.cs
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpecBuilder.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+
+namespace Cachix.SecretSpec;
+
+/// <summary>Configures a SecretSpec resolution.</summary>
+public sealed class SecretSpecBuilder
+{
+    private readonly ResolveRequest _request = new();
+
+    public SecretSpecBuilder WithPath(string? path)
+    {
+        _request.Path = path;
+        return this;
+    }
+
+    public SecretSpecBuilder WithProvider(string? provider)
+    {
+        _request.Provider = provider;
+        return this;
+    }
+
+    public SecretSpecBuilder WithProfile(string? profile)
+    {
+        _request.Profile = profile;
+        return this;
+    }
+
+    public SecretSpecBuilder WithReason(string? reason)
+    {
+        _request.Reason = reason;
+        return this;
+    }
+
+    public SecretSpecBuilder WithNoValues(bool noValues = true)
+    {
+        _request.NoValues = noValues;
+        return this;
+    }
+
+    /// <summary>Resolves the configured secrets.</summary>
+    /// <exception cref="MissingRequiredException">A required secret was missing.</exception>
+    /// <exception cref="SecretSpecException">Resolution otherwise failed.</exception>
+    public Resolved Load()
+    {
+        var response = Call<ResolveResponseContract>(_request, "resolve");
+        EnsureSchemaVersion(response.SchemaVersion, JsonContracts.ResolveSchemaVersion, "resolve");
+
+        if (response.MissingRequired.Count > 0)
+            throw new MissingRequiredException(response.MissingRequired);
+
+        return new Resolved(
+            response.Provider,
+            response.Profile,
+            response.Secrets,
+            response.MissingOptional);
+    }
+
+    /// <summary>
+    /// Resolves a value-free inventory/preflight report. Missing required
+    /// secrets appear in the report rather than throwing.
+    /// </summary>
+    public ResolutionReport Report()
+    {
+        var request = _request with { Mode = "report" };
+        var response = Call<ReportResponseContract>(request, "report");
+        EnsureSchemaVersion(response.SchemaVersion, JsonContracts.ReportSchemaVersion, "report");
+
+        return new ResolutionReport(response.Provider, response.Profile, response.Secrets);
+    }
+
+    private static T Call<T>(ResolveRequest request, string kind)
+        where T : class
+    {
+        var payload = JsonSerializer.Serialize(request, JsonContracts.Options);
+        var raw = Native.Resolve(payload);
+        Envelope<T>? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<Envelope<T>>(raw, JsonContracts.Options);
+        }
+        catch (JsonException error)
+        {
+            throw new SecretSpecException("parse", error.Message, error);
+        }
+
+        if (envelope is null)
+            throw new SecretSpecException("parse", "native resolver returned an empty response");
+
+        if (!envelope.Ok)
+            throw new SecretSpecException(
+                envelope.Error?.Kind ?? "unknown",
+                envelope.Error?.Message ?? "native resolver returned an unspecified error");
+
+        return envelope.Response
+            ?? throw new SecretSpecException(
+                "ffi",
+                $"secretspec_resolve reported ok with no {kind} response");
+    }
+
+    private static void EnsureSchemaVersion(int actual, int expected, string kind)
+    {
+        if (actual != expected)
+        {
+            throw new SecretSpecException(
+                "version",
+                $"unsupported {kind} schema version {actual} (expected {expected}); " +
+                "the secretspec-ffi library and this SDK are out of sync");
+        }
+    }
+}

--- a/secretspec-dotnet/tests/SecretSpec.Tests/Program.cs
+++ b/secretspec-dotnet/tests/SecretSpec.Tests/Program.cs
@@ -1,0 +1,334 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Cachix.SecretSpec;
+using SecretSpecClient = Cachix.SecretSpec.SecretSpec;
+
+internal static class Program
+{
+    private const string Manifest = """
+        [project]
+        name = "dotnet-test"
+        revision = "1.0"
+
+        [profiles.default]
+        DATABASE_URL = { description = "DB", required = true }
+        LOG_LEVEL = { description = "log", required = false, default = "info" }
+        SENTRY_DSN = { description = "sentry", required = false }
+        """;
+
+    private static readonly List<(string Name, Action Test)> Tests =
+    [
+        ("ABI version", TestAbiVersion),
+        ("load values and provenance", TestLoad),
+        ("missing required exception", TestMissingRequired),
+        ("invalid manifest exception", TestInvalidManifest),
+        ("as_path cleanup", TestAsPathCleanup),
+        ("value-free report", TestReport),
+        ("environment export", TestSetAsEnv),
+        ("one-shot API", TestOneShot),
+        ("cross-language conformance", TestConformance),
+    ];
+
+    public static int Main()
+    {
+        var failures = new List<string>();
+        foreach (var (name, test) in Tests)
+        {
+            try
+            {
+                test();
+                Console.WriteLine($"PASS {name}");
+            }
+            catch (Exception error)
+            {
+                failures.Add(name);
+                Console.Error.WriteLine($"FAIL {name}: {error}");
+            }
+        }
+
+        if (failures.Count == 0)
+        {
+            Console.WriteLine($"All {Tests.Count} C# SDK tests passed");
+            return 0;
+        }
+
+        Console.Error.WriteLine($"{failures.Count} C# SDK test(s) failed: {string.Join(", ", failures)}");
+        return 1;
+    }
+
+    private static void TestAbiVersion() =>
+        Assert(!string.IsNullOrWhiteSpace(SecretSpecClient.AbiVersion()), "ABI version was empty");
+
+    private static void TestLoad()
+    {
+        using var project = Project.Create(Manifest, "DATABASE_URL=postgres://db\n");
+        using var resolved = project.Builder().Load();
+
+        Equal("default", resolved.Profile);
+        Equal("postgres://db", resolved.Secrets["DATABASE_URL"].Get());
+        Equal("provider", resolved.Secrets["DATABASE_URL"].Source);
+        Assert(resolved.Secrets["DATABASE_URL"].SourceProvider is not null, "provider provenance missing");
+        Equal("info", resolved.Secrets["LOG_LEVEL"].Get());
+        Equal("default", resolved.Secrets["LOG_LEVEL"].Source);
+        SequenceEqual(["SENTRY_DSN"], resolved.MissingOptional);
+        Assert(!resolved.Secrets.ContainsKey("SENTRY_DSN"), "missing optional secret was returned");
+
+        var fields = JsonNode.Parse(resolved.FieldsJson());
+        Equal("postgres://db", fields?["DATABASE_URL"]?.GetValue<string>());
+    }
+
+    private static void TestMissingRequired()
+    {
+        using var project = Project.Create(Manifest, "");
+        var error = Throws<MissingRequiredException>(() => project.Builder().Load());
+        SequenceEqual(["DATABASE_URL"], error.Missing);
+        Equal("missing_required", error.Kind);
+    }
+
+    private static void TestInvalidManifest()
+    {
+        var error = Throws<SecretSpecException>(() =>
+            SecretSpecClient.Builder()
+                .WithPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "secretspec.toml"))
+                .WithReason("C# test")
+                .Load());
+        Assert(error is not MissingRequiredException, "transport failure became missing-required");
+        Assert(!string.IsNullOrWhiteSpace(error.Kind), "error kind was empty");
+    }
+
+    private static void TestAsPathCleanup()
+    {
+        const string manifest = """
+            [project]
+            name = "dotnet-test"
+            revision = "1.0"
+
+            [profiles.default]
+            TLS_CERT = { description = "cert", required = true, as_path = true }
+            """;
+        using var project = Project.Create(manifest, "TLS_CERT=----cert----\n");
+        string path;
+        using (var resolved = project.Builder().Load())
+        {
+            var cert = resolved.Secrets["TLS_CERT"];
+            Assert(cert.AsPath, "TLS_CERT was not marked as_path");
+            Assert(cert.Value is null, "as_path secret exposed an inline value");
+            path = cert.Get() ?? throw new Exception("as_path secret had no path");
+            Equal("----cert----", File.ReadAllText(path));
+        }
+        Assert(!File.Exists(path), "Dispose did not remove the secret temp file");
+    }
+
+    private static void TestReport()
+    {
+        using var project = Project.Create(Manifest, "");
+        var report = project.Builder().Report();
+
+        Equal("default", report.Profile);
+        var database = report.Secrets.Single(secret => secret.Name == "DATABASE_URL");
+        Equal("missing_required", database.Status);
+        Assert(database.Required, "DATABASE_URL was not reported as required");
+        var logLevel = report.Secrets.Single(secret => secret.Name == "LOG_LEVEL");
+        Assert(logLevel.DefaultApplied, "LOG_LEVEL default was not reported");
+    }
+
+    private static void TestSetAsEnv()
+    {
+        using var project = Project.Create(Manifest, "DATABASE_URL=postgres://environment\n");
+        var previous = Environment.GetEnvironmentVariable("DATABASE_URL");
+        try
+        {
+            using var resolved = project.Builder().Load();
+            resolved.SetAsEnv();
+            Equal("postgres://environment", Environment.GetEnvironmentVariable("DATABASE_URL"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DATABASE_URL", previous);
+        }
+    }
+
+    private static void TestOneShot()
+    {
+        using var project = Project.Create(Manifest, "DATABASE_URL=postgres://one-shot\n");
+        using var resolved = SecretSpecClient.Resolve(
+            path: project.ManifestPath,
+            provider: project.Provider,
+            reason: "C# test");
+        Equal("postgres://one-shot", resolved.Secrets["DATABASE_URL"].Get());
+
+        var report = SecretSpecClient.Report(
+            path: project.ManifestPath,
+            provider: project.Provider,
+            reason: "C# test");
+        Equal("resolved", report.Secrets.Single(secret => secret.Name == "DATABASE_URL").Status);
+    }
+
+    private static void TestConformance()
+    {
+        var root = FindRepositoryRoot();
+        var fixtures = Path.Combine(root, "conformance", "fixtures");
+        foreach (var directory in Directory.EnumerateDirectories(fixtures).Order())
+        {
+            var manifest = Path.Combine(directory, "secretspec.toml");
+            var provider = $"dotenv://{Path.Combine(directory, ".env")}";
+            SecretSpecBuilder Fixture() => SecretSpecClient.Builder()
+                .WithPath(manifest)
+                .WithProvider(provider)
+                .WithReason("conformance");
+
+            using (var resolved = Fixture().Load())
+            {
+                AssertJsonEqual(
+                    File.ReadAllText(Path.Combine(directory, "expected.json")),
+                    CanonicalResolved(resolved).ToJsonString());
+            }
+
+            using (var noValues = Fixture().WithNoValues().Load())
+            {
+                AssertJsonEqual(
+                    File.ReadAllText(Path.Combine(directory, "expected_no_values.json")),
+                    noValues.FieldsJson());
+            }
+
+            var report = Fixture().Report();
+            AssertJsonEqual(
+                File.ReadAllText(Path.Combine(directory, "expected_report.json")),
+                CanonicalReport(report).ToJsonString());
+        }
+    }
+
+    private static JsonObject CanonicalResolved(Resolved resolved)
+    {
+        var secrets = new JsonObject();
+        foreach (var (name, secret) in resolved.Secrets)
+        {
+            var value = secret.AsPath
+                ? File.ReadAllText(secret.Get() ?? throw new Exception($"{name} had no path"))
+                : secret.Value;
+            secrets[name] = new JsonObject
+            {
+                ["value"] = value,
+                ["source"] = secret.Source,
+                ["as_path"] = secret.AsPath,
+            };
+        }
+
+        return new JsonObject
+        {
+            ["profile"] = resolved.Profile,
+            ["secrets"] = secrets,
+            ["missing_required"] = new JsonArray(),
+            ["missing_optional"] = new JsonArray(
+                resolved.MissingOptional
+                    .Select(value => (JsonNode?)JsonValue.Create(value))
+                    .ToArray()),
+        };
+    }
+
+    private static JsonObject CanonicalReport(ResolutionReport report)
+    {
+        var secrets = new JsonObject();
+        foreach (var secret in report.Secrets)
+        {
+            secrets[secret.Name] = new JsonObject
+            {
+                ["status"] = secret.Status,
+                ["required"] = secret.Required,
+                ["as_path"] = secret.AsPath,
+                ["generated"] = secret.Generated,
+                ["default_applied"] = secret.DefaultApplied,
+                ["source_provider"] = secret.SourceProvider is not null,
+            };
+        }
+
+        return new JsonObject
+        {
+            ["profile"] = report.Profile,
+            ["secrets"] = secrets,
+        };
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Cargo.toml")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "conformance")))
+                return directory.FullName;
+        }
+        throw new DirectoryNotFoundException("could not find the SecretSpec repository root");
+    }
+
+    private static void AssertJsonEqual(string expected, string actual)
+    {
+        var expectedNode = JsonNode.Parse(expected);
+        var actualNode = JsonNode.Parse(actual);
+        Assert(
+            JsonNode.DeepEquals(expectedNode, actualNode),
+            $"JSON mismatch\nactual:   {actual}\nexpected: {expected}");
+    }
+
+    private static T Throws<T>(Action action) where T : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (T error)
+        {
+            return error;
+        }
+        throw new Exception($"expected {typeof(T).Name}");
+    }
+
+    private static void Assert(bool condition, string message)
+    {
+        if (!condition)
+            throw new Exception(message);
+    }
+
+    private static void Equal<T>(T expected, T actual)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+            throw new Exception($"expected {expected}, got {actual}");
+    }
+
+    private static void SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+    {
+        if (!expected.SequenceEqual(actual))
+            throw new Exception($"expected [{string.Join(", ", expected)}], got [{string.Join(", ", actual)}]");
+    }
+
+    private sealed class Project : IDisposable
+    {
+        private Project(string root)
+        {
+            Root = root;
+            ManifestPath = Path.Combine(root, "secretspec.toml");
+            Provider = $"dotenv://{Path.Combine(root, ".env")}";
+        }
+
+        private string Root { get; }
+        internal string ManifestPath { get; }
+        internal string Provider { get; }
+
+        internal SecretSpecBuilder Builder() => SecretSpecClient.Builder()
+            .WithPath(ManifestPath)
+            .WithProvider(Provider)
+            .WithReason("C# test");
+
+        internal static Project Create(string manifest, string dotenv)
+        {
+            var project = new Project(Path.Combine(Path.GetTempPath(), $"secretspec-dotnet-{Guid.NewGuid()}"));
+            Directory.CreateDirectory(project.Root);
+            File.WriteAllText(project.ManifestPath, manifest);
+            File.WriteAllText(Path.Combine(project.Root, ".env"), dotenv);
+            return project;
+        }
+
+        public void Dispose() => Directory.Delete(Root, recursive: true);
+    }
+}

--- a/secretspec-dotnet/tests/SecretSpec.Tests/SecretSpec.Tests.csproj
+++ b/secretspec-dotnet/tests/SecretSpec.Tests/SecretSpec.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/SecretSpec/SecretSpec.csproj" />
+  </ItemGroup>
+</Project>

--- a/secretspec-ffi/Cargo.toml
+++ b/secretspec-ffi/Cargo.toml
@@ -18,6 +18,11 @@ crate-type = ["cdylib", "staticlib", "lib"]
 # crate is only the C ABI wrapper.
 secretspec = { workspace = true }
 
+[features]
+# Binary SDK packages use this on Linux so the resolver does not acquire a
+# runtime dependency on the host's libdbus.
+vendored-dbus = ["secretspec/vendored-dbus"]
+
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -200,6 +200,7 @@ works identically with no per-language resolution logic:
 - [Node.js / TypeScript](https://secretspec.dev/sdk/nodejs) (napi-rs addon)
 - [Haskell](https://secretspec.dev/sdk/haskell) (build-time FFI link)
 - [PHP](https://secretspec.dev/sdk/php) (ext-php-rs extension, with an `ext-ffi` fallback)
+- [C# (0.16+)](https://secretspec.dev/sdk/csharp) (P/Invoke with native assets in the NuGet package; unavailable in 0.15)
 
 ```python
 from secretspec import SecretSpec


### PR DESCRIPTION
## What changed

- add a dependency-free .NET 8 client over the shared `secretspec-ffi` JSON ABI
- expose fluent and one-shot resolution, typed errors, value-free reports,
  provenance, environment export, codegen fields, and `IDisposable` cleanup for
  `as_path` files
- add a nine-scenario test runner covering the shared cross-language
  conformance fixtures
- package Linux x64/Arm64, macOS Arm64, and Windows x64 native assets in
  `Cachix.SecretSpec`
- add NuGet build/publish CI, aggregate SDK/conformance integration, version
  syncing, release notes, and version-labeled 0.16 documentation

## Why

SecretSpec has thin SDKs for the other supported application ecosystems, but
.NET applications currently need to launch through the CLI. This adds an
idiomatic C# surface while keeping all resolution behavior in the existing Rust
core.

## User impact

Starting with SecretSpec 0.16, .NET 8 applications can install
`Cachix.SecretSpec` and resolve the same providers, profiles, fallback chains,
references, generators, and file-shaped secrets as the CLI and other SDKs. The
current 0.15 fallback remains documented as
`secretspec run -- dotnet run`.

## Validation

- C# SDK test runner: 9/9 passed against the real native resolver
- shared resolve, no-values, and report conformance fixtures passed
- `dotnet build` completed with zero warnings
- `dotnet format --verify-no-changes` passed for client and tests
- `dotnet pack` passed; verified managed files and native runtime asset layout
- `cargo test -p secretspec-ffi` passed (9 tests)
- `cargo check -p secretspec-ffi --features vendored-dbus` passed
- Astro docs check/build passed (one pre-existing hint)
- shell syntax, YAML parsing, `actionlint`, version sync, and
  `git diff --check` passed
