### PR TITLE
docs(infisical): mark the provider available since 0.16, not upcoming

### DIFF
--- a/docs/src/content/docs/providers/infisical.md
+++ b/docs/src/content/docs/providers/infisical.md
@@ -7,8 +7,7 @@ The Infisical provider integrates with [Infisical](https://infisical.com) over i
 both Infisical Cloud and self-hosted instances.
 
 :::note[Version compatibility]
-The Infisical provider is an upcoming SecretSpec 0.16 feature and is not available
-in SecretSpec 0.15.
+Available since SecretSpec 0.16.
 :::
 
 ## At a glance
@@ -20,7 +19,7 @@ in SecretSpec 0.15.
 | Access | Read and write; version-pinned references are read-only |
 | Best for | Infisical Cloud or self-hosted Infisical deployments |
 | Authentication | Universal Auth machine identity or access token |
-| Availability | Upcoming in SecretSpec 0.16; requires the `infisical` build feature |
+| Availability | SecretSpec 0.16+; requires the `infisical` build feature |
 | Default storage | Key `{key}` in `{path}/{project}/{profile}` |
 
 ## Quick start

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -206,7 +206,9 @@ akv://myvault?suffix=vault.azure.cn      # Sovereign cloud (explicit suffix, bar
 **Prerequisites**: An Azure Key Vault instance, authenticated via one of the methods above, build with `--features akv`
 **Storage**: Secret name `secretspec--{base32(project)}--{base32(profile)}--{base32(key)}` (lowercase, unpadded Base32 preserves case and punctuation distinctions within Azure's case-insensitive secret-name namespace)
 
-## Infisical Provider (0.16+)
+## Infisical Provider
+
+Available since SecretSpec 0.16.
 
 **URI**: `infisical://[HOST]/PROJECT_ID[?env=SLUG][&path=/PREFIX][&tls=false]` - Stores secrets in Infisical
 
@@ -272,4 +274,4 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Vault/OpenBao | ✅ Vault encryption | Vault/OpenBao server | ✅ Yes |
 | BWS | ✅ End-to-end | Cloud (Bitwarden) | ✅ Yes |
 | AKV | ✅ Azure-managed | Cloud (Azure) | ✅ Yes |
-| Infisical (0.16+) | ✅ Infisical-managed | Cloud (Infisical) or self-hosted | ✅ Yes |
+| Infisical | ✅ Infisical-managed | Cloud (Infisical) or self-hosted | ✅ Yes |


### PR DESCRIPTION
0.16 shipped with the Infisical provider, so the "upcoming / not available" framing on its docs page is now stale. This replaces it with the durable "Available since SecretSpec 0.16" wording — matching how the gopass page reads after its own 0.15 release.

## Changes

- **`providers/infisical.md`**: version-compatibility note and the "Availability" row now say *Available since 0.16* / *SecretSpec 0.16+* instead of *upcoming / not available in 0.15*.
- **`reference/providers.md`**: the Infisical section heading drops the `(0.16+)` suffix and gains an *Available since SecretSpec 0.16.* line, matching the released-provider form used by GoPass and Vault; the security-considerations table row drops its marker too (GoPass has none there).

## What deliberately stays

The `(0.16+)` markers in provider lists, the concepts and configuration tables, the sidebar blurb, the config-init examples, and the READMEs are left intact. Those are durable *requires 0.16 or later* markers — exactly how gopass's `(0.15+)` still appears in the same listings after release.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
