### PR TITLE
Harden .NET SDK distribution matrix

### DIFF
--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -396,13 +396,12 @@ jobs:
           $project = Join-Path $testRoot "SecretSpec.PackageSmoke.csproj"
 
           # Prime an isolated package cache from the artifact-only source. The
-          # RID restore then adds NuGet.org for Microsoft runtime/AOT packs.
+          # RID/AOT restore then uses the runner's standard NuGet configuration
+          # for Microsoft runtime packs without selecting a published SDK copy.
           dotnet restore $project --source $packageSource "-p:Version=$version"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet restore $project --runtime "${{ matrix.rid }}" `
-            --source $packageSource `
-            --source "https://api.nuget.org/v3/index.json" `
-            "-p:Version=$version"
+            "-p:PublishAot=true" "-p:Version=$version"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           Remove-Item Env:SECRETSPEC_FFI_LIB -ErrorAction SilentlyContinue
@@ -421,9 +420,7 @@ jobs:
           dotnet publish $project --configuration Release `
             --runtime "${{ matrix.rid }}" --self-contained true `
             "-p:PublishAot=true" "-p:Version=$version" `
-            --source $packageSource `
-            --source "https://api.nuget.org/v3/index.json" `
-            --output $publishDir
+            --no-restore --output $publishDir
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $app = Join-Path $publishDir "SecretSpec.PackageSmoke.exe"
           Push-Location $env:RUNNER_TEMP

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -336,7 +336,7 @@ jobs:
         shell: bash
         env:
           # Git Bash otherwise rewrites https:// NuGet sources as local paths.
-          MSYS_NO_PATHCONV: "1"
+          MSYS2_ARG_CONV_EXCL: "*"
         run: |
           set -euo pipefail
           version="$(sed -n \

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -334,6 +334,9 @@ jobs:
       - name: Restore, run, and NativeAOT-publish a clean NuGet consumer
         if: matrix.musl == false
         shell: bash
+        env:
+          # Git Bash otherwise rewrites https:// NuGet sources as local paths.
+          MSYS_NO_PATHCONV: "1"
         run: |
           set -euo pipefail
           version="$(sed -n \

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -1,9 +1,9 @@
 name: ".NET SDK"
 
 # Builds the C# client and the runtime-specific secretspec-ffi libraries packed
-# into Cachix.SecretSpec. Linux uses a manylinux_2_28 baseline and vendors dbus,
-# so the NuGet asset works on older supported glibc distributions without a
-# system libdbus dependency.
+# into Cachix.SecretSpec. Glibc Linux uses a manylinux_2_28 baseline; Alpine
+# receives separate musl assets. Both vendor dbus so consumers do not need a
+# system libdbus installation.
 
 on:
   workflow_call:
@@ -48,20 +48,36 @@ jobs:
             container: quay.io/pypa/manylinux_2_28_x86_64
             library: libsecretspec_ffi.so
             cargo_features: --features vendored-dbus
+            rustflags: -C strip=symbols
           - rid: linux-arm64
             target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             container: quay.io/pypa/manylinux_2_28_aarch64
             library: libsecretspec_ffi.so
             cargo_features: --features vendored-dbus
+            rustflags: -C strip=symbols
+          - rid: osx-x64
+            target: x86_64-apple-darwin
+            runner: macos-15-intel
+            library: libsecretspec_ffi.dylib
+            deployment_target: "12.0"
+            rustflags: -C strip=symbols
           - rid: osx-arm64
             target: aarch64-apple-darwin
             runner: macos-latest
             library: libsecretspec_ffi.dylib
+            deployment_target: "12.0"
+            rustflags: -C strip=symbols
           - rid: win-x64
             target: x86_64-pc-windows-msvc
             runner: windows-latest
             library: secretspec_ffi.dll
+            rustflags: -C strip=symbols -C target-feature=+crt-static
+          - rid: win-arm64
+            target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+            library: secretspec_ffi.dll
+            rustflags: -C strip=symbols -C target-feature=+crt-static
 
     steps:
       - uses: actions/checkout@v5
@@ -91,16 +107,34 @@ jobs:
 
       - name: Build native resolver
         shell: bash
+        env:
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
+          RUSTFLAGS: ${{ matrix.rustflags }}
         run: >-
           cargo build -p secretspec-ffi --release
           --target ${{ matrix.target }} ${{ matrix.cargo_features }}
 
-      - name: Verify library portability (glibc <= 2.28, libdbus linked in)
+      - name: Verify glibc portability (glibc <= 2.28, no dynamic libdbus)
         if: matrix.container
         shell: bash
         run: >-
           bash scripts/check-linux-portability.sh
           "target/${{ matrix.target }}/release/${{ matrix.library }}"
+
+      - name: Verify Windows CRT is statically linked
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          rustup component add llvm-tools-preview
+          host="$(rustc -vV | sed -n 's/^host: //p')"
+          llvm_objdump="$(rustc --print sysroot)/lib/rustlib/$host/bin/llvm-objdump"
+          imports="$("$llvm_objdump" -p \
+            "target/${{ matrix.target }}/release/${{ matrix.library }}")"
+          if grep -Eiq 'DLL Name: (VCRUNTIME|MSVCP)' <<<"$imports"; then
+            echo "the packaged resolver still depends on the MSVC runtime" >&2
+            grep -Ei 'DLL Name: (VCRUNTIME|MSVCP)' <<<"$imports" >&2
+            exit 1
+          fi
 
       - name: Run C# SDK tests against native resolver
         shell: bash
@@ -123,9 +157,77 @@ jobs:
           name: dotnet-native-${{ matrix.rid }}
           path: staged/${{ matrix.rid }}
 
+  musl:
+    name: ${{ matrix.rid }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-musl-x64
+            target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+          - rid: linux-musl-arm64
+            target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Sync SDK package versions
+        run: bash scripts/sync-sdk-versions.sh
+      - name: Install Rust and the native musl toolchain
+        run: |
+          rustup toolchain install
+          rustup target add "${{ matrix.target }}"
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+      - name: Build dynamically loadable musl resolver
+        shell: bash
+        env:
+          RUSTFLAGS: -C target-feature=-crt-static -C strip=symbols
+        run: |
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-musl)
+              export CC_x86_64_unknown_linux_musl=musl-gcc
+              export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+              ;;
+            aarch64-unknown-linux-musl)
+              export CC_aarch64_unknown_linux_musl=musl-gcc
+              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+              ;;
+          esac
+          cargo build -p secretspec-ffi --release \
+            --target "${{ matrix.target }}" --features vendored-dbus
+          test -f \
+            "target/${{ matrix.target }}/release/libsecretspec_ffi.so"
+      - name: Verify musl portability
+        shell: bash
+        run: |
+          library="target/${{ matrix.target }}/release/libsecretspec_ffi.so"
+          dynamic="$(readelf -d "$library")"
+          versions="$(readelf --version-info "$library")"
+          if grep -q 'GLIBC_' <<<"$versions"; then
+            echo "$library unexpectedly references glibc" >&2
+            exit 1
+          fi
+          if grep NEEDED <<<"$dynamic" | grep -q dbus; then
+            echo "$library links libdbus dynamically" >&2
+            grep NEEDED <<<"$dynamic" >&2
+            exit 1
+          fi
+      - name: Stage native NuGet asset
+        run: |
+          mkdir -p "staged/${{ matrix.rid }}/native"
+          cp "target/${{ matrix.target }}/release/libsecretspec_ffi.so" \
+             "staged/${{ matrix.rid }}/native/"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-native-${{ matrix.rid }}
+          path: staged/${{ matrix.rid }}
+
   package:
     name: NuGet package
-    needs: [native]
+    needs: [native, musl]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -171,10 +273,150 @@ jobs:
           name: dotnet-nuget
           path: artifacts/*.nupkg
 
+  consumer:
+    name: consume ${{ matrix.rid }}
+    needs: [package]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-x64
+            runner: ubuntu-latest
+            musl: false
+          - rid: linux-arm64
+            runner: ubuntu-24.04-arm
+            musl: false
+          - rid: linux-musl-x64
+            runner: ubuntu-latest
+            musl: true
+          - rid: linux-musl-arm64
+            runner: ubuntu-24.04-arm
+            musl: true
+          - rid: osx-x64
+            runner: macos-15-intel
+            musl: false
+          - rid: osx-arm64
+            runner: macos-latest
+            musl: false
+          - rid: win-x64
+            runner: windows-latest
+            musl: false
+          - rid: win-arm64
+            runner: windows-11-arm
+            musl: false
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: dotnet-nuget
+          path: artifacts
+      - uses: actions/setup-dotnet@v4
+        if: matrix.musl == false
+        with:
+          dotnet-version: "8.0.x"
+      - name: Install Linux NativeAOT toolchain
+        if: runner.os == 'Linux' && matrix.musl == false
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang zlib1g-dev
+
+      - name: Restore, run, and NativeAOT-publish a clean NuGet consumer
+        if: matrix.musl == false
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(sed -n \
+            '/^\[workspace.package\]/,/^\[/s/^version = "\(.*\)"/\1/p' \
+            Cargo.toml)"
+          test_root="$RUNNER_TEMP/SecretSpec.PackageSmoke"
+          package_source="$GITHUB_WORKSPACE/artifacts"
+          export NUGET_PACKAGES="$RUNNER_TEMP/nuget-packages"
+          cp -R secretspec-dotnet/tests/SecretSpec.PackageSmoke "$test_root"
+          project="$test_root/SecretSpec.PackageSmoke.csproj"
+
+          # Prime an isolated package cache from the artifact-only source. The
+          # RID restore then adds NuGet.org for Microsoft runtime/AOT packs
+          # without any chance of selecting the already-published bootstrap.
+          dotnet restore "$project" --source "$package_source" \
+            -p:Version="$version"
+          dotnet restore "$project" --runtime "${{ matrix.rid }}" \
+            --source "$package_source" \
+            --source https://api.nuget.org/v3/index.json \
+            -p:Version="$version"
+          (
+            cd "$RUNNER_TEMP"
+            unset SECRETSPEC_FFI_LIB
+            dotnet run --project "$project" --configuration Release \
+              --runtime "${{ matrix.rid }}" --no-restore -p:Version="$version"
+          )
+
+          publish_dir="$RUNNER_TEMP/publish-${{ matrix.rid }}"
+          dotnet publish "$project" --configuration Release \
+            --runtime "${{ matrix.rid }}" --self-contained true \
+            -p:PublishAot=true -p:Version="$version" \
+            --source "$package_source" \
+            --source https://api.nuget.org/v3/index.json \
+            --output "$publish_dir"
+          app="$publish_dir/SecretSpec.PackageSmoke"
+          if [[ -f "$app.exe" ]]; then app="$app.exe"; fi
+          (
+            cd "$RUNNER_TEMP"
+            unset SECRETSPEC_FFI_LIB
+            "$app"
+          )
+
+      - name: Restore, run, and NativeAOT-publish on Alpine
+        if: matrix.musl
+        shell: bash
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --volume "$RUNNER_TEMP:/runner" \
+            --workdir /runner \
+            mcr.microsoft.com/dotnet/sdk:8.0-alpine \
+            sh -c '
+              set -eu
+              apk add --no-cache build-base clang zlib-dev
+              version="$(sed -n \
+                "/^\[workspace.package\]/,/^\[/s/^version = \"\(.*\)\"/\1/p" \
+                /workspace/Cargo.toml)"
+              test_root=/runner/SecretSpec.PackageSmoke
+              package_source=/workspace/artifacts
+              export NUGET_PACKAGES=/runner/nuget-packages
+              cp -R /workspace/secretspec-dotnet/tests/SecretSpec.PackageSmoke \
+                "$test_root"
+              project="$test_root/SecretSpec.PackageSmoke.csproj"
+
+              # Prime the isolated cache from the just-built package before
+              # NuGet.org is enabled for Microsoft runtime/AOT packs.
+              dotnet restore "$project" --source "$package_source" \
+                -p:Version="$version"
+              dotnet restore "$project" --runtime "${{ matrix.rid }}" \
+                --source "$package_source" \
+                --source https://api.nuget.org/v3/index.json \
+                -p:Version="$version"
+              unset SECRETSPEC_FFI_LIB
+              dotnet run --project "$project" --configuration Release \
+                --runtime "${{ matrix.rid }}" --no-restore -p:Version="$version"
+
+              publish_dir=/runner/publish-${{ matrix.rid }}
+              dotnet publish "$project" --configuration Release \
+                --runtime "${{ matrix.rid }}" --self-contained true \
+                -p:PublishAot=true -p:Version="$version" \
+                --source "$package_source" \
+                --source https://api.nuget.org/v3/index.json \
+                --output "$publish_dir"
+              cd /runner
+              unset SECRETSPEC_FFI_LIB
+              "$publish_dir/SecretSpec.PackageSmoke"
+            '
+
   publish:
     name: publish to NuGet
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish
-    needs: [package]
+    needs: [consumer]
     runs-on: ubuntu-latest
     # Must match the "Environment" on nuget.org's trusted publishing policy
     # for Cachix.SecretSpec (see RELEASE.md); nuget.org matches policies by
@@ -204,3 +446,23 @@ jobs:
           --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
           --source https://api.nuget.org/v3/index.json
           --skip-duplicate
+      - name: Unlist the unsupported 0.15.0 bootstrap
+        shell: bash
+        run: |
+          package="$(find artifacts -name '*.nupkg' \
+            ! -name '*.symbols.nupkg' -print -quit)"
+          if [[ "$package" == *Cachix.SecretSpec.0.15.0.nupkg ]]; then
+            echo "keeping the bootstrap listed until 0.16.0 is published"
+            exit 0
+          fi
+          listed="$(curl -fsSL \
+            https://api.nuget.org/v3/registration5-semver1/cachix.secretspec/0.15.0.json |
+            python3 -c 'import json, sys; print(str(json.load(sys.stdin)["listed"]).lower())')"
+          if [[ "$listed" != true ]]; then
+            echo "the 0.15.0 bootstrap is already unlisted"
+            exit 0
+          fi
+          dotnet nuget delete Cachix.SecretSpec 0.15.0 \
+            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --non-interactive

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -332,11 +332,8 @@ jobs:
           sudo apt-get install -y clang zlib1g-dev
 
       - name: Restore, run, and NativeAOT-publish a clean NuGet consumer
-        if: matrix.musl == false
+        if: matrix.musl == false && runner.os != 'Windows'
         shell: bash
-        env:
-          # Git Bash otherwise rewrites https:// NuGet sources as local paths.
-          MSYS2_ARG_CONV_EXCL: "*"
         run: |
           set -euo pipefail
           version="$(sed -n \
@@ -378,6 +375,64 @@ jobs:
             unset SECRETSPEC_FFI_LIB
             "$app"
           )
+
+      - name: Restore, run, and NativeAOT-publish a clean NuGet consumer on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $versionMatch = Select-String -Path Cargo.toml `
+            -Pattern '^version = "([^"]+)"' | Select-Object -First 1
+          if (-not $versionMatch) {
+            throw "workspace package version not found"
+          }
+          $version = $versionMatch.Matches[0].Groups[1].Value
+          $testRoot = Join-Path $env:RUNNER_TEMP "SecretSpec.PackageSmoke"
+          $packageSource = Join-Path $env:GITHUB_WORKSPACE "artifacts"
+          $env:NUGET_PACKAGES = Join-Path $env:RUNNER_TEMP "nuget-packages"
+          New-Item -ItemType Directory -Path $testRoot | Out-Null
+          Copy-Item -Recurse `
+            "secretspec-dotnet/tests/SecretSpec.PackageSmoke/*" $testRoot
+          $project = Join-Path $testRoot "SecretSpec.PackageSmoke.csproj"
+
+          # Prime an isolated package cache from the artifact-only source. The
+          # RID restore then adds NuGet.org for Microsoft runtime/AOT packs.
+          dotnet restore $project --source $packageSource "-p:Version=$version"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          dotnet restore $project --runtime "${{ matrix.rid }}" `
+            --source $packageSource `
+            --source "https://api.nuget.org/v3/index.json" `
+            "-p:Version=$version"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          Remove-Item Env:SECRETSPEC_FFI_LIB -ErrorAction SilentlyContinue
+          Push-Location $env:RUNNER_TEMP
+          try {
+            dotnet run --project $project --configuration Release `
+              --runtime "${{ matrix.rid }}" --no-restore `
+              "-p:Version=$version"
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          } finally {
+            Pop-Location
+          }
+
+          $publishDir = Join-Path `
+            $env:RUNNER_TEMP "publish-${{ matrix.rid }}"
+          dotnet publish $project --configuration Release `
+            --runtime "${{ matrix.rid }}" --self-contained true `
+            "-p:PublishAot=true" "-p:Version=$version" `
+            --source $packageSource `
+            --source "https://api.nuget.org/v3/index.json" `
+            --output $publishDir
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $app = Join-Path $publishDir "SecretSpec.PackageSmoke.exe"
+          Push-Location $env:RUNNER_TEMP
+          try {
+            & $app
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          } finally {
+            Pop-Location
+          }
 
       - name: Restore, run, and NativeAOT-publish on Alpine
         if: matrix.musl

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -167,37 +167,34 @@ jobs:
           - rid: linux-musl-x64
             target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
+            image: quay.io/pypa/musllinux_1_2_x86_64
           - rid: linux-musl-arm64
             target: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
+            image: quay.io/pypa/musllinux_1_2_aarch64
 
     steps:
       - uses: actions/checkout@v5
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
-      - name: Install Rust and the native musl toolchain
-        run: |
-          rustup toolchain install
-          rustup target add "${{ matrix.target }}"
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
       - name: Build dynamically loadable musl resolver
         shell: bash
-        env:
-          RUSTFLAGS: -C target-feature=-crt-static -C strip=symbols
         run: |
-          case "${{ matrix.target }}" in
-            x86_64-unknown-linux-musl)
-              export CC_x86_64_unknown_linux_musl=musl-gcc
-              export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
-              ;;
-            aarch64-unknown-linux-musl)
-              export CC_aarch64_unknown_linux_musl=musl-gcc
-              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
-              ;;
-          esac
-          cargo build -p secretspec-ffi --release \
-            --target "${{ matrix.target }}" --features vendored-dbus
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            --env CARGO_TARGET_DIR=/workspace/target \
+            --env "RUSTFLAGS=-C target-feature=-crt-static -C strip=symbols" \
+            "${{ matrix.image }}" \
+            bash -c '
+              set -euo pipefail
+              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs |
+                sh -s -- -y --default-toolchain none
+              export PATH="$HOME/.cargo/bin:$PATH"
+              rustup toolchain install
+              cargo build -p secretspec-ffi --release \
+                --target "${{ matrix.target }}" --features vendored-dbus
+            '
           test -f \
             "target/${{ matrix.target }}/release/libsecretspec_ffi.so"
       - name: Verify musl portability

--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -202,14 +202,26 @@ jobs:
         run: |
           library="target/${{ matrix.target }}/release/libsecretspec_ffi.so"
           dynamic="$(readelf -d "$library")"
-          versions="$(readelf --version-info "$library")"
-          if grep -q 'GLIBC_' <<<"$versions"; then
-            echo "$library unexpectedly references glibc" >&2
+          needed="$(grep NEEDED <<<"$dynamic")"
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-musl)
+              expected_libc=libc.musl-x86_64.so.1
+              ;;
+            aarch64-unknown-linux-musl)
+              expected_libc=libc.musl-aarch64.so.1
+              ;;
+          esac
+          # ARM musl's libgcc_s exports a compatibility symbol version named
+          # GLIBC_2.0, so inspect the actual dynamic dependencies instead.
+          if grep -q '\[libc\.so\.6\]' <<<"$needed" ||
+             ! grep -Fq "[$expected_libc]" <<<"$needed"; then
+            echo "$library does not use the expected musl libc" >&2
+            echo "$needed" >&2
             exit 1
           fi
-          if grep NEEDED <<<"$dynamic" | grep -q dbus; then
+          if grep -q dbus <<<"$needed"; then
             echo "$library links libdbus dynamically" >&2
-            grep NEEDED <<<"$dynamic" >&2
+            echo "$needed" >&2
             exit 1
           fi
       - name: Stage native NuGet asset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through the shared native resolver, with fluent builder and one-shot APIs,
   typed failure exceptions, value-free preflight reports, provenance,
   environment export, typed-codegen input, and deterministic cleanup of
-  `as_path` files. The NuGet package includes native resolver builds for Linux
-  x64/Arm64, macOS Arm64, and Windows x64.
+  `as_path` files. The trimming-safe, NativeAOT-compatible NuGet package
+  includes native resolver builds for glibc and musl Linux x64/Arm64, macOS
+  x64/Arm64, and Windows x64/Arm64; Windows applications do not need a separate
+  Visual C++ Redistributable.
 - Infisical provider (`infisical://`), for Infisical Cloud and self-hosted
   instances. Authenticates as a machine identity via Universal Auth, whose
   `client_id` and `client_secret` can be sourced as provider credentials (with

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -101,10 +101,13 @@ owner `cachix`, repository `secretspec`, workflow file `dotnet-package.yml`,
 environment `nuget`), and the repository's `nuget` GitHub environment holds
 `NUGET_USER` — the nuget.org profile name that owns the policy. The first
 publish (0.15.0, a manual `dotnet-package.yml` run with `publish: true`)
-claimed the package ID and permanently activated the policy. Nothing left to
-do — version tags build all native runtime assets, pack them into one
-`.nupkg`, and publish it with a short-lived OIDC-issued API key
-(`--skip-duplicate` makes re-runs of an already-published version harmless).
+claimed the package ID and permanently activated the policy. It is an
+unsupported bootstrap artifact rather than the C# SDK release; the first
+supported package is 0.16.0, whose publish job also unlists 0.15.0. Nothing
+else is needed — version tags build all native runtime assets, pack them into
+one `.nupkg`, run clean-package and NativeAOT consumers on every RID, and
+publish with a short-lived OIDC-issued API key (`--skip-duplicate` makes
+re-runs of an already-published version harmless).
 
 ## Python (PyPI) — `python-wheels.yml`
 
@@ -250,14 +253,18 @@ In order:
 
 ## .NET (NuGet) — `dotnet-package.yml`
 
-- **Client:** a .NET 8 assembly with no managed package dependencies. It invokes
-  the stable JSON C ABI through P/Invoke and exposes the same builder, resolved
-  value, report, and typed-error vocabulary as the other SDKs.
+- **Client:** a trimming-safe, NativeAOT-compatible .NET 8 assembly with no
+  managed package dependencies. It invokes the stable JSON C ABI through
+  source-generated P/Invoke and exposes the same builder, resolved value,
+  report, and typed-error vocabulary as the other SDKs.
 - **Native assets:** one NuGet package carries `secretspec-ffi` under the
-  standard `runtimes/<rid>/native/` layout for `linux-x64`, `linux-arm64`,
-  `osx-arm64`, and `win-x64`. Linux builds use a manylinux 2.28 baseline and
-  the resolver's vendored-dbus feature.
+  standard `runtimes/<rid>/native/` layout for glibc and musl Linux x64/Arm64,
+  macOS x64/Arm64, and Windows x64/Arm64. Glibc builds use a manylinux 2.28
+  baseline, Linux builds vendor dbus, and Windows builds statically link the
+  MSVC runtime.
 - **Publish:** `dotnet-package.yml` tests every native asset on its target,
-  assembles `Cachix.SecretSpec.<version>.nupkg`, and pushes it with a
-  short-lived API key from NuGet Trusted Publishing (OIDC), running in the
-  `nuget` GitHub environment. One-time setup is described above.
+  assembles `Cachix.SecretSpec.<version>.nupkg`, then installs that exact
+  package in isolated framework-dependent and NativeAOT consumers on all eight
+  RIDs before pushing it with a short-lived API key from NuGet Trusted
+  Publishing (OIDC), running in the `nuget` GitHub environment. One-time setup
+  is described above.

--- a/docs/src/content/docs/sdk/csharp.md
+++ b/docs/src/content/docs/sdk/csharp.md
@@ -3,10 +3,11 @@ title: C# SDK
 description: Resolve SecretSpec secrets from C# and .NET
 ---
 
-> **Version compatibility:** The C# SDK targets SecretSpec 0.16 and is
-> unavailable in the current 0.15 release. With 0.15, use the CLI integration:
-> `secretspec run -- dotnet run`. The `Cachix.SecretSpec` package and API below
-> become available with 0.16.
+> **Version compatibility:** The supported C# SDK targets SecretSpec 0.16 and
+> is unavailable in the current 0.15 release. The 0.15.0 NuGet package is an
+> unsupported bootstrap artifact used to reserve the package ID. With 0.15,
+> use `secretspec run -- dotnet run`; the API below becomes available with
+> 0.16.
 
 The C# SDK (`Cachix.SecretSpec`) is a thin client over the same Rust resolver as
 the CLI. Every provider, fallback chain, profile, generator, reference, and
@@ -18,9 +19,20 @@ the CLI. Every provider, fallback chain, profile, generator, reference, and
 dotnet add package Cachix.SecretSpec
 ```
 
-The package targets .NET 8 and includes the native resolver for Linux x64 and
-Arm64, macOS Arm64, and Windows x64. No separate SecretSpec CLI or native
-library installation is needed at runtime.
+The package targets .NET 8 and includes native resolvers for glibc and musl
+Linux x64/Arm64, macOS x64/Arm64, and Windows x64/Arm64. Windows assets
+statically include the C runtime. No separate SecretSpec CLI, native library,
+Visual C++ Redistributable, or system `libdbus` installation is needed.
+
+The managed client is safe to trim and supports NativeAOT publishing. A
+NativeAOT application still carries the matching SecretSpec native resolver
+beside its executable; `dotnet publish` selects and copies that runtime asset
+automatically.
+
+```bash
+dotnet publish -c Release -r linux-x64 --self-contained \
+  -p:PublishAot=true
+```
 
 ## Quick start
 

--- a/docs/src/content/docs/sdk/overview.md
+++ b/docs/src/content/docs/sdk/overview.md
@@ -8,10 +8,11 @@ PHP, and C# (0.16+). They all resolve secrets from the same declarative
 `secretspec.toml`, and they all behave identically, because they share one
 resolver.
 
-> **C# compatibility:** The C# SDK targets SecretSpec 0.16 and is unavailable
-> in the current 0.15 release. With 0.15, run a .NET application through
-> `secretspec run -- dotnet run`; the `Cachix.SecretSpec` NuGet API shown in the
-> C# guide becomes available in 0.16.
+> **C# compatibility:** The supported C# SDK targets SecretSpec 0.16 and is
+> unavailable in the current 0.15 release. The 0.15.0 NuGet package is an
+> unsupported package-ID bootstrap. With 0.15, run a .NET application through
+> `secretspec run -- dotnet run`; the API shown in the C# guide becomes
+> available in 0.16.
 
 ## One resolver, thin clients
 
@@ -90,7 +91,9 @@ no runtime library path to set:
   native C extension in the gem.
 - **Haskell** statically links the same archive at build time via the GHC FFI.
 - **C# (0.16+)** ships the `cdylib` as runtime-specific native assets in one
-  NuGet package and loads the matching asset through P/Invoke.
+  NuGet package and loads the matching asset through P/Invoke. The managed
+  client supports trimming and NativeAOT; glibc/musl Linux, Intel/Arm macOS,
+  and x64/Arm64 Windows assets are included.
 - **Go** embeds the `cdylib` in the module and loads it at runtime via purego
   (no cgo); an opt-in `-tags static` build links it statically instead.
 - **Node.js** builds the resolver into a napi-rs addon.

--- a/scripts/sync-sdk-versions.sh
+++ b/scripts/sync-sdk-versions.sh
@@ -129,5 +129,6 @@ update_file secretspec-rb/secretspec.gemspec gemspec
 update_file secretspec-hs/secretspec.cabal cabal
 update_file secretspec-node/package.json package-json
 update_file secretspec-dotnet/src/SecretSpec/SecretSpec.csproj csproj
+update_file secretspec-dotnet/tests/SecretSpec.PackageSmoke/SecretSpec.PackageSmoke.csproj csproj
 
 echo "synced SDK package versions to $workspace_version"

--- a/secretspec-dotnet/README.md
+++ b/secretspec-dotnet/README.md
@@ -1,7 +1,8 @@
 # SecretSpec for .NET
 
-> Requires SecretSpec 0.16 or newer. The C# SDK is targeted for SecretSpec 0.16
-> and is not available in the current 0.15 release.
+> Supported starting with SecretSpec 0.16. A 0.15.0 package was published only
+> to reserve the NuGet package ID; it is an unsupported bootstrap artifact and
+> is not the C# SDK release.
 
 `Cachix.SecretSpec` is the C# SDK for
 [SecretSpec](https://secretspec.dev/), the declarative secrets manager. It is a
@@ -67,7 +68,17 @@ returns its path. `Resolved` implements `IDisposable`; keep the result in a
 
 ## Native resolver
 
-The NuGet package carries the resolver for Linux x64/Arm64, macOS Arm64, and
-Windows x64. During local SDK development, `SECRETSPEC_FFI_LIB` can point to an
-explicit `libsecretspec_ffi` build; the SDK also discovers a Cargo `target`
-directory when used from a SecretSpec source checkout.
+The NuGet package carries the resolver for glibc and musl Linux x64/Arm64,
+macOS x64/Arm64, and Windows x64/Arm64. Windows builds include the C runtime,
+so users do not need to install the Visual C++ Redistributable. The managed
+client is trimming-safe and supports NativeAOT; the matching native resolver
+remains beside the published application as a runtime asset.
+
+```bash
+dotnet publish -c Release -r linux-x64 --self-contained \
+  -p:PublishAot=true
+```
+
+During local SDK development, `SECRETSPEC_FFI_LIB` can point to an explicit
+`libsecretspec_ffi` build; the SDK also discovers a Cargo `target` directory
+when used from a SecretSpec source checkout.

--- a/secretspec-dotnet/src/SecretSpec/JsonContracts.cs
+++ b/secretspec-dotnet/src/SecretSpec/JsonContracts.cs
@@ -7,12 +7,23 @@ internal static class JsonContracts
 {
     internal const int ResolveSchemaVersion = 1;
     internal const int ReportSchemaVersion = 1;
-
-    internal static readonly JsonSerializerOptions Options = new()
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
 }
+
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(
+    typeof(ResolveRequest),
+    TypeInfoPropertyName = "ResolveRequest")]
+[JsonSerializable(
+    typeof(Envelope<ResolveResponseContract>),
+    TypeInfoPropertyName = "ResolveEnvelope")]
+[JsonSerializable(
+    typeof(Envelope<ReportResponseContract>),
+    TypeInfoPropertyName = "ReportEnvelope")]
+[JsonSerializable(
+    typeof(IReadOnlyDictionary<string, string?>),
+    TypeInfoPropertyName = "SecretFields")]
+internal sealed partial class SecretSpecJsonContext : JsonSerializerContext;
 
 internal sealed record ResolveRequest
 {

--- a/secretspec-dotnet/src/SecretSpec/Models.cs
+++ b/secretspec-dotnet/src/SecretSpec/Models.cs
@@ -76,7 +76,11 @@ public sealed class Resolved : IDisposable
                 StringComparer.Ordinal));
 
     /// <summary>Serializes <see cref="Fields"/> for a generated deserializer.</summary>
-    public string FieldsJson() => JsonSerializer.Serialize(Fields(), JsonContracts.Options);
+    public string FieldsJson() =>
+        JsonSerializer.Serialize(
+            Fields(),
+            typeof(IReadOnlyDictionary<string, string?>),
+            SecretSpecJsonContext.Default);
 
     /// <summary>Removes temporary files backing <c>as_path</c> secrets.</summary>
     public void Close()

--- a/secretspec-dotnet/src/SecretSpec/Native.cs
+++ b/secretspec-dotnet/src/SecretSpec/Native.cs
@@ -1,9 +1,10 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Cachix.SecretSpec;
 
-internal static class Native
+internal static partial class Native
 {
     private const string LibraryName = "secretspec_ffi";
 
@@ -103,13 +104,15 @@ internal static class Native
         return IntPtr.Zero;
     }
 
-    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr secretspec_resolve(
-        [MarshalAs(UnmanagedType.LPUTF8Str)] string requestJson);
+    [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial IntPtr secretspec_resolve(string requestJson);
 
-    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-    private static extern void secretspec_free(IntPtr pointer);
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial void secretspec_free(IntPtr pointer);
 
-    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr secretspec_abi_version();
+    [LibraryImport(LibraryName)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial IntPtr secretspec_abi_version();
 }

--- a/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
@@ -4,6 +4,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsAotCompatible>true</IsAotCompatible>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 

--- a/secretspec-dotnet/src/SecretSpec/SecretSpecBuilder.cs
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpecBuilder.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Cachix.SecretSpec;
 
@@ -42,7 +43,10 @@ public sealed class SecretSpecBuilder
     /// <exception cref="SecretSpecException">Resolution otherwise failed.</exception>
     public Resolved Load()
     {
-        var response = Call<ResolveResponseContract>(_request, "resolve");
+        var response = Call(
+            _request,
+            "resolve",
+            SecretSpecJsonContext.Default.ResolveEnvelope);
         EnsureSchemaVersion(response.SchemaVersion, JsonContracts.ResolveSchemaVersion, "resolve");
 
         if (response.MissingRequired.Count > 0)
@@ -62,21 +66,29 @@ public sealed class SecretSpecBuilder
     public ResolutionReport Report()
     {
         var request = _request with { Mode = "report" };
-        var response = Call<ReportResponseContract>(request, "report");
+        var response = Call(
+            request,
+            "report",
+            SecretSpecJsonContext.Default.ReportEnvelope);
         EnsureSchemaVersion(response.SchemaVersion, JsonContracts.ReportSchemaVersion, "report");
 
         return new ResolutionReport(response.Provider, response.Profile, response.Secrets);
     }
 
-    private static T Call<T>(ResolveRequest request, string kind)
+    private static T Call<T>(
+        ResolveRequest request,
+        string kind,
+        JsonTypeInfo<Envelope<T>> envelopeTypeInfo)
         where T : class
     {
-        var payload = JsonSerializer.Serialize(request, JsonContracts.Options);
+        var payload = JsonSerializer.Serialize(
+            request,
+            SecretSpecJsonContext.Default.ResolveRequest);
         var raw = Native.Resolve(payload);
         Envelope<T>? envelope;
         try
         {
-            envelope = JsonSerializer.Deserialize<Envelope<T>>(raw, JsonContracts.Options);
+            envelope = JsonSerializer.Deserialize(raw, envelopeTypeInfo);
         }
         catch (JsonException error)
         {

--- a/secretspec-dotnet/tests/SecretSpec.PackageSmoke/Program.cs
+++ b/secretspec-dotnet/tests/SecretSpec.PackageSmoke/Program.cs
@@ -1,0 +1,46 @@
+using Cachix.SecretSpec;
+using SecretSpecClient = Cachix.SecretSpec.SecretSpec;
+
+var root = Path.Combine(
+    Path.GetTempPath(),
+    $"secretspec-dotnet-package-smoke-{Guid.NewGuid()}");
+
+try
+{
+    Directory.CreateDirectory(root);
+    var manifest = Path.Combine(root, "secretspec.toml");
+    var dotenv = Path.Combine(root, ".env");
+
+    File.WriteAllText(
+        manifest,
+        """
+        [project]
+        name = "dotnet-package-smoke"
+        revision = "1.0"
+
+        [profiles.default]
+        PACKAGE_SMOKE = { description = "Package smoke value", required = true }
+        """);
+    File.WriteAllText(dotenv, "PACKAGE_SMOKE=loaded-from-packaged-native-resolver\n");
+
+    var abiVersion = SecretSpecClient.AbiVersion();
+    if (string.IsNullOrWhiteSpace(abiVersion))
+        throw new Exception("native resolver returned an empty ABI version");
+
+    using var resolved = SecretSpecClient.Builder()
+        .WithPath(manifest)
+        .WithProvider($"dotenv://{dotenv}")
+        .WithReason("NuGet package smoke test")
+        .Load();
+
+    var value = resolved.Secrets["PACKAGE_SMOKE"].Get();
+    if (value != "loaded-from-packaged-native-resolver")
+        throw new Exception($"unexpected resolved value: {value}");
+
+    Console.WriteLine($"PASS packaged native resolver ABI {abiVersion}");
+}
+finally
+{
+    if (Directory.Exists(root))
+        Directory.Delete(root, recursive: true);
+}

--- a/secretspec-dotnet/tests/SecretSpec.PackageSmoke/SecretSpec.PackageSmoke.csproj
+++ b/secretspec-dotnet/tests/SecretSpec.PackageSmoke/SecretSpec.PackageSmoke.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Version>0.15.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Cachix.SecretSpec" Version="$(Version)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- expand the `Cachix.SecretSpec` native asset matrix to glibc and musl Linux x64/Arm64, macOS x64/Arm64, and Windows x64/Arm64
- test the generated NuGet package as a clean framework-dependent and NativeAOT consumer on every RID, outside the checkout and without `SECRETSPEC_FFI_LIB`
- make managed JSON serialization and P/Invoke source-generated, trimming-safe, and NativeAOT-compatible
- statically link and verify the Windows MSVC runtime, strip native release binaries, and build dedicated dynamically loadable musl assets
- document the supported 0.16 release boundary and unlist the unsupported 0.15 bootstrap after the first supported package publishes

## Why

The previous matrix proved that each native resolver worked only through the explicit development-library override. It did not exercise NuGet RID selection, copy-to-output behavior, normal P/Invoke loading, self-contained publishing, or NativeAOT. It also omitted Intel macOS, Windows Arm64, and Alpine/musl, while the Windows binary depended on a separately installed Visual C++ runtime.

## Impact

.NET 8 consumers receive a self-contained runtime asset for the major x64 and Arm64 desktop/server targets. Trimmed and NativeAOT applications are supported, Alpine selects a musl resolver instead of falling back to an incompatible glibc binary, and Windows users no longer need the Visual C++ Redistributable.

## Validation

- `dotnet build` with warnings as errors and AOT analyzers: zero warnings
- all 9 C# SDK tests
- clean generated-NuGet framework-dependent consumer on Linux x64
- generated-NuGet NativeAOT consumer on glibc Linux
- generated-NuGet framework-dependent and NativeAOT consumers on Alpine/musl
- all 9 `secretspec-ffi` tests
- `dotnet format --verify-no-changes`
- docs build
- repository hooks, Action workflow linting, version sync, and `git diff --check`

The full macOS/Windows/Arm64 matrix runs in GitHub Actions.
