### PR TITLE
Show provider and SDK counts on landing page

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -2,8 +2,10 @@
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import { getCollection } from 'astro:content';
 
+const docs = await getCollection('docs');
+
 // Latest blog post, surfaced in a banner near the top of the landing page.
-const posts = (await getCollection('docs'))
+const posts = docs
   .filter((e) => e.id.startsWith('blog/') && !e.data.draft)
   .sort(
     (a, b) =>
@@ -11,6 +13,10 @@ const posts = (await getCollection('docs'))
   );
 
 const latestPost = posts[0];
+const providerCount = docs.filter((e) => e.id.startsWith('providers/')).length;
+const sdkCount = docs.filter(
+  (e) => e.id.startsWith('sdk/') && e.id !== 'sdk/overview',
+).length;
 
 const latestPostDate = latestPost?.data.date
   ? new Intl.DateTimeFormat('en', {
@@ -54,7 +60,7 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
 <StarlightPage
   frontmatter={{
     title: 'Declare secrets once. Store them anywhere.',
-    description: 'Replace shared .env files with a manifest of what your application expects. Keep values out of git and resolve them from any of 14 providers.',
+    description: `Replace shared .env files with a manifest of what your application expects. Keep values out of git and resolve them from any of ${providerCount} providers.`,
     template: 'splash',
     hero: { tagline: '' },
   }}
@@ -85,13 +91,13 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
     <div class="landing-hero-head">
       <h1 id="_top" class="landing-hero-title">Declare secrets once.<br>Store them anywhere.</h1>
       <p class="landing-hero-subtitle">
-        Stop leaking <code class="inline-code">.env</code> files. Commit what your application expects in <code class="inline-code">secretspec.toml</code>, never the values. Developers, CI, and production can each resolve the same declaration from any of 14 providers.
+        Stop leaking <code class="inline-code">.env</code> files. Commit what your application expects in <code class="inline-code">secretspec.toml</code>, never the values. Developers, CI, and production can each resolve the same declaration from any of {providerCount} providers.
       </p>
       <div class="landing-hero-actions">
         <a href="/quick-start/" class="landing-btn landing-btn-primary">Get Started</a>
         <a href="/concepts/overview/" class="landing-btn landing-btn-secondary">Concepts</a>
-        <a href="/concepts/providers/" class="landing-btn landing-btn-secondary">Providers</a>
-        <a href="/sdk/overview/" class="landing-btn landing-btn-secondary">SDKs</a>
+        <a href="/concepts/providers/" class="landing-btn landing-btn-secondary">Providers ({providerCount})</a>
+        <a href="/sdk/overview/" class="landing-btn landing-btn-secondary">SDKs ({sdkCount})</a>
       </div>
     </div>
 
@@ -197,7 +203,7 @@ $ secretspec run --profile production -- npm start
           <span class="landing-step-num">2</span>
           <p class="landing-step-title">Provider</p>
         </div>
-        <p class="landing-step-desc">Choose where this machine looks for values: a system keyring, password manager, cloud secret store, or one of 14 providers.</p>
+        <p class="landing-step-desc">Choose where this machine looks for values: a system keyring, password manager, cloud secret store, or one of {providerCount} providers.</p>
         <pre is:raw class="landing-step-code"><code>$ secretspec config init
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
@@ -228,7 +234,7 @@ $ secretspec run --profile production -- npm start
 
     <div class="landing-bento">
       <a href="/concepts/providers/" class="landing-bento-card is-link landing-bento-2">
-        <div class="landing-bento-big-num">14</div>
+        <div class="landing-bento-big-num">{providerCount}</div>
         <p class="landing-bento-title">Providers</p>
         <p class="landing-bento-desc">Keep values in a local keyring, a team password manager, a cloud secret store, <code class="inline-code">.env</code>, or environment variables.</p>
         <pre is:raw class="landing-bento-mini-code"><code><span class="tok-sec">[defaults]</span>
@@ -644,11 +650,25 @@ $ secretspec export --format json
       <span class="landing-showcase-eyebrow">Language SDKs</span>
       <h2 class="landing-section-title">Resolve secrets directly from your language.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        SDKs for Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell, PHP, and C# use the same resolver as the CLI, so provider and profile behavior stays consistent. <a href="/sdk/overview/" class="landing-link">Explore the SDKs →</a>
+        All {sdkCount} SDKs—Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell, PHP, and C#—use the same resolver as the CLI, so provider and profile behavior stays consistent. <a href="/sdk/overview/" class="landing-link">Explore the SDKs →</a>
       </p>
     </div>
 
     <div class="landing-fallback">
+      <!-- Rust -->
+      <div class="landing-terminal">
+        <div class="landing-terminal-header">
+          <div class="landing-terminal-dots"><span></span><span></span><span></span></div>
+          <span class="landing-terminal-title">Rust</span>
+        </div>
+        <pre is:raw class="landing-terminal-body"><code><span class="tok-key">secretspec_derive</span><span class="tok-pun">::</span><span class="tok-key">declare_secrets!</span><span class="tok-pun">(</span><span class="tok-str">"secretspec.toml"</span><span class="tok-pun">);</span>
+
+<span class="tok-key">let</span> s <span class="tok-pun">=</span> SecretSpec<span class="tok-pun">::</span>builder<span class="tok-pun">()</span>
+    <span class="tok-pun">.</span>with_provider<span class="tok-pun">(</span><span class="tok-str">"keyring://"</span><span class="tok-pun">)</span>
+    <span class="tok-pun">.</span>with_reason<span class="tok-pun">(</span><span class="tok-str">"boot"</span><span class="tok-pun">).</span>load<span class="tok-pun">()?;</span>
+println<span class="tok-pun">!(</span><span class="tok-str">"{}"</span><span class="tok-pun">,</span> s<span class="tok-pun">.</span>secrets<span class="tok-pun">.</span>database_url<span class="tok-pun">);</span></code></pre>
+      </div>
+
       <!-- Python -->
       <div class="landing-terminal">
         <div class="landing-terminal-header">
@@ -662,7 +682,9 @@ s <span class="tok-pun">=</span> SecretSpec.builder() \
     .with_reason(<span class="tok-str">"boot"</span>).load()
 print(s.secrets[<span class="tok-str">"DATABASE_URL"</span>].get)</code></pre>
       </div>
+    </div>
 
+    <div class="landing-fallback" style="margin-top: 1.5rem;">
       <!-- Node.js / TypeScript -->
       <div class="landing-terminal">
         <div class="landing-terminal-header">
@@ -676,9 +698,7 @@ print(s.secrets[<span class="tok-str">"DATABASE_URL"</span>].get)</code></pre>
   .withReason(<span class="tok-str">"boot"</span>).load();
 console.log(s.secrets.DATABASE_URL.get());</code></pre>
       </div>
-    </div>
 
-    <div class="landing-fallback" style="margin-top: 1.5rem;">
       <!-- Go -->
       <div class="landing-terminal">
         <div class="landing-terminal-header">
@@ -690,7 +710,9 @@ console.log(s.secrets.DATABASE_URL.get());</code></pre>
     WithReason(<span class="tok-str">"boot"</span>).Load()
 fmt.Println(s.Secrets[<span class="tok-str">"DATABASE_URL"</span>].Get())</code></pre>
       </div>
+    </div>
 
+    <div class="landing-fallback" style="margin-top: 1.5rem;">
       <!-- Ruby -->
       <div class="landing-terminal">
         <div class="landing-terminal-header">
@@ -702,9 +724,7 @@ fmt.Println(s.Secrets[<span class="tok-str">"DATABASE_URL"</span>].Get())</code>
       .with_reason(<span class="tok-str">"boot"</span>).load
 puts s.secrets[<span class="tok-str">"DATABASE_URL"</span>].get</code></pre>
       </div>
-    </div>
 
-    <div class="landing-fallback" style="margin-top: 1.5rem;">
       <!-- Haskell -->
       <div class="landing-terminal">
         <div class="landing-terminal-header">
@@ -716,7 +736,9 @@ puts s.secrets[<span class="tok-str">"DATABASE_URL"</span>].get</code></pre>
       <span class="tok-pun">&amp;</span> S.withReason <span class="tok-str">"boot"</span>)
 print (S.get <span class="tok-pun">=&lt;&lt;</span> Map.lookup <span class="tok-str">"DATABASE_URL"</span> (S.resolvedSecrets s))</code></pre>
       </div>
+    </div>
 
+    <div class="landing-fallback" style="margin-top: 1.5rem;">
       <!-- PHP -->
       <div class="landing-terminal">
         <div class="landing-terminal-header">
@@ -730,9 +752,7 @@ print (S.get <span class="tok-pun">=&lt;&lt;</span> Map.lookup <span class="tok-
     <span class="tok-pun">-&gt;</span>withReason<span class="tok-pun">(</span><span class="tok-str">'boot web app'</span><span class="tok-pun">)-&gt;</span>load<span class="tok-pun">();</span>
 <span class="tok-key">$s</span><span class="tok-pun">-&gt;</span>setAsEnv<span class="tok-pun">();</span></code></pre>
       </div>
-    </div>
 
-    <div class="landing-fallback" style="margin-top: 1.5rem;">
       <!-- C# -->
       <div class="landing-terminal">
         <div class="landing-terminal-header">


### PR DESCRIPTION
## Summary

- derive provider and SDK counts from the documentation collection
- show the counts directly in the landing-page Providers and SDKs buttons
- add a Rust example to the language SDK showcase and rebalance the snippet grid
- reuse the derived counts in existing landing-page copy

## Why

The landing page should make the breadth of SecretSpec's provider and SDK support immediately visible without introducing counts that drift as documentation pages are added.

## User impact

Visitors now see `Providers (14)` and `SDKs (8)` in the hero navigation, and Rust users get an inline typed SDK example alongside the other language examples.

## Validation

- `npm run build`
