### PR TITLE
Windows support across the SDK packages

### DIFF
--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -4,6 +4,16 @@ name: "Haskell SDK"
 # secretspec-ffi staticlib. The SDK statically links the C ABI archive at build
 # time, so the Rust resolver is embedded in the binary and there is no runtime
 # loader path (no LD_LIBRARY_PATH).
+#
+# The Windows job cannot use devenv (no Nix on Windows runners), so it sets up
+# rustup + MSYS2 + GHC directly. GHC on Windows links with a MinGW toolchain,
+# so the staticlib comes from the x86_64-pc-windows-gnu Rust target (declared
+# in rust-toolchain.toml); the MSYS2 mingw gcc compiles the archive's C deps
+# (aws-lc-sys, sqlite, zstd) and NASM assembles aws-lc's x86_64 assembly. Some
+# of the archive's link libraries are import libraries shipped inside cargo
+# registry crates rather than in any MinGW distribution -- those are staged
+# next to the archive (scripts/copy-mingw-import-libs.sh) so GHC's linker
+# finds them.
 
 on:
   workflow_call:
@@ -19,6 +29,7 @@ on:
       - "secretspec/**"
       - ".github/workflows/haskell-build.yml"
       - "scripts/sync-sdk-versions.sh"
+      - "scripts/copy-mingw-import-libs.sh"
   push:
     branches: [main]
     tags:
@@ -71,10 +82,108 @@ jobs:
               --write-ghc-environment-files=always --test-show-details=streaming
           '
 
+  build-windows:
+    name: build (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Sync SDK package versions
+        run: bash scripts/sync-sdk-versions.sh
+      - name: Install Rust (pinned by rust-toolchain.toml)
+        run: rustup toolchain install
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
+      - name: Install NASM (aws-lc-sys assembly)
+        uses: ilammy/setup-nasm@v1
+      # MINGW64 (msvcrt-based) matches the CRT the x86_64-pc-windows-gnu Rust
+      # target links, so every object in the archive agrees on one C runtime.
+      - name: Install MSYS2 MinGW toolchain (compiles the staticlib's C deps)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          path-type: inherit
+          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-binutils
+      - name: Install GHC and cabal
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: "9.6"
+      - name: Build staticlib + CLI and run the Haskell SDK test-suite
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          # The archive for GHC's MinGW linker; --crate-type overrides the
+          # crate's list so the unused cdylib is never linked. Release like
+          # the shipped artifacts: a debug archive carries sectionless .dwo
+          # members that objcopy below refuses to process.
+          cargo rustc -p secretspec-ffi --release --target x86_64-pc-windows-gnu \
+            --crate-type staticlib
+          # The CLI (for the test-suite's end-to-end codegen test) builds for
+          # the default MSVC host target, same as the released binaries.
+          cargo build -p secretspec
+          export SECRETSPEC_BIN="$(cygpath -w "$PWD/target/debug/secretspec.exe")"
+          native_libs="$(cargo rustc -q -p secretspec-ffi --release \
+            --target x86_64-pc-windows-gnu --crate-type staticlib -- \
+            --print native-static-libs 2>&1 \
+            | sed -n 's/^note: native-static-libs: //p' | tail -1)"
+          # Stage the .a alone (target/ also holds rlibs) plus the import
+          # libraries that ship inside cargo registry crates (see header).
+          hs_lib_dir="$(mktemp -d)"
+          cp target/x86_64-pc-windows-gnu/release/libsecretspec_ffi.a "$hs_lib_dir/"
+          # Two archive fixups for GHC's older bundled toolchain, which links
+          # the final test binary:
+          #  * rustc's windows-gnu objects carry `-exclude-symbols` .drectve
+          #    directives (DLL export hygiene) that GHC 9.6's ld.lld rejects
+          #    inside .drectve (LLVM allows them only from 17); meaningless
+          #    for a static executable link, so strip the section.
+          #  * the MSYS2-compiled aws-lc objects call nanosleep through its
+          #    time64 asm alias (nanosleep64), which GHC's older winpthreads
+          #    does not export; on x86_64 time_t is 64-bit either way, so
+          #    alias it back and GHC's winpthreads import library satisfies
+          #    it. (Linking MSYS2's winpthreads statically instead collides:
+          #    GHC's driver always links its own winpthreads import library,
+          #    and the two define overlapping internals.)
+          # objcopy refuses archives holding sectionless split-debuginfo
+          # members (the prebuilt std ships .dwo members a linker never
+          # selects), so drop those first.
+          ar t "$hs_lib_dir/libsecretspec_ffi.a" | grep '\.dwo$' | while read -r m; do
+            ar d "$hs_lib_dir/libsecretspec_ffi.a" "$m"
+          done
+          objcopy --remove-section=.drectve --redefine-sym nanosleep64=nanosleep \
+            "$hs_lib_dir/libsecretspec_ffi.a"
+          printf '%s\n' "$native_libs" > "$hs_lib_dir/native-static-libs.txt"
+          bash scripts/copy-mingw-import-libs.sh \
+            "$hs_lib_dir/native-static-libs.txt" "$hs_lib_dir"
+          ghc_optl=()
+          for l in $native_libs; do ghc_optl+=("--ghc-options=-optl$l"); done
+          # Resolving pthread symbols from GHC's winpthreads import library
+          # makes the test binary import libwinpthread-1.dll at runtime, and
+          # cabal does not put GHC's bundled toolchain bin on PATH
+          # (STATUS_DLL_NOT_FOUND when the suite starts). Add it ourselves;
+          # the ls fails the job early if the GHC layout ever changes.
+          mingw_bin="$(cygpath -u "$(ghc --print-libdir)")/../mingw/bin"
+          ls "$mingw_bin"/libwinpthread-1.dll
+          export PATH="$PATH:$mingw_bin"
+          cd secretspec-hs
+          cabal update
+          cabal test --extra-lib-dirs="$(cygpath -w "$hs_lib_dir")" "${ghc_optl[@]}" \
+            --write-ghc-environment-files=always --test-show-details=streaming || {
+            # cabal keeps the suite's output in a log file; surface it, and
+            # run the binary directly to expose a load-time failure's status.
+            echo "=== test suite log ==="
+            find dist-newstyle -name "*.log" -path "*secretspec-test*" -exec cat {} +
+            exe="$(find dist-newstyle -name "secretspec-test.exe" | head -1)"
+            echo "=== imported DLLs ==="
+            objdump -p "$exe" | grep -i "DLL Name" || true
+            ldd "$exe" || true
+            echo "=== direct run: $exe ==="
+            "$exe" || echo "direct run exit code: $?"
+            exit 1
+          }
+
   publish:
     name: publish to Hackage
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build]
+    needs: [build, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/php-ext.yml
+++ b/.github/workflows/php-ext.yml
@@ -51,18 +51,22 @@ jobs:
         # Full php x target cross-product: the `include` entries share the
         # `target` key with the axis, so they merge in the runner (rather than
         # creating standalone combinations). Non-thread-safe (NTS) is the default
-        # CLI/FPM build. 8.1 is omitted (end of life). Windows and ZTS builds are
-        # a follow-up (ext-php-rs on Windows needs the PHP SDK dev pack + rust-lld;
-        # Windows users can use the ext-ffi backend meanwhile).
+        # CLI/FPM build. 8.1 is omitted (end of life). ZTS builds are a
+        # follow-up. On Windows, ext-php-rs's build script downloads the PHP
+        # devel pack matching the installed php.exe (setup-php installs the
+        # official windows.php.net build) and links its php8.lib, so no manual
+        # dev-pack step is needed.
         php: ["8.2", "8.3", "8.4"]
         target:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
           - aarch64-apple-darwin
+          - x86_64-pc-windows-msvc
         include:
-          - { target: x86_64-unknown-linux-gnu, runner: ubuntu-latest }
-          - { target: aarch64-unknown-linux-gnu, runner: ubuntu-24.04-arm }
-          - { target: aarch64-apple-darwin, runner: macos-latest }
+          - { target: x86_64-unknown-linux-gnu, runner: ubuntu-latest, libext: so }
+          - { target: aarch64-unknown-linux-gnu, runner: ubuntu-24.04-arm, libext: so }
+          - { target: aarch64-apple-darwin, runner: macos-latest, libext: so }
+          - { target: x86_64-pc-windows-msvc, runner: windows-latest, libext: dll }
 
     steps:
       - uses: actions/checkout@v5
@@ -84,24 +88,51 @@ jobs:
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
 
+      # PHP's Windows ABI uses the vectorcall calling convention, which stable
+      # Rust does not expose; ext-php-rs therefore requires nightly on Windows
+      # (its own CI builds Windows on nightly, all other platforms on stable).
+      - name: Install Rust nightly (vectorcall ABI, Windows only)
+        if: runner.os == 'Windows'
+        run: rustup toolchain install nightly --profile minimal
+
+      # Keyed per target and PHP minor: ext-php-rs's build script generates
+      # per-PHP-version bindings into the build dir. (The Windows rows build
+      # on nightly, whose daily version bump naturally expires their cache.)
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}-php${{ matrix.php }}
+
       - name: Build and stage the extension under its distribution name
         id: stage
         shell: bash
         # Each runner is the target's native arch, so a plain release build emits
         # the target's binary (no cross-compilation). build-ext.sh owns the
-        # platform-to-library-name mapping and stages lib/secretspec.so.
+        # platform-to-library-name mapping and stages lib/secretspec.<ext>.
         run: |
           set -euo pipefail
+          # RUSTUP_TOOLCHAIN outranks rust-toolchain.toml; see the nightly note.
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            export RUSTUP_TOOLCHAIN=nightly
+            # PHP's Windows loader refuses modules linked with a newer MSVC
+            # linker than the php.exe core (the official 8.x builds are
+            # VS16/VS17; the runner's link.exe is newer). rust-lld stamps a
+            # compatible PE linker version -- the setup ext-php-rs recommends.
+            export RUSTFLAGS="-C linker=rust-lld"
+          fi
           bash secretspec-php/scripts/build-ext.sh
-          asset="secretspec-php-native-${{ matrix.php }}-nts-${{ matrix.target }}.so"
-          cp secretspec-php/lib/secretspec.so "$asset"
+          asset="secretspec-php-native-${{ matrix.php }}-nts-${{ matrix.target }}.${{ matrix.libext }}"
+          cp "secretspec-php/lib/secretspec.${{ matrix.libext }}" "$asset"
           echo "asset=$asset" >> "$GITHUB_OUTPUT"
 
       - name: Smoke test (load the extension, check it registers)
         # Every row builds natively, so the runner can load what it built.
         shell: bash
         run: |
-          php -d extension="$PWD/${{ steps.stage.outputs.asset }}" -r '
+          # php.exe needs a Windows path, not Git Bash's /d/a/... form.
+          dir="$PWD"
+          case "$(uname -s)" in MINGW*|MSYS*) dir="$(pwd -W)" ;; esac
+          php -d extension="$dir/${{ steps.stage.outputs.asset }}" -r '
             assert(function_exists("secretspec_native_resolve"));
             assert(function_exists("secretspec_native_abi_version"));
             echo secretspec_native_abi_version(), PHP_EOL;

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -11,10 +11,11 @@ name: "Python wheels"
 # dynamic system deps, notably libdbus from the keyring provider), so no
 # separate auditwheel step is needed. macOS builds natively.
 #
-# A Windows wheel is a follow-up: the default Windows toolchain is MSVC, and
-# the wheel build would have to vendor the provider system deps. The SDK
-# itself is exercised on every PR by the devenv-based sdks.yml; this workflow
-# only builds the distributable wheels.
+# Windows builds natively on the MSVC toolchain; the keyring provider uses
+# Windows Credential Manager (keyring's windows-native feature), so unlike
+# Linux there are no system deps to vendor into the wheel. The SDK itself is
+# exercised on every PR by the devenv-based sdks.yml; this workflow only
+# builds the distributable wheels.
 #
 # The build/repair pipeline is validated in CI; the publish job additionally
 # needs PyPI Trusted Publishing configured for this repo's "pypi" environment
@@ -58,6 +59,9 @@ jobs:
           manylinux: 2_28
           rust-toolchain: "1.92.0" # matches rust-toolchain.toml
           before-script-linux: yum install -y dbus-devel
+          # Compiler cache backed by the GitHub Actions cache; works inside
+          # the manylinux container, where a host-level cargo cache cannot.
+          sccache: true
           args: --release --out ${{ github.workspace }}/wheelhouse
       - uses: actions/upload-artifact@v4
         with:
@@ -72,6 +76,7 @@ jobs:
       matrix:
         include:
           - { target: macos-aarch64, runner: macos-latest }
+          - { target: windows-x86_64, runner: windows-latest }
     steps:
       - uses: actions/checkout@v5
       - name: Sync SDK package versions
@@ -85,6 +90,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           working-directory: secretspec-py
+          sccache: true
           args: --release --out ${{ github.workspace }}/wheelhouse
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ruby-gems.yml
+++ b/.github/workflows/ruby-gems.yml
@@ -11,12 +11,15 @@ name: "Ruby gems"
 # the remaining follow-up; the build + bundling mechanism below is what is
 # validated. Install requires a C compiler + Ruby headers (+ libdbus-1-dev).
 #
-# A Windows (x64-mingw) gem is a follow-up: the staging script and the gem's
-# mkmf extension assume the Unix `lib<name>.a` archive, but the MinGW Ruby
-# devkit needs an archive from the `x86_64-pc-windows-gnu` Rust target (the
-# default Windows toolchain is MSVC, which emits `<name>.lib`). The SDK itself
-# is exercised on every PR by the devenv-based sdks.yml; this workflow only
-# builds the distributable gems.
+# The Windows gem (x64-mingw-ucrt) bundles a staticlib from the
+# `x86_64-pc-windows-gnu` Rust target (declared in rust-toolchain.toml):
+# RubyInstaller's devkit is MinGW, whose linker cannot consume MSVC `.lib`
+# archives, while the GNU target emits the same `lib<name>.a` naming the
+# staging script and mkmf extension already assume. setup-ruby's MSYS2 devkit
+# supplies the mingw gcc that aws-lc-sys and the other C deps compile with;
+# NASM assembles aws-lc's x86_64 assembly. The SDK itself is exercised on
+# every PR by the devenv-based sdks.yml; this workflow only builds the
+# distributable gems.
 
 on:
   workflow_call:
@@ -33,6 +36,7 @@ on:
       - "secretspec-rb/**"
       - ".github/workflows/ruby-gems.yml"
       - "scripts/sync-sdk-versions.sh"
+      - "scripts/copy-mingw-import-libs.sh"
 
 jobs:
   gems:
@@ -45,6 +49,7 @@ jobs:
           - { target: x86_64-linux, runner: ubuntu-latest }
           - { target: aarch64-linux, runner: ubuntu-24.04-arm }
           - { target: arm64-darwin, runner: macos-latest }
+          - { target: x64-mingw-ucrt, runner: windows-latest }
 
     steps:
       - uses: actions/checkout@v5
@@ -57,6 +62,27 @@ jobs:
 
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
+
+      # See the header: the Windows gem links with RubyInstaller's MinGW
+      # devkit, so the staticlib must come from the GNU target, not the
+      # runner's default MSVC one. stage-staticlib.sh reads CARGO_BUILD_TARGET
+      # to locate the per-target artifact.
+      - name: Target the GNU toolchain (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "CARGO_BUILD_TARGET=x86_64-pc-windows-gnu" >> "$GITHUB_ENV"
+      - name: Install NASM (aws-lc-sys assembly, Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
+      # Placed after the CARGO_BUILD_TARGET/toolchain setup so the cache key
+      # reflects them; keyed per matrix target (the automatic key covers only
+      # the job id, toolchain, and lockfile).
+      - name: Cache Rust builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   automatically in GitHub Actions and Forgejo Actions jobs with `id-token:
   write`. The role and optional audience can be set in the provider URI or with
   `VAULT_JWT_ROLE` and `VAULT_JWT_AUDIENCE`.
+- The Python SDK now publishes a Windows x64 wheel to PyPI, so
+  `pip install secretspec` and `uv add secretspec` work on Windows.
+  ([#177](https://github.com/cachix/secretspec/issues/177))
+- The Ruby SDK now publishes a Windows gem (`x64-mingw-ucrt`) to RubyGems, so
+  `gem install secretspec` works with RubyInstaller on Windows.
+- The PHP SDK now publishes prebuilt Windows x64 extension binaries
+  (`secretspec-php-native-<php>-nts-x86_64-pc-windows-msvc.dll`) alongside the
+  Linux and macOS builds on each release.
 
 ### Changed
 - Secret status output now emphasizes secret names, de-emphasizes descriptions,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
  "zeroize",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.1",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -122,7 +133,7 @@ dependencies = [
  "base64ct",
  "blake2",
  "cpufeatures 0.2.17",
- "password-hash 0.6.0",
+ "password-hash",
  "zeroize",
 ]
 
@@ -157,7 +168,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -194,7 +205,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -371,11 +382,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -590,7 +601,7 @@ checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "tracing",
 ]
 
@@ -674,29 +685,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bindgen"
-version = "0.68.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
- "which",
-]
 
 [[package]]
 name = "bit-set"
@@ -802,7 +790,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b8689df316d423b62aade5e0f55cd6de8d2eebbb90a38cf50cd8f3485fbb1b"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "argon2",
  "bitwarden-encoding",
  "bitwarden-error",
@@ -813,7 +801,7 @@ dependencies = [
  "ed25519-dalek",
  "generic-array",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "num-bigint",
  "num-traits",
  "pbkdf2 0.12.2",
@@ -825,8 +813,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_repr",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.18",
  "tracing",
@@ -866,7 +854,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -954,7 +942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4773816a659edc3db0fc5b9a90fc870adf67910ff106c7fe4f8ce2810c732037"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -982,6 +970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -1032,22 +1021,11 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -1087,7 +1065,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1136,7 +1114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -1159,7 +1137,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -1212,8 +1190,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+dependencies = [
+ "crypto-common 0.2.1",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1246,7 +1234,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -1258,7 +1246,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1352,10 +1340,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -1371,6 +1365,15 @@ name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1410,6 +1413,12 @@ dependencies = [
  "ciborium",
  "ciborium-io",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1475,7 +1484,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1523,7 +1532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1559,17 +1568,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
+ "syn",
 ]
 
 [[package]]
@@ -1594,20 +1593,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -1616,8 +1601,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
- "syn 2.0.117",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -1629,19 +1614,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -1652,7 +1626,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1663,7 +1637,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1689,7 +1663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1715,13 +1689,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1753,7 +1743,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1763,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1785,7 +1775,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1801,7 +1791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1813,8 +1803,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -1825,7 +1817,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1875,7 +1867,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1950,16 +1942,18 @@ dependencies = [
 
 [[package]]
 name = "ext-php-rs"
-version = "0.13.1"
+version = "0.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ebc08b233139f41c0aa0c9005510a5988f5524e215eec8fd5f97a96fb3aac2"
+checksum = "abe62f25cd053f5f95dc7bbf94e5b41818ea3cf39b36cc25de8ca6b4de68a0eb"
 dependencies = [
  "anyhow",
- "bindgen",
  "bitflags",
  "cc",
  "cfg-if",
+ "ext-php-rs-bindgen",
+ "ext-php-rs-build",
  "ext-php-rs-derive",
+ "inventory",
  "native-tls",
  "once_cell",
  "parking_lot",
@@ -1969,18 +1963,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "ext-php-rs-derive"
-version = "0.10.2"
+name = "ext-php-rs-bindgen"
+version = "0.72.1-extphprs.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee71f9125d01946f305868b6269042c6a4dc061f68ad34e2a151ea478f5b3ee"
+checksum = "32ceb73da3b8b18a3424765dd6926dbc29464a0a7bc31ab491600bfa02adc4bc"
 dependencies = [
- "anyhow",
- "darling 0.14.4",
- "ident_case",
- "lazy_static",
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "ext-php-rs-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561bce8a6312a6182c078cd987d8d9cb6bf9292a35817cfd009ea0bffa794f5f"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "ext-php-rs-derive"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f57a075f878ad51bcc56745fb21efe601429a509204f8a385bbe526566597320"
+dependencies = [
+ "convert_case 0.11.0",
+ "darling 0.23.0",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2032,6 +2054,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2132,7 +2155,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2218,11 +2241,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2249,7 +2274,7 @@ dependencies = [
  "chrono",
  "google-cloud-gax",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 1.4.0",
  "reqwest 0.13.2",
  "rustc_version",
@@ -2257,7 +2282,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -2509,7 +2534,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2522,12 +2547,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2906,6 +2931,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "inquire"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,6 +2963,15 @@ dependencies = [
  "once_cell",
  "similar",
  "tempfile",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2969,6 +3012,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,7 +3049,7 @@ checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3056,7 +3108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3105,16 +3157,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -3185,14 +3237,8 @@ checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3234,6 +3280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
+dependencies = [
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,7 +3321,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3343,7 +3398,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3358,7 +3413,7 @@ dependencies = [
  "quote",
  "regex",
  "semver",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3526,7 +3581,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3616,34 +3671,11 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "password-hash"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccbd25f71dd5249dba9ed843d52500c8757a25511560d01a94f4abf56b52a1d5"
 dependencies = [
  "phc",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac",
- "password-hash 0.4.2",
- "sha2",
 ]
 
 [[package]]
@@ -3656,16 +3688,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
+name = "pbkdf2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.2",
+ "hmac 0.13.0",
+]
 
 [[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -3703,7 +3748,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3724,7 +3769,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs8",
  "spki",
 ]
@@ -3735,7 +3780,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "spki",
 ]
 
@@ -3787,6 +3832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3802,7 +3853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3824,7 +3875,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3889,7 +3940,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3901,7 +3952,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3915,7 +3966,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -3936,7 +3987,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
@@ -4103,7 +4154,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4243,7 +4294,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
@@ -4279,12 +4330,6 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4300,19 +4345,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4320,7 +4352,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -4489,7 +4521,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4576,7 +4608,7 @@ dependencies = [
  "secretspec",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "trybuild",
@@ -4721,7 +4753,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4732,7 +4764,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4767,7 +4799,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4819,7 +4851,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4834,6 +4866,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4842,6 +4885,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4963,7 +5017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -4971,12 +5025,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -5013,17 +5061,6 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -5050,7 +5087,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5074,7 +5111,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -5093,7 +5130,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -5133,7 +5170,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5144,7 +5181,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5164,6 +5201,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5236,7 +5274,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5459,7 +5497,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5513,8 +5551,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -5570,7 +5614,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5633,16 +5677,32 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
+ "der 0.8.1",
  "flate2",
  "log",
  "native-tls",
- "once_cell",
- "url",
+ "percent-encoding",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -5662,6 +5722,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5714,7 +5780,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5842,7 +5908,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5932,18 +5998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whoami"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6008,7 +6062,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6019,7 +6073,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6322,7 +6376,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6338,7 +6392,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6411,7 +6465,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6432,7 +6486,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6452,7 +6506,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6473,7 +6527,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6512,28 +6566,41 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "aes",
- "byteorder",
+ "aes 0.9.1",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
- "crossbeam-utils",
+ "deflate64",
  "flate2",
- "hmac",
- "pbkdf2 0.11.0",
- "sha1",
+ "getrandom 0.4.2",
+ "hmac 0.13.0",
+ "indexmap 2.13.0",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2 0.13.0",
+ "ppmd-rust",
+ "sha1 0.11.0",
  "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
@@ -6542,21 +6609,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "zopfli"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 
@@ -6579,7 +6657,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "fancy-regex",
- "itertools",
+ "itertools 0.13.0",
  "lazy_static",
  "regex",
  "time",

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -291,6 +291,10 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
               label: "Adding Providers",
               slug: "development/adding-providers",
             },
+            {
+              label: "SDK Development",
+              slug: "development/sdks",
+            },
           ],
         },
       ],

--- a/docs/src/content/docs/development/sdks.md
+++ b/docs/src/content/docs/development/sdks.md
@@ -1,0 +1,142 @@
+---
+title: SDK Development
+description: How the language SDKs are built, packaged, and released, and which platforms each one supports
+---
+
+SecretSpec ships SDKs for Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell,
+PHP, and C#. This page is for contributors: how the SDKs are put together, how
+each one is packaged and released, which platforms each artifact covers, and
+what to update when adding a platform or a new SDK. For the user-facing
+architecture and API, see the [SDK overview](/sdk/overview).
+
+## One resolver, many packages
+
+All resolution logic lives in the `secretspec` Rust crate. The SDKs reach it
+two ways:
+
+- **Through the C ABI** (`secretspec-ffi`, which builds a `cdylib` for dynamic
+  loading and a `staticlib` for embedding): Ruby (mkmf extension statically
+  links the archive), Go (purego `dlopen` of the cdylib, or cgo against the
+  archive with `-tags static`), Haskell (GHC FFI against the archive), C#
+  (P/Invoke against per-runtime cdylibs in the NuGet package), and PHP's
+  `ext-ffi` fallback (runtime `dlopen` of the cdylib).
+- **As an embedded extension**: Python ([pyo3](https://pyo3.rs/)), Node.js
+  ([napi-rs](https://napi.rs/)), and PHP's preferred backend
+  ([ext-php-rs](https://github.com/davidcole1340/ext-php-rs)) compile the
+  resolver directly into a language-native extension module.
+
+Every SDK exchanges the same JSON request/response with the core, and the
+cross-language conformance suite (`conformance/`, run by
+`.github/workflows/sdks.yml` on every PR) asserts they all reduce the same
+inputs to the same result.
+
+Package versions for the non-Rust SDKs are not hand-edited: release workflows
+run `scripts/sync-sdk-versions.sh`, which stamps the Cargo workspace version
+into every package manifest.
+
+## Packaging workflows
+
+Each SDK has a dedicated distribution workflow that builds artifacts per
+platform and publishes on a version tag:
+
+| SDK | Package | Workflow |
+| --- | --- | --- |
+| Rust | `secretspec` on crates.io (source) | `publish.yml` |
+| Python | `secretspec` wheels on PyPI | `python-wheels.yml` |
+| Node.js | `secretspec` + per-platform packages on npm | `node-addon.yml` |
+| Go | Go module (source) + `secretspec-ffi` release assets | `go-embed.yml`, `go-static.yml`, `ffi-build.yml` |
+| Ruby | `secretspec` platform gems on RubyGems | `ruby-gems.yml` |
+| C# | `Cachix.SecretSpec` on NuGet | `dotnet-package.yml` |
+| PHP | Composer package (source) + prebuilt extension binaries and `secretspec-ffi` release assets | `php-ext.yml`, `ffi-build.yml` |
+| Haskell | `secretspec` on Hackage (source) | `haskell-build.yml` |
+
+## Platform support
+
+Platforms each released artifact covers. Windows support for the Python wheel,
+the Ruby gem, and the PHP extension binaries targets SecretSpec 0.17 and is not
+available in the current release.
+
+| SDK | Linux x64 | Linux arm64 | macOS Intel | macOS Apple silicon | Windows x64 | Windows arm64 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Rust (source crate) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Python | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
+| Node.js | ✓ | ✓ | — | ✓ | ✓ | — |
+| Go | ✓ | ✓ | — | ✓ | ✓ | — |
+| Ruby | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
+| C# | ✓ (glibc and musl) | ✓ (glibc and musl) | ✓ | ✓ | ✓ | ✓ |
+| PHP | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
+| Haskell (source) | ✓ (CI-covered) | — | — | — | ✓ (CI-covered, 0.17+) | — |
+
+Notes:
+
+- Most Linux binary artifacts build inside manylinux_2_28 containers so they
+  run on any distro with glibc >= 2.28 (the Ruby Linux gem still links the
+  build runner's glibc; a baseline toolchain there is a tracked follow-up).
+  On Linux the keyring provider's libdbus is either compiled in
+  (`vendored-dbus`) or required at runtime, per artifact — each workflow's
+  header comment states which.
+- Hackage distributes source only; the Haskell column records which platforms
+  CI builds and tests, since users link `secretspec-ffi` themselves.
+- The fully-static Go binary (`-tags static`, musl) is Linux x64 only.
+
+## Windows toolchains
+
+Windows artifacts split across two Rust targets, and the split is load-bearing:
+
+- **MSVC (`x86_64-pc-windows-msvc`)** for artifacts loaded by MSVC-built
+  hosts: the CLI, the FFI cdylib, the Python wheel, the Node addon, the NuGet
+  natives, and the PHP extension. PHP is the special case: PHP's Windows ABI
+  uses the vectorcall calling convention, which stable Rust does not expose,
+  so `php-ext.yml` builds that one artifact on nightly Rust (the same setup
+  ext-php-rs's own CI uses). ext-php-rs downloads the PHP development pack
+  matching the installed `php.exe` during the build.
+- **MinGW (`x86_64-pc-windows-gnu`, declared in `rust-toolchain.toml`)** for
+  artifacts linked by MinGW toolchains, which cannot consume MSVC `.lib`
+  archives: the staticlib bundled in the Ruby gem (RubyInstaller's devkit) and
+  the one the Haskell CI job links (GHC's bundled toolchain). Building it
+  needs a MinGW C compiler for the archive's C dependencies (aws-lc-sys,
+  SQLite, zstd) and NASM for aws-lc's assembly.
+
+A `staticlib` does not carry its native link-time dependencies; consumers
+capture them from `cargo rustc ... -- --print native-static-libs`. On
+`windows-gnu` that list names import libraries that ship inside cargo registry
+crates (`libwindows.*.a` from `windows_x86_64_gnu`, `libwinapi_*.a` from
+`winapi-x86_64-pc-windows-gnu`) and exist in no MinGW distribution.
+`scripts/copy-mingw-import-libs.sh` stages exactly the referenced ones next to
+the archive — the Ruby gem bundles them in `vendor/`, the Haskell job points
+GHC's linker at them.
+
+## Adding a platform to an SDK
+
+1. Add the platform to the SDK's distribution workflow matrix, and make the
+   publish job consume the new artifact.
+2. Build natively on a runner of that platform where possible; the workflows
+   deliberately avoid cross-compiling because the crate links system
+   libraries.
+3. Keep the artifact self-contained: vendor or statically link anything an end
+   user's machine will not have (see the manylinux/dbus and MinGW import
+   library notes above).
+4. Smoke test in the same workflow: install or load the built artifact and
+   call one function through it.
+5. Update the platform table above, the [SDK overview](/sdk/overview) platform
+   section, and label the platform with its target release (for example
+   `(0.17+)`) until that release ships.
+6. Add a user-facing CHANGELOG entry.
+
+## Adding a new SDK
+
+1. Create the binding crate/package as a workspace sibling
+   (`secretspec-<lang>/`), thin: marshal the JSON envelope, expose the
+   builder/resolve API mirroring the existing SDKs' vocabulary.
+2. Wire the package manifest into `scripts/sync-sdk-versions.sh` so its
+   version tracks the workspace.
+3. Add the SDK to the conformance suite and to `.github/workflows/sdks.yml`.
+4. Create a distribution workflow following an existing one
+   (`ruby-gems.yml` and `python-wheels.yml` are the smallest), including
+   publish-on-tag with trusted publishing where the registry supports it.
+5. Document it: `docs/src/content/docs/sdk/<lang>.md`, the sidebar in
+   `docs/astro.config.ts`, the [SDK overview](/sdk/overview), and the platform
+   tables on this page and the overview.
+6. Follow the same release-visibility rules as providers: label everything
+   with the target version until the release ships (see
+   [Adding Providers](/development/adding-providers)).

--- a/docs/src/content/docs/sdk/overview.md
+++ b/docs/src/content/docs/sdk/overview.md
@@ -102,3 +102,26 @@ Because the resolver is linked or embedded directly, the SDKs do not depend on a
 separately installed `cdylib` or an `LD_LIBRARY_PATH`/`SECRETSPEC_FFI_LIB`
 override at runtime — the one exception being PHP's optional `ext-ffi` fallback,
 where `SECRETSPEC_FFI_LIB` can point at a specific library build.
+
+## Platform support
+
+Prebuilt packages cover the following platforms. Windows support for the
+Python wheel, the Ruby gem, and the PHP extension binaries targets SecretSpec
+0.17 and is not available in the current release.
+
+| SDK | Linux x64 | Linux arm64 | macOS Intel | macOS Apple silicon | Windows x64 | Windows arm64 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Rust (source crate) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Python | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
+| Node.js | ✓ | ✓ | — | ✓ | ✓ | — |
+| Go | ✓ | ✓ | — | ✓ | ✓ | — |
+| Ruby | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
+| C# | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| PHP | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
+| Haskell (source) | ✓ | — | — | — | ✓ (0.17+) | — |
+
+Most Linux packages build against a manylinux_2_28 baseline (glibc 2.28 or
+newer); the C# package additionally ships musl Linux assets. Hackage
+distributes the Haskell SDK as source, so its row records the platforms CI
+builds and tests. Contributors: the [SDK development](/development/sdks) page
+documents how these artifacts are built and how to add a platform.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,6 +7,13 @@
 [toolchain]
 channel = "1.92.0"
 # musl targets for the fully-static Go SDK binary (-tags static + -extldflags
-# -static, built in the SDKs/go-static workflows). rustup reads these on the
-# native runners; devenv reads them via toolchainFile.
-targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
+# -static, built in the SDKs/go-static workflows). The windows-gnu target
+# feeds the MinGW-linked staticlib that the Ruby gem and Haskell SDK embed on
+# Windows (RubyInstaller's devkit and GHC both link with a MinGW toolchain,
+# which cannot consume MSVC archives). rustup reads these on the native
+# runners; devenv reads them via toolchainFile.
+targets = [
+  "x86_64-unknown-linux-musl",
+  "aarch64-unknown-linux-musl",
+  "x86_64-pc-windows-gnu",
+]

--- a/scripts/copy-mingw-import-libs.sh
+++ b/scripts/copy-mingw-import-libs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Copy the MinGW import libraries a windows-gnu staticlib's link line needs out
+# of the cargo registry. rustc's native-static-libs note names them like system
+# libraries (-lwindows.0.52.0, -lwinapi_advapi32), but they ship inside the
+# windows-sys/winapi support crates -- a MinGW toolchain does not provide them,
+# so a consumer linking the staticlib outside cargo (mkmf, GHC) needs a copy in
+# its library search path. System libraries in the note (kernel32, ws2_32, ...)
+# are skipped: every MinGW distribution provides those.
+#
+# Usage: copy-mingw-import-libs.sh <native-static-libs-file> <dest-dir>
+set -euo pipefail
+
+note_file="$1"
+dest="$2"
+
+# In an MSYS2 shell HOME is the MSYS home, but rustup's registry lives under
+# the Windows profile; prefer CARGO_HOME, then the profile, then POSIX HOME.
+cargo_home="${CARGO_HOME:-}"
+if [ -z "$cargo_home" ]; then
+  if [ -n "${USERPROFILE:-}" ] && [ -d "$USERPROFILE/.cargo" ]; then
+    cargo_home="$USERPROFILE/.cargo"
+  else
+    cargo_home="$HOME/.cargo"
+  fi
+fi
+if command -v cygpath >/dev/null 2>&1; then
+  cargo_home="$(cygpath -u "$cargo_home")"
+fi
+
+mkdir -p "$dest"
+while read -r name; do
+  for dir in "$cargo_home"/registry/src/*/windows_x86_64_gnu-*/lib \
+             "$cargo_home"/registry/src/*/winapi-x86_64-pc-windows-gnu-*/lib; do
+    if [ -f "$dir/lib$name.a" ]; then
+      cp -f "$dir/lib$name.a" "$dest/"
+      echo "bundled lib$name.a (cargo registry import library)"
+      break
+    fi
+  done
+done < <(tr ' ' '\n' < "$note_file" | sed -n 's/^-l//p')

--- a/secretspec-php/Cargo.toml
+++ b/secretspec-php/Cargo.toml
@@ -21,5 +21,8 @@ path = "native/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ext-php-rs = "0.13"
+# 0.15+: the 0.13 series leaves Zend data symbols (zend_ce_*,
+# zend_string_init_interned) without dllimport linkage on Windows, which
+# fails the MSVC link of the extension DLL.
+ext-php-rs = "0.15"
 secretspec = { workspace = true }

--- a/secretspec-php/native/lib.rs
+++ b/secretspec-php/native/lib.rs
@@ -11,6 +11,12 @@
 //! no `ffi.enable`, and it works in FPM/web the same way `ext-redis` or
 //! `ext-pdo` do — the deployment model Laravel and Symfony users already manage.
 
+// PHP's Windows ABI uses the vectorcall calling convention, which is feature
+// gated per crate (nightly only): ext-php-rs's macros emit
+// `extern "vectorcall"` items into this crate, so the gate must be enabled
+// here. Other platforms build on stable, where the cfg_attr stays inert.
+#![cfg_attr(windows, feature(abi_vectorcall))]
+
 use ext_php_rs::prelude::*;
 
 /// Resolve secrets from a JSON request string, returning the JSON response
@@ -32,4 +38,6 @@ pub fn secretspec_native_abi_version() -> String {
 #[php_module]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
+        .function(wrap_function!(secretspec_native_resolve))
+        .function(wrap_function!(secretspec_native_abi_version))
 }

--- a/secretspec-rb/ext/secretspec/extconf.rb
+++ b/secretspec-rb/ext/secretspec/extconf.rb
@@ -57,5 +57,9 @@ $INCFLAGS << " -I#{include_dir}"
 # for the referenced symbols) precedes the system libs it depends on.
 $LOCAL_LIBS << " #{staticlib}"
 $libs = "#{$libs} #{find_native_libs(vendor, repo_root)}"
+# The Windows gem bundles MinGW import libraries next to the staticlib
+# (libwindows.*.a / libwinapi_*.a ship inside cargo registry crates, so an
+# installing machine has them nowhere else); let the linker search vendor/.
+$LIBPATH << vendor if File.directory?(vendor)
 
 create_makefile("secretspec/secretspec_ext")

--- a/secretspec-rb/scripts/stage-staticlib.sh
+++ b/secretspec-rb/scripts/stage-staticlib.sh
@@ -9,15 +9,33 @@ set -euo pipefail
 pkg_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_root="$(cd "$pkg_dir/.." && pwd)"
 
-cargo build -p secretspec-ffi --release --manifest-path "$repo_root/Cargo.toml"
+# Crate-type override: the gem only ships the staticlib, so skip the crate's
+# other types (on windows-gnu this avoids linking the unused cdylib entirely).
+cargo rustc -p secretspec-ffi --release --manifest-path "$repo_root/Cargo.toml" \
+  --crate-type staticlib
 
+# The trailing sed unescapes the JSON-escaped backslashes a Windows target
+# directory arrives with (D:\\a\\... -> D:/a/...); a no-op elsewhere.
 target_dir="$(cargo metadata --no-deps --format-version 1 --manifest-path "$repo_root/Cargo.toml" \
-  | grep -o '"target_directory":"[^"]*"' | head -1 | sed 's/.*:"\(.*\)"/\1/')"
+  | grep -o '"target_directory":"[^"]*"' | head -1 | sed 's/.*:"\(.*\)"/\1/' | sed 's/\\\\/\//g')"
+
+# When CARGO_BUILD_TARGET is set (the Windows gem builds the
+# x86_64-pc-windows-gnu staticlib), cargo nests output under the triple.
+out_dir="$target_dir/${CARGO_BUILD_TARGET:+$CARGO_BUILD_TARGET/}release"
 
 mkdir -p "$pkg_dir/vendor"
-cp "$target_dir/release/libsecretspec_ffi.a" "$pkg_dir/vendor/libsecretspec_ffi.a"
+cp "$out_dir/libsecretspec_ffi.a" "$pkg_dir/vendor/libsecretspec_ffi.a"
 cp "$repo_root/secretspec-ffi/include/secretspec.h" "$pkg_dir/vendor/secretspec.h"
 cargo rustc -q -p secretspec-ffi --release --manifest-path "$repo_root/Cargo.toml" \
   --crate-type staticlib -- --print native-static-libs 2>&1 \
   | sed -n 's/^note: native-static-libs: //p' | tail -1 > "$pkg_dir/vendor/native-static-libs.txt"
+
+# The windows-gnu link line references import libraries that live inside cargo
+# registry crates, not in the MinGW toolchain; a user installing the gem has no
+# cargo registry, so bundle them (extconf.rb adds vendor/ to the search path).
+if [[ "${CARGO_BUILD_TARGET:-}" == *-windows-gnu ]]; then
+  bash "$repo_root/scripts/copy-mingw-import-libs.sh" \
+    "$pkg_dir/vendor/native-static-libs.txt" "$pkg_dir/vendor"
+fi
+
 echo "staged libsecretspec_ffi.a + secretspec.h + native-static-libs.txt into vendor/"


### PR DESCRIPTION
## Summary

Closes the Windows gap across the SDK distribution pipeline. Fixes #177 (Python SDK not installable on Windows) and extends the same treatment to the remaining SDKs that lacked Windows artifacts.

- **Python**: `python-wheels.yml` builds a `cp39-abi3-win_amd64` wheel on `windows-latest`. The old header note claimed Windows was blocked on vendoring provider system deps; that is Linux-only (libdbus) — keyring uses Windows Credential Manager natively, and the core crate already ships on MSVC via cargo-dist.
- **Ruby**: `ruby-gems.yml` builds an `x64-mingw-ucrt` platform gem. RubyInstaller's devkit links with MinGW, which cannot consume MSVC archives, so the gem bundles a staticlib from the `x86_64-pc-windows-gnu` target (now declared in `rust-toolchain.toml`). The windows-gnu link line references import libraries that ship inside cargo registry crates (`libwindows.*.a`, `libwinapi_*.a`) and exist in no MinGW distribution; the new shared `scripts/copy-mingw-import-libs.sh` bundles exactly the referenced ones into `vendor/` (~28MB) and `extconf.rb` adds `vendor/` to the linker search path.
- **PHP**: `php-ext.yml` builds `x86_64-pc-windows-msvc` extension DLLs for PHP 8.2/8.3/8.4. ext-php-rs downloads the PHP devel pack matching the installed `php.exe` during the build; the leg needs only setup-php plus nightly Rust (PHP's Windows ABI uses vectorcall, which stable Rust does not expose — same setup as ext-php-rs's own CI).
- **Haskell**: `haskell-build.yml` gains a native `windows-latest` job (no Nix there): MSYS2 MINGW64 gcc + NASM build the windows-gnu staticlib, GHC 9.6 links it with the staged import libraries, and the full cabal test-suite runs against the MSVC-built CLI. Hackage publishing now gates on it.
- **Docs**: new `development/sdks` contributor page (architecture, packaging workflows, platform matrix, the MSVC-vs-MinGW toolchain split, add-a-platform/add-an-SDK checklists) plus a user-facing platform table in the SDK overview, with the upcoming Windows artifacts labeled `0.17+`.

## Verification

- The full provider dependency tree (aws-lc-sys, ring, rusqlite, zstd, bitwarden) was cross-compiled locally for `x86_64-pc-windows-gnu` to de-risk the MinGW path; the staticlib builds cleanly and its `native-static-libs` note drove the import-library bundling (verified copying exactly the 11 referenced archives).
- The Ruby Linux path was regression-tested end-to-end with the reworked staging script: stage → `gem build` → `gem install` → smoke (`abi 0.16.0`).
- actionlint passes on all four workflows; the docs site builds all 47 pages.
- The Windows legs themselves can only be exercised by CI — the touched paths trigger `python-wheels`, `ruby-gems`, `php-ext`, and `haskell-build` on this PR. The Ruby leg is the most experimental (mixed msvcrt/ucrt runtimes, the tradeoff rb-sys also ships with); Python and PHP mirror setups already proven in this repo or upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)