### PR TITLE
Prepare SecretSpec 0.16 post and composition syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Composed secrets derive read-only values such as connection strings from
-  other declared secrets using strict `{SECRET_NAME}` templates. Dependencies
-  are order-independent, may include other compositions, and are validated for
-  unknown references and cycles before provider access; unlike dotenv
-  expansion, values are substituted once without ambient environment lookup,
-  fallback operators, recursive expansion, or silent empty replacements.
+  other declared secrets using strict `${UPPERCASE_NAME}` templates; names must
+  match `[A-Z][A-Z0-9_]*`, `$$` produces a literal dollar sign, and ordinary
+  braces remain literal. Dependencies are order-independent, may include other
+  compositions, and are validated for unknown references and cycles before
+  provider access; unlike dotenv expansion, values are substituted once
+  without ambient environment lookup, fallback operators, recursive expansion,
+  or silent empty replacements.
 - C# SDK (`Cachix.SecretSpec`, available in 0.16): resolve secrets from .NET
   through the shared native resolver, with fluent builder and one-shot APIs,
   typed failure exceptions, value-free preflight reports, provenance,

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -89,8 +89,9 @@ DATABASE_URL = { default = "postgresql://localhost/dev" }
 ## Composed Secrets (0.16+)
 
 \`composed\` derives a read-only value from other declared secrets with strict,
-order-independent \`{SECRET_NAME}\` references. It does not perform dotenv,
-shell, ambient-environment, or recursive expansion.
+order-independent \`\${UPPERCASE_NAME}\` references. Names must match
+\`[A-Z][A-Z0-9_]*\`; it does not perform dotenv, shell, ambient-environment, or
+recursive expansion.
 
 ## Type-safe Rust SDK
 

--- a/docs/src/content/docs/blog/secretspec-0-16-composed-secrets-infisical-and-csharp-sdk.md
+++ b/docs/src/content/docs/blog/secretspec-0-16-composed-secrets-infisical-and-csharp-sdk.md
@@ -1,0 +1,233 @@
+---
+title: "SecretSpec 0.16: Composed secrets, Infisical, and C# SDK"
+description: Derive secrets from other declared values, use Infisical Cloud or self-hosted, and resolve secrets natively from .NET.
+date: 2026-07-18
+authors:
+  - domen
+---
+
+[SecretSpec 0.16](https://github.com/cachix/secretspec/releases/tag/v0.16.0 "SecretSpec 0.16 release")
+ships:
+
+- **[Composed secrets](/concepts/composed-secrets/)** — derive a read-only
+  value, such as a connection string, from other secrets declared in the
+  manifest.
+- **[Infisical](/providers/infisical/)** — read and write secrets in Infisical
+  Cloud or a self-hosted instance, with Universal Auth, access-token, and
+  provider-credential authentication.
+- **[C# SDK](/sdk/csharp/)** — resolve the same manifests from .NET through the
+  shared native resolver, distributed as the `Cachix.SecretSpec` NuGet package.
+
+## Build one value from several secrets
+
+Applications often need a connection string while secret stores work better
+with its independently rotated parts. SecretSpec can now keep those parts
+separate and assemble the application-facing value only during resolution:
+
+```toml title="secretspec.toml"
+[profiles.default]
+DB_USER = { description = "Database user" }
+DB_PASSWORD = { description = "Database password" }
+DB_HOST = { description = "Database host" }
+
+DATABASE_URL = {
+  description = "PostgreSQL connection string",
+  composed = "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/app"
+}
+```
+
+`DB_USER`, `DB_PASSWORD`, and `DB_HOST` still come from their configured
+providers. `DATABASE_URL` is rendered in memory and included in `check`, `run`,
+`export`, `get`, and SDK resolution like any other secret. It is never read
+from or written to a provider.
+
+Composition uses a deliberately small template language. `${UPPERCASE_NAME}`
+inserts one declared secret; names must match `[A-Z][A-Z0-9_]*`, and `$$`
+produces a literal dollar sign. Ordinary braces remain literal, so JSON, CSS,
+and regular-expression syntax does not need brace escaping. There is no ambient
+environment lookup, shell fallback syntax, command substitution, or recursive
+expansion. Substitution happens once, so reference-looking text inside a secret
+value remains ordinary secret bytes rather than becoming new template syntax.
+Composition is still raw string concatenation: literal JSON braces are fine,
+but use `secretspec export --format json` when values need JSON encoding.
+
+SecretSpec builds and validates the dependency graph before contacting a
+provider. Declaration order does not matter, compositions may depend on other
+compositions, and unknown names or cycles fail while loading the manifest:
+
+```toml title="secretspec.toml"
+[profiles.default]
+USER = { description = "Database user" }
+PASSWORD = { description = "Database password" }
+HOST = { description = "Database host" }
+
+AUTHORITY = {
+  description = "Database authority",
+  composed = "${USER}:${PASSWORD}"
+}
+DATABASE_URL = {
+  description = "Database URL",
+  composed = "postgres://${AUTHORITY}@${HOST}/app"
+}
+```
+
+Missing and empty values also stay distinct. An empty dependency inserts an
+empty string; a missing dependency makes a required composition missing. Set
+`required = false` on the composed secret to omit the result when a dependency
+is unavailable. SecretSpec never silently turns a missing dependency into
+empty text.
+
+Composed secrets are read-only. `set` rejects them and `import` skips them,
+because the stored values are their dependencies. A composition also cannot
+declare a competing source such as `default`, `providers`, `ref`, or
+`generate`. See [Composed Secrets](/concepts/composed-secrets/) for profile
+inheritance, `as_path`, escaping, and the full validation rules.
+
+## Infisical joins the provider list
+
+The new `infisical://` provider works with Infisical Cloud, its EU service, and
+self-hosted instances. It uses an Infisical project UUID and authenticates as a
+machine identity through Universal Auth:
+
+```bash
+export INFISICAL_CLIENT_ID=...
+export INFISICAL_CLIENT_SECRET=...
+
+secretspec run \
+  --provider "infisical://app.infisical.com/7e2f1a4c-...?env=prod" \
+  -- npm start
+```
+
+A ready-made access token can instead be supplied through `INFISICAL_TOKEN`.
+Both authentication forms also integrate with
+[provider credentials](/concepts/providers/#provider-credentials), so the
+machine identity does not have to pass through the application's environment:
+
+```toml title="secretspec.toml"
+[providers.infisical]
+uri = "infisical://app.infisical.com/7e2f1a4c-..."
+
+[providers.infisical.credentials]
+client_id = "keyring"
+client_secret = "keyring"
+```
+
+Run `secretspec config provider login infisical` to write those credentials to
+their declared source provider. A pre-minted `token` can be sourced the same
+way.
+
+By default, the active SecretSpec profile also names the Infisical environment.
+A `production` profile reads the `production` environment, while a `dev`
+profile reads `dev`. If the two naming schemes do not line up, `?env=` pins the
+Infisical environment. Profiles remain isolated because they still occupy
+separate folders:
+
+```text
+project "myapp", profile "production", key "DATABASE_URL"
+  -> environment production
+     folder      /secretspec/myapp/production
+     key         DATABASE_URL
+```
+
+The `?path=` option replaces the `/secretspec` prefix. Secret keys are stored
+verbatim, folders are created as needed, and secrets in the same folder are
+fetched together in one request. Infisical folder imports and its own secret
+references are resolved with Infisical's precedence, matching its CLI.
+
+Existing secrets can be addressed with SecretSpec's provider-independent
+[`ref`](/concepts/references/) coordinates. For Infisical, `item` contains the
+folder and key, and `version` can pin a revision:
+
+```toml title="secretspec.toml"
+[providers]
+infisical_prod = "infisical://app.infisical.com/7e2f1a4c-...?env=prod"
+
+[profiles.production]
+DATABASE_URL = {
+  description = "Postgres DSN",
+  ref = { item = "/infra/shared/DB_PASSWORD" },
+  providers = ["infisical_prod"]
+}
+API_KEY = {
+  description = "Pinned API key",
+  ref = { item = "/infra/API_KEY", version = "3" },
+  providers = ["infisical_prod"]
+}
+```
+
+Version-pinned references are read-only. For self-hosting, put the instance
+host in the URI or set `INFISICAL_DOMAIN`; the legacy `INFISICAL_API_URL`
+variable remains supported. See the [Infisical provider guide](/providers/infisical/)
+for permissions, URI options, approval policies, and limitations.
+
+## Resolve secrets from C# and .NET
+
+The `Cachix.SecretSpec` NuGet package brings the shared SecretSpec resolver to
+.NET 8:
+
+```bash
+dotnet add package Cachix.SecretSpec
+```
+
+```csharp
+using Cachix.SecretSpec;
+
+using var resolved = SecretSpec.Builder()
+    .WithProvider("keyring://")
+    .WithProfile("production")
+    .WithReason("boot web app")
+    .Load();
+
+Console.WriteLine(resolved.Secrets["DATABASE_URL"].Get());
+resolved.SetAsEnv();
+```
+
+The SDK is a thin P/Invoke client over the same Rust core as the CLI and the
+other language SDKs. Providers, profiles, fallback chains, references,
+generators, audit reasons, and composed secrets therefore behave the same way
+without C#-specific resolution logic.
+
+The NuGet package includes native resolver builds for Linux x64 and Arm64,
+macOS Arm64, and Windows x64. No separate SecretSpec CLI or native-library
+installation is required at runtime.
+
+A missing required secret throws `MissingRequiredException`, with the missing
+names available on the exception. Other failures use `SecretSpecException` and
+a stable error kind. For deployment checks, `Report()` returns the same
+value-free inventory as `secretspec check --json`; missing values appear as
+statuses instead of exceptions.
+
+`Resolved` implements `IDisposable`. Keeping it in a `using` declaration makes
+the lifetime of any `as_path` temporary files explicit and removes them
+deterministically:
+
+```csharp
+using var resolved = SecretSpec.Builder()
+    .WithReason("TLS service boot")
+    .Load();
+
+var certificatePath = resolved.Secrets["TLS_CERT"].Get();
+// Use the file before resolved is disposed.
+```
+
+The SDK can also expose a flat JSON field map for deserializing into a C# model
+generated from `secretspec schema`. See the [C# SDK guide](/sdk/csharp/) for
+ASP.NET Core integration, one-shot resolution, preflight reports, and typed
+access.
+
+## Upgrading
+
+```bash
+cargo install secretspec
+```
+
+All three additions are opt-in: existing manifests and provider configurations
+continue to work unchanged. Add `composed` when a value should be derived,
+select an `infisical://` provider to use Infisical, or install
+`Cachix.SecretSpec` in a .NET application.
+
+See the [full changelog](https://github.com/cachix/secretspec/blob/main/CHANGELOG.md)
+for every change in this release.
+
+Questions or feedback? Join us on
+[Discord](https://discord.gg/naMgvexb6q).

--- a/docs/src/content/docs/concepts/composed-secrets.md
+++ b/docs/src/content/docs/concepts/composed-secrets.md
@@ -19,7 +19,7 @@ DB_HOST = { description = "Database host" }
 
 DATABASE_URL = {
   description = "PostgreSQL connection string",
-  composed = "postgres://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/app"
+  composed = "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/app"
 }
 ```
 
@@ -29,7 +29,8 @@ them. The composed result is never read from or written to a provider.
 
 ## Static dependency graph
 
-Every `{NAME}` must name a secret declared in the effective profile.
+Every `${UPPERCASE_NAME}` must name a secret declared in the effective profile.
+Reference names must match `[A-Z][A-Z0-9_]*`.
 SecretSpec validates the complete graph while loading `secretspec.toml`, before
 accessing a provider:
 
@@ -44,8 +45,8 @@ USER = { description = "Database user" }
 PASSWORD = { description = "Database password" }
 HOST = { description = "Database host" }
 
-AUTHORITY = { description = "Database authority", composed = "{USER}:{PASSWORD}" }
-DATABASE_URL = { description = "Database URL", composed = "postgres://{AUTHORITY}@{HOST}/app" }
+AUTHORITY = { description = "Database authority", composed = "${USER}:${PASSWORD}" }
+DATABASE_URL = { description = "Database URL", composed = "postgres://${AUTHORITY}@${HOST}/app" }
 ```
 
 This differs deliberately from dotenv expansion, where behavior can depend on
@@ -58,21 +59,25 @@ Composition is a small, strict language:
 
 | Syntax | Meaning |
 |---|---|
-| `{SECRET_NAME}` | Insert one declared secret's exported value |
-| `{{` | Insert a literal `{` |
-| `}}` | Insert a literal `}` |
+| `${UPPERCASE_NAME}` | Insert one declared secret's exported value |
+| `$$` | Insert a literal `$` |
+
+For example, `$${EXTERNAL_NAME}` renders the literal text
+`${EXTERNAL_NAME}` without treating it as a SecretSpec reference.
 
 The following are intentionally unsupported:
 
-- `${NAME}` and shell-style expressions such as `${NAME:-fallback}`;
+- lowercase or mixed-case references such as `${password}` or `${Password}`;
+- shell-style expressions such as `${NAME:-fallback}`;
 - ambient environment-variable lookup;
 - command substitution;
 - recursive expansion.
 
-Substitution is one pass. If `PASSWORD` contains the literal text `{HOST}`,
-inserting `{PASSWORD}` produces `{HOST}`; it is not scanned again. This keeps
-secret bytes opaque and prevents values from unexpectedly becoming executable
-template syntax.
+Plain `{` and `}` are literal, so JSON objects, CSS blocks, and regular-expression
+quantifiers do not require brace escaping. Substitution is one pass. If
+`PASSWORD` contains the literal text `${HOST}`, inserting `${PASSWORD}`
+produces `${HOST}`; it is not scanned again. This keeps secret bytes opaque and
+prevents values from unexpectedly becoming executable template syntax.
 
 ## Missing, empty, and optional values
 
@@ -110,10 +115,10 @@ declarations:
 DB_USER = { description = "Database user" }
 DB_PASSWORD = { description = "Database password" }
 DB_HOST = { description = "Database host" }
-DATABASE_URL = { description = "Database URL", composed = "postgres://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/app" }
+DATABASE_URL = { description = "Database URL", composed = "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/app" }
 
 [profiles.development]
-DATABASE_URL = { composed = "postgres://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/app_dev" }
+DATABASE_URL = { composed = "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/app_dev" }
 ```
 
 Profile-level storage defaults do not apply to composed secrets, because their
@@ -126,10 +131,12 @@ When a dependency uses `as_path = true`, its exported temporary-file path is
 inserted. Setting `as_path = true` on the composed secret instead writes the
 final rendered value to a temporary file.
 
-Composition performs raw string concatenation. It does not URL-encode values:
-SecretSpec cannot infer whether a component is a username, password, host,
-path, or query parameter. Store each component in the representation required
-by the destination format.
+Composition performs raw string concatenation. It does not URL-encode or
+JSON-encode values: SecretSpec cannot infer whether a component is a username,
+password, host, path, query parameter, or structured value. Store each
+component in the representation required by the destination format. To export
+the resolved secret map as safely encoded JSON, use
+`secretspec export --format json`.
 
 See the [`composed` configuration reference](/reference/configuration/#composed-secrets)
 for the field-level constraints.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -88,7 +88,7 @@ Each secret variable is defined as a table with the following fields:
 | `description` | string | Yes (see notes) | Human-readable description of the secret |
 | `required` | boolean | No | Whether absence is an error (default: true, or false when `default` is present) |
 | `default` | string | No | Default value if not provided |
-| `composed` (0.16+) | string | No | Derive a read-only value from other declared secrets using `{SECRET_NAME}` references |
+| `composed` (0.16+) | string | No | Derive a read-only value from other declared secrets using `${UPPERCASE_NAME}` references |
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
 | `ref` | table | No | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
@@ -122,23 +122,25 @@ CLI behavior, profile inheritance, and the differences from dotenv expansion:
 DB_USER = { description = "Database user" }
 DB_PASSWORD = { description = "Database password" }
 DB_HOST = { description = "Database host" }
-DATABASE_URL = { description = "PostgreSQL DSN", composed = "postgres://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/app" }
+DATABASE_URL = { description = "PostgreSQL DSN", composed = "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/app" }
 ```
 
 References form a static dependency graph. Declaration order does not matter,
 and composed secrets may reference other composed secrets. SecretSpec rejects
-unknown references, cycles, malformed braces, and source conflicts while
+unknown references, cycles, malformed references, and source conflicts while
 loading the manifest. A composed secret is read-only and cannot also set
 `default`, `providers`, `ref`, `type`, or enabled `generate`.
 
 Composition intentionally does **not** implement dotenv or shell expansion:
 
-- only `{DECLARED_SECRET}` is a reference; ambient environment variables are
-  never consulted;
-- `${NAME}`, fallback operators such as `${NAME:-fallback}`, commands, and
-  recursive expansion are unsupported;
+- only `${UPPERCASE_NAME}` is a reference, and the name must match
+  `[A-Z][A-Z0-9_]*` and identify a declared secret;
+- ambient environment variables are never consulted;
+- fallback operators such as `${NAME:-fallback}`, commands, and recursive
+  expansion are unsupported;
 - inserted values are opaque and are never scanned again;
-- `{{` and `}}` produce literal braces;
+- `$$` produces a literal `$` (`$${NAME}` renders `${NAME}`), while ordinary
+  braces are literal;
 - a missing dependency makes a required composition missing, while a
   `required = false` composition is omitted;
 - empty values remain empty and are distinct from missing values.
@@ -148,9 +150,11 @@ text inserted into the composed value. Applying `as_path = true` to the
 composed secret materializes the final combined value.
 
 Composition is raw string concatenation. SecretSpec cannot know whether a
-component occupies a URL username, password, host, path, or query position, so
-it does not URL-encode components. Store components in the form required by the
-target format.
+component occupies a URL username, password, host, path, query, or structured
+document position, so it does not URL-encode or JSON-encode components. Store
+components in the form required by the target format; use
+`secretspec export --format json` when exporting the resolved secret map as
+JSON.
 
 ## Complete Example
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -243,7 +243,7 @@ DATABASE_URL = { required = true }</code></pre>
       <a href="/concepts/composed-secrets/" class="landing-bento-card is-link landing-bento-2">
         <p class="landing-bento-title">Composed secrets</p>
         <p class="landing-bento-desc">Build read-only DSNs and arguments from independently stored secrets with strict, order-independent references.</p>
-        <pre is:raw class="landing-bento-mini-code"><code>DATABASE_URL = { composed = "postgres://{USER}:{PASSWORD}@{HOST}/app" }</code></pre>
+        <pre is:raw class="landing-bento-mini-code"><code>DATABASE_URL = { composed = "postgres://${USER}:${PASSWORD}@${HOST}/app" }</code></pre>
       </a>
 
       <a href="/concepts/providers/" class="landing-bento-card is-link landing-bento-3">

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -34,7 +34,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
 - **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
-- **Composed Secrets (0.16+)**: Derive read-only values such as DSNs from declared secrets with strict, order-independent `{SECRET_NAME}` references
+- **Composed Secrets (0.16+)**: Derive read-only values such as DSNs from declared secrets with strict, order-independent `${UPPERCASE_NAME}` references
 - **[Configuration Inheritance](https://secretspec.dev/concepts/inheritance/)**: Extend and override shared configurations using the `extends` feature
 - **[Audit Logging](https://secretspec.dev/concepts/audit/)**: Every secret access recorded locally (who, when, why, outcome) — on by default, secret values never logged
 - **[Discovery](https://secretspec.dev/reference/cli#init)**: `secretspec init` to discover secrets from existing `.env` files

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1267,12 +1267,12 @@ mod tests {
     fn generate_toml_preserves_composed_templates() {
         let out = generate_toml_with_comments(&config_with_secret(Secret {
             description: Some("dsn".to_string()),
-            composed: Some("postgres://{USER}@{HOST}/db".to_string()),
+            composed: Some("postgres://${USER}@${HOST}/db".to_string()),
             ..Default::default()
         }))
         .unwrap();
         assert!(
-            out.contains(", composed = \"postgres://{USER}@{HOST}/db\""),
+            out.contains(", composed = \"postgres://${USER}@${HOST}/db\""),
             "got: {out}"
         );
     }

--- a/secretspec/src/composition.rs
+++ b/secretspec/src/composition.rs
@@ -1,10 +1,9 @@
 //! Strict parsing and one-pass rendering for composed secrets.
 //!
 //! This deliberately is not a dotenv or shell interpolator. References may
-//! name only declared secrets, inserted values are opaque, and literal braces
-//! must be escaped as `{{` and `}}`.
+//! name only declared uppercase secrets, inserted values are opaque, and `$$`
+//! produces a literal dollar sign.
 
-use crate::config::is_valid_identifier;
 use std::collections::BTreeSet;
 
 const MAX_RENDERED_BYTES: usize = 16 * 1024 * 1024;
@@ -30,21 +29,12 @@ impl Template {
 
         while let Some(ch) = chars.next() {
             match ch {
+                '$' if chars.peek() == Some(&'$') => {
+                    chars.next();
+                    literal.push('$');
+                }
                 '$' if chars.peek() == Some(&'{') => {
-                    return Err(
-                        "dotenv-style `${...}` expansion is not supported; use `{SECRET_NAME}`"
-                            .into(),
-                    );
-                }
-                '{' if chars.peek() == Some(&'{') => {
                     chars.next();
-                    literal.push('{');
-                }
-                '}' if chars.peek() == Some(&'}') => {
-                    chars.next();
-                    literal.push('}');
-                }
-                '{' => {
                     if !literal.is_empty() {
                         parts.push(Part::Literal(std::mem::take(&mut literal)));
                     }
@@ -55,32 +45,27 @@ impl Template {
                             Some('}') => break,
                             Some('{') => {
                                 return Err(
-                                    "nested `{` in a composed reference; use `{{` for a literal brace"
-                                        .into(),
+                                    "nested `{` in a composed reference; references use `${UPPERCASE_NAME}`"
+                                        .into()
                                 );
                             }
                             Some(ch) => name.push(ch),
                             None => {
                                 return Err(
-                                    "unclosed `{` in composed template; use `{{` for a literal brace"
-                                        .into(),
+                                    "unclosed `${` in composed template; references use `${UPPERCASE_NAME}`"
+                                        .into()
                                 );
                             }
                         }
                     }
 
-                    if !is_valid_identifier(&name) {
+                    if !is_valid_reference_name(&name) {
                         return Err(format!(
-                            "invalid composed reference `{{{name}}}`; references must be secret identifiers"
+                            "invalid composed reference `${{{name}}}`; names must match `[A-Z][A-Z0-9_]*`"
                         ));
                     }
                     dependencies.insert(name.clone());
                     parts.push(Part::Reference(name));
-                }
-                '}' => {
-                    return Err(
-                        "unmatched `}` in composed template; use `}}` for a literal brace".into(),
-                    );
                 }
                 other => literal.push(other),
             }
@@ -128,14 +113,24 @@ impl Template {
     }
 }
 
+fn is_valid_reference_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    matches!(bytes.next(), Some(b'A'..=b'Z'))
+        && bytes.all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
 
     #[test]
-    fn parses_escaped_braces_and_deduplicates_dependencies() {
-        let template = Template::parse("{{dsn}}:{USER}:{USER}@{HOST}").unwrap();
+    fn parses_dollar_references_and_deduplicates_dependencies() {
+        let template =
+            Template::parse(
+                r#"{"dsn":"${USER}:${USER}@${HOST}","pattern":"a{2,4}","env":"$$HOME","literal":"$${EXTERNAL}"}"#,
+            )
+            .unwrap();
         assert_eq!(
             template.dependencies(),
             &["HOST".to_string(), "USER".to_string()]
@@ -143,31 +138,42 @@ mod tests {
         let values = HashMap::from([("USER", "alice"), ("HOST", "db")]);
         assert_eq!(
             template.render(|name| values.get(name).copied()).unwrap(),
-            "{dsn}:alice:alice@db"
+            r#"{"dsn":"alice:alice@db","pattern":"a{2,4}","env":"$HOME","literal":"${EXTERNAL}"}"#
         );
     }
 
     #[test]
     fn inserted_values_are_not_reparsed() {
-        let template = Template::parse("value={A}").unwrap();
+        let template = Template::parse("value=${A}").unwrap();
         assert_eq!(
             template
-                .render(|name| (name == "A").then_some("{B}"))
+                .render(|name| (name == "A").then_some("${B}"))
                 .unwrap(),
-            "value={B}"
+            "value=${B}"
         );
     }
 
     #[test]
-    fn rejects_shell_and_malformed_syntax() {
-        for invalid in ["{A:-fallback}", "${A}", "{A", "A}", "{}", "{A{B}}"] {
+    fn rejects_operators_lowercase_names_and_malformed_syntax() {
+        for invalid in [
+            "${A:-fallback}",
+            "${A",
+            "${}",
+            "${A${B}}",
+            "${lower}",
+            "${Mixed}",
+            "${_A}",
+            "${1A}",
+            "${Ä}",
+            "{A}",
+        ] {
             assert!(Template::parse(invalid).is_err(), "{invalid} should fail");
         }
     }
 
     #[test]
     fn missing_value_is_not_replaced_with_empty_text() {
-        let template = Template::parse("{A}:{B}").unwrap();
+        let template = Template::parse("${A}:${B}").unwrap();
         assert_eq!(
             template.render(|name| (name == "A").then_some("set")),
             Err("composed dependency `B` is not resolved".into())

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -433,7 +433,7 @@ fn validate_composition_graph(
         for dependency in template.dependencies() {
             if !profile.secrets.contains_key(dependency) {
                 return Err(ParseError::Validation(format!(
-                    "Profile '{}': Secret '{}': composed reference `{{{}}}` does not name a declared secret",
+                    "Profile '{}': Secret '{}': composed reference `${{{}}}` does not name a declared secret",
                     profile_name, name, dependency
                 )));
             }
@@ -1207,7 +1207,7 @@ pub struct Secret {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<String>,
     /// A strict template derived from other declared secrets. References use
-    /// `{SECRET_NAME}`; `{{` and `}}` produce literal braces.
+    /// `${UPPERCASE_NAME}`; `$$` produces a literal dollar sign.
     ///
     /// Available since SecretSpec 0.16.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1437,9 +1437,7 @@ impl Secret {
     }
 }
 
-/// Check if a string is a valid identifier. Shared with composed-template
-/// references, so a declarable secret name and a referenceable one can never
-/// drift apart.
+/// Check if a string is a valid declared secret identifier.
 pub(crate) fn is_valid_identifier(s: &str) -> bool {
     if s.is_empty() {
         return false;
@@ -2092,7 +2090,7 @@ revision = "1.0"
             r#"
 USER = { description = "user" }
 HOST = { description = "host" }
-DSN = { description = "dsn", composed = "db://{USER}@{HOST}" }
+DSN = { description = "dsn", composed = "db://${USER}@${HOST}" }
 "#,
         )
         .validate()
@@ -2100,7 +2098,7 @@ DSN = { description = "dsn", composed = "db://{USER}@{HOST}" }
 
         let unknown = parse(
             r#"
-DSN = { description = "dsn", composed = "db://{AMBIENT_ENV}" }
+DSN = { description = "dsn", composed = "db://${AMBIENT_ENV}" }
 "#,
         )
         .validate()
@@ -2113,9 +2111,9 @@ DSN = { description = "dsn", composed = "db://{AMBIENT_ENV}" }
 
         let cycle = parse(
             r#"
-A = { description = "a", composed = "{B}" }
-B = { description = "b", composed = "{C}" }
-C = { description = "c", composed = "{A}" }
+A = { description = "a", composed = "${B}" }
+B = { description = "b", composed = "${C}" }
+C = { description = "c", composed = "${A}" }
 "#,
         )
         .validate()
@@ -2125,7 +2123,7 @@ C = { description = "c", composed = "{A}" }
     }
 
     #[test]
-    fn composed_rejects_dotenv_syntax_and_storage_sources() {
+    fn composed_rejects_operators_and_storage_sources() {
         let invalid: Config = toml::from_str(
             r#"
 [project]
@@ -2140,7 +2138,7 @@ BAD = { description = "bad", composed = "${A:-fallback}" }
         .unwrap();
         let error = invalid.validate().unwrap_err().to_string();
         assert!(
-            error.contains("dotenv-style `${...}` expansion is not supported"),
+            error.contains("names must match `[A-Z][A-Z0-9_]*`"),
             "{error}"
         );
 
@@ -2152,7 +2150,7 @@ revision = "1.0"
 
 [profiles.default]
 A = { description = "a" }
-BAD = { description = "bad", composed = "{A}", providers = ["keyring"] }
+BAD = { description = "bad", composed = "${A}", providers = ["keyring"] }
 "#,
         )
         .unwrap();
@@ -2170,7 +2168,7 @@ revision = "1.0"
 
 [profiles.default]
 PART = { description = "part" }
-RESULT = { description = "result", composed = "{PART}" }
+RESULT = { description = "result", composed = "${PART}" }
 
 [profiles.default.defaults]
 default = "fallback"

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -434,7 +434,7 @@ mod tests {
                 "RESULT".to_string(),
                 Secret {
                     description: Some("derived".to_string()),
-                    composed: Some("prefix-{PART}".to_string()),
+                    composed: Some("prefix-${PART}".to_string()),
                     ..Default::default()
                 },
             ),

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -597,10 +597,10 @@ fn composed_secrets_resolve_in_dependency_order_without_reparsing_values() {
     let temp_dir = TempDir::new().unwrap();
     let env_path = temp_dir.path().join(".env");
     // The reference-looking password is intentional: composition must insert
-    // it as opaque text rather than recursively interpreting `{DB_HOST}`.
+    // it as opaque text rather than recursively interpreting `${DB_HOST}`.
     fs::write(
         &env_path,
-        "DB_USER=alice\nDB_PASSWORD={DB_HOST}\nDB_HOST=db.example\n",
+        "DB_USER=alice\nDB_PASSWORD='${DB_HOST}'\nDB_HOST=db.example\n",
     )
     .unwrap();
 
@@ -619,7 +619,7 @@ fn composed_secrets_resolve_in_dependency_order_without_reparsing_values() {
         "AUTH".to_string(),
         Secret {
             description: Some("credentials".to_string()),
-            composed: Some("{DB_USER}:{DB_PASSWORD}".to_string()),
+            composed: Some("${DB_USER}:${DB_PASSWORD}".to_string()),
             ..Default::default()
         },
     );
@@ -627,7 +627,7 @@ fn composed_secrets_resolve_in_dependency_order_without_reparsing_values() {
         "DATABASE_URL".to_string(),
         Secret {
             description: Some("dsn".to_string()),
-            composed: Some("postgres://{AUTH}@{DB_HOST}/app".to_string()),
+            composed: Some("postgres://${AUTH}@${DB_HOST}/app".to_string()),
             ..Default::default()
         },
     );
@@ -639,12 +639,12 @@ fn composed_secrets_resolve_in_dependency_order_without_reparsing_values() {
 
     let response = spec.resolve().unwrap();
     let auth = &response.secrets["AUTH"];
-    assert_eq!(auth.value.as_deref(), Some("alice:{DB_HOST}"));
+    assert_eq!(auth.value.as_deref(), Some("alice:${DB_HOST}"));
     assert_eq!(auth.source, ResolvedSource::Composed);
     let dsn = &response.secrets["DATABASE_URL"];
     assert_eq!(
         dsn.value.as_deref(),
-        Some("postgres://alice:{DB_HOST}@db.example/app")
+        Some("postgres://alice:${DB_HOST}@db.example/app")
     );
     assert_eq!(dsn.source, ResolvedSource::Composed);
     assert!(dsn.source_provider.is_none());
@@ -676,7 +676,7 @@ fn composed_secrets_propagate_missingness_and_are_read_only() {
             Secret {
                 description: Some("optional result".to_string()),
                 required: Some(false),
-                composed: Some("prefix-{OPTIONAL_PART}".to_string()),
+                composed: Some("prefix-${OPTIONAL_PART}".to_string()),
                 ..Default::default()
             },
         ),
@@ -684,7 +684,7 @@ fn composed_secrets_propagate_missingness_and_are_read_only() {
             "REQUIRED_RESULT".to_string(),
             Secret {
                 description: Some("required result".to_string()),
-                composed: Some("prefix-{OPTIONAL_PART}".to_string()),
+                composed: Some("prefix-${OPTIONAL_PART}".to_string()),
                 ..Default::default()
             },
         ),
@@ -736,7 +736,7 @@ fn composed_secrets_use_the_exported_path_of_as_path_dependencies() {
             "CERT_ARG".to_string(),
             Secret {
                 description: Some("certificate argument".to_string()),
-                composed: Some("--cert={CERT}".to_string()),
+                composed: Some("--cert=${CERT}".to_string()),
                 ..Default::default()
             },
         ),


### PR DESCRIPTION
## Summary

- add the SecretSpec 0.16 release post, dated July 18, covering composed secrets, Infisical, and the C# SDK
- change unreleased composed-secret references from `{NAME}` to strict `${UPPERCASE_NAME}` syntax matching `[A-Z][A-Z0-9_]*`
- make ordinary braces literal and support `$$` for a literal dollar sign, including `$${NAME}` for literal `${NAME}` text
- update the changelog, README, landing page, concept guide, configuration reference, Rust API docs, examples, and tests

## Why

Bare-brace references conflict with JSON objects, CSS blocks, and regex quantifiers. Requiring the `${...}` marker leaves ordinary braces untouched, while uppercase-only names keep references explicit and deterministic. The feature is still unreleased, so the syntax can change without breaking a released manifest format.

## Impact

Composed templates must use `${UPPERCASE_NAME}` references. Lowercase names, mixed-case names, fallback operators, malformed expressions, unknown references, and cycles fail during manifest validation. Substitution remains one-pass and never reads ambient environment variables or reparses inserted values.

The release post is included in production output with a July 18, 2026 publish date and a temporary availability notice while 0.16 remains unreleased.

## Validation

- `cargo test --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run build` in `docs/`
- `git diff --check`
- commit hooks: Clippy and rustfmt
