### PR TITLE
Add composed secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Composed secrets derive read-only values such as connection strings from
+  other declared secrets using strict `{SECRET_NAME}` templates. Dependencies
+  are order-independent, may include other compositions, and are validated for
+  unknown references and cycles before provider access; unlike dotenv
+  expansion, values are substituted once without ambient environment lookup,
+  fallback operators, recursive expansion, or silent empty replacements.
 - C# SDK (`Cachix.SecretSpec`, available in 0.16): resolve secrets from .NET
   through the shared native resolver, with fluent builder and one-shot APIs,
   typed failure exceptions, value-free preflight reports, provenance,

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -83,6 +83,12 @@ DB_PASSWORD  = { description = "DB password", type = "password", generate = true
 DATABASE_URL = { default = "postgresql://localhost/dev" }
 \`\`\`
 
+## Composed Secrets (0.16+)
+
+\`composed\` derives a read-only value from other declared secrets with strict,
+order-independent \`{SECRET_NAME}\` references. It does not perform dotenv,
+shell, ambient-environment, or recursive expansion.
+
 ## Type-safe Rust SDK
 
 \`\`\`rust
@@ -156,6 +162,10 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
               slug: "concepts/inheritance",
             },
             { label: "Secret Generation (0.7+)", slug: "concepts/generation" },
+            {
+              label: "Composed Secrets (0.16+)",
+              slug: "concepts/composed-secrets",
+            },
             { label: "Secret References (0.14+)", slug: "concepts/references" },
             { label: "Audit Logging (0.12+)", slug: "concepts/audit" },
           ],

--- a/docs/src/content/docs/concepts/composed-secrets.md
+++ b/docs/src/content/docs/concepts/composed-secrets.md
@@ -1,0 +1,135 @@
+---
+title: Composed Secrets
+description: Derive read-only values from other declared secrets with strict templates
+---
+
+:::caution[Version compatibility]
+Available since SecretSpec 0.16.
+:::
+
+Composed secrets derive one exported value from other secrets in the active
+profile. They are useful for connection strings, command arguments, and other
+formats whose components should remain independently stored:
+
+```toml
+[profiles.default]
+DB_USER = { description = "Database user" }
+DB_PASSWORD = { description = "Database password" }
+DB_HOST = { description = "Database host" }
+
+DATABASE_URL = {
+  description = "PostgreSQL connection string",
+  composed = "postgres://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/app"
+}
+```
+
+`DB_USER`, `DB_PASSWORD`, and `DB_HOST` resolve through their ordinary
+providers. `DATABASE_URL` is then rendered in memory and exported alongside
+them. The composed result is never read from or written to a provider.
+
+## Static dependency graph
+
+Every `{NAME}` must name a secret declared in the effective profile.
+SecretSpec validates the complete graph while loading `secretspec.toml`, before
+accessing a provider:
+
+- declaration order does not matter;
+- a composition may reference another composition;
+- unknown references are errors;
+- dependency cycles are errors.
+
+```toml
+[profiles.default]
+USER = { description = "Database user" }
+PASSWORD = { description = "Database password" }
+HOST = { description = "Database host" }
+
+AUTHORITY = { description = "Database authority", composed = "{USER}:{PASSWORD}" }
+DATABASE_URL = { description = "Database URL", composed = "postgres://{AUTHORITY}@{HOST}/app" }
+```
+
+This differs deliberately from dotenv expansion, where behavior can depend on
+file order, process environment, and how a particular parser handles undefined
+or recursive variables.
+
+## Template syntax
+
+Composition is a small, strict language:
+
+| Syntax | Meaning |
+|---|---|
+| `{SECRET_NAME}` | Insert one declared secret's exported value |
+| `{{` | Insert a literal `{` |
+| `}}` | Insert a literal `}` |
+
+The following are intentionally unsupported:
+
+- `${NAME}` and shell-style expressions such as `${NAME:-fallback}`;
+- ambient environment-variable lookup;
+- command substitution;
+- recursive expansion.
+
+Substitution is one pass. If `PASSWORD` contains the literal text `{HOST}`,
+inserting `{PASSWORD}` produces `{HOST}`; it is not scanned again. This keeps
+secret bytes opaque and prevents values from unexpectedly becoming executable
+template syntax.
+
+## Missing, empty, and optional values
+
+Missing and empty are different:
+
+- an empty dependency inserts an empty string;
+- a missing dependency makes a required composition missing;
+- when the composed secret sets `required = false`, a missing dependency omits
+  the composed result instead.
+
+SecretSpec never silently replaces a missing reference with empty text.
+Interactive `secretspec check` prompts for the unresolved provider-backed
+dependencies, not for the derived result.
+
+## Read-only behavior
+
+A composed secret cannot also declare `default`, `providers`, `ref`, `type`, or
+enabled `generate`. These fields would give the same name two competing value
+sources.
+
+- `get` resolves the target's transitive dependencies and prints the result;
+- `set` rejects the composed name as read-only;
+- `import` skips composed names because there is no stored value to copy;
+- `check`, `run`, `export`, and SDK resolution include the composed value like
+  any other resolved secret.
+
+## Profiles and inheritance
+
+References are checked against the effective profile after `default` profile
+inheritance. A profile may override the template while inheriting component
+declarations:
+
+```toml
+[profiles.default]
+DB_USER = { description = "Database user" }
+DB_PASSWORD = { description = "Database password" }
+DB_HOST = { description = "Database host" }
+DATABASE_URL = { description = "Database URL", composed = "postgres://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/app" }
+
+[profiles.development]
+DATABASE_URL = { composed = "postgres://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/app_dev" }
+```
+
+Profile-level storage defaults do not apply to composed secrets, because their
+source is the dependency graph rather than a provider. Profile-level
+`required` defaults still apply.
+
+## Paths and encoding
+
+When a dependency uses `as_path = true`, its exported temporary-file path is
+inserted. Setting `as_path = true` on the composed secret instead writes the
+final rendered value to a temporary file.
+
+Composition performs raw string concatenation. It does not URL-encode values:
+SecretSpec cannot infer whether a component is a username, password, host,
+path, or query parameter. Store each component in the representation required
+by the destination format.
+
+See the [`composed` configuration reference](/reference/configuration/#composed-secrets)
+for the field-level constraints.

--- a/docs/src/content/docs/concepts/declarative.md
+++ b/docs/src/content/docs/concepts/declarative.md
@@ -35,6 +35,7 @@ SECRET_NAME = {
 - `description`: Explains the secret's purpose (required in the `default` profile; profile overrides inherit it when omitted)
 - `required`: Whether the secret must be provided (default: `true`)
 - `default`: Fallback value for optional secrets
+- `composed` (0.16+): Derive a read-only value from other declared secrets (see [Composed Secrets](/concepts/composed-secrets/) for the strict template and dependency semantics)
 - `type`: Secret type for auto-generation (`password`, `hex`, `base64`, `uuid`, `command`)
 - `generate`: Enable auto-generation when the secret is missing (`true` or a table with options)
 
@@ -42,6 +43,8 @@ SECRET_NAME = {
 
 - [Configuration Inheritance](/concepts/inheritance/) lets projects share common secret definitions via the `extends` field
 - [Secret Generation](/concepts/generation/) auto-creates passwords, tokens, and keys when secrets are missing
+- [Composed Secrets (0.16+)](/concepts/composed-secrets/) derive values from
+  other declared secrets without dotenv or shell expansion
 
 ## Best Practices
 

--- a/docs/src/content/docs/concepts/overview.md
+++ b/docs/src/content/docs/concepts/overview.md
@@ -34,3 +34,5 @@ Each concern is independent: you can change your storage backend without touchin
 
 - [Configuration Inheritance](/concepts/inheritance/) lets projects share common secret definitions via `extends`
 - [Secret Generation](/concepts/generation/) auto-creates passwords, tokens, and keys when secrets are missing
+- [Composed Secrets (0.16+)](/concepts/composed-secrets/) derive read-only
+  values from other declared secrets

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -236,6 +236,9 @@ $ secretspec get DATABASE_URL --profile production
 postgresql://prod.example.com/mydb
 ```
 
+For a composed secret, `get` resolves its transitive dependencies and prints
+the derived value. Available since SecretSpec 0.16.
+
 ### schema
 Emit a single-root JSON Schema for the manifest's typed shape: by default the
 union `SecretSpec` (safe for any profile); with `--profile`, that profile's exact
@@ -287,6 +290,9 @@ secretspec set [OPTIONS] <NAME> [VALUE]
 $ secretspec set API_KEY sk-1234567890
 ✓ Secret 'API_KEY' saved to keyring (profile: development)
 ```
+
+`set` rejects composed secrets because their values are derived and read-only.
+Available since SecretSpec 0.16.
 
 ### run
 Run a command with secrets injected as environment variables.
@@ -397,6 +403,9 @@ $ secretspec import dotenv:/home/user/old-project/.env
 - Migrate from .env files to a secure provider like keyring or OnePassword
 - Copy secrets between different profiles or projects
 - Import existing environment variables into SecretSpec management
+
+`import` skips composed secrets because they have no stored value to copy; their
+component secrets are imported normally. Available since SecretSpec 0.16.
 
 ### audit
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -88,6 +88,7 @@ Each secret variable is defined as a table with the following fields:
 | `description` | string | Yes (see notes) | Human-readable description of the secret |
 | `required` | boolean | No | Whether absence is an error (default: true, or false when `default` is present) |
 | `default` | string | No | Default value if not provided |
+| `composed` (0.16+) | string | No | Derive a read-only value from other declared secrets using `{SECRET_NAME}` references |
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
 | `ref` | table | No | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
@@ -105,6 +106,51 @@ Field notes:
   though the provider does not have to supply it.
 - `type` is required when `generate` is enabled.
 - `generate` and `default` cannot both be set.
+
+#### Composed secrets
+
+:::caution[Version compatibility]
+Available since SecretSpec 0.16.
+:::
+
+A composed secret derives a value from other secrets in the effective profile.
+See [Composed Secrets](/concepts/composed-secrets/) for the dependency model,
+CLI behavior, profile inheritance, and the differences from dotenv expansion:
+
+```toml
+[profiles.default]
+DB_USER = { description = "Database user" }
+DB_PASSWORD = { description = "Database password" }
+DB_HOST = { description = "Database host" }
+DATABASE_URL = { description = "PostgreSQL DSN", composed = "postgres://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/app" }
+```
+
+References form a static dependency graph. Declaration order does not matter,
+and composed secrets may reference other composed secrets. SecretSpec rejects
+unknown references, cycles, malformed braces, and source conflicts while
+loading the manifest. A composed secret is read-only and cannot also set
+`default`, `providers`, `ref`, `type`, or enabled `generate`.
+
+Composition intentionally does **not** implement dotenv or shell expansion:
+
+- only `{DECLARED_SECRET}` is a reference; ambient environment variables are
+  never consulted;
+- `${NAME}`, fallback operators such as `${NAME:-fallback}`, commands, and
+  recursive expansion are unsupported;
+- inserted values are opaque and are never scanned again;
+- `{{` and `}}` produce literal braces;
+- a missing dependency makes a required composition missing, while a
+  `required = false` composition is omitted;
+- empty values remain empty and are distinct from missing values.
+
+If a dependency uses `as_path = true`, its exported temporary-file path is the
+text inserted into the composed value. Applying `as_path = true` to the
+composed secret materializes the final combined value.
+
+Composition is raw string concatenation. SecretSpec cannot know whether a
+component occupies a URL username, password, host, path, or query position, so
+it does not URL-encode components. Store components in the form required by the
+target format.
 
 ## Complete Example
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -240,6 +240,12 @@ DATABASE_URL = { required = true }</code></pre>
         <pre is:raw class="landing-bento-mini-code"><code>DB_PASSWORD = { type = "password", generate = true }</code></pre>
       </a>
 
+      <a href="/concepts/composed-secrets/" class="landing-bento-card is-link landing-bento-2">
+        <p class="landing-bento-title">Composed secrets</p>
+        <p class="landing-bento-desc">Build read-only DSNs and arguments from independently stored secrets with strict, order-independent references.</p>
+        <pre is:raw class="landing-bento-mini-code"><code>DATABASE_URL = { composed = "postgres://{USER}:{PASSWORD}@{HOST}/app" }</code></pre>
+      </a>
+
       <a href="/concepts/providers/" class="landing-bento-card is-link landing-bento-3">
         <p class="landing-bento-title">Per-secret fallback chains</p>
         <p class="landing-bento-desc">Each secret can specify its own ordered provider list. Tries Vault first, falls back to keyring, then env — until the value is found.</p>

--- a/schema/resolve-response.schema.json
+++ b/schema/resolve-response.schema.json
@@ -10,7 +10,7 @@
     "schema_version": {
       "description": "Wire-format version. Consumers should refuse versions they do not understand.",
       "type": "integer",
-      "const": 1
+      "const": 2
     },
     "provider": {
       "description": "Credential-free URI of the provider the resolution is reported against.",
@@ -57,7 +57,7 @@
         "source": {
           "description": "Where the value came from.",
           "type": "string",
-          "enum": ["provider", "generated", "default"]
+          "enum": ["provider", "generated", "default", "composed"]
         },
         "source_provider": {
           "description": "Credential-free URI of the provider that answered, present when `source` is `provider`.",

--- a/secretspec-dotnet/src/SecretSpec/JsonContracts.cs
+++ b/secretspec-dotnet/src/SecretSpec/JsonContracts.cs
@@ -5,7 +5,7 @@ namespace Cachix.SecretSpec;
 
 internal static class JsonContracts
 {
-    internal const int ResolveSchemaVersion = 1;
+    internal const int ResolveSchemaVersion = 2;
     internal const int ReportSchemaVersion = 1;
 
     internal static readonly JsonSerializerOptions Options = new()

--- a/secretspec-ffi/tests/c_abi.rs
+++ b/secretspec-ffi/tests/c_abi.rs
@@ -74,7 +74,7 @@ fn resolve_returns_values_and_provenance() {
     let env = resolve(&request);
     assert_eq!(env["ok"], true, "envelope: {env}");
     let response = &env["response"];
-    assert_eq!(response["schema_version"], 1);
+    assert_eq!(response["schema_version"], 2);
     assert_eq!(response["profile"], "default");
     assert_eq!(
         response["secrets"]["DATABASE_URL"]["value"],

--- a/secretspec-go/secretspec.go
+++ b/secretspec-go/secretspec.go
@@ -27,7 +27,7 @@ import (
 // It tracks secretspec-ffi's RESOLVE_SCHEMA_VERSION; a mismatch means the loaded
 // library is incompatible with this SDK, so Load reports it rather than silently
 // misparsing.
-const resolveSchemaVersion = 1
+const resolveSchemaVersion = 2
 
 // Error is a resolution failure (bad manifest, provider error, reason policy).
 type Error struct {

--- a/secretspec-hs/src/SecretSpec.hs
+++ b/secretspec-hs/src/SecretSpec.hs
@@ -78,7 +78,7 @@ foreign import ccall safe "secretspec_abi_version"
 -- | Wire-format version of the value-carrying resolve response this SDK
 -- understands. Tracks @secretspec@'s @RESOLVE_SCHEMA_VERSION@.
 resolveSchemaVersion :: Int
-resolveSchemaVersion = 1
+resolveSchemaVersion = 2
 
 -- | Wire-format version of the value-free report. Tracks @secretspec@'s
 -- @RESOLUTION_REPORT_SCHEMA_VERSION@.

--- a/secretspec-node/index.js
+++ b/secretspec-node/index.js
@@ -47,7 +47,7 @@ const native = loadNative();
 
 // Response wire-format version this SDK understands. Tracks secretspec-ffi's
 // RESOLVE_SCHEMA_VERSION; a mismatch means the native addon is out of sync.
-const RESOLVE_SCHEMA_VERSION = 1;
+const RESOLVE_SCHEMA_VERSION = 2;
 
 // Wire-format version of the value-free report. Tracks secretspec's
 // RESOLUTION_REPORT_SCHEMA_VERSION.

--- a/secretspec-php/src/Builder.php
+++ b/secretspec-php/src/Builder.php
@@ -15,7 +15,7 @@ final class Builder
      * Response wire-format version this SDK understands. Tracks secretspec-ffi's
      * RESOLVE_SCHEMA_VERSION; a mismatch means the loaded library is incompatible.
      */
-    private const RESOLVE_SCHEMA_VERSION = 1;
+    private const RESOLVE_SCHEMA_VERSION = 2;
 
     /**
      * Wire-format version of the value-free report. Tracks secretspec's

--- a/secretspec-py/secretspec/__init__.py
+++ b/secretspec-py/secretspec/__init__.py
@@ -24,7 +24,7 @@ from secretspec import _native
 
 # Response wire-format version this SDK understands. Tracks secretspec-ffi's
 # RESOLVE_SCHEMA_VERSION; a mismatch means the loaded library is incompatible.
-_RESOLVE_SCHEMA_VERSION = 1
+_RESOLVE_SCHEMA_VERSION = 2
 
 # Wire-format version of the value-free report. Tracks secretspec's
 # RESOLUTION_REPORT_SCHEMA_VERSION.

--- a/secretspec-rb/lib/secretspec.rb
+++ b/secretspec-rb/lib/secretspec.rb
@@ -19,7 +19,7 @@ require "secretspec/secretspec_ext"
 module Secretspec
   # Response wire-format version this SDK understands. Tracks secretspec-ffi's
   # RESOLVE_SCHEMA_VERSION; a mismatch means the loaded library is incompatible.
-  RESOLVE_SCHEMA_VERSION = 1
+  RESOLVE_SCHEMA_VERSION = 2
 
   # Wire-format version of the value-free report. Tracks secretspec's
   # RESOLUTION_REPORT_SCHEMA_VERSION.

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -34,6 +34,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
 - **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
+- **Composed Secrets (0.16+)**: Derive read-only values such as DSNs from declared secrets with strict, order-independent `{SECRET_NAME}` references
 - **[Configuration Inheritance](https://secretspec.dev/concepts/inheritance/)**: Extend and override shared configurations using the `extends` feature
 - **[Audit Logging](https://secretspec.dev/concepts/audit/)**: Every secret access recorded locally (who, when, why, outcome) — on by default, secret values never logged
 - **[Discovery](https://secretspec.dev/reference/cli#init)**: `secretspec init` to discover secrets from existing `.env` files

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -293,6 +293,9 @@ fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
             if let Some(default) = &secret_config.default {
                 inline.insert("default", Value::from(default.as_str()));
             }
+            if let Some(composed) = &secret_config.composed {
+                inline.insert("composed", Value::from(composed.as_str()));
+            }
             profile_table.insert(&secret_name, toml_edit::value(inline));
         }
 
@@ -1258,6 +1261,20 @@ mod tests {
         let out = generate_toml_with_comments(&config_with_secret(secret)).unwrap();
         assert!(out.contains(", required = false"), "got: {out}");
         assert!(out.contains(", default = \"v\""), "got: {out}");
+    }
+
+    #[test]
+    fn generate_toml_preserves_composed_templates() {
+        let out = generate_toml_with_comments(&config_with_secret(Secret {
+            description: Some("dsn".to_string()),
+            composed: Some("postgres://{USER}@{HOST}/db".to_string()),
+            ..Default::default()
+        }))
+        .unwrap();
+        assert!(
+            out.contains(", composed = \"postgres://{USER}@{HOST}/db\""),
+            "got: {out}"
+        );
     }
 
     #[test]

--- a/secretspec/src/composition.rs
+++ b/secretspec/src/composition.rs
@@ -1,0 +1,186 @@
+//! Strict parsing and one-pass rendering for composed secrets.
+//!
+//! This deliberately is not a dotenv or shell interpolator. References may
+//! name only declared secrets, inserted values are opaque, and literal braces
+//! must be escaped as `{{` and `}}`.
+
+use crate::config::is_valid_identifier;
+use std::collections::BTreeSet;
+
+const MAX_RENDERED_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Part {
+    Literal(String),
+    Reference(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Template {
+    parts: Vec<Part>,
+    dependencies: Vec<String>,
+}
+
+impl Template {
+    pub(crate) fn parse(input: &str) -> Result<Self, String> {
+        let mut chars = input.chars().peekable();
+        let mut parts = Vec::new();
+        let mut literal = String::new();
+        let mut dependencies = BTreeSet::new();
+
+        while let Some(ch) = chars.next() {
+            match ch {
+                '$' if chars.peek() == Some(&'{') => {
+                    return Err(
+                        "dotenv-style `${...}` expansion is not supported; use `{SECRET_NAME}`"
+                            .into(),
+                    );
+                }
+                '{' if chars.peek() == Some(&'{') => {
+                    chars.next();
+                    literal.push('{');
+                }
+                '}' if chars.peek() == Some(&'}') => {
+                    chars.next();
+                    literal.push('}');
+                }
+                '{' => {
+                    if !literal.is_empty() {
+                        parts.push(Part::Literal(std::mem::take(&mut literal)));
+                    }
+
+                    let mut name = String::new();
+                    loop {
+                        match chars.next() {
+                            Some('}') => break,
+                            Some('{') => {
+                                return Err(
+                                    "nested `{` in a composed reference; use `{{` for a literal brace"
+                                        .into(),
+                                );
+                            }
+                            Some(ch) => name.push(ch),
+                            None => {
+                                return Err(
+                                    "unclosed `{` in composed template; use `{{` for a literal brace"
+                                        .into(),
+                                );
+                            }
+                        }
+                    }
+
+                    if !is_valid_identifier(&name) {
+                        return Err(format!(
+                            "invalid composed reference `{{{name}}}`; references must be secret identifiers"
+                        ));
+                    }
+                    dependencies.insert(name.clone());
+                    parts.push(Part::Reference(name));
+                }
+                '}' => {
+                    return Err(
+                        "unmatched `}` in composed template; use `}}` for a literal brace".into(),
+                    );
+                }
+                other => literal.push(other),
+            }
+        }
+
+        if !literal.is_empty() {
+            parts.push(Part::Literal(literal));
+        }
+        if dependencies.is_empty() {
+            return Err("a composed template must reference at least one declared secret".into());
+        }
+
+        Ok(Self {
+            parts,
+            dependencies: dependencies.into_iter().collect(),
+        })
+    }
+
+    pub(crate) fn dependencies(&self) -> &[String] {
+        &self.dependencies
+    }
+
+    /// Render once. Values returned by `lookup` are appended as opaque bytes;
+    /// braces or reference-looking text inside them are never interpreted.
+    pub(crate) fn render<'a>(
+        &self,
+        mut lookup: impl FnMut(&str) -> Option<&'a str>,
+    ) -> Result<String, String> {
+        let mut rendered = String::new();
+        for part in &self.parts {
+            let value = match part {
+                Part::Literal(value) => value.as_str(),
+                Part::Reference(name) => lookup(name)
+                    .ok_or_else(|| format!("composed dependency `{name}` is not resolved"))?,
+            };
+            if rendered.len() + value.len() > MAX_RENDERED_BYTES {
+                return Err(format!(
+                    "composed value exceeds the {} MiB limit",
+                    MAX_RENDERED_BYTES / 1024 / 1024
+                ));
+            }
+            rendered.push_str(value);
+        }
+        Ok(rendered)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn parses_escaped_braces_and_deduplicates_dependencies() {
+        let template = Template::parse("{{dsn}}:{USER}:{USER}@{HOST}").unwrap();
+        assert_eq!(
+            template.dependencies(),
+            &["HOST".to_string(), "USER".to_string()]
+        );
+        let values = HashMap::from([("USER", "alice"), ("HOST", "db")]);
+        assert_eq!(
+            template.render(|name| values.get(name).copied()).unwrap(),
+            "{dsn}:alice:alice@db"
+        );
+    }
+
+    #[test]
+    fn inserted_values_are_not_reparsed() {
+        let template = Template::parse("value={A}").unwrap();
+        assert_eq!(
+            template
+                .render(|name| (name == "A").then_some("{B}"))
+                .unwrap(),
+            "value={B}"
+        );
+    }
+
+    #[test]
+    fn rejects_shell_and_malformed_syntax() {
+        for invalid in ["{A:-fallback}", "${A}", "{A", "A}", "{}", "{A{B}}"] {
+            assert!(Template::parse(invalid).is_err(), "{invalid} should fail");
+        }
+    }
+
+    #[test]
+    fn missing_value_is_not_replaced_with_empty_text() {
+        let template = Template::parse("{A}:{B}").unwrap();
+        assert_eq!(
+            template.render(|name| (name == "A").then_some("set")),
+            Err("composed dependency `B` is not resolved".into())
+        );
+        assert_eq!(
+            template
+                .render(|name| match name {
+                    "A" => Some("set"),
+                    "B" => Some(""),
+                    _ => None,
+                })
+                .unwrap(),
+            "set:"
+        );
+    }
+}

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -33,9 +33,10 @@
 //! DATABASE_URL = { description = "Production database", required = true }
 //! ```
 
+use crate::composition::Template;
 use crate::manifest::CompiledManifest;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet, hash_map};
+use std::collections::{BTreeMap, HashMap, HashSet, hash_map};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -413,6 +414,72 @@ fn validate_compiled_profile(
                 profile_name, name, e
             ))
         })?;
+    }
+    validate_composition_graph(profile_name, profile)?;
+    Ok(())
+}
+
+fn validate_composition_graph(
+    profile_name: &str,
+    profile: &crate::manifest::CompiledProfile,
+) -> Result<(), ParseError> {
+    // Templates were parsed during manifest compilation; a malformed one was
+    // already rejected by `validate_semantics` before this runs.
+    let mut graph: BTreeMap<&str, &[String]> = BTreeMap::new();
+    for (name, secret) in &profile.secrets {
+        let Some(template) = &secret.composition else {
+            continue;
+        };
+        for dependency in template.dependencies() {
+            if !profile.secrets.contains_key(dependency) {
+                return Err(ParseError::Validation(format!(
+                    "Profile '{}': Secret '{}': composed reference `{{{}}}` does not name a declared secret",
+                    profile_name, name, dependency
+                )));
+            }
+        }
+        graph.insert(name.as_str(), template.dependencies());
+    }
+
+    fn visit<'a>(
+        name: &'a str,
+        graph: &BTreeMap<&'a str, &'a [String]>,
+        state: &mut HashMap<&'a str, u8>,
+        stack: &mut Vec<&'a str>,
+    ) -> Result<(), Vec<String>> {
+        match state.get(name).copied() {
+            Some(2) => return Ok(()),
+            Some(1) => {
+                let start = stack.iter().position(|item| *item == name).unwrap_or(0);
+                let mut cycle: Vec<String> = stack[start..].iter().map(|s| s.to_string()).collect();
+                cycle.push(name.to_string());
+                return Err(cycle);
+            }
+            _ => {}
+        }
+        state.insert(name, 1);
+        stack.push(name);
+        if let Some(dependencies) = graph.get(name) {
+            for dependency in *dependencies {
+                if graph.contains_key(dependency.as_str()) {
+                    visit(dependency, graph, state, stack)?;
+                }
+            }
+        }
+        stack.pop();
+        state.insert(name, 2);
+        Ok(())
+    }
+
+    let mut state = HashMap::new();
+    for name in graph.keys() {
+        if let Err(cycle) = visit(name, &graph, &mut state, &mut Vec::new()) {
+            return Err(ParseError::Validation(format!(
+                "Profile '{}': composed secret cycle: {}",
+                profile_name,
+                cycle.join(" -> ")
+            )));
+        }
     }
     Ok(())
 }
@@ -1139,6 +1206,12 @@ pub struct Secret {
     /// Optional default value if the secret is not provided
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<String>,
+    /// A strict template derived from other declared secrets. References use
+    /// `{SECRET_NAME}`; `{{` and `}}` produce literal braces.
+    ///
+    /// Available since SecretSpec 0.16.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub composed: Option<String>,
     /// Optional list of provider aliases for retrieving this secret.
     /// Providers are tried in order until one has the secret.
     /// If not specified, uses the profile defaults.providers or global provider.
@@ -1220,6 +1293,21 @@ impl Secret {
     }
 
     fn validate_semantics(&self) -> Result<(), String> {
+        if let Some(composed) = &self.composed {
+            Template::parse(composed)?;
+            if self.default.is_some()
+                || self.providers.is_some()
+                || self.reference.is_some()
+                || self.secret_type.is_some()
+                || self.would_generate()
+            {
+                return Err(
+                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `type`, or enabled `generate`"
+                        .into(),
+                );
+            }
+        }
+
         // A `ref` supplies naming only: it composes with `providers` routing
         // and with `generate` (a missing referenced secret is minted and
         // written to its coordinates, like any other generated value).
@@ -1328,14 +1416,19 @@ impl Secret {
                 .or_else(|| default.and_then(&field))
         }
 
+        let composed = inherit(current, default, |s| s.composed.clone());
+        // A composed secret's source is its dependency graph, so the
+        // `[defaults]` storage fields (`default`, `providers`) do not apply.
+        let storage_defaults = if composed.is_some() { None } else { defaults };
         Some(Secret {
             description: inherit(current, default, |s| s.description.clone()),
             required: inherit(current, default, |s| s.required)
                 .or(defaults.and_then(|d| d.required)),
             default: inherit(current, default, |s| s.default.clone())
-                .or_else(|| defaults.and_then(|d| d.default.clone())),
+                .or_else(|| storage_defaults.and_then(|d| d.default.clone())),
+            composed,
             providers: inherit(current, default, |s| s.providers.clone())
-                .or_else(|| defaults.and_then(|d| d.providers.clone())),
+                .or_else(|| storage_defaults.and_then(|d| d.providers.clone())),
             reference: inherit(current, default, |s| s.reference.clone()),
             as_path: inherit(current, default, |s| s.as_path),
             secret_type: inherit(current, default, |s| s.secret_type.clone()),
@@ -1344,8 +1437,10 @@ impl Secret {
     }
 }
 
-/// Check if a string is a valid identifier.
-fn is_valid_identifier(s: &str) -> bool {
+/// Check if a string is a valid identifier. Shared with composed-template
+/// references, so a declarable secret name and a referenceable one can never
+/// drift apart.
+pub(crate) fn is_valid_identifier(s: &str) -> bool {
     if s.is_empty() {
         return false;
     }
@@ -1975,6 +2070,118 @@ ADMIN_PASSWORD = { description = "Password securing the admin page", required = 
             .validate()
             .unwrap_err();
         assert!(err.to_string().contains("Invalid secret name"));
+    }
+
+    #[test]
+    fn composed_references_are_validated_as_a_static_graph() {
+        let parse = |body: &str| {
+            toml::from_str::<Config>(&format!(
+                r#"
+[project]
+name = "composed"
+revision = "1.0"
+
+[profiles.default]
+{body}
+"#
+            ))
+            .unwrap()
+        };
+
+        parse(
+            r#"
+USER = { description = "user" }
+HOST = { description = "host" }
+DSN = { description = "dsn", composed = "db://{USER}@{HOST}" }
+"#,
+        )
+        .validate()
+        .unwrap();
+
+        let unknown = parse(
+            r#"
+DSN = { description = "dsn", composed = "db://{AMBIENT_ENV}" }
+"#,
+        )
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(
+            unknown.contains("does not name a declared secret"),
+            "{unknown}"
+        );
+
+        let cycle = parse(
+            r#"
+A = { description = "a", composed = "{B}" }
+B = { description = "b", composed = "{C}" }
+C = { description = "c", composed = "{A}" }
+"#,
+        )
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(cycle.contains("A -> B -> C -> A"), "{cycle}");
+    }
+
+    #[test]
+    fn composed_rejects_dotenv_syntax_and_storage_sources() {
+        let invalid: Config = toml::from_str(
+            r#"
+[project]
+name = "composed"
+revision = "1.0"
+
+[profiles.default]
+A = { description = "a" }
+BAD = { description = "bad", composed = "${A:-fallback}" }
+"#,
+        )
+        .unwrap();
+        let error = invalid.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("dotenv-style `${...}` expansion is not supported"),
+            "{error}"
+        );
+
+        let conflicting: Config = toml::from_str(
+            r#"
+[project]
+name = "composed"
+revision = "1.0"
+
+[profiles.default]
+A = { description = "a" }
+BAD = { description = "bad", composed = "{A}", providers = ["keyring"] }
+"#,
+        )
+        .unwrap();
+        let error = conflicting.validate().unwrap_err().to_string();
+        assert!(error.contains("cannot also set"), "{error}");
+    }
+
+    #[test]
+    fn composed_secrets_do_not_inherit_storage_profile_defaults() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "composed"
+revision = "1.0"
+
+[profiles.default]
+PART = { description = "part" }
+RESULT = { description = "result", composed = "{PART}" }
+
+[profiles.default.defaults]
+default = "fallback"
+providers = ["keyring"]
+"#,
+        )
+        .unwrap();
+        let compiled = config.validate_and_compile().unwrap();
+        let result = &compiled.profile("default").unwrap().secrets["RESULT"].config;
+        assert!(result.default.is_none());
+        assert!(result.providers.is_none());
     }
 
     #[test]

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -39,6 +39,10 @@ pub enum SecretSpecError {
     SecretNotFound(String),
     #[error("Secret '{0}' is required but not set")]
     RequiredSecretMissing(String),
+    #[error("Composed secret '{0}' is derived from other secrets and cannot be written")]
+    ComposedSecretReadOnly(String),
+    #[error("Failed to compose secret: {0}")]
+    CompositionFailed(String),
     #[error("No secretspec.toml found in current or any parent directory")]
     NoManifest,
     #[error("Extended config file not found: {0}")]
@@ -85,6 +89,8 @@ impl SecretSpecError {
             SecretSpecError::ProviderNotFound(_) => "provider_not_found",
             SecretSpecError::SecretNotFound(_) => "secret_not_found",
             SecretSpecError::RequiredSecretMissing(_) => "required_secret_missing",
+            SecretSpecError::ComposedSecretReadOnly(_) => "composed_secret_read_only",
+            SecretSpecError::CompositionFailed(_) => "composition_failed",
             SecretSpecError::NoManifest => "no_manifest",
             SecretSpecError::ExtendedConfigNotFound(_) => "extended_config_not_found",
             SecretSpecError::NoProjectName => "no_project_name",
@@ -159,6 +165,14 @@ mod tests {
             (
                 SecretSpecError::RequiredSecretMissing("X".into()),
                 "required_secret_missing",
+            ),
+            (
+                SecretSpecError::ComposedSecretReadOnly("X".into()),
+                "composed_secret_read_only",
+            ),
+            (
+                SecretSpecError::CompositionFailed("too large".into()),
+                "composition_failed",
             ),
             (SecretSpecError::NoManifest, "no_manifest"),
             (

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -43,6 +43,7 @@
 // Internal modules
 mod audit;
 pub mod codegen;
+mod composition;
 mod config;
 mod error;
 pub(crate) mod generator;

--- a/secretspec/src/manifest.rs
+++ b/secretspec/src/manifest.rs
@@ -5,6 +5,7 @@
 //! generated types instead consume this module's effective view, where profile
 //! inheritance and missing-value behavior have already been decided once.
 
+use crate::composition::Template;
 use crate::config::{Config, Secret};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -36,6 +37,11 @@ pub(crate) struct CompiledSecret {
     /// The effective `required` flag for reporting. Kept distinct from
     /// `missing`: a required generated/defaulted field is still guaranteed.
     pub(crate) declared_required: bool,
+    /// The parsed `composed` template, decided once here so graph validation,
+    /// planning, and the executor's render pass all read one parse. A
+    /// malformed template compiles to `None`; `Secret::validate_semantics`
+    /// rejects it before any of those consumers run.
+    pub(crate) composition: Option<Template>,
 }
 
 impl CompiledSecret {
@@ -53,10 +59,15 @@ impl CompiledSecret {
         } else {
             MissingPolicy::Omit
         };
+        let composition = config
+            .composed
+            .as_deref()
+            .and_then(|source| Template::parse(source).ok());
         Self {
             config,
             missing,
             declared_required,
+            composition,
         }
     }
 }

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -16,6 +16,7 @@
 //! ([`SecretSpecError::ProviderNotFound`]) and the corrected `1password`
 //! misspelling; a plan never opens a store.
 
+use crate::composition::Template;
 use crate::config::{NativeAddress, Secret};
 use crate::error::Result;
 use crate::manifest::CompiledSecret;
@@ -106,10 +107,13 @@ pub(crate) struct PlannedSecret {
     /// The declared secret name (the manifest's `UPPER_SNAKE` key).
     pub name: String,
     /// The compiled effective secret: its merged config, missing-value policy,
-    /// and required marker travel together so they cannot fall out of sync.
+    /// required marker, and parsed composition travel together so they cannot
+    /// fall out of sync.
     pub secret: CompiledSecret,
-    /// The resolved read/write route.
-    pub route: Route,
+    /// The resolved read/write route, or `None` for a composed secret: its
+    /// value is derived from other secrets, so there is no store to consult
+    /// and consumers must decide what a routeless secret means for them.
+    pub route: Option<Route>,
 }
 
 impl PlannedSecret {
@@ -145,6 +149,15 @@ impl PlannedSecret {
     pub(crate) fn as_path(&self) -> bool {
         self.secret.config.as_path.unwrap_or(false)
     }
+
+    pub(crate) fn is_composed(&self) -> bool {
+        self.secret.composition.is_some()
+    }
+
+    /// The parsed derived-value template, for composed secrets.
+    pub(crate) fn composition(&self) -> Option<&Template> {
+        self.secret.composition.as_ref()
+    }
 }
 
 /// An immutable, fully-decided plan for resolving one profile.
@@ -170,7 +183,11 @@ impl ResolutionPlan {
         let mut groups: Vec<(Option<&str>, Vec<&PlannedSecret>)> = Vec::new();
         let mut group_index: HashMap<Option<&str>, usize> = HashMap::new();
         for secret in &self.secrets {
-            let primary = secret.route.group_key();
+            // Composed secrets have no route, so nothing fetches them.
+            let Some(route) = &secret.route else {
+                continue;
+            };
+            let primary = route.group_key();
             match group_index.get(&primary) {
                 Some(&idx) => groups[idx].1.push(secret),
                 None => {
@@ -279,7 +296,13 @@ impl Secrets {
         secret: &CompiledSecret,
         override_spec: &Option<String>,
     ) -> Result<PlannedSecret> {
-        let route = self.route_for(&secret.config, override_spec)?;
+        // A composed secret's value is derived by the executor, so it routes
+        // to no store, including an explicit `--provider` override.
+        let route = if secret.composition.is_some() {
+            None
+        } else {
+            Some(self.route_for(&secret.config, override_spec)?)
+        };
         Ok(PlannedSecret {
             name,
             secret: secret.clone(),
@@ -377,6 +400,11 @@ mod tests {
             .expect("secret in plan")
     }
 
+    /// The provider route a non-composed planned secret must carry.
+    fn route(planned: &PlannedSecret) -> &Route {
+        planned.route.as_ref().expect("a provider route")
+    }
+
     /// The plan's groups as (primary store, secret names) for easy assertion.
     fn group_names(plan: &ResolutionPlan) -> Vec<(Option<&str>, Vec<&str>)> {
         plan.groups()
@@ -392,9 +420,33 @@ mod tests {
         let plan = plan(&spec(secrets, None, &[]));
 
         let planned = find(&plan, "DATABASE_URL");
-        assert_eq!(planned.route.primary(), None);
-        assert!(planned.route.fallback.is_empty());
+        assert_eq!(route(planned).primary(), None);
+        assert!(route(planned).fallback.is_empty());
         assert_eq!(group_names(&plan), vec![(None, vec!["DATABASE_URL"])]);
+    }
+
+    #[test]
+    fn composed_secrets_have_no_provider_route_or_fetch_group() {
+        let _env = scrub_resolution_env();
+        let secrets = HashMap::from([
+            ("PART".to_string(), secret(None)),
+            (
+                "RESULT".to_string(),
+                Secret {
+                    description: Some("derived".to_string()),
+                    composed: Some("prefix-{PART}".to_string()),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let plan = plan(&spec(secrets, Some("dotenv://.env.mock"), &[]));
+
+        assert!(find(&plan, "RESULT").is_composed());
+        assert!(find(&plan, "RESULT").route.is_none());
+        assert_eq!(
+            group_names(&plan),
+            vec![(Some("dotenv://.env.mock"), vec!["PART"])]
+        );
     }
 
     #[test]
@@ -410,9 +462,9 @@ mod tests {
         let plan = plan(&spec);
 
         let planned = find(&plan, "API_KEY");
-        assert_eq!(planned.route.primary(), Some("dotenv://.env.mock"));
+        assert_eq!(route(planned).primary(), Some("dotenv://.env.mock"));
         assert!(
-            planned.route.fallback.is_empty(),
+            route(planned).fallback.is_empty(),
             "the override must collapse the chain: no fallback survives"
         );
         assert_eq!(plan.override_uri, Some("dotenv://.env.mock".to_string()));
@@ -429,8 +481,8 @@ mod tests {
         let plan = plan(&spec);
 
         let planned = find(&plan, "API_KEY");
-        assert_eq!(planned.route.group_key(), Some("mock"));
-        assert_eq!(planned.route.primary(), Some("dotenv://.env.mock"));
+        assert_eq!(route(planned).group_key(), Some("mock"));
+        assert_eq!(route(planned).primary(), Some("dotenv://.env.mock"));
         assert_eq!(plan.override_uri, Some("dotenv://.env.mock".to_string()));
     }
 
@@ -447,8 +499,8 @@ mod tests {
         // The primary is resolved to its URI; the fallback stays as the raw
         // alias, resolved only if the primary misses at read time.
         let planned = find(&plan, "API_KEY");
-        assert_eq!(planned.route.primary(), Some("onepassword://Shared"));
-        assert_eq!(planned.route.fallback, vec!["kr".to_string()]);
+        assert_eq!(route(planned).primary(), Some("onepassword://Shared"));
+        assert_eq!(route(planned).fallback, vec!["kr".to_string()]);
     }
 
     #[test]
@@ -460,9 +512,9 @@ mod tests {
         let plan = plan(&spec(secrets, None, &[("kr", "keyring://")]));
 
         let planned = find(&plan, "API_KEY");
-        assert_eq!(planned.route.primary(), Some("keyring://"));
+        assert_eq!(route(planned).primary(), Some("keyring://"));
         // The undefined alias is carried raw, not resolved (which would error).
-        assert_eq!(planned.route.fallback, vec!["ghost".to_string()]);
+        assert_eq!(route(planned).fallback, vec!["ghost".to_string()]);
     }
 
     #[test]
@@ -475,7 +527,7 @@ mod tests {
         let plan = plan(&spec(secrets, None, &[]));
 
         let planned = find(&plan, "API_KEY");
-        assert_eq!(planned.route.primary(), Some("onepassword://Production"));
+        assert_eq!(route(planned).primary(), Some("onepassword://Production"));
     }
 
     #[test]
@@ -496,7 +548,7 @@ mod tests {
         let secrets = HashMap::from([("API_KEY".to_string(), secret(Some(vec!["keyring"])))]);
         let plan = plan(&spec(secrets, None, &[]));
 
-        assert_eq!(find(&plan, "API_KEY").route.primary(), Some("keyring"));
+        assert_eq!(route(find(&plan, "API_KEY")).primary(), Some("keyring"));
     }
 
     #[test]
@@ -594,11 +646,14 @@ mod tests {
             .plan_secret("API_KEY", "default", None)
             .unwrap()
             .unwrap();
-        assert_eq!(one.route.primary(), Some("onepassword://Production"));
-        assert_eq!(one.route.fallback, vec!["keyring://".to_string()]);
+        assert_eq!(route(&one).primary(), Some("onepassword://Production"));
+        assert_eq!(route(&one).fallback, vec!["keyring://".to_string()]);
 
         // Same route the whole-profile plan derives.
         let batch = plan(&spec);
-        assert_eq!(one.route.primary(), find(&batch, "API_KEY").route.primary());
+        assert_eq!(
+            route(&one).primary(),
+            route(find(&batch, "API_KEY")).primary()
+        );
     }
 }

--- a/secretspec/src/report.rs
+++ b/secretspec/src/report.rs
@@ -54,6 +54,11 @@ pub struct SecretResolution {
     pub default_applied: bool,
     /// Whether the value was freshly minted by the secret's `generate` config.
     pub generated: bool,
+    /// Whether the value was derived from other declared secrets.
+    /// Internal provenance used by human-readable output and the value-carrying
+    /// resolve response; omitted from the report v1 wire format.
+    #[serde(skip)]
+    pub composed: bool,
     /// Whether the value is materialized to a temp file and exposed as a path.
     pub as_path: bool,
 }
@@ -105,10 +110,14 @@ impl ResolutionReport {
         for s in &self.secrets {
             let detail = match s.status {
                 ResolutionStatus::Resolved => {
+                    // Same provenance order as `resolve_impl`'s `ResolvedSource`
+                    // mapping; the flags are mutually exclusive.
                     if s.generated {
                         "ok        generated".to_string()
                     } else if s.default_applied {
                         "ok        default value".to_string()
+                    } else if s.composed {
+                        "ok        composed".to_string()
                     } else if let Some(uri) = &s.source_provider {
                         format!("ok        source {}", uri)
                     } else {
@@ -148,6 +157,7 @@ mod tests {
                     source_provider: None,
                     default_applied: false,
                     generated: false,
+                    composed: false,
                     as_path: false,
                 },
                 SecretResolution {
@@ -157,6 +167,7 @@ mod tests {
                     source_provider: Some("keyring://".to_string()),
                     default_applied: false,
                     generated: false,
+                    composed: false,
                     as_path: false,
                 },
                 SecretResolution {
@@ -166,6 +177,7 @@ mod tests {
                     source_provider: None,
                     default_applied: false,
                     generated: true,
+                    composed: false,
                     as_path: false,
                 },
                 SecretResolution {
@@ -175,6 +187,7 @@ mod tests {
                     source_provider: None,
                     default_applied: true,
                     generated: false,
+                    composed: false,
                     as_path: false,
                 },
                 SecretResolution {
@@ -184,6 +197,7 @@ mod tests {
                     source_provider: None,
                     default_applied: false,
                     generated: false,
+                    composed: false,
                     as_path: false,
                 },
             ],
@@ -244,6 +258,7 @@ mod tests {
                 source_provider: None,
                 default_applied: false,
                 generated: false,
+                composed: false,
                 as_path: true,
             }],
         );

--- a/secretspec/src/resolve.rs
+++ b/secretspec/src/resolve.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 /// Version of the [`ResolveResponse`] wire format.
-pub const RESOLVE_SCHEMA_VERSION: u32 = 1;
+pub const RESOLVE_SCHEMA_VERSION: u32 = 2;
 
 /// Where a resolved value came from.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -37,6 +37,10 @@ pub enum ResolvedSource {
     Generated,
     /// The manifest's committed `default` value.
     Default,
+    /// Derived from other declared secrets using a strict template.
+    ///
+    /// Available since SecretSpec 0.16.
+    Composed,
 }
 
 /// One resolved secret. Exactly one of `value` or `path` is set: `path` when

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1600,7 +1600,15 @@ impl Secrets {
             }
         };
 
-        let backend = match self.write_provider_for_route(&planned.route, Some(&profile_name)) {
+        // A composed secret plans no route: its value is derived, so a write
+        // has nowhere to go.
+        let Some(route) = &planned.route else {
+            let err = SecretSpecError::ComposedSecretReadOnly(name.to_string());
+            self.record_key_error(AuditAction::Set, &profile_name, name, None, None, &err);
+            return Err(err);
+        };
+
+        let backend = match self.write_provider_for_route(route, Some(&profile_name)) {
             Ok(backend) => backend,
             Err(err) => {
                 self.record_key_error(AuditAction::Set, &profile_name, name, None, None, &err);
@@ -1721,13 +1729,54 @@ impl Secrets {
                 return Err(err);
             }
         };
+        // A composed secret plans no route: resolve its dependency closure
+        // through the batch executor and print the rendered value.
+        let Some(route) = &planned.route else {
+            let names = self.composed_dependency_names(name, &profile_name);
+            let plan = self.build_plan_from_names(profile_name.clone(), names)?;
+            return match self.execute_plan(&plan, Materialize::Values)? {
+                Ok(mut validated) => {
+                    if !validated.resolved.secrets.contains_key(name) {
+                        let err = SecretSpecError::SecretNotFound(name.to_string());
+                        self.record_key_error(
+                            AuditAction::Get,
+                            &profile_name,
+                            name,
+                            None,
+                            None,
+                            &err,
+                        );
+                        return Err(err);
+                    }
+                    validated.keep_temp_files()?;
+                    let value = &validated.resolved.secrets[name];
+                    self.record(
+                        AuditAction::Get,
+                        &profile_name,
+                        AuditOutcome::Found,
+                        AuditFields {
+                            key: Some(name),
+                            ..Default::default()
+                        },
+                    );
+                    println!("{}", value.expose_secret());
+                    Ok(())
+                }
+                Err(errors) => {
+                    let err =
+                        SecretSpecError::RequiredSecretMissing(errors.missing_required.join(", "));
+                    self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
+                    Err(err)
+                }
+            };
+        };
         let default = planned.config().default.clone();
         let as_path = planned.as_path();
 
         // Walk the route's chain in order; each entry is resolved lazily and a
         // broken link is skipped with a warning, so an undefined alias never
         // blocks a provider elsewhere in the chain from answering.
-        let read_specs = planned.route.specs();
+        let read_specs = route.specs();
         let result = self.get_secret_from_providers(
             name,
             planned.as_address(&self.config.project.name, &profile_name),
@@ -1869,7 +1918,13 @@ impl Secrets {
                         ));
                     }
 
-                    let missing = &validation_errors.missing_required;
+                    let missing =
+                        self.promptable_missing_names(&validation_errors, &profile_display);
+                    if missing.is_empty() {
+                        return Err(SecretSpecError::RequiredSecretMissing(
+                            validation_errors.missing_required.join(", "),
+                        ));
+                    }
                     let total = missing.len();
                     // Name the provider without constructing it: this value is
                     // display-only (each prompted write builds its own route's
@@ -1894,7 +1949,7 @@ impl Secrets {
                         profile_display.bold(),
                         default_backend_name.bold(),
                     );
-                    for secret_name in missing {
+                    for secret_name in &missing {
                         let description = self
                             .resolve_secret_config(secret_name, Some(&profile_display))
                             .and_then(|c| c.description)
@@ -1926,8 +1981,13 @@ impl Secrets {
 
                             let value = prompt.prompt()?;
 
-                            let backend = self
-                                .write_provider_for_route(&planned.route, Some(&profile_display))?;
+                            let backend = self.write_provider_for_route(
+                                planned
+                                    .route
+                                    .as_ref()
+                                    .expect("prompted names are provider-backed leaves"),
+                                Some(&profile_display),
+                            )?;
                             let set_result = backend.set(
                                 planned.as_address(&self.config.project.name, &profile_display),
                                 &SecretString::new(value.into()),
@@ -2221,14 +2281,17 @@ impl Secrets {
             // supplies the same write route and address `set` executes. Sorted
             // names keep the per-secret summary lines in a stable order.
             for name in import_names {
-                read_names.push(name.clone());
                 let planned = self
                     .plan_secret(&name, &profile_display, None)?
                     .expect("Secret should exist since we're iterating over it");
+                // A composed secret has no stored value to copy.
+                let Some(route) = &planned.route else {
+                    continue;
+                };
+                read_names.push(name.clone());
                 let description = planned.config().description.as_deref();
 
-                let to_provider =
-                    self.write_provider_for_route(&planned.route, Some(&profile_display))?;
+                let to_provider = self.write_provider_for_route(route, Some(&profile_display))?;
 
                 // The secret's address (native `ref` coordinates or convention
                 // naming) applies to both stores: naming is orthogonal to
@@ -2402,7 +2465,13 @@ impl Secrets {
         // Store the generated value at the plan's address, through the plan's
         // write route: the same decisions every other write path executes.
         let addr = planned.as_address(&self.config.project.name, profile_name);
-        let backend = self.write_provider_for_route(&planned.route, Some(profile_name))?;
+        let backend = self.write_provider_for_route(
+            planned
+                .route
+                .as_ref()
+                .expect("a generating secret is provider-backed"),
+            Some(profile_name),
+        )?;
         // The provider states why a write is refused; wrapping it here would
         // only nest a second "Provider operation failed" prefix.
         backend.check_writable(addr)?;
@@ -2588,6 +2657,8 @@ impl Secrets {
                         ResolvedSource::Generated
                     } else if entry.default_applied {
                         ResolvedSource::Default
+                    } else if entry.composed {
+                        ResolvedSource::Composed
                     } else {
                         ResolvedSource::Provider
                     };
@@ -2747,6 +2818,79 @@ impl Secrets {
         result
     }
 
+    /// The target plus its transitive declared dependencies, sorted for a
+    /// deterministic, least-access `get` plan.
+    fn composed_dependency_names(&self, target: &str, profile_name: &str) -> Vec<String> {
+        fn visit(
+            name: &str,
+            profile: &crate::manifest::CompiledProfile,
+            names: &mut HashSet<String>,
+        ) {
+            if !names.insert(name.to_string()) {
+                return;
+            }
+            if let Some(template) = &profile.secrets[name].composition {
+                for dependency in template.dependencies() {
+                    visit(dependency, profile, names);
+                }
+            }
+        }
+
+        let profile = self
+            .manifest
+            .profile(profile_name)
+            .expect("profile is validated before dependency planning");
+        let mut names = HashSet::new();
+        visit(target, profile, &mut names);
+        let mut names: Vec<String> = names.into_iter().collect();
+        names.sort();
+        names
+    }
+
+    /// Replace missing derived nodes with the unresolved provider-backed leaves
+    /// a user can actually set. This also permits an optional leaf to be
+    /// prompted when a required composition depends on it.
+    fn promptable_missing_names(
+        &self,
+        errors: &ValidationErrors,
+        profile_name: &str,
+    ) -> Vec<String> {
+        let statuses: HashMap<&str, &ResolutionStatus> = errors
+            .resolution
+            .iter()
+            .map(|entry| (entry.name.as_str(), &entry.status))
+            .collect();
+        let profile = self
+            .manifest
+            .profile(profile_name)
+            .expect("profile is validated before prompting");
+
+        fn visit(
+            name: &str,
+            profile: &crate::manifest::CompiledProfile,
+            statuses: &HashMap<&str, &ResolutionStatus>,
+            promptable: &mut HashSet<String>,
+        ) {
+            let Some(template) = &profile.secrets[name].composition else {
+                promptable.insert(name.to_string());
+                return;
+            };
+            for dependency in template.dependencies() {
+                if statuses.get(dependency.as_str()).copied() != Some(&ResolutionStatus::Resolved) {
+                    visit(dependency, profile, statuses, promptable);
+                }
+            }
+        }
+
+        let mut promptable = HashSet::new();
+        for name in &errors.missing_required {
+            visit(name, profile, &statuses, &mut promptable);
+        }
+        let mut promptable: Vec<String> = promptable.into_iter().collect();
+        promptable.sort();
+        promptable
+    }
+
     /// Rejects a `ref` routed at exactly one store that cannot honor its
     /// coordinates. Run per primary-store group right after the provider is
     /// built and before any fetch is spawned, so the definite error surfaces up
@@ -2769,7 +2913,11 @@ impl Secrets {
         for planned in group {
             // Only the routes that consult exactly one store; a chain with a
             // fallback defers coordinate checking to per-store read time.
-            if planned.route.fallback_specs().is_some() {
+            // (Groups never contain a routeless composed secret.)
+            let Some(route) = &planned.route else {
+                continue;
+            };
+            if route.fallback_specs().is_some() {
                 continue;
             }
             if let Some(native) = planned.reference() {
@@ -2903,12 +3051,17 @@ impl Secrets {
         // chain, generation, or default, and record a value-free provenance entry
         // for the resolution report.
         for planned in &plan.secrets {
+            // Composed secrets have no route; they render after this loop,
+            // once their dependencies are decided.
+            let Some(route) = &planned.route else {
+                continue;
+            };
             let name = &planned.name;
             let required = planned.required();
             let as_path = planned.as_path();
             // The group key (primary spec), matching how `group_uris` and
             // `failed_primary_uris` were keyed from `plan.groups()` above.
-            let primary_uri = planned.route.group_key();
+            let primary_uri = route.group_key();
 
             let status;
             let mut source_provider = None;
@@ -2940,7 +3093,7 @@ impl Secrets {
                     // undefined alias is skipped with a warning so a working
                     // provider after it still answers. An override or the
                     // default store has no fallback.
-                    let (fallback_value, fallback_uri) = match planned.route.fallback_specs() {
+                    let (fallback_value, fallback_uri) = match route.fallback_specs() {
                         Some(fallback) => {
                             let resolved = self.get_secret_from_providers(
                                 name,
@@ -3043,13 +3196,116 @@ impl Secrets {
                 source_provider,
                 default_applied,
                 generated,
+                composed: false,
                 as_path,
             });
         }
 
+        // Render composed secrets after every provider-backed secret has been
+        // decided, dependencies before dependents. Load-time graph validation
+        // guarantees acyclicity, so a depth-first post-order over the composed
+        // nodes is a topological order; rooting the walk at the plan's
+        // name-sorted secrets keeps the report order deterministic.
+        fn composition_order<'a>(
+            planned: &'a PlannedSecret,
+            composed: &HashMap<&str, &'a PlannedSecret>,
+            visited: &mut HashSet<&'a str>,
+            ordered: &mut Vec<&'a PlannedSecret>,
+        ) {
+            if !visited.insert(planned.name.as_str()) {
+                return;
+            }
+            let template = planned
+                .composition()
+                .expect("only composed nodes are ordered");
+            for dependency in template.dependencies() {
+                if let Some(dependency) = composed.get(dependency.as_str()) {
+                    composition_order(dependency, composed, visited, ordered);
+                }
+            }
+            ordered.push(planned);
+        }
+        let composed: HashMap<&str, &PlannedSecret> = plan
+            .secrets
+            .iter()
+            .filter(|secret| secret.is_composed())
+            .map(|secret| (secret.name.as_str(), secret))
+            .collect();
+        let mut ordered = Vec::with_capacity(composed.len());
+        let mut visited = HashSet::new();
+        for planned in plan.secrets.iter().filter(|secret| secret.is_composed()) {
+            composition_order(planned, &composed, &mut visited, &mut ordered);
+        }
+
+        if !ordered.is_empty() {
+            // Statuses of the already-decided secrets, extended as each
+            // composition renders so nested compositions see derived
+            // dependencies. Built only when the plan has composed secrets.
+            let mut statuses: HashMap<String, ResolutionStatus> = resolution
+                .iter()
+                .map(|entry| (entry.name.clone(), entry.status.clone()))
+                .collect();
+            for planned in ordered {
+                let template = planned
+                    .composition()
+                    .expect("only composed nodes are ordered");
+                let dependencies_resolved = template.dependencies().iter().all(|dependency| {
+                    statuses.get(dependency) == Some(&ResolutionStatus::Resolved)
+                });
+                let status = if dependencies_resolved {
+                    if materialize == Materialize::Values {
+                        let rendered = template
+                            .render(|dependency| {
+                                secrets.get(dependency).map(|value| value.expose_secret())
+                            })
+                            .map_err(SecretSpecError::CompositionFailed)?;
+                        self.insert_resolved(
+                            &mut secrets,
+                            &mut temp_files,
+                            planned.name.clone(),
+                            SecretString::new(rendered.into()),
+                            planned.as_path(),
+                        )?;
+                    }
+                    ResolutionStatus::Resolved
+                } else {
+                    match planned.secret.missing {
+                        MissingPolicy::Error => {
+                            missing_required.push(planned.name.clone());
+                            ResolutionStatus::MissingRequired
+                        }
+                        MissingPolicy::Omit => {
+                            missing_optional.push(planned.name.clone());
+                            ResolutionStatus::MissingOptional
+                        }
+                        MissingPolicy::Generate | MissingPolicy::UseDefault => {
+                            unreachable!("composed source conflicts are rejected at load time")
+                        }
+                    }
+                };
+
+                statuses.insert(planned.name.clone(), status.clone());
+                resolution.push(SecretResolution {
+                    name: planned.name.clone(),
+                    status,
+                    required: planned.required(),
+                    source_provider: None,
+                    default_applied: false,
+                    generated: false,
+                    composed: true,
+                    as_path: planned.as_path(),
+                });
+            }
+        }
+
+        // Composed secrets carry no route; the stores their leaves route to
+        // name the report, exactly as for ordinary secrets.
         let report_provider_uri = self.validation_report_provider_uri(
             plan.override_uri.as_deref(),
-            plan.secrets.iter().map(|s| s.route.primary()),
+            plan.secrets
+                .iter()
+                .filter_map(|secret| secret.route.as_ref())
+                .map(|route| route.primary()),
             Some(&plan.profile),
         )?;
 

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -559,7 +559,7 @@ fn test_resolve_carries_values_and_provenance() {
     let spec = Secrets::new(resolve_test_config(secrets), None, Some(provider), None);
 
     let response = spec.resolve().unwrap();
-    assert_eq!(response.schema_version, 1);
+    assert_eq!(response.schema_version, 2);
     assert_eq!(response.profile, "default");
     assert!(response.is_ok());
     assert_eq!(response.missing_optional, vec!["SENTRY_DSN".to_string()]);
@@ -587,6 +587,174 @@ fn test_resolve_carries_values_and_provenance() {
     assert_eq!(
         stripped.secrets["DATABASE_URL"].source,
         ResolvedSource::Provider
+    );
+}
+
+#[test]
+fn composed_secrets_resolve_in_dependency_order_without_reparsing_values() {
+    use crate::resolve::ResolvedSource;
+
+    let temp_dir = TempDir::new().unwrap();
+    let env_path = temp_dir.path().join(".env");
+    // The reference-looking password is intentional: composition must insert
+    // it as opaque text rather than recursively interpreting `{DB_HOST}`.
+    fs::write(
+        &env_path,
+        "DB_USER=alice\nDB_PASSWORD={DB_HOST}\nDB_HOST=db.example\n",
+    )
+    .unwrap();
+
+    let stored = |description: &str| Secret {
+        description: Some(description.to_string()),
+        ..Default::default()
+    };
+    let mut secrets = HashMap::from([
+        ("DB_USER".to_string(), stored("user")),
+        ("DB_PASSWORD".to_string(), stored("password")),
+        ("DB_HOST".to_string(), stored("host")),
+    ]);
+    // Nested compositions and hash-map declaration order must not affect the
+    // dependency graph's evaluation order.
+    secrets.insert(
+        "AUTH".to_string(),
+        Secret {
+            description: Some("credentials".to_string()),
+            composed: Some("{DB_USER}:{DB_PASSWORD}".to_string()),
+            ..Default::default()
+        },
+    );
+    secrets.insert(
+        "DATABASE_URL".to_string(),
+        Secret {
+            description: Some("dsn".to_string()),
+            composed: Some("postgres://{AUTH}@{DB_HOST}/app".to_string()),
+            ..Default::default()
+        },
+    );
+
+    let config = resolve_test_config(secrets);
+    config.validate().unwrap();
+    let provider = format!("dotenv://{}", env_path.display());
+    let spec = Secrets::new(config, None, Some(provider), None);
+
+    let response = spec.resolve().unwrap();
+    let auth = &response.secrets["AUTH"];
+    assert_eq!(auth.value.as_deref(), Some("alice:{DB_HOST}"));
+    assert_eq!(auth.source, ResolvedSource::Composed);
+    let dsn = &response.secrets["DATABASE_URL"];
+    assert_eq!(
+        dsn.value.as_deref(),
+        Some("postgres://alice:{DB_HOST}@db.example/app")
+    );
+    assert_eq!(dsn.source, ResolvedSource::Composed);
+    assert!(dsn.source_provider.is_none());
+
+    let report = spec.report().unwrap();
+    assert!(
+        report
+            .to_explain_string()
+            .contains("DATABASE_URL  ok        composed")
+    );
+}
+
+#[test]
+fn composed_secrets_propagate_missingness_and_are_read_only() {
+    let temp_dir = TempDir::new().unwrap();
+    let env_path = temp_dir.path().join(".env");
+    fs::write(&env_path, "").unwrap();
+    let secrets = HashMap::from([
+        (
+            "OPTIONAL_PART".to_string(),
+            Secret {
+                description: Some("optional".to_string()),
+                required: Some(false),
+                ..Default::default()
+            },
+        ),
+        (
+            "OPTIONAL_RESULT".to_string(),
+            Secret {
+                description: Some("optional result".to_string()),
+                required: Some(false),
+                composed: Some("prefix-{OPTIONAL_PART}".to_string()),
+                ..Default::default()
+            },
+        ),
+        (
+            "REQUIRED_RESULT".to_string(),
+            Secret {
+                description: Some("required result".to_string()),
+                composed: Some("prefix-{OPTIONAL_PART}".to_string()),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let config = resolve_test_config(secrets);
+    config.validate().unwrap();
+    let spec = Secrets::new(
+        config,
+        None,
+        Some(format!("dotenv://{}", env_path.display())),
+        None,
+    );
+
+    let response = spec.resolve().unwrap();
+    assert_eq!(
+        response.missing_required,
+        vec!["REQUIRED_RESULT".to_string()]
+    );
+    assert!(
+        response
+            .missing_optional
+            .contains(&"OPTIONAL_RESULT".to_string())
+    );
+
+    let error = spec
+        .set("REQUIRED_RESULT", Some("override".to_string()))
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        SecretSpecError::ComposedSecretReadOnly(ref name) if name == "REQUIRED_RESULT"
+    ));
+}
+
+#[test]
+fn composed_secrets_use_the_exported_path_of_as_path_dependencies() {
+    let temp_dir = TempDir::new().unwrap();
+    let env_path = temp_dir.path().join(".env");
+    fs::write(&env_path, "CERT=certificate-bytes\n").unwrap();
+    let secrets = HashMap::from([
+        (
+            "CERT".to_string(),
+            Secret {
+                description: Some("certificate".to_string()),
+                as_path: Some(true),
+                ..Default::default()
+            },
+        ),
+        (
+            "CERT_ARG".to_string(),
+            Secret {
+                description: Some("certificate argument".to_string()),
+                composed: Some("--cert={CERT}".to_string()),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let config = resolve_test_config(secrets);
+    config.validate().unwrap();
+    let spec = Secrets::new(
+        config,
+        None,
+        Some(format!("dotenv://{}", env_path.display())),
+        None,
+    );
+
+    let response = spec.resolve().unwrap();
+    let cert_path = response.secrets["CERT"].path.as_deref().unwrap();
+    assert_eq!(
+        response.secrets["CERT_ARG"].value.as_deref(),
+        Some(format!("--cert={cert_path}").as_str())
     );
 }
 
@@ -4866,6 +5034,7 @@ fn test_resolve_secret_config_merges_type_and_generate() {
             description: Some("Database password".to_string()),
             required: None,
             default: None,
+            composed: None,
             providers: None,
             reference: None,
             as_path: None,


### PR DESCRIPTION
## Summary

- add read-only `composed` secrets using strict `{SECRET_NAME}` templates
- validate dependencies as a static graph, rejecting unknown references, malformed syntax, and cycles before provider access
- resolve nested compositions independently of declaration order across `get`, `check`, `run`, `export`, and SDK resolution
- propagate required/optional missingness, preserve empty values, support `as_path`, skip composed values during imports, and reject direct writes
- report composed provenance through resolve schema v2 and update every SDK's expected schema version
- document the 0.16+ feature on the landing page, in a dedicated concept guide, and in configuration and CLI references

Closes #160.

## Why

Dotenv-style interpolation has several semantics that are unsafe for a declarative secret graph: ambient process variables can override file values, undefined references can silently become empty strings, file order can affect results, and recursively expanded values stop being opaque secret bytes.

Composition deliberately uses a smaller contract: only declared secrets may be referenced, substitution happens once, inserted values are never reparsed, missing remains distinct from empty, and `${...}` / shell fallback syntax is rejected.

## Compatibility

This targets SecretSpec 0.16 and is unavailable in 0.15 and earlier. Adding `composed` to the closed `ResolvedSource` enum bumps the value-carrying resolve schema to v2; the value-free resolution report remains schema v1.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run build` in `docs/`
- `git diff --check`
