### PR TITLE
Fix crates publish order

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,16 +43,17 @@ jobs:
         id: auth
 
       - name: Publish Rust crates
-        # The derive crate is a registry dependency of the main crate, so it
-        # must be published first. Registry checks make retries idempotent when
-        # a previous run published successfully but failed during cleanup.
+        # The derive crate has a registry dependency on the main crate, so the
+        # main crate must be published first. Registry checks make retries
+        # idempotent when a previous run published successfully but failed
+        # during cleanup.
         shell: bash
         run: |
           set -euo pipefail
           version="$(sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\(.*\)"/\1/p' Cargo.toml)"
           user_agent="secretspec-release/${version} (https://github.com/cachix/secretspec)"
 
-          for crate in secretspec-derive secretspec; do
+          for crate in secretspec secretspec-derive; do
             if curl -fsS -A "$user_agent" \
               "https://crates.io/api/v1/crates/${crate}/${version}" >/dev/null; then
               echo "${crate} ${version} is already published"


### PR DESCRIPTION
The `Publish Crates` workflow for `v0.16.0` failed: `secretspec-derive` was published before `secretspec`, but `secretspec-derive` has a registry `[dependencies]` entry on `secretspec = "^0.16.0"`, which isn't on crates.io until the main crate is published. `cargo publish -p secretspec-derive` failed with:

```
failed to select a version for the requirement `secretspec = "^0.16.0"`
candidate versions found which didn't match: 0.15.0, 0.14.0, ...
```

With `set -euo pipefail` the loop aborted, so neither crate was published. This is the first release on the reworked publish workflow, so the ordering bug was never exercised before.

Fix: publish `secretspec` first, then `secretspec-derive`, and correct the now-backwards comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)