### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.0] - 2026-07-17
 
 ### Added
 - Composed secrets derive read-only values such as connection strings from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-derive"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "http 1.4.0",
  "insta",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-ffi"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "secretspec",
  "serde_json",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-node-native"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-php-native"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ext-php-rs",
  "secretspec",
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-py-native"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "pyo3",
  "secretspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 
 [workspace.dependencies]
@@ -54,8 +54,8 @@ azure_identity = "1.0.0"
 azure_security_keyvault_secrets = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
-secretspec-derive = { version = "0.15.0", path = "./secretspec-derive" }
-secretspec = { version = "0.15.0", path = "./secretspec" }
+secretspec-derive = { version = "0.16.0", path = "./secretspec-derive" }
+secretspec = { version = "0.16.0", path = "./secretspec" }
 rand = "0.9"
 rsa = { version = "0.9", features = ["pem"] }
 uuid = { version = "1", features = ["v4"] }

--- a/secretspec-derive/Cargo.toml
+++ b/secretspec-derive/Cargo.toml
@@ -15,7 +15,7 @@ quote.workspace = true
 proc-macro2.workspace = true
 toml.workspace = true
 serde.workspace = true
-secretspec = { version = "0.15.0", path = "../secretspec", default-features = false }
+secretspec = { version = "0.16.0", path = "../secretspec", default-features = false }
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>Cachix.SecretSpec</PackageId>
-    <Version>0.15.0</Version>
+    <Version>0.16.0</Version>
     <Authors>Cachix</Authors>
     <Description>C# SDK for SecretSpec, the declarative secrets manager.</Description>
     <PackageTags>secrets;configuration;security;dotnet</PackageTags>

--- a/secretspec-hs/secretspec.cabal
+++ b/secretspec-hs/secretspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               secretspec
-version:            0.15.0
+version:            0.16.0
 synopsis:           Haskell SDK for SecretSpec, a declarative secrets manager
 description:
   A thin client over the @secretspec-ffi@ C ABI (linked at build time).

--- a/secretspec-node/package.json
+++ b/secretspec-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretspec",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Declarative secrets, every environment, any provider (Node.js SDK)",
   "license": "Apache-2.0",
   "homepage": "https://secretspec.dev/",

--- a/secretspec-py/pyproject.toml
+++ b/secretspec-py/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "secretspec"
-version = "0.15.0"
+version = "0.16.0"
 description = "Declarative secrets, every environment, any provider (Python SDK)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/secretspec-rb/secretspec.gemspec
+++ b/secretspec-rb/secretspec.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "secretspec"
-  spec.version     = "0.15.0"
+  spec.version     = "0.16.0"
   spec.summary     = "Declarative secrets, every environment, any provider (Ruby SDK)"
   spec.description = "Ruby bindings for SecretSpec: a native extension that " \
                      "statically links the secretspec-ffi C ABI."


### PR DESCRIPTION
Release 0.16.0.

## Highlights

### Added
- **Composed secrets**: derive read-only values (such as connection strings) from other declared secrets using strict `{SECRET_NAME}` templates, validated for unknown references and cycles before provider access.
- **C# SDK** (`Cachix.SecretSpec`): resolve secrets from .NET through the shared native resolver, with fluent builder and one-shot APIs, typed failures, provenance, environment export, and typed-codegen input. Trimming-safe, NativeAOT-compatible NuGet package with native builds for Linux (glibc/musl x64/Arm64), macOS x64/Arm64, and Windows x64/Arm64.
- **Infisical provider** (`infisical://`) for Infisical Cloud and self-hosted instances, authenticating as a machine identity via Universal Auth.

## Release checklist
- [x] Bump workspace version and dependency pins
- [x] Bump SDK packaging files (node, py, hs, rb, dotnet)
- [x] Update CHANGELOG.md
- [x] `cargo build` (Cargo.lock updated)
- [ ] Merge, then tag `v0.16.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)