### PR TITLE
docs: document secretspec-update

### DIFF
--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -16,6 +16,16 @@ Choose your preferred installation method:
 curl -sSL https://install.secretspec.dev | sh
 ```
 
+The static installer also installs `secretspec-update`. Run it to install the
+latest SecretSpec release:
+
+```bash
+secretspec-update
+```
+
+If you installed SecretSpec through Nix or another package manager, update it
+through that package manager instead.
+
 </TabItem>
 <TabItem label="Devenv.sh">
 


### PR DESCRIPTION
## Summary

- document `secretspec-update` alongside the static installer instructions
- clarify that package-manager installations should be updated through their package manager

## Why

Issue #172 showed that the updater was already installed with static releases but was not discoverable in the documentation.

## User impact

Static installer users can now find the supported update command, while Nix and other package-manager users are directed to the correct update path.

## Validation

- `devenv shell -- npm --prefix docs run build`
- `git diff --check`
