### PR TITLE
docs: clarify provider guides

### DIFF
--- a/docs/src/content/docs/blog/secretspec-0-15-provider-credentials-azure-key-vault-gopass-and-php-sdk.md
+++ b/docs/src/content/docs/blog/secretspec-0-15-provider-credentials-azure-key-vault-gopass-and-php-sdk.md
@@ -52,8 +52,8 @@ keyring at the normal `{project}/{profile}/access_token` address. The active
 development can authenticate as different machines without changing the alias.
 
 When a credential already has a provider-native address, use a `ref`. Here a
-[Vault AppRole](/providers/vault/#approle) is kept as two fields of one
-[1Password item](/providers/onepassword/#secret-references):
+[Vault AppRole](/providers/vault/#approle-authentication) is kept as two fields of one
+[1Password item](/providers/onepassword/#use-existing-secrets):
 
 ```toml title="secretspec.toml"
 [providers.vault_prod]

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -54,8 +54,9 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [akv](/providers/akv/) | Azure Key Vault (requires the `akv` build feature) | ✓ | ✓ | ✓ |
 | [infisical](/providers/infisical/) (0.16+) | Infisical (requires the `infisical` build feature) | ✓ | ✓ | ✓ |
 
-See each provider's page for its URI format, authentication requirements, and
-storage conventions.
+Each provider page starts with a minimal working example, then covers setup,
+project configuration, storage conventions, existing provider-native secrets,
+and CI/CD where applicable.
 
 ## How SecretSpec selects a provider
 

--- a/docs/src/content/docs/providers/akv.md
+++ b/docs/src/content/docs/providers/akv.md
@@ -6,19 +6,55 @@ description: Azure Key Vault integration
 The Azure Key Vault provider integrates with Azure for centralized secret management.
 
 :::note[Version compatibility]
-The Azure Key Vault provider is an upcoming SecretSpec 0.15 feature and is not
-available in SecretSpec 0.14.
+Available since SecretSpec 0.15.
 :::
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `akv` |
+| URI | `akv://VAULT_NAME[?auth=METHOD][&suffix=DNS_SUFFIX]` |
+| Access | Read and write; secret references are read-only |
+| Best for | Workloads and teams on Azure |
+| Authentication | Service principal, Azure CLI, managed identity, or workload identity |
+| Availability | SecretSpec 0.15+; requires the `akv` build feature |
+| Default storage | `secretspec--{base32(project)}--{base32(profile)}--{base32(key)}` |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider akv://myvault
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to akv (profile: default)
+
+# Get it back
+$ secretspec get DATABASE_URL --provider akv://myvault
+postgresql://localhost/mydb
+```
+
+## Setup
+
+### Prerequisites
 
 - An Azure Key Vault instance
 - Authenticated via a service principal, the Azure CLI (`az login`), a managed identity, or AKS workload identity
 - Build with `--features akv`
 
+### Authentication
+
+Select an authentication mode with the URI's `auth` option:
+
+- `env` (default): service-principal provider credentials or environment
+  variables, falling back to an Azure CLI session when none are set.
+- `cli`: Azure CLI or Azure Developer CLI only.
+- `managed_identity`: system-assigned managed identity.
+- `workload_identity`: AKS workload identity federation.
+
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity][&suffix=DNS_SUFFIX]
@@ -32,58 +68,26 @@ akv://VAULT_NAME[?auth=env|cli|managed_identity|workload_identity][&suffix=DNS_S
   - `workload_identity` — AKS workload identity federation (`AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_FEDERATED_TOKEN_FILE`, injected automatically by AKS)
 - `suffix`: an explicit Key Vault DNS suffix for a bare `VAULT_NAME`, e.g. `akv://myvault?suffix=vault.azure.cn` for a sovereign cloud, instead of relying on a dotted `VAULT_NAME`
 
-### Examples
+### URI examples
 
-```bash
-# Set a secret (reads env vars, or falls back to `az login`)
-$ secretspec set DATABASE_URL --provider akv://myvault
-
-# Get a secret
-$ secretspec get DATABASE_URL --provider akv://myvault
-
-# Check secrets using a managed identity
-$ secretspec check --provider akv://myvault?auth=managed_identity
-
-# Run with secrets
-$ secretspec run --provider akv://myvault -- npm start
-
-# Sovereign cloud, via an explicit suffix instead of a dotted vault name
-$ secretspec check --provider akv://myvault?suffix=vault.azure.cn
+```text
+akv://myvault
+akv://myvault?auth=managed_identity
+akv://myvault?auth=workload_identity
+akv://myvault?suffix=vault.azure.cn
 ```
 
-## Secret References
+### Project configuration
 
-By default each secret is stored as
-`secretspec--{base32(project)}--{base32(profile)}--{base32(key)}`. A secret's
-[`ref`](/reference/configuration/#secret-references) field names an
-existing secret instead: `item` is the secret name (`field` and `version` are
-not yet supported). References are **read-only** in this provider, and `item`
-must already be a valid Azure Key Vault secret name (letters, digits, and
-hyphens only) — unlike convention secrets, it is validated but never rewritten,
-since silently rewriting a `ref` could point at a different secret than the
-one you named.
+```toml title="secretspec.toml"
+[providers]
+azure = "akv://myvault"
 
-```toml
 [profiles.production]
-DATABASE_URL = { description = "DB", ref = { item = "database-url" }, providers = ["akv://myvault"] }
+DATABASE_URL = { description = "Database URL", providers = ["azure"] }
 ```
 
-## Usage
-
-### Basic Commands
-
-```bash
-# Set a secret
-$ secretspec set DATABASE_URL --provider akv://myvault
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-✓ Secret 'DATABASE_URL' saved to akv (profile: default)
-
-# Get it back
-$ secretspec get DATABASE_URL --provider akv://myvault
-postgresql://localhost/mydb
-```
-
-### Secret Naming
+## Storage model
 
 Azure Key Vault secret names may only contain ASCII letters, digits and
 hyphens, and Azure compares object identifiers case-insensitively. SecretSpec
@@ -97,7 +101,25 @@ though Key Vault's identifiers do not preserve all of those distinctions. The
 encoded components contain no hyphens, so the `--` component separators cannot
 be confused with component data.
 
-### CI/CD with a Service Principal
+## Use existing secrets
+
+A secret's
+[`ref`](/reference/configuration/#secret-references) field names an
+existing secret instead: `item` is the secret name (`field` and `version` are
+not yet supported). References are **read-only** in this provider, and `item`
+must already be a valid Azure Key Vault secret name (letters, digits, and
+hyphens only) — unlike convention secrets, it is validated but never rewritten,
+since silently rewriting a `ref` could point at a different secret than the
+one you named.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "DB", ref = { item = "database-url" }, providers = ["akv://myvault"] }
+```
+
+## CI/CD
+
+### Service principal
 
 The `auth=env` mode accepts `tenant_id`, `client_id`, and `client_secret` as
 [provider credentials](/concepts/providers/#provider-credentials). For example,
@@ -137,7 +159,7 @@ Across provider credentials and environment fallbacks, all three values must be
 available together. A partial service principal is treated as a configuration
 error rather than a silent fallback to the Azure CLI session.
 
-### AKS with Workload Identity
+### AKS workload identity
 
 ```bash
 # AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE are

--- a/docs/src/content/docs/providers/awssm.md
+++ b/docs/src/content/docs/providers/awssm.md
@@ -5,86 +5,19 @@ description: AWS Secrets Manager integration
 
 The AWS Secrets Manager provider integrates with AWS for centralized secret management.
 
-## Prerequisites
+## At a glance
 
-- AWS account with Secrets Manager access
-- AWS credentials configured (CLI, environment variables, IAM roles, or SSO)
-- Build with `--features awssm`
+| | |
+| --- | --- |
+| Provider | `awssm` |
+| URI | `awssm://[AWS_PROFILE@]REGION[?options]` |
+| Access | Read and write; secret references are read-only |
+| Best for | Workloads and teams on AWS |
+| Authentication | Standard AWS SDK credential chain |
+| Build feature | `awssm` |
+| Default storage | `[prefix/]secretspec/{project}/{profile}/{key}` |
 
-## Configuration
-
-### URI Format
-
-```
-awssm://[AWS_PROFILE@]REGION[?prefix=PREFIX][&kms_key_id=KEY][&tag.NAME=VALUE...]
-```
-
-- `REGION`: AWS region (e.g., `us-east-1`). If omitted, the SDK default region chain is used.
-- `AWS_PROFILE`: Optional AWS profile from `~/.aws/credentials`. If omitted, the SDK default credential chain is used.
-- `PREFIX`: Optional root prefix prepended to all secret names. Useful when IAM policies scope access by prefix (e.g., only allow `myteam/*`).
-- `kms_key_id`: Optional KMS key (id, ARN, or `alias/...`) used to encrypt secrets that secretspec creates.
-- `tag.NAME=VALUE`: Optional tags applied to secrets that secretspec creates. Repeat for multiple tags.
-
-`kms_key_id` and `tag.NAME=VALUE` are applied **only when secretspec creates a
-secret** (`CreateSecret`); updating a value (`PutSecretValue`) accepts neither,
-and a pre-existing secret keeps the key and tags it was created with. This
-supports AWS "tag-on-create" guardrails, where an SCP or IAM condition denies
-`CreateSecret` unless required `aws:RequestTag/*` tags (and often a
-customer-managed key) are present in the same call.
-
-### Examples
-
-```bash
-# Set a secret (SDK default credentials)
-$ secretspec set DATABASE_URL --provider awssm://us-east-1
-
-# Use a specific AWS profile
-$ secretspec check --provider awssm://production@us-east-1
-
-# Use a prefix to scope secrets under "myteam/"
-$ secretspec set DATABASE_URL --provider "awssm://us-east-1?prefix=myteam"
-
-# Create secrets with a customer-managed KMS key and required tags
-$ secretspec set DATABASE_URL --provider "awssm://prod@us-east-1?kms_key_id=alias/my-key&tag.team=platform&tag.env=prod"
-
-# Get a secret
-$ secretspec get DATABASE_URL --provider awssm://us-east-1
-
-# Run with secrets
-$ secretspec run --provider awssm://us-east-1 -- npm start
-
-# Use SDK defaults for both profile and region
-$ secretspec set DATABASE_URL --provider awssm
-```
-
-Because guardrail tags and keys usually vary per environment, they are a natural
-fit for a checked-in [provider alias](/reference/configuration/) in
-`secretspec.toml`:
-
-```toml
-[providers]
-prod = "awssm://prod@us-east-1?kms_key_id=alias/my-key&tag.team=platform&tag.env=prod"
-```
-
-## Secret References
-
-By default each secret is stored under `secretspec/{project}/{profile}/{key}`. A
-secret's [`ref`](/reference/configuration/#secret-references) field names an
-existing secret instead: `item` is the secret name (or ARN), and the optional
-`field` selects one key of a JSON secret value. Without `field`, the whole
-secret string is returned. References are **read-only** in this provider.
-
-```toml
-[profiles.production]
-# Whole secret value
-DATABASE_URL = { description = "DB", ref = { item = "prod/database-url" }, providers = ["awssm://us-east-1"] }
-# One key of a JSON secret value
-DB_PASSWORD = { description = "DB pw", ref = { item = "prod/db-credentials", field = "password" }, providers = ["awssm://us-east-1"] }
-```
-
-## Usage
-
-### Basic Commands
+## Quick start
 
 ```bash
 # Set a secret
@@ -92,17 +25,17 @@ $ secretspec set DATABASE_URL --provider awssm://us-east-1
 Enter value for DATABASE_URL: postgresql://localhost/mydb
 ✓ Secret 'DATABASE_URL' saved to awssm (profile: default)
 
-# Import from .env
-$ secretspec import dotenv://.env
+# Run with secrets
+$ secretspec run --provider awssm://us-east-1 -- npm start
 ```
 
-### Secret Naming
+## Setup
 
-Secrets are stored as: `[prefix/]secretspec/{project}/{profile}/{key}`
+### Prerequisites
 
-Example: `secretspec/myapp/production/DATABASE_URL`
-
-With `?prefix=myteam`: `myteam/secretspec/myapp/production/DATABASE_URL`
+- AWS account with Secrets Manager access
+- AWS credentials configured (CLI, environment variables, IAM roles, or SSO)
+- Build with `--features awssm`
 
 ### Authentication
 
@@ -113,7 +46,7 @@ AWS Secrets Manager uses the standard AWS SDK credential chain:
 3. AWS SSO (`aws sso login`)
 4. IAM roles (EC2 instance profiles, ECS task roles, Lambda execution roles)
 
-### Required IAM Permissions
+### Required IAM permissions
 
 ```json
 {
@@ -133,14 +66,15 @@ AWS Secrets Manager uses the standard AWS SDK credential chain:
 }
 ```
 
-If you use a prefix (e.g., `?prefix=myteam`), adjust the resource ARN accordingly:
+If you use a prefix such as `?prefix=myteam`, adjust the resource ARN:
 
 ```
 arn:aws:secretsmanager:*:*:secret:myteam/secretspec/*
 ```
 
 :::note
-The `BatchGetSecretValue` permission is required for batch fetching, which is used automatically during `check` and `run` commands to reduce API calls. If your IAM policy was created before this feature, you may need to add this permission.
+The `BatchGetSecretValue` permission is required for batch fetching, which is
+used automatically during `check` and `run` commands to reduce API calls.
 :::
 
 :::note
@@ -148,7 +82,79 @@ Using `tag.NAME=VALUE` additionally requires `secretsmanager:TagResource`, and a
 `kms_key_id` requires `kms:GenerateDataKey` and `kms:Decrypt` on that key.
 :::
 
-### CI/CD
+## Configuration
+
+### URI format
+
+```
+awssm://[AWS_PROFILE@]REGION[?prefix=PREFIX][&kms_key_id=KEY][&tag.NAME=VALUE...]
+```
+
+- `REGION`: AWS region (e.g., `us-east-1`). If omitted, the SDK default region chain is used.
+- `AWS_PROFILE`: Optional AWS profile from `~/.aws/credentials`. If omitted, the SDK default credential chain is used.
+- `PREFIX`: Optional root prefix prepended to all secret names. Useful when IAM policies scope access by prefix (e.g., only allow `myteam/*`).
+- `kms_key_id`: Optional KMS key (id, ARN, or `alias/...`) used to encrypt secrets that secretspec creates.
+- `tag.NAME=VALUE`: Optional tags applied to secrets that secretspec creates. Repeat for multiple tags.
+
+`kms_key_id` and `tag.NAME=VALUE` are applied **only when secretspec creates a
+secret** (`CreateSecret`); updating a value (`PutSecretValue`) accepts neither,
+and a pre-existing secret keeps the key and tags it was created with. This
+supports AWS "tag-on-create" guardrails, where an SCP or IAM condition denies
+`CreateSecret` unless required `aws:RequestTag/*` tags (and often a
+customer-managed key) are present in the same call.
+
+### URI examples
+
+```text
+awssm://us-east-1
+awssm://production@us-east-1
+awssm://us-east-1?prefix=myteam
+awssm://prod@us-east-1?kms_key_id=alias/my-key&tag.team=platform&tag.env=prod
+awssm
+```
+
+### Project configuration
+
+Because guardrail tags and keys usually vary per environment, they are a natural
+fit for a checked-in [provider alias](/reference/configuration/) in
+`secretspec.toml`:
+
+```toml
+[providers]
+prod = "awssm://prod@us-east-1?kms_key_id=alias/my-key&tag.team=platform&tag.env=prod"
+```
+
+Route secrets through the alias in project configuration:
+
+```toml title="secretspec.toml"
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["prod"] }
+```
+
+## Storage model
+
+Secrets are stored as `[prefix/]secretspec/{project}/{profile}/{key}`.
+
+For example, `DATABASE_URL` in project `myapp` and profile `production` is
+stored as `secretspec/myapp/production/DATABASE_URL`. With `?prefix=myteam`,
+it becomes `myteam/secretspec/myapp/production/DATABASE_URL`.
+
+## Use existing secrets
+
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing secret instead: `item` is the secret name (or ARN), and the optional
+`field` selects one key of a JSON secret value. Without `field`, the whole
+secret string is returned. References are **read-only** in this provider.
+
+```toml
+[profiles.production]
+# Whole secret value
+DATABASE_URL = { description = "DB", ref = { item = "prod/database-url" }, providers = ["awssm://us-east-1"] }
+# One key of a JSON secret value
+DB_PASSWORD = { description = "DB pw", ref = { item = "prod/db-credentials", field = "password" }, providers = ["awssm://us-east-1"] }
+```
+
+## CI/CD
 
 ```bash
 # Using environment variables

--- a/docs/src/content/docs/providers/bws.md
+++ b/docs/src/content/docs/providers/bws.md
@@ -5,15 +5,64 @@ description: Bitwarden Secrets Manager integration
 
 The Bitwarden Secrets Manager (BWS) provider integrates with Bitwarden for centralized, end-to-end encrypted secret management.
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `bws` |
+| URI | `bws://[SERVER_BASE@]PROJECT_UUID` |
+| Access | Read and write |
+| Best for | Machine and CI/CD secrets managed in Bitwarden |
+| Authentication | A machine-account access token |
+| Build feature | `bws` |
+| Default storage | Flat key names in the selected BWS project |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to bws (profile: default)
+
+# Run with secrets
+$ secretspec run --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c -- npm start
+```
+
+## Setup
+
+### Prerequisites
 
 - Bitwarden Secrets Manager subscription
 - Machine account access token (`BWS_ACCESS_TOKEN` environment variable)
 - Build with `--features bws`
 
+### Authentication
+
+Generate a machine account access token from the Bitwarden Secrets Manager web
+interface.
+
+In SecretSpec 0.15 and later, you can declare the access token as a
+[provider credential](/concepts/providers/#provider-credentials), for example
+to store it in your system keyring so it never lives in a shell profile:
+
+```toml title="secretspec.toml"
+[providers]
+bitwarden = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", credentials = { access_token = "keyring" } }
+```
+
+When no explicit `access_token` credential is supplied, the provider falls
+back to `BWS_ACCESS_TOKEN`:
+
+```bash
+export BWS_ACCESS_TOKEN="0.your-access-token..."
+```
+
+SecretSpec 0.14 supports only the environment-variable form.
+
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 bws://[SERVER_BASE@]PROJECT_UUID
@@ -30,32 +79,33 @@ When `SERVER_BASE` is set, the identity and API endpoints are derived as
 Use the web vault hostname here, for example `vault.bitwarden.eu` for the EU
 cloud. Only a bare hostname is supported (no scheme prefix or custom port).
 
-### Examples
+### URI examples
 
-```bash
-# US cloud (default)
-$ secretspec set DATABASE_URL --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
-
-# EU cloud
-$ secretspec set DATABASE_URL --provider bws://vault.bitwarden.eu@a9230ec4-5507-4870-b8b5-b3f500587e4c
-
-# Self hosted instance
-$ secretspec set DATABASE_URL --provider bws://bw.example.com@a9230ec4-5507-4870-b8b5-b3f500587e4c
-
-# Get a secret
-$ secretspec get DATABASE_URL --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
-
-# Check secrets
-$ secretspec check --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
-
-# Run with secrets
-$ secretspec run --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c -- npm start
+```text
+bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
+bws://vault.bitwarden.eu@a9230ec4-5507-4870-b8b5-b3f500587e4c
+bws://bw.example.com@a9230ec4-5507-4870-b8b5-b3f500587e4c
 ```
 
-## Secret References
+### Project configuration
 
-By default each secret is matched by the BWS key name equal to the secret's own
-name. A secret's [`ref`](/reference/configuration/#secret-references) field names
+```toml title="secretspec.toml"
+[providers]
+bitwarden = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", credentials = { access_token = "keyring" } }
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["bitwarden"] }
+```
+
+## Storage model
+
+SecretSpec uses flat key names matching the secret key directly, such as
+`DATABASE_URL`. The BWS project UUID provides namespace isolation, so use
+separate BWS projects when applications or environments need separate values.
+
+## Use existing secrets
+
+A secret's [`ref`](/reference/configuration/#secret-references) field names
 a different key instead: `item` is the BWS key name (`field` is not supported).
 Reads and writes target that key in place.
 
@@ -64,48 +114,7 @@ Reads and writes target that key in place.
 DATABASE_URL = { description = "DB", ref = { item = "prod-db-connection" }, providers = ["bws://a9230ec4-5507-4870-b8b5-b3f500587e4c"] }
 ```
 
-## Usage
-
-### Authentication
-
-Generate a machine account access token from the Bitwarden Secrets Manager web
-interface.
-
-In SecretSpec 0.14, supply it through `BWS_ACCESS_TOKEN`:
-
-```bash
-export BWS_ACCESS_TOKEN="0.your-access-token..."
-```
-
-Starting with SecretSpec 0.15, you can instead declare the access token as a
-[provider credential](/concepts/providers/#provider-credentials), for example
-to store it in your system keyring so it never lives in a shell profile:
-
-```toml title="secretspec.toml"
-[providers]
-bws = { uri = "bws://a9230ec4-5507-4870-b8b5-b3f500587e4c", credentials = { access_token = "keyring" } }
-```
-
-In 0.15 and later, the provider continues to fall back to `BWS_ACCESS_TOKEN`
-when no explicit `access_token` credential is supplied.
-
-### Basic Commands
-
-```bash
-# Set a secret
-$ secretspec set DATABASE_URL --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-✓ Secret 'DATABASE_URL' saved to bws (profile: default)
-
-# Import from .env
-$ secretspec import dotenv://.env
-```
-
-### Secret Naming
-
-Secrets are stored with flat key names matching the secret key directly (e.g., `DATABASE_URL`). The BWS project UUID in the URI provides namespace isolation, so different projects or environments should use separate BWS projects.
-
-### CI/CD with Machine Accounts
+## CI/CD
 
 ```bash
 # Set access token (from CI secrets)

--- a/docs/src/content/docs/providers/dotenv.md
+++ b/docs/src/content/docs/providers/dotenv.md
@@ -5,9 +5,64 @@ description: Traditional .env file storage for secrets
 
 The Dotenv provider stores secrets in local `.env` files for development setups and compatibility with existing tools.
 
-## File Format
+## At a glance
 
-Standard dotenv format with `KEY=VALUE` pairs:
+| | |
+| --- | --- |
+| Provider | `dotenv` |
+| URI | `dotenv[:path]` |
+| Access | Read and write |
+| Best for | Local development and compatibility with `.env`-based tools |
+| Authentication | None |
+| Default storage | `.env` next to `secretspec.toml` (plain text) |
+
+## Quick start
+
+```bash
+# Initialize from existing .env
+$ secretspec init --from .env
+
+# Set a secret
+$ secretspec set DATABASE_URL --provider dotenv
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+
+# Run with secrets
+$ secretspec run --provider dotenv -- npm start
+```
+
+## Configuration
+
+### URI format
+
+```bash
+# Default (.env next to secretspec.toml)
+dotenv
+
+# Custom paths
+dotenv:.env.local
+dotenv:config/.env
+dotenv:/absolute/path/.env
+```
+
+### Environment variable
+
+```bash
+export SECRETSPEC_PROVIDER=dotenv:.env.local
+```
+
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+local = "dotenv:.env.local"
+
+[profiles.default]
+DATABASE_URL = { description = "Database URL", providers = ["local"] }
+```
+
+## Storage model
+
+Dotenv uses standard `KEY=VALUE` pairs:
 
 ```bash
 # .env
@@ -21,27 +76,14 @@ MIIEpAIBAAKCAQEA...
 -----END RSA PRIVATE KEY-----"
 ```
 
-## Configuration
-
-### URI Syntax
-
-```bash
-# Default (.env in current directory)
-dotenv
-
-# Custom paths
-dotenv:.env.local
-dotenv:config/.env
-dotenv:/absolute/path/.env
-```
-
-### Environment Variable
+The file itself provides the namespace. Project and profile names are not
+included in keys; use a different file when environments need separate values:
 
 ```bash
-export SECRETSPEC_PROVIDER=dotenv:.env.local
+$ secretspec run --provider dotenv:.env.production -- node server.js
 ```
 
-## Secret References
+## Use existing secrets
 
 By default each secret reads the key named after it. A secret's
 [`ref`](/reference/configuration/#secret-references) field reads a key stored
@@ -53,23 +95,9 @@ Reads and writes target that key in place; the secret's own name is ignored.
 DATABASE_URL = { description = "DB", ref = { item = "POSTGRES_URL" }, providers = ["dotenv://.env.shared"] }
 ```
 
-## Usage
+## Security considerations
 
-```bash
-# Initialize from existing .env
-$ secretspec init --from .env
-
-# Set a secret
-$ secretspec set DATABASE_URL --provider dotenv
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-
-# Run with secrets
-$ secretspec run --provider dotenv -- npm start
-
-# Use different files for different environments
-$ secretspec run --provider dotenv:.env.production -- node server.js
-```
-
-## Security
-
-⚠️ **Warning**: Secrets are stored in plain text. Use only for development and always add `.env` files to `.gitignore`.
+:::caution
+Secrets are stored in plain text. Use this provider only where that is
+acceptable, and always add secret-bearing `.env` files to `.gitignore`.
+:::

--- a/docs/src/content/docs/providers/env.md
+++ b/docs/src/content/docs/providers/env.md
@@ -5,38 +5,18 @@ description: Read-only access to environment variables
 
 The Environment Variable provider reads secrets directly from process environment variables. This is a **read-only** provider designed for CI/CD compatibility and containerized environments.
 
-## Configuration
+## At a glance
 
-The env provider accepts no configuration options:
+| | |
+| --- | --- |
+| Provider | `env` |
+| URI | `env://` |
+| Access | Read-only |
+| Best for | CI/CD, containers, and temporary overrides |
+| Authentication | None |
+| Default storage | Current process environment; values are not persisted |
 
-```bash
-# All these are equivalent
-$ secretspec check --provider env
-$ secretspec check --provider env:
-$ secretspec check --provider env://
-```
-
-## Secret References
-
-By default each secret reads the environment variable named after it. A secret's
-[`ref`](/reference/configuration/#secret-references) field reads a different
-variable, which is useful when your infrastructure already exposes a value under
-another name: `item` is the variable name, case-sensitive and preserved verbatim
-(`field` is not supported). Like the rest of this provider, references are
-read-only.
-
-```toml
-[profiles.default]
-DATABASE_URL = { description = "DB", ref = { item = "POSTGRES_CONNECTION_STRING" }, providers = ["env"] }
-```
-
-## When to Use
-
-- Running in CI/CD pipelines where secrets are injected as environment variables
-- Testing with temporary environment variables
-- Working with containerized applications that use environment variables
-
-## Example
+## Quick start
 
 ```bash
 # Set environment variables
@@ -51,7 +31,48 @@ $ secretspec check --provider env
 $ secretspec run --provider env -- npm start
 ```
 
-### CI/CD Integration
+## Configuration
+
+The env provider accepts no configuration options:
+
+```bash
+# All these are equivalent
+$ secretspec check --provider env
+$ secretspec check --provider env:
+$ secretspec check --provider env://
+```
+
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+injected = "env"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["injected"] }
+```
+
+## Storage model
+
+Convention secrets read the environment variable with the same name. The
+provider reads only the current process environment, never writes variables,
+and does not persist values.
+
+## Use existing secrets
+
+A secret's
+[`ref`](/reference/configuration/#secret-references) field reads a different
+variable, which is useful when your infrastructure already exposes a value under
+another name: `item` is the variable name, case-sensitive and preserved verbatim
+(`field` is not supported). Like the rest of this provider, references are
+read-only.
+
+```toml
+[profiles.default]
+DATABASE_URL = { description = "DB", ref = { item = "POSTGRES_CONNECTION_STRING" }, providers = ["env"] }
+```
+
+## CI/CD
 
 ```yaml
 # GitHub Actions
@@ -62,3 +83,9 @@ $ secretspec run --provider env -- npm start
   run: |
     secretspec run --provider env -- npm run deploy
 ```
+
+## When to use
+
+- Running in CI/CD pipelines where secrets are injected as environment variables
+- Testing with temporary environment variables
+- Working with containerized applications that use environment variables

--- a/docs/src/content/docs/providers/gcsm.md
+++ b/docs/src/content/docs/providers/gcsm.md
@@ -5,16 +5,53 @@ description: Google Cloud Secret Manager integration
 
 The Google Cloud Secret Manager provider integrates with GCP for centralized secret management.
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `gcsm` |
+| URI | `gcsm://PROJECT_ID` |
+| Access | Read and write; secret references are read-only |
+| Best for | Workloads and teams on Google Cloud |
+| Authentication | Google Application Default Credentials |
+| Build feature | `gcsm` |
+| Default storage | `secretspec-{project}-{profile}-{key}` |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider gcsm://my-gcp-project
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to gcsm (profile: default)
+
+# Run with secrets
+$ secretspec run --provider gcsm://my-gcp-project -- npm start
+```
+
+## Setup
+
+### Prerequisites
 
 - Google Cloud CLI (`gcloud`)
 - GCP project with Secret Manager API enabled
-- Authenticated via `gcloud auth application-default login`
 - Build with `--features gcsm`
+
+### Authentication
+
+Google Cloud Secret Manager uses Application Default Credentials. For local
+development:
+
+```bash
+$ gcloud auth application-default login
+```
+
+In Google Cloud runtimes, Application Default Credentials use the attached
+service account automatically.
 
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 gcsm://PROJECT_ID
@@ -22,26 +59,31 @@ gcsm://PROJECT_ID
 
 - `PROJECT_ID`: Your GCP project ID
 
-### Examples
+### URI examples
 
-```bash
-# Set a secret
-$ secretspec set DATABASE_URL --provider gcsm://my-gcp-project
-
-# Get a secret
-$ secretspec get DATABASE_URL --provider gcsm://my-gcp-project
-
-# Check secrets
-$ secretspec check --provider gcsm://my-gcp-project
-
-# Run with secrets
-$ secretspec run --provider gcsm://my-gcp-project -- npm start
+```text
+gcsm://my-gcp-project
 ```
 
-## Secret References
+### Project configuration
 
-By default each secret is stored as `secretspec-{project}-{profile}-{key}`. A
-secret's [`ref`](/reference/configuration/#secret-references) field names an
+```toml title="secretspec.toml"
+[providers]
+google = "gcsm://my-gcp-project"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["google"] }
+```
+
+## Storage model
+
+Secrets are stored as `secretspec-{project}-{profile}-{key}`. For example,
+project `myapp`, profile `production`, and key `DATABASE_URL` map to
+`secretspec-myapp-production-DATABASE_URL`.
+
+## Use existing secrets
+
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
 existing secret instead: `item` is the secret id, and the optional `version`
 pins a version (defaults to latest; `field` is not supported). References are
 **read-only** in this provider.
@@ -52,27 +94,7 @@ DATABASE_URL = { description = "DB", ref = { item = "database-url" }, providers 
 SIGNING_KEY = { description = "Key", ref = { item = "signing-key", version = "3" }, providers = ["gcsm://my-gcp-project"] }
 ```
 
-## Usage
-
-### Basic Commands
-
-```bash
-# Set a secret
-$ secretspec set DATABASE_URL --provider gcsm://my-gcp-project
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-✓ Secret 'DATABASE_URL' saved to gcsm (profile: default)
-
-# Import from .env
-$ secretspec import dotenv://.env
-```
-
-### Secret Naming
-
-Secrets are stored as: `secretspec-{project}-{profile}-{key}`
-
-Example: `secretspec-myapp-production-DATABASE_URL`
-
-### CI/CD with Service Accounts
+## CI/CD
 
 ```bash
 # Set credentials

--- a/docs/src/content/docs/providers/gopass.md
+++ b/docs/src/content/docs/providers/gopass.md
@@ -6,11 +6,40 @@ description: GPG-encrypted, git-synced password store integration
 The Gopass provider integrates with [gopass](https://www.gopass.pw/), a multi-user, multi-store abstraction layer on top of `pass` that keeps secrets GPG-encrypted and syncs them via git.
 
 :::note[Version compatibility]
-The Gopass provider is an upcoming SecretSpec 0.15 feature and is not available
-in SecretSpec 0.14.
+Available since SecretSpec 0.15.
 :::
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `gopass` |
+| URI | `gopass://[folder_prefix]` |
+| Access | Read and write |
+| Best for | GPG-encrypted, git-synced, multi-user password stores |
+| Authentication | The GPG key configured for the password store |
+| Availability | SecretSpec 0.15+ |
+| Default storage | `secretspec/{project}/{profile}/{key}` |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider gopass
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret DATABASE_URL saved to gopass
+
+# Get a secret
+$ secretspec get DATABASE_URL --provider gopass
+postgresql://localhost/mydb
+
+# Run with secrets
+$ secretspec run --provider gopass -- npm start
+```
+
+## Setup
+
+### Prerequisites
 
 Install the `gopass` CLI and initialize a password store:
 ```bash
@@ -24,9 +53,14 @@ sudo apt install gopass
 nix-env -iA nixpkgs.gopass
 ```
 
+### Authentication
+
+SecretSpec uses the GPG identities configured by `gopass`. Confirm that the
+target store is initialized and can be unlocked before using the provider.
+
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 gopass://[folder_prefix]
@@ -34,19 +68,30 @@ gopass://[folder_prefix]
 
 - `folder_prefix`: Optional path prefix supporting `{project}`, `{profile}`, and `{key}` placeholders. Defaults to `secretspec/{project}/{profile}/{key}`.
 
-### Examples
+### URI examples
 
-```bash
-# Use default gopass storage
-$ secretspec set DATABASE_URL --provider gopass
-
-# Custom folder prefix (e.g., to share secrets across projects — see below)
-$ secretspec set DATABASE_URL --provider "gopass://secretspec/shared/{profile}/{key}"
+```text
+gopass
+gopass://secretspec/shared/{profile}/{key}
 ```
 
-## Secret References
+### Project configuration
 
-By default each secret is stored under `secretspec/{project}/{profile}/{key}`.
+```toml title="secretspec.toml"
+[providers]
+team = "gopass://"
+
+[profiles.default]
+DATABASE_URL = { description = "Database URL", providers = ["team"] }
+```
+
+## Storage model
+
+Each secret is stored under `secretspec/{project}/{profile}/{key}`. Gopass
+encrypts the entry with GPG and can synchronize the password store through git.
+
+## Use existing secrets
+
 A secret's [`ref`](/reference/configuration/#secret-references) field names an
 existing entry instead: `item` is the full entry path, including any mount-point
 prefix for multi-store setups (`field` is not supported). Reads and writes
@@ -57,27 +102,9 @@ target that entry in place.
 DATABASE_URL = { description = "Production DB", ref = { item = "work-store/infra/postgres" }, providers = ["gopass"] }
 ```
 
-## Usage
+## Advanced configuration
 
-```bash
-# Set a secret
-$ secretspec set DATABASE_URL
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-✓ Secret DATABASE_URL saved to gopass
-
-# Get a secret
-$ secretspec get DATABASE_URL
-postgresql://localhost/mydb
-
-# Run with secrets
-$ secretspec run -- npm start
-
-# Use with profiles
-$ secretspec set API_KEY --profile production
-$ secretspec run --profile production -- npm start
-```
-
-## Shared Secrets
+### Shared secrets
 
 By default, secrets are stored under `secretspec/{project}/{profile}/{key}`, which isolates them per project. To share secrets across projects, use a custom folder prefix via the URI:
 
@@ -97,7 +124,7 @@ ARTIFACTORY_USER = { description = "Artifactory user", providers = ["shared"] }
 
 Both projects will resolve `ARTIFACTORY_USER` from `secretspec/shared/default/ARTIFACTORY_USER`.
 
-## Limitations
+## Troubleshooting and limitations
 
 Only the first line of an entry is read back — if an entry was written outside
 of `secretspec` and contains multiple lines, everything after the first line is

--- a/docs/src/content/docs/providers/infisical.md
+++ b/docs/src/content/docs/providers/infisical.md
@@ -11,15 +11,87 @@ The Infisical provider is an upcoming SecretSpec 0.16 feature and is not availab
 in SecretSpec 0.15.
 :::
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `infisical` |
+| URI | `infisical://[host]/PROJECT_ID[?options]` |
+| Access | Read and write; version-pinned references are read-only |
+| Best for | Infisical Cloud or self-hosted Infisical deployments |
+| Authentication | Universal Auth machine identity or access token |
+| Availability | Upcoming in SecretSpec 0.16; requires the `infisical` build feature |
+| Default storage | Key `{key}` in `{path}/{project}/{profile}` |
+
+## Quick start
+
+```bash
+# Store a secret
+$ secretspec set DATABASE_URL --provider "infisical://app.infisical.com/7e2f1a4c-...?env=dev"
+
+# Verify every secret is set
+$ secretspec check --provider "infisical://app.infisical.com/7e2f1a4c-...?env=dev"
+
+# Run with secrets injected
+$ secretspec run --provider "infisical://app.infisical.com/7e2f1a4c-...?env=dev" -- npm start
+```
+
+Secrets sharing a folder are fetched in one request, so a run costs one call
+per folder rather than one per secret.
+
+## Setup
+
+### Prerequisites
 
 - An Infisical project
-- A machine identity with access to it (see [Authentication](#authentication))
+- A machine identity with access to it
 - Build with `--features infisical`
+
+### Universal Auth machine identity
+
+Create a machine identity in Infisical, grant it access to the project, and set:
+
+```bash
+$ export INFISICAL_CLIENT_ID=...
+$ export INFISICAL_CLIENT_SECRET=...
+```
+
+The provider exchanges these for a short-lived access token once per run.
+
+### Access token
+
+A token minted elsewhere can be used directly:
+
+```bash
+$ export INFISICAL_TOKEN=...
+```
+
+Service tokens are not supported: Infisical deprecated them in favour of
+machine identities.
+
+### Credentials from another provider
+
+A machine identity's credentials can live in another store rather than in the
+environment, declared as
+[provider credentials](/concepts/providers/#provider-credentials):
+
+```toml title="secretspec.toml"
+[providers.infisical]
+uri = "infisical://app.infisical.com/7e2f1a4c-..."
+
+[providers.infisical.credentials]
+client_id = "keyring"
+client_secret = "keyring"
+```
+
+The provider declares `client_id` and `client_secret` for Universal Auth, and
+`token` for a ready-made access token. Each falls back to its corresponding
+environment variable when it is not declared. Use
+`secretspec config provider login infisical` to store declared credentials.
 
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 infisical://[host]/{project-id}[?env=slug&path=/prefix&tls=false]
@@ -34,23 +106,28 @@ infisical://[host]/{project-id}[?env=slug&path=/prefix&tls=false]
 
 Infisical's API addresses a project by UUID, not by the slug shown in its UI.
 
-### Examples
+### URI examples
 
-```bash
-# Infisical Cloud (US, and the default host)
-secretspec set DATABASE_URL --provider infisical://app.infisical.com/7e2f1a4c-...
-
-# Infisical Cloud (EU)
-secretspec check --provider infisical://eu.infisical.com/7e2f1a4c-...
-
-# Self-hosted
-secretspec run --provider infisical://vault.example.com/7e2f1a4c-... -- npm start
-
-# Self-hosted over plain HTTP
-secretspec run --provider "infisical://localhost:8080/7e2f1a4c-...?tls=false" -- npm start
+```text
+infisical://app.infisical.com/7e2f1a4c-...
+infisical://eu.infisical.com/7e2f1a4c-...
+infisical://vault.example.com/7e2f1a4c-...
+infisical://localhost:8080/7e2f1a4c-...?tls=false
 ```
 
-## Profiles and environments
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+infisical = "infisical://app.infisical.com/7e2f1a4c-...?env=prod"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["infisical"] }
+```
+
+## Storage model
+
+### Profiles and environments
 
 By default a SecretSpec profile names the Infisical environment: a `production` profile reads the
 `production` environment, and `dev` reads `dev`. New Infisical projects come with `dev`, `staging`
@@ -77,7 +154,7 @@ infisical_prod = "infisical://app.infisical.com/7e2f1a4c-...?env=prod"
 DATABASE_URL = { description = "Production database", providers = ["infisical_prod"] }
 ```
 
-### Secret Naming
+### Secret naming
 
 Secrets are stored under the folder `{path}/{project}/{profile}`, in the environment named by the
 profile (or by `?env=`):
@@ -96,14 +173,17 @@ renamed.
 
 Folders are created as needed when writing a secret.
 
-## Secret References
+## Use existing secrets
 
 A secret can name one Infisical secret by its own coordinates, instead of SecretSpec's layout:
 
 ```toml
+[providers]
+infisical_prod = "infisical://app.infisical.com/7e2f1a4c-...?env=prod"
+
 [profiles.production]
-DATABASE_URL = { description = "Postgres DSN", ref = { item = "/infra/shared/DB_PASSWORD" } }
-API_KEY = { description = "Pinned key", ref = { item = "/infra/API_KEY", version = "3" } }
+DATABASE_URL = { description = "Postgres DSN", ref = { item = "/infra/shared/DB_PASSWORD" }, providers = ["infisical_prod"] }
+API_KEY = { description = "Pinned key", ref = { item = "/infra/API_KEY", version = "3" }, providers = ["infisical_prod"] }
 ```
 
 - `item`: the folder and key. A leading slash names the environment's root — `/infra/shared/DB_PASSWORD`
@@ -116,77 +196,31 @@ A ref has no profile to name an environment with, so the provider URI must pin o
 Infisical secrets are single values with no sub-components, so `field`, `section` and `vault` are
 rejected.
 
-## Imported folders
+## CI/CD
+
+Use Universal Auth credentials stored in the CI platform, or provide an access
+token minted by your deployment environment:
+
+```bash
+$ export INFISICAL_CLIENT_ID="$CI_INFISICAL_CLIENT_ID"
+$ export INFISICAL_CLIENT_SECRET="$CI_INFISICAL_CLIENT_SECRET"
+$ secretspec run --provider "infisical://app.infisical.com/7e2f1a4c-...?env=prod" -- deploy
+```
+
+## Advanced configuration
+
+### Imported folders
 
 A folder that imports another resolves the imported keys too, with Infisical's own precedence: a
 secret defined directly in the folder wins over an imported one, and a later import wins over an
 earlier one. This matches their CLI, so a value reads the same way through either tool.
 
-## Secret references inside values
+### Secret references inside values
 
 Values are read with Infisical's own `${...}` references expanded, matching its CLI, so a value of
 `postgres://${DB_USER}@host` arrives resolved.
 
-## Authentication
-
-### Universal Auth (machine identity)
-
-Create a machine identity in Infisical, grant it access to the project, and set:
-
-```bash
-export INFISICAL_CLIENT_ID=...
-export INFISICAL_CLIENT_SECRET=...
-```
-
-The provider exchanges these for a short-lived access token once per run.
-
-### Token
-
-A token minted elsewhere is used as it stands, which is what CI often has to hand:
-
-```bash
-export INFISICAL_TOKEN=...
-```
-
-Service tokens are not supported: Infisical deprecated them in favour of machine identities.
-
-### Sourcing credentials from another provider
-
-A machine identity's credentials can live in another store rather than in the environment, declared
-as [provider credentials](/concepts/providers/#provider-credentials):
-
-```toml title="secretspec.toml"
-[providers]
-infisical = { uri = "infisical://app.infisical.com/7e2f1a4c-...", credentials = {
-  client_id = "keyring",
-  client_secret = "keyring",
-} }
-```
-
-The provider declares three credentials: `client_id` and `client_secret` for Universal Auth, and
-`token` for a ready-made access token. Each falls back to its environment variable
-(`INFISICAL_CLIENT_ID`, `INFISICAL_CLIENT_SECRET`, `INFISICAL_TOKEN`) when not declared here.
-
-`secretspec config provider login infisical` prompts for each and stores it where resolution later
-reads it from.
-
-## Usage
-
-```bash
-# Store a secret
-secretspec set DATABASE_URL --provider infisical://app.infisical.com/7e2f1a4c-...
-
-# Verify every secret is set
-secretspec check --provider infisical://app.infisical.com/7e2f1a4c-...
-
-# Run with secrets injected
-secretspec run --provider infisical://app.infisical.com/7e2f1a4c-... -- npm start
-```
-
-Secrets sharing a folder are fetched in one request, so a run costs one call per folder rather than
-one per secret.
-
-## Self-hosting
+### Self-hosting
 
 Point the URI at the instance, or set `INFISICAL_DOMAIN`:
 
@@ -198,13 +232,13 @@ secretspec run --provider "infisical:///7e2f1a4c-..." -- npm start
 Infisical's legacy `INFISICAL_API_URL` is honoured too, so an instance already configured for
 their CLI works unchanged. `INFISICAL_DOMAIN` wins when both are set, matching the CLI.
 
-## Approval policies
+### Approval policies
 
 A project under an approval policy turns a write into a change request: Infisical stores nothing
 until a human merges it. `secretspec set` reports that rather than claiming the secret was stored,
 so the value is written once the request is approved.
 
-## Limitations
+## Troubleshooting and limitations
 
 - The project is addressed by UUID; Infisical's API does not accept a project slug
 - A project or profile whose name is not spellable as an Infisical folder (letters, digits, dashes,

--- a/docs/src/content/docs/providers/keyring.md
+++ b/docs/src/content/docs/providers/keyring.md
@@ -5,13 +5,42 @@ description: Secure system credential store integration
 
 The Keyring provider stores secrets in your system's native credential store. Recommended for local development.
 
-## Supported Platforms
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `keyring` |
+| URI | `keyring://[folder_prefix]` |
+| Access | Read and write |
+| Best for | Secure local development |
+| Authentication | Current operating-system user |
+| Default storage | `secretspec/{project}/{profile}/{key}` |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider keyring
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret DATABASE_URL saved to keyring
+
+# Get a secret
+$ secretspec get DATABASE_URL --provider keyring
+postgresql://localhost/mydb
+
+# Run with secrets
+$ secretspec run --provider keyring -- npm start
+```
+
+## Setup
+
+### Supported platforms
 
 - **macOS**: Keychain
 - **Windows**: Credential Manager
 - **Linux**: Secret Service (GNOME Keyring, KWallet)
 
-## Installation
+### Linux prerequisites
 
 Linux only - install if missing:
 ```bash
@@ -27,7 +56,7 @@ $ sudo pacman -S gnome-keyring
 
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 keyring://[folder_prefix]
@@ -35,20 +64,32 @@ keyring://[folder_prefix]
 
 - `folder_prefix`: Optional path prefix supporting `{project}`, `{profile}`, and `{key}` placeholders. Defaults to `secretspec/{project}/{profile}/{key}`.
 
-### Examples
+### URI examples
 
-```bash
-# Use default keyring storage
-$ secretspec set DATABASE_URL --provider keyring
-
-# Custom folder prefix (e.g., to share secrets across projects — see below)
-$ secretspec set DATABASE_URL --provider "keyring://shared/{profile}/{key}"
+```text
+keyring
+keyring://shared/{profile}/{key}
 ```
 
-## Secret References
+### Project configuration
 
-By default each secret is stored under `secretspec/{project}/{profile}/{key}` with
-the current system username as the account. A secret's
+```toml title="secretspec.toml"
+[providers]
+local = "keyring://"
+
+[profiles.default]
+DATABASE_URL = { description = "Database URL", providers = ["local"] }
+```
+
+## Storage model
+
+Each secret is stored under `secretspec/{project}/{profile}/{key}` as the
+keyring service, with the current system username as the account. Project and
+profile names keep convention secrets isolated.
+
+## Use existing secrets
+
+A secret's
 [`ref`](/reference/configuration/#secret-references) field names an exact keyring
 entry instead, useful for reading a credential another application already
 stored: `item` is the service, and the optional `field` is the account
@@ -60,27 +101,9 @@ place.
 API_TOKEN = { description = "Token", ref = { item = "com.example.app", field = "me@example.com" }, providers = ["keyring"] }
 ```
 
-## Usage
+## Advanced configuration
 
-```bash
-# Set a secret
-$ secretspec set DATABASE_URL
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-✓ Secret DATABASE_URL saved to keyring
-
-# Get a secret
-$ secretspec get DATABASE_URL
-postgresql://localhost/mydb
-
-# Run with secrets
-$ secretspec run -- npm start
-
-# Use with profiles
-$ secretspec set API_KEY --profile production
-$ secretspec run --profile production -- npm start
-```
-
-## Shared Secrets
+### Shared secrets
 
 By default, secrets are stored under `secretspec/{project}/{profile}/{key}`, which isolates them per project. To share secrets across projects, use a custom folder prefix via the URI:
 

--- a/docs/src/content/docs/providers/lastpass.md
+++ b/docs/src/content/docs/providers/lastpass.md
@@ -5,7 +5,34 @@ description: LastPass password manager integration
 
 The LastPass provider integrates with LastPass password manager for secure cloud-based secret storage.
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `lastpass` |
+| URI | `lastpass://[item_template]` |
+| Access | Read and write |
+| Best for | Teams already using LastPass |
+| Authentication | An authenticated `lpass` CLI session |
+| Default storage | `secretspec/{project}/{profile}/{key}` |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider lastpass
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+
+# Get a secret
+$ secretspec get DATABASE_URL --provider lastpass
+
+# Run with secrets
+$ secretspec run --provider lastpass -- npm start
+```
+
+## Setup
+
+### Prerequisites
 
 Install LastPass CLI:
 ```bash
@@ -19,36 +46,57 @@ sudo apt install lastpass-cli
 nix-env -iA nixpkgs.lastpass-cli
 ```
 
-## Configuration
-
-### URI Format
-
-```bash
-# Basic
-lastpass
-
-# With folder prefix
-lastpass://folder_name
-lastpass://Work/Projects
-```
-
 ### Authentication
 
 ```bash
 # Standard login
-lpass login your-email@example.com
+$ lpass login your-email@example.com
 
 # Trust device (reduces MFA prompts)
-lpass login --trust your-email@example.com
-
-# CI/CD environments
-export LPASS_DISABLE_PINENTRY=1
-echo "password" | lpass login --trust your-email@example.com
+$ lpass login --trust your-email@example.com
 ```
 
-## Secret References
+## Configuration
 
-By default each secret maps to an item named `secretspec/{project}/{profile}/{key}`.
+### URI format
+
+```
+lastpass://[item_template]
+```
+
+`item_template` is optional and replaces the default
+`secretspec/{project}/{profile}/{key}` layout. It supports the `{project}`,
+`{profile}`, and `{key}` placeholders. Include `{key}` unless every SecretSpec
+key should resolve to the same LastPass item.
+
+### URI examples
+
+```bash
+# Default SecretSpec layout
+lastpass
+
+# Keep SecretSpec items in a team folder
+lastpass://Work/SecretSpec/{project}/{profile}/{key}
+```
+
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+team = "lastpass://"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["team"] }
+```
+
+## Storage model
+
+By default, each secret maps to an item named
+`secretspec/{project}/{profile}/{key}`. A custom `item_template` replaces that
+layout; include all placeholders needed to keep secrets distinct.
+
+## Use existing secrets
+
 A secret's [`ref`](/reference/configuration/#secret-references) field names an
 existing item instead: `item` is the full item name, including any folder
 (`field` is not supported). Reads and writes target that item in place.
@@ -58,26 +106,12 @@ existing item instead: `item` is the full item name, including any folder
 DATABASE_URL = { description = "DB", ref = { item = "Shared-Infra/Production DB" }, providers = ["lastpass"] }
 ```
 
-## Usage
+## CI/CD
 
 ```bash
-# Set a secret
-secretspec set DATABASE_URL --provider lastpass
-Enter value for DATABASE_URL: postgresql://localhost/mydb
+# Disable interactive pinentry and authenticate with a CI-managed password
+$ export LPASS_DISABLE_PINENTRY=1
+$ echo "$LASTPASS_PASSWORD" | lpass login --trust your-email@example.com
 
-# Set with folder
-secretspec set API_KEY --provider lastpass://Production
-Enter value for API_KEY: sk-123456
-
-# Get a secret
-secretspec get DATABASE_URL --provider lastpass
-
-# Run with secrets
-secretspec run --provider lastpass -- npm start
-
-# Profile-specific secrets
-secretspec set DATABASE_URL --profile dev --provider lastpass://Development
-secretspec set DATABASE_URL --profile prod --provider lastpass://Production
+$ secretspec run --provider lastpass -- deploy
 ```
-
-Secrets are stored as: `{folder_prefix}/{profile}/{project}/{key}`

--- a/docs/src/content/docs/providers/onepassword.md
+++ b/docs/src/content/docs/providers/onepassword.md
@@ -5,15 +5,40 @@ description: OnePassword secrets management integration
 
 The OnePassword provider integrates with OnePassword for team-based secret management with advanced access controls.
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `onepassword` |
+| URI | `onepassword://[account@]vault` |
+| Access | Read and write |
+| Best for | Team-managed secrets in 1Password vaults |
+| Authentication | Desktop app integration, a service account token, or a legacy shell session |
+| Default storage | Secure Note `secretspec/{project}/{profile}/{key}` |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider onepassword://Production
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret DATABASE_URL saved to OnePassword
+
+# Get a secret
+$ secretspec get DATABASE_URL --provider onepassword://Production
+
+# Run with secrets
+$ secretspec run --provider onepassword://Production -- npm start
+```
+
+## Setup
+
+### Prerequisites
 
 - OnePassword CLI (`op`)
 - OnePassword account
-- Authenticated (see [Authentication](#authentication) below)
 
-## Authentication
-
-`secretspec` supports three ways to authenticate against 1Password.
+Choose one of the following authentication methods.
 
 ### Desktop app integration (recommended for local dev)
 
@@ -40,12 +65,9 @@ Manager only) does **not** carry the setgid bit and desktop
 integration will fail; use the NixOS module, or fall back to a
 service account token for headless setups.
 
-### Service account tokens (recommended for CI/CD)
+### Service account token
 
-In SecretSpec 0.14, supply the service account token through
-`OP_SERVICE_ACCOUNT_TOKEN` or the `onepassword+token://` URI scheme.
-
-Starting with SecretSpec 0.15, you can instead declare it as a
+In SecretSpec 0.15 and later, you can declare the token as a
 [provider credential](/concepts/providers/#provider-credentials), for example
 to load it from your keyring:
 
@@ -54,10 +76,9 @@ to load it from your keyring:
 op = { uri = "onepassword://Production", credentials = { service_account_token = "keyring" } }
 ```
 
-In 0.15 and later, the provider continues to support
-`OP_SERVICE_ACCOUNT_TOKEN` and the `onepassword+token://` URI scheme when no
-explicit `service_account_token` is supplied. See the
-[CI/CD section](#cicd-with-service-accounts) below.
+When no explicit `service_account_token` is supplied, the provider falls back
+to `OP_SERVICE_ACCOUNT_TOKEN` or the `onepassword+token://` URI scheme. These
+fallbacks also work in SecretSpec 0.14.
 
 ### Manual signin (legacy)
 
@@ -67,7 +88,7 @@ expire after 30 minutes of inactivity; if they expire mid-session,
 
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 onepassword://[account@]vault
@@ -79,29 +100,37 @@ onepassword+token://[token@]vault
 - `token`: Service account token
 
 The URI names a vault only; item paths (e.g. `onepassword://Vault/item/field`)
-are rejected. To name a specific item, use a [secret reference](#secret-references).
+are rejected. To name a specific item, see [Use existing secrets](#use-existing-secrets).
 
-### Examples
+### URI examples
 
-```bash
-# Use specific vault
-$ secretspec set API_KEY --provider onepassword://Production
-
-# Use specific account and vault
-$ secretspec set DATABASE_URL --provider "onepassword://work@DevVault"
-
-# Use service account token
-$ secretspec set SECRET --provider "onepassword+token://ops_token123@Production"
-
-# Default vault (Private)
-$ secretspec set KEY --provider onepassword://
+```text
+onepassword://Production
+onepassword://work@DevVault
+onepassword+token://ops_token123@Production
+onepassword://
 ```
 
-## Secret References
+### Project configuration
 
-By default, secretspec manages its own items in 1Password (Secure Notes named
-`secretspec/{project}/{profile}/{key}`). If your secrets already live in
-1Password items you manage yourself, name those items with the
+```toml title="secretspec.toml"
+[providers]
+team = "onepassword://Production"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["team"] }
+```
+
+## Storage model
+
+SecretSpec creates Secure Notes named
+`secretspec/{project}/{profile}/{key}` in the selected vault. The secret value
+is stored in the note's `value` field.
+
+## Use existing secrets
+
+If your secrets already live in 1Password items you manage yourself, name those
+items with the
 [`ref`](/reference/configuration/#secret-references) field and route the secret
 at a vault with `providers`:
 
@@ -140,35 +169,24 @@ produces an error that spells out the translation:
 DATABASE_URL = { description = "Production DB", ref = { vault = "Infra", item = "Postgres", field = "connection-url" }, providers = ["onepassword://Infra"] }
 ```
 
-## Usage
+## Advanced configuration
 
-### Basic Commands
-
-```bash
-# Set a secret
-$ secretspec set DATABASE_URL
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-✓ Secret DATABASE_URL saved to OnePassword
-
-# Get a secret
-$ secretspec get DATABASE_URL
-
-# Run with secrets
-$ secretspec run -- npm start
-```
-
-### Profile Configuration
+### Profile configuration
 
 ```toml
 # secretspec.toml
-[development]
-provider = "onepassword://Development"
+[providers]
+development = "onepassword://Development"
+production = "onepassword://Production"
 
-[production]
-provider = "onepassword://Production"
+[profiles.development.defaults]
+providers = ["development"]
+
+[profiles.production.defaults]
+providers = ["production"]
 ```
 
-### CI/CD with Service Accounts
+## CI/CD
 
 ```bash
 # Set token

--- a/docs/src/content/docs/providers/pass.md
+++ b/docs/src/content/docs/providers/pass.md
@@ -5,7 +5,31 @@ description: Unix password manager integration with GPG encryption
 
 The Pass provider stores secrets using the Unix password manager `pass` (password-store). Secrets are GPG-encrypted for secure local development.
 
-## Installation
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `pass` |
+| URI | `pass://[folder_prefix][?store_dir=/path/to/store]` |
+| Access | Read and write |
+| Best for | Local, GPG-encrypted secret storage |
+| Authentication | The GPG key configured for the password store |
+| Default storage | `secretspec/{project}/{profile}/{key}` |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider pass
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+
+# Run with secrets
+$ secretspec run --provider pass -- npm start
+```
+
+## Setup
+
+### Prerequisites
 
 ```bash
 # Debian/Ubuntu
@@ -21,9 +45,18 @@ $ sudo pacman -S pass
 $ brew install pass
 ```
 
+### Authentication
+
+SecretSpec uses the GPG identity configured for the password store. Initialize
+the store once if needed:
+
+```bash
+$ pass init <gpg-key-id>
+```
+
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 pass://[folder_prefix][?store_dir=/path/to/store]
@@ -32,47 +65,25 @@ pass://[folder_prefix][?store_dir=/path/to/store]
 - `folder_prefix`: Optional path prefix supporting `{project}`, `{profile}`, and `{key}` placeholders. Defaults to `secretspec/{project}/{profile}/{key}`.
 - `store_dir`: Optional password store directory. When set, it is exported as `PASSWORD_STORE_DIR` for every `pass` invocation, overriding the default `~/.password-store`. The variable is scoped to the spawned `pass` process and does not affect secretspec's own environment.
 
-### Examples
+### URI examples
 
-```bash
-# Use default pass storage
-$ secretspec set DATABASE_URL --provider pass
-
-# Custom folder prefix (e.g., to share secrets across projects — see below)
-$ secretspec set DATABASE_URL --provider "pass://shared/{profile}/{key}"
-
-# Custom password store directory
-$ secretspec set DATABASE_URL --provider "pass://?store_dir=/path/to/store"
+```text
+pass
+pass://shared/{profile}/{key}
+pass://?store_dir=/path/to/store
 ```
 
-## Secret References
+### Project configuration
 
-By default each secret is stored at `secretspec/{project}/{profile}/{key}`. A
-secret's [`ref`](/reference/configuration/#secret-references) field names an
-existing store entry instead, letting you read credentials you already keep in
-`pass`: `item` is the entry path (`field` is not supported). Reads and writes
-target that entry in place.
+```toml title="secretspec.toml"
+[providers]
+local = "pass://"
 
-```toml
 [profiles.default]
-GITHUB_TOKEN = { description = "GH token", ref = { item = "github/token" }, providers = ["pass"] }
+DATABASE_URL = { description = "Database URL", providers = ["local"] }
 ```
 
-## Usage
-
-```bash
-# Initialize password store (first time only)
-$ pass init <gpg-key-id>
-
-# Set a secret
-$ secretspec set DATABASE_URL
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-
-# Run with secrets
-$ secretspec run -- npm start
-```
-
-## Storage Format
+## Storage model
 
 Secrets are stored with a hierarchical path structure:
 `secretspec/{project}/{profile}/{key}`
@@ -83,7 +94,21 @@ $ pass show secretspec/myapp/default/DATABASE_URL
 postgresql://localhost/mydb
 ```
 
-## Shared Secrets
+## Use existing secrets
+
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing store entry instead, letting you read credentials you already keep in
+`pass`: `item` is the entry path (`field` is not supported). Reads and writes
+target that entry in place.
+
+```toml
+[profiles.default]
+GITHUB_TOKEN = { description = "GH token", ref = { item = "github/token" }, providers = ["pass"] }
+```
+
+## Advanced configuration
+
+### Shared secrets
 
 By default, secrets are stored under `secretspec/{project}/{profile}/{key}`, which isolates them per project. To share secrets across projects, use a custom folder prefix via the URI:
 

--- a/docs/src/content/docs/providers/protonpass.md
+++ b/docs/src/content/docs/providers/protonpass.md
@@ -5,15 +5,52 @@ description: Proton Pass integration via the official pass-cli
 
 The Proton Pass provider integrates with [Proton Pass](https://proton.me/pass) for end-to-end encrypted cloud secret storage.
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `protonpass` |
+| URI | `protonpass://[vault_name[/title-template]]` |
+| Access | Read and write |
+| Best for | End-to-end encrypted cloud storage through Proton Pass |
+| Authentication | A `pass-cli` login or personal access token |
+| Default storage | Note item `{project}/{profile}/{key}` in the `secretspec` vault |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider protonpass://Personal
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+
+# Get a secret
+$ secretspec get DATABASE_URL --provider protonpass://Personal
+
+# Run with secrets
+$ secretspec run --provider protonpass://Personal -- npm start
+```
+
+## Setup
+
+### Prerequisites
 
 - Proton Pass CLI (`pass-cli`) - download from [proton.me/pass/download](https://proton.me/pass/download)
 - A Proton account, signed in via `pass-cli login`
 - A vault to store secrets in (e.g. `pass-cli vault create secretspec`)
 
+### Authentication
+
+For local use, sign in interactively:
+
+```bash
+$ pass-cli login
+```
+
+For CI, use a personal access token as shown in [CI/CD](#cicd).
+
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 protonpass://[vault_name[/title-template]]
@@ -22,7 +59,7 @@ protonpass://[vault_name[/title-template]]
 - `vault_name`: Target vault (defaults to `secretspec`)
 - `title-template`: Item title pattern supporting `{project}`, `{profile}`, `{key}` placeholders
 
-### Examples
+### URI examples
 
 ```bash
 # Default vault ("secretspec")
@@ -35,10 +72,25 @@ protonpass://Work
 protonpass://Work/{project}/{profile}/{key}
 ```
 
-## Secret References
+### Project configuration
 
-By default each secret maps to an item titled `{project}/{profile}/{key}`. A
-secret's [`ref`](/reference/configuration/#secret-references) field names an
+```toml title="secretspec.toml"
+[providers]
+team = "protonpass://Work"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["team"] }
+```
+
+## Storage model
+
+Secrets are stored as note items. The vault defaults to `secretspec`, and the
+item title defaults to `{project}/{profile}/{key}`. The URI can select another
+vault or replace the title template.
+
+## Use existing secrets
+
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
 existing item instead: `item` is the exact item title, whose note is read
 (`field` is not supported). Reads and writes target that item in place.
 
@@ -47,26 +99,7 @@ existing item instead: `item` is the exact item title, whose note is read
 DATABASE_URL = { description = "DB", ref = { item = "Production Database" }, providers = ["protonpass://Work"] }
 ```
 
-## Usage
-
-```bash
-# Set a secret
-$ secretspec set DATABASE_URL --provider protonpass://Personal
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-
-# Get a secret
-$ secretspec get DATABASE_URL --provider protonpass://Personal
-
-# Run with secrets
-$ secretspec run --provider protonpass://Personal -- npm start
-
-# Profile-specific vault
-$ secretspec set DATABASE_URL --profile prod --provider protonpass://Production
-```
-
-Secrets are stored as note items; the item title defaults to `{project}/{profile}/{key}`.
-
-### CI/CD with Personal Access Tokens
+## CI/CD
 
 ```bash
 # Create a token
@@ -76,6 +109,8 @@ $ pass-cli personal-access-token create --name ci --expiration 1y
 $ pass-cli login --pat $PROTON_PASS_PAT
 $ secretspec run -- deploy
 ```
+
+## Advanced configuration
 
 ### Agent sessions
 

--- a/docs/src/content/docs/providers/vault.md
+++ b/docs/src/content/docs/providers/vault.md
@@ -5,16 +5,74 @@ description: HashiCorp Vault and OpenBao integration
 
 The Vault provider integrates with HashiCorp Vault and OpenBao for centralized secret management using the KV (Key-Value) secrets engine. Since OpenBao is an API-compatible fork of Vault, a single provider works for both.
 
-## Prerequisites
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `vault` or `openbao` |
+| URI | `vault://[namespace@]host[:port][/mount][?options]` |
+| Access | Read and write; secret references are read-only |
+| Best for | Self-managed, policy-controlled secret infrastructure |
+| Authentication | Token or AppRole |
+| Build feature | `vault` |
+| Default storage | KV path `secretspec/{project}/{profile}/{key}`, field `value` |
+
+## Quick start
+
+```bash
+# With default "secret" mount
+$ secretspec set DATABASE_URL --provider vault://vault.example.com:8200
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to vault (profile: default)
+
+# Using OpenBao
+$ secretspec check --provider openbao://bao.internal:8200/secret
+```
+
+## Setup
+
+### Prerequisites
 
 - A running Vault or OpenBao server
-- Authentication credentials (see [Authentication](#authentication))
+- Authentication credentials
 - KV secrets engine enabled (v1 or v2)
 - Build with `--features vault`
 
+### Token authentication
+
+Token authentication is the default. SecretSpec reads `VAULT_TOKEN` or
+`~/.vault-token`:
+
+```bash
+$ export VAULT_TOKEN=hvs.your-token-here
+```
+
+### AppRole authentication
+
+Select AppRole with `?auth=approle` and provide both environment variables:
+
+```bash
+$ export VAULT_ROLE_ID=your-role-id
+$ export VAULT_SECRET_ID=your-secret-id
+```
+
+Starting with SecretSpec 0.15, these credentials can instead be read from
+another provider so they do not live in a shell profile:
+
+```toml title="secretspec.toml"
+[providers.vault_approle]
+uri = "vault://vault.example.com:8200/secret?auth=approle"
+
+[providers.vault_approle.credentials]
+role_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } }
+secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } }
+```
+
+SecretSpec 0.14 supports only `VAULT_ROLE_ID` and `VAULT_SECRET_ID`.
+
 ## Configuration
 
-### URI Format
+### URI format
 
 ```
 vault://[namespace@]host[:port][/mount][?key=value&...]
@@ -28,26 +86,36 @@ openbao://[namespace@]host[:port][/mount][?key=value&...]
 - `?kv=1`: Use KV v1 engine (default: v2)
 - `?tls=false`: Disable TLS (for development servers)
 
-### Examples
+### URI examples
 
-```bash
-# Set a secret using Vault KV v2
-$ secretspec set DATABASE_URL --provider vault://vault.example.com:8200/secret
-
-# Get a secret
-$ secretspec get DATABASE_URL --provider vault://vault.example.com:8200/secret
-
-# Check secrets
-$ secretspec check --provider vault://vault.example.com:8200/secret
-
-# Run with secrets
-$ secretspec run --provider vault://vault.example.com:8200/secret -- npm start
+```text
+vault://vault.example.com:8200/secret
+vault://team-a@vault.example.com:8200/secret
+vault://vault.example.com:8200/secret?auth=approle
+openbao://bao.internal:8200/secret
 ```
 
-## Secret References
+### Project configuration
 
-By default each secret is stored at `secretspec/{project}/{profile}/{key}` under
-the mount, with a `value` field. A secret's
+```toml title="secretspec.toml"
+[providers]
+vault_prod = "vault://vault.example.com:8200/secret"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["vault_prod"] }
+```
+
+## Storage model
+
+Each secret is stored at `secretspec/{project}/{profile}/{key}` under the
+configured mount, with its value in a field named `value`.
+
+For KV v2, `DATABASE_URL` for project `myapp` and profile `production` is read
+from `GET /v1/secret/data/secretspec/myapp/production/DATABASE_URL`.
+
+## Use existing secrets
+
+A secret's
 [`ref`](/reference/configuration/#secret-references) field names an existing KV
 entry instead: `item` is the KV path relative to the mount, and `field` selects
 the field to read. `field` is required, since KV entries are maps. References
@@ -62,31 +130,26 @@ The mount is not a ref coordinate: it comes from the provider URI (`secret` in
 the example above). To read one secret from a different mount, give that secret
 a `providers` entry with the mount in the URI.
 
-## Usage
+## CI/CD
 
-### Basic Commands
+AppRole avoids relying on a user token in deployment environments:
 
 ```bash
-# With default "secret" mount
-$ secretspec set DATABASE_URL --provider vault://vault.example.com:8200
-Enter value for DATABASE_URL: postgresql://localhost/mydb
-✓ Secret 'DATABASE_URL' saved to vault (profile: default)
-
-# With custom mount
-$ secretspec set API_KEY --provider vault://vault.example.com:8200/custom-kv
-
-# Using OpenBao
-$ secretspec check --provider openbao://bao.internal:8200/secret
+$ export VAULT_ROLE_ID="$CI_VAULT_ROLE_ID"
+$ export VAULT_SECRET_ID="$CI_VAULT_SECRET_ID"
+$ secretspec run --provider "vault://vault.example.com:8200/secret?auth=approle" -- deploy
 ```
 
-### KV Version 1
+## Advanced configuration
+
+### KV version 1
 
 ```bash
 # Use KV v1 engine
 $ secretspec set DATABASE_URL --provider "vault://vault.example.com:8200/secret?kv=1"
 ```
 
-### Vault Namespaces
+### Vault namespaces
 
 ```bash
 # Using namespace in URI
@@ -97,15 +160,7 @@ $ export VAULT_NAMESPACE=team-a
 $ secretspec check --provider vault://vault.example.com:8200/secret
 ```
 
-### Secret Naming
-
-Secrets are stored at the KV path: `secretspec/{project}/{profile}/{key}`
-
-Each secret is stored as a KV entry with a `value` field.
-
-Example for KV v2: `GET /v1/secret/data/secretspec/myapp/production/DATABASE_URL`
-
-### Development Mode
+### Development mode
 
 For local development with Vault in dev mode:
 
@@ -116,44 +171,4 @@ $ vault server -dev
 # Use with TLS disabled
 $ export VAULT_TOKEN=hvs.dev-root-token
 $ secretspec check --provider "vault://127.0.0.1:8200/secret?tls=false"
-```
-
-### Authentication
-
-The authentication method is selected via the `auth` query parameter.
-
-#### Token (default)
-
-Reads the token from `VAULT_TOKEN` environment variable or `~/.vault-token` file.
-
-```bash
-export VAULT_TOKEN=hvs.your-token-here
-secretspec run --provider vault://vault.example.com:8200 -- npm start
-```
-
-#### AppRole
-
-Authenticates using `VAULT_ROLE_ID` and `VAULT_SECRET_ID` environment variables. Useful for CI/CD pipelines and deployment platforms where a static token is not appropriate.
-
-```bash
-export VAULT_ROLE_ID=your-role-id
-export VAULT_SECRET_ID=your-secret-id
-secretspec run --provider "vault://vault.example.com:8200/secret?auth=approle" -- deploy
-```
-
-#### Sourcing credentials from another provider
-
-:::note[Version compatibility]
-Sourcing Vault credentials from another provider is available starting with
-SecretSpec 0.15. In SecretSpec 0.14, use the Vault environment variables shown
-above.
-:::
-
-These credentials can be read from another provider instead of the environment, so a Vault token or AppRole credentials never live in a shell profile — see [Provider Credentials](/concepts/providers/#provider-credentials):
-
-```toml title="secretspec.toml"
-[providers.vault_prod]
-uri = "vault://vault.example.com:8200/secret?auth=approle"
-credentials = { role_id   = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "role_id" } },
-                secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-approle", field = "secret_id" } } }
 ```

--- a/docs/src/content/docs/reference/adding-providers.md
+++ b/docs/src/content/docs/reference/adding-providers.md
@@ -62,18 +62,68 @@ The documentation site is built from `main`, so it can describe code that has
 not reached the latest SecretSpec release yet. A new provider must not appear
 to be available in the currently released binary before it is published.
 
+### Provider page structure
+
+Provider pages should be predictable to scan. Keep the shared sections in the
+following relative order, inserting provider-specific topics where readers need
+them:
+
+1. A one-sentence description and, for an unreleased provider, the version
+   compatibility notice.
+2. **At a glance**: the provider name, URI, read/write behavior, best use case,
+   authentication, optional build feature or availability, and default storage
+   layout.
+3. **Quick start**: the shortest useful `set`, `get`, and `run` workflow.
+   Assume the reader completes the following setup section first; keep this
+   example focused on the successful path.
+4. **Setup**: prerequisites, authentication methods, and required permissions.
+5. **Configuration**: **URI format**, copyable **URI examples**, and a
+   **Project configuration** example showing a checked-in alias used by a
+   secret.
+6. **Storage model**: the exact provider-native name or path SecretSpec creates,
+   including how projects and profiles stay isolated.
+7. **Use existing secrets**: how `ref` maps to provider-native coordinates and
+   whether referenced secrets are writable.
+8. **CI/CD**, when machine authentication or deployment setup differs from
+   local use.
+9. **Advanced configuration** for optional provider-specific behavior.
+10. **Troubleshooting and limitations** or **Security considerations**, when
+    there are important operational constraints.
+
+Keep the at-a-glance table compact; explain edge cases in the relevant section
+instead of expanding the table. Start with this shape:
+
+```md
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `mybackend` |
+| URI | `mybackend://HOST[/path]` |
+| Access | Read and write |
+| Best for | The main workload or audience this provider serves |
+| Authentication | The identity or credential users need |
+| Build feature | `mybackend` |
+| Default storage | `secretspec/{project}/{profile}/{key}` |
+```
+
+Use sentence case for section headings. If a standard section does not apply,
+omit it rather than adding an empty placeholder. Keep command sequences in
+**Quick start** and list bare provider specifications in **URI examples** so
+the two sections do not repeat one another.
+
 When adding a provider for an upcoming release:
 
 1. Add a version notice near the top of the provider page:
 
    ```md
    :::note[Version compatibility]
-   The MyBackend provider is an upcoming SecretSpec 0.15 feature and is not
-   available in SecretSpec 0.14.
+   The MyBackend provider is an upcoming SecretSpec 0.16 feature and is not
+   available in SecretSpec 0.15.
    :::
    ```
 
-2. Mark the provider as `(0.15+)` anywhere it appears in a provider list,
+2. Mark the provider as `(0.16+)` anywhere it appears in a provider list,
    table, selector example, sidebar, landing page, README, or generated
    documentation description.
 3. If the provider changes authentication or configuration syntax, show the
@@ -95,8 +145,8 @@ Update every provider location; names otherwise drift out of sync:
 7. `README.md` — provider lists and provider selector example
 
 When the release is published, replace temporary wording such as “upcoming”
-and “not available in 0.14” with durable wording such as “Available since
-SecretSpec 0.15.” The `(0.15+)` labels may remain where knowing the minimum
+and “not available in 0.15” with durable wording such as “Available since
+SecretSpec 0.16.” The `(0.16+)` labels may remain where knowing the minimum
 version is useful.
 
 Apply the same rule to unreleased CLI commands and configuration fields:

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -152,10 +152,10 @@ Provider aliases may be declared in two places:
 On conflict the project-level alias wins, so a stale local config cannot silently shadow the team's mapping.
 
 :::note[Version compatibility]
-SecretSpec 0.14 accepts provider alias values only as bare URI strings.
-The table form with `uri` and `credentials` is an upcoming SecretSpec 0.15
-feature. If you use 0.14, configure provider credentials through the
-provider's existing environment variables, such as `BWS_ACCESS_TOKEN`.
+Provider alias tables with `uri` and `credentials` are available since
+SecretSpec 0.15. SecretSpec 0.14 accepts only bare URI strings; when using
+0.14, configure provider credentials through the provider's existing
+environment variables, such as `BWS_ACCESS_TOKEN`.
 :::
 
 ```toml title="secretspec.toml"
@@ -195,26 +195,9 @@ $ secretspec config provider remove prod_vault
 
 The CLI commands operate on the user-global config only — edit `secretspec.toml` by hand to change project-level aliases.
 
-#### SecretSpec 0.14 alias values
-
-In SecretSpec 0.14, every alias value must be a provider URI string:
-
-```toml title="secretspec.toml"
-[providers]
-bws = "bws://project-uuid"
-```
-
-For example, authenticate the 0.14 BWS provider by setting its environment
-variable before running SecretSpec:
-
-```bash
-export BWS_ACCESS_TOKEN="0.your-access-token..."
-secretspec check
-```
-
 #### SecretSpec 0.15 alias values
 
-Starting with SecretSpec 0.15, an alias value is either a bare provider URI
+In SecretSpec 0.15 and later, an alias value is either a bare provider URI
 string or a table that also declares the credentials the provider needs. Both
 forms are accepted in the project `[providers]` and user
 `[defaults.providers]` tables.
@@ -239,6 +222,23 @@ credentials = { role_id   = { provider = "onepassword", ref = { vault = "Infra",
 ```
 
 Configured credentials take precedence over provider environment fallbacks, credential chains are limited to one hop, and a fetched credential is never written to the environment. Store the credentials with [`secretspec config provider login`](/reference/cli/#config-provider-login). See [Provider Credentials](/concepts/providers/#provider-credentials) for the full behavior.
+
+#### SecretSpec 0.14 alias values
+
+In SecretSpec 0.14, every alias value must be a provider URI string:
+
+```toml title="secretspec.toml"
+[providers]
+bws = "bws://project-uuid"
+```
+
+For example, authenticate the 0.14 BWS provider by setting its environment
+variable before running SecretSpec:
+
+```bash
+export BWS_ACCESS_TOKEN="0.your-access-token..."
+secretspec check
+```
 
 ### Audit Logging
 
@@ -337,17 +337,20 @@ chain, and each provider is asked for the same coordinates.
 
 | Provider | `item` | `field` | Without `field` | Writes via ref |
 |----------|--------|---------|-----------------|----------------|
-| [OnePassword](/providers/onepassword/#secret-references) | Item title or UUID | Field label; `vault` and `section` also apply | Reads the item like a convention secret (its value or password field); writes edit the `value` field | ✅ via `op item edit` (adds a missing field, never creates items) |
-| [keyring](/providers/keyring/#secret-references) | Service | Account (defaults to the current system username) | Current user's entry | ✅ |
-| [dotenv](/providers/dotenv/#secret-references) | `.env` key | Rejected | Reads the key | ✅ |
-| [env](/providers/env/#secret-references) | Variable name | Rejected | Reads the variable | — (read-only) |
-| [pass](/providers/pass/#secret-references) | Entry path | Rejected | Reads the entry | ✅ |
-| [LastPass](/providers/lastpass/#secret-references) | Item name | Rejected | Reads the item | ✅ |
-| [Proton Pass](/providers/protonpass/#secret-references) | Item title | Rejected | Reads the note | ✅ |
-| [Vault / OpenBao](/providers/vault/#secret-references) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
-| [AWS Secrets Manager](/providers/awssm/#secret-references) | Secret name or ARN | JSON key | Whole secret string | — (read-only) |
-| [GCSM](/providers/gcsm/#secret-references) | Secret id; `version` also applies | Rejected | Reads latest or the pinned version | — (read-only) |
-| [Bitwarden (bws)](/providers/bws/#secret-references) | BWS key name | Rejected | Reads the key | ✅ |
+| [OnePassword](/providers/onepassword/#use-existing-secrets) | Item title or UUID | Field label; `vault` and `section` also apply | Reads the item like a convention secret (its value or password field); writes edit the `value` field | ✅ via `op item edit` (adds a missing field, never creates items) |
+| [keyring](/providers/keyring/#use-existing-secrets) | Service | Account (defaults to the current system username) | Current user's entry | ✅ |
+| [dotenv](/providers/dotenv/#use-existing-secrets) | `.env` key | Rejected | Reads the key | ✅ |
+| [env](/providers/env/#use-existing-secrets) | Variable name | Rejected | Reads the variable | — (read-only) |
+| [pass](/providers/pass/#use-existing-secrets) | Entry path | Rejected | Reads the entry | ✅ |
+| [Gopass (0.15+)](/providers/gopass/#use-existing-secrets) | Entry path, including any mount-point prefix | Rejected | Reads the entry | ✅ |
+| [LastPass](/providers/lastpass/#use-existing-secrets) | Item name | Rejected | Reads the item | ✅ |
+| [Proton Pass](/providers/protonpass/#use-existing-secrets) | Item title | Rejected | Reads the note | ✅ |
+| [Vault / OpenBao](/providers/vault/#use-existing-secrets) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
+| [AWS Secrets Manager](/providers/awssm/#use-existing-secrets) | Secret name or ARN | JSON key | Whole secret string | — (read-only) |
+| [GCSM](/providers/gcsm/#use-existing-secrets) | Secret id; `version` also applies | Rejected | Reads latest or the pinned version | — (read-only) |
+| [Bitwarden (bws)](/providers/bws/#use-existing-secrets) | BWS key name | Rejected | Reads the key | ✅ |
+| [Azure Key Vault (0.15+)](/providers/akv/#use-existing-secrets) | Secret name | Rejected | Reads the secret | — (read-only) |
+| [Infisical (0.16+)](/providers/infisical/#use-existing-secrets) | Folder and key; `version` also applies | Rejected | Reads the latest version | ✅ unless a version is pinned |
 
 A provider rejects coordinates it has no equivalent for, with an error naming
 the coordinate (for example, `field` on the env provider).

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -5,6 +5,10 @@ description: Complete reference for SecretSpec storage providers and their URI c
 
 SecretSpec supports multiple storage backends for secrets. Each provider has its own URI format and configuration options.
 
+This page is a compact URI reference. For installation, authentication,
+copyable project configuration, storage behavior, and CI/CD guidance, follow
+the link for the individual provider.
+
 ## DotEnv Provider
 
 **URI**: `dotenv://[path]` - Stores secrets in `.env` files
@@ -53,21 +57,23 @@ keyring://                   # System default keychain
 ```
 
 **Features**: Read/write, secure encryption, profiles, cross-platform
-**Storage**: Service `secretspec/{project}`, username `{profile}:{key}`
+**Storage**: Service `secretspec/{project}/{profile}/{key}`, with the current
+operating-system username as the account
 
 ## LastPass Provider
 
-**URI**: `lastpass://[folder]` - Integrates with LastPass via `lpass` CLI
+**URI**: `lastpass://[item_template]` - Integrates with LastPass via `lpass` CLI
 
 ```bash
-lastpass://work              # Store in work folder
-lastpass:///personal/projects # Nested folder
-lastpass://localhost         # Root (no folder)
+lastpass://                                      # Default layout
+lastpass://Work/SecretSpec/{project}/{profile}/{key} # Custom item template
 ```
 
 **Features**: Read/write, cloud sync, profiles via folders, auto-sync
 **Prerequisites**: `lpass` CLI, authenticated with `lpass login`
-**Storage**: Item name `{folder}/{profile}/{project}/{key}`
+**Storage**: Item name `secretspec/{project}/{profile}/{key}` by default. A URI
+item template replaces the default and supports `{project}`, `{profile}`, and
+`{key}` placeholders.
 
 ## OnePassword Provider
 
@@ -80,8 +86,10 @@ onepassword+token://user:op_token@SecureVault   # Service account
 ```
 
 **Features**: Read/write, cloud sync, profiles via vaults, service accounts
-**Prerequisites**: `op` CLI, authenticated with `op signin`
-**Storage**: Item name `{project}/{key}`, tags `automated`, `{project}`
+**Prerequisites**: `op` CLI, authenticated through desktop app integration, a
+service account token, or a legacy `op signin` shell session
+**Storage**: Secure Note named `secretspec/{project}/{profile}/{key}`, with tags
+`automated` and `{project}`
 
 The URI names a vault only; item paths on the URI are rejected. To read and
 write an existing item's field in place, name it with the `ref` field

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -42,6 +42,7 @@ const providerMetadata: ProviderMetadata[] = [
   { slug: 'protonpass', label: 'Proton Pass' },
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },
+  { slug: 'env', label: 'Environment variables' },
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
   { slug: 'keyring', label: 'Credential Manager' },
 ];
@@ -53,7 +54,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
 <StarlightPage
   frontmatter={{
     title: 'Declare secrets once. Store them anywhere.',
-    description: 'Declare what your application needs in secretspec.toml — resolve the values through any of 13 providers. No secrets in git. Same code, every environment.',
+    description: 'Declare what your application needs in secretspec.toml — resolve the values through any of 14 providers. No secrets in git. Same code, every environment.',
     template: 'splash',
     hero: { tagline: '' },
   }}
@@ -85,7 +86,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
       <p class="landing-badge">Declarative secrets manager</p>
       <h1 id="_top" class="landing-hero-title">Declare secrets once.<br>Store them anywhere.</h1>
       <p class="landing-hero-subtitle">
-        Stop leaking <code class="inline-code">.env</code> files. Define what your application needs in <code class="inline-code">secretspec.toml</code>, then plug in keyring, 1Password, Vault, AWS, Azure, Gopass, or any of 13 providers — same code, every environment.
+        Stop leaking <code class="inline-code">.env</code> files. Define what your application needs in <code class="inline-code">secretspec.toml</code>, then plug in keyring, 1Password, Vault, AWS, Azure, Gopass, or any of 14 providers — same code, every environment.
       </p>
       <div class="landing-hero-actions">
         <a href="/quick-start/" class="landing-btn landing-btn-primary">Get Started</a>
@@ -192,7 +193,7 @@ $ secretspec run --profile production -- npm start
       <div class="landing-step">
         <span class="landing-step-num">2</span>
         <p class="landing-step-title">Configure</p>
-        <p class="landing-step-desc">Pick from 13 providers: system keyring, password managers, cloud secret stores, Gopass, dotenv, or environment variables.</p>
+        <p class="landing-step-desc">Pick from 14 providers: system keyring, password managers, cloud secret stores, Gopass, dotenv, or environment variables.</p>
         <pre is:raw class="landing-step-code"><code>$ secretspec config init
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
@@ -284,7 +285,7 @@ println!("{}", s.secrets.database_url);</code></pre>
       <span class="landing-showcase-eyebrow">Declaration vs storage</span>
       <h2 class="landing-section-title">Declare a secret. Swap the source.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        Your <code class="inline-code">secretspec.toml</code> never changes. The same code reads from Keychain, 1Password, Vault, AWS, Azure, or any of 13 providers.
+        Your <code class="inline-code">secretspec.toml</code> never changes. The same code reads from Keychain, 1Password, Vault, AWS, Azure, or any of 14 providers.
       </p>
     </div>
 


### PR DESCRIPTION
## What changed

- restructure all 14 provider guides around the same task-oriented flow: at a glance, quick start, setup, configuration, storage model, existing secrets, and CI/CD or advanced guidance where applicable
- add copyable provider URIs and checked-in `secretspec.toml` alias examples to every guide
- separate provider-native storage behavior from `ref`-based access to existing secrets
- update the provider authoring checklist so future pages retain the same information architecture
- repair renamed anchors and complete the provider-coordinate reference table
- add the environment-variable provider to landing-page metadata and update stale 13-provider copy to 14
- replace stale pre-release wording for SecretSpec 0.15 features with durable compatibility language

## Why

Provider pages had grown independently, so the same information appeared under different headings and in different orders. Readers often had to pass URI details and reference semantics before finding a minimal working example, while storage naming, authentication, permissions, and CI guidance were scattered or nested under usage.

The shared structure makes each provider predictable to scan and gives direct-entry readers the setup, checked-in configuration, storage behavior, and compatibility information they need on the provider page itself.

## Coverage

Registered provider modules, provider pages, landing metadata, sidebar entries, concepts-table rows, reference sections, security rows, selector examples, and README listings reconcile at 14 providers.

## Validation

- `devenv shell npm run build`
- `git diff --check`
- implementation-to-documentation provider coverage reconciliation
