### PR TITLE
Support named secret presence constraint groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The `required` field accepts `at_least_one` and `exactly_one` group tables,
+  supporting overlapping alternative and mutually exclusive credentials
+  across `check`, `run`, and SDK resolution.
 - Vault / OpenBao JWT/OIDC authentication (`?auth=jwt`) logs in through a
   configured Vault role using `VAULT_JWT`, or requests a short-lived OIDC token
   automatically in GitHub Actions and Forgejo Actions jobs with `id-token:

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -79,6 +79,29 @@ REDIS_URL = { description = "Redis cache", required = false, default = "redis://
 DATABASE_URL = { description = "Production database", required = true }
 ```
 
+#### Cross-secret presence constraints (0.17+)
+
+:::caution[Version compatibility]
+Added in SecretSpec 0.17.
+:::
+
+A profile can require alternative credentials by assigning secrets to a named
+group:
+
+```toml
+[profiles.default]
+PASSWORD = { description = "Account password", required = { at_least_one = "account_auth" } }
+ACCESS_TOKEN = { description = "Personal access token", required = { at_least_one = "account_auth" } }
+
+GITHUB_TOKEN = { description = "GitHub token", required = { exactly_one = "github_auth" } }
+GITHUB_APP_KEY = { description = "GitHub App private key", required = { exactly_one = "github_auth" } }
+```
+
+`at_least_one` requires one or more group members to resolve; `exactly_one`
+requires one. Each field also accepts an array of group names for overlapping
+groups. Groups must contain at least two secrets and cannot mix modes. Group
+members are individually optional.
+
 #### Secret Variable Options
 
 Each secret variable is defined as a table with the following fields:
@@ -86,7 +109,7 @@ Each secret variable is defined as a table with the following fields:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `description` | string | Yes (see notes) | Human-readable description of the secret |
-| `required` | boolean | No | Whether absence is an error (default: true, or false when `default` is present) |
+| `required` | boolean or table | No | Whether absence is an error; the table form (0.17+) accepts `at_least_one`/`exactly_one` presence groups (defaults to true; false with `default` or a presence group) |
 | `default` | string | No | Default value if not provided |
 | `composed` (0.16+) | string | No | Derive a read-only value from other declared secrets using `${UPPERCASE_NAME}` references |
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
@@ -100,7 +123,8 @@ Field notes:
 - `description` is required in the `default` profile. A secret overriding one
   that the default profile already declares inherits its `description` (and
   other omitted fields) and may leave it out.
-- `required` defaults to false when `default` is provided.
+- `required` defaults to false when `default` is provided. In 0.17+, its table
+  form accepts `at_least_one` and `exactly_one` as a group name or array of names.
 - `default` is invalid with an explicit `required = true`. A defaulted secret is
   guaranteed to be present in successful resolution and generated types, even
   though the provider does not have to supply it.

--- a/schema/resolution-report.schema.json
+++ b/schema/resolution-report.schema.json
@@ -24,9 +24,40 @@
       "description": "One entry per declared secret, sorted by name.",
       "type": "array",
       "items": { "$ref": "#/$defs/secretResolution" }
+    },
+    "constraint_violations": {
+      "description": "Cross-secret presence constraints that failed. Added in SecretSpec 0.17 and omitted when empty.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/constraintViolation" }
     }
   },
   "$defs": {
+    "constraintViolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "group", "secrets", "present"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["at_least_one", "exactly_one"]
+        },
+        "group": {
+          "description": "Group name declared by its member secrets.",
+          "type": "string"
+        },
+        "secrets": {
+          "description": "All declared members of the constraint group.",
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string" }
+        },
+        "present": {
+          "description": "Group members that resolved; values are never included.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
     "secretResolution": {
       "type": "object",
       "additionalProperties": false,

--- a/secretspec-derive/src/lib.rs
+++ b/secretspec-derive/src/lib.rs
@@ -959,8 +959,13 @@ mod secret_spec_generation {
                 }
                 match spec.validate()? {
                     Ok(valid_secrets) => Ok(valid_secrets),
-                    Err(validation_errors) => Err(secretspec::SecretSpecError::RequiredSecretMissing(
-                        validation_errors.missing_required.join(", ")
+                    Err(validation_errors) if validation_errors.constraint_violations.is_empty() => {
+                        Err(secretspec::SecretSpecError::RequiredSecretMissing(
+                            validation_errors.missing_required.join(", ")
+                        ))
+                    }
+                    Err(validation_errors) => Err(secretspec::SecretSpecError::ValidationFailed(
+                        Box::new(validation_errors)
                     ))
                 }
             }

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -289,6 +289,28 @@ fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
             );
             if let Some(required) = secret_config.required {
                 inline.insert("required", Value::from(required));
+            } else if secret_config.at_least_one.is_some() || secret_config.exactly_one.is_some() {
+                let mut groups = InlineTable::new();
+                for (name, memberships) in [
+                    ("at_least_one", &secret_config.at_least_one),
+                    ("exactly_one", &secret_config.exactly_one),
+                ] {
+                    let Some(memberships) = memberships else {
+                        continue;
+                    };
+                    let value = match memberships.as_slice() {
+                        [membership] => Value::from(membership.as_str()),
+                        memberships => {
+                            let mut array = Array::new();
+                            for membership in memberships {
+                                array.push(membership.as_str());
+                            }
+                            Value::Array(array)
+                        }
+                    };
+                    groups.insert(name, value);
+                }
+                inline.insert("required", Value::InlineTable(groups));
             }
             if let Some(default) = &secret_config.default {
                 inline.insert("default", Value::from(default.as_str()));
@@ -1261,6 +1283,33 @@ mod tests {
         let out = generate_toml_with_comments(&config_with_secret(secret)).unwrap();
         assert!(out.contains(", required = false"), "got: {out}");
         assert!(out.contains(", default = \"v\""), "got: {out}");
+    }
+
+    #[test]
+    fn generate_toml_emits_grouped_requiredness() {
+        let secret = Secret {
+            description: Some("desc".to_string()),
+            at_least_one: Some(vec!["auth".to_string(), "deploy".to_string()]),
+            exactly_one: Some(vec!["identity".to_string()]),
+            ..Default::default()
+        };
+        let out = generate_toml_with_comments(&config_with_secret(secret)).unwrap();
+        assert!(
+            out.contains(
+                "required = { at_least_one = [\"auth\", \"deploy\"], exactly_one = \"identity\" }"
+            ),
+            "got: {out}"
+        );
+        let parsed: Config = toml::from_str(&out).expect("must round-trip");
+        let secret = &parsed.profiles["default"].secrets["S"];
+        assert_eq!(
+            secret.at_least_one.as_deref(),
+            Some(["auth".to_string(), "deploy".to_string()].as_slice())
+        );
+        assert_eq!(
+            secret.exactly_one.as_deref(),
+            Some(["identity".to_string()].as_slice())
+        );
     }
 
     #[test]

--- a/secretspec/src/codegen.rs
+++ b/secretspec/src/codegen.rs
@@ -388,6 +388,34 @@ mod tests {
     }
 
     #[test]
+    fn constraint_members_are_optional() {
+        let config = config_with(vec![(
+            "default",
+            vec![
+                (
+                    "PASSWORD",
+                    Secret {
+                        at_least_one: Some(vec!["auth".to_string()]),
+                        ..secret(None, None, None)
+                    },
+                ),
+                (
+                    "TOKEN",
+                    Secret {
+                        at_least_one: Some(vec!["auth".to_string(), "deploy".to_string()]),
+                        exactly_one: Some(vec!["github".to_string()]),
+                        ..secret(None, None, None)
+                    },
+                ),
+            ],
+        )]);
+
+        let ir = build_ir(&config);
+        assert!(union_field(&ir, "PASSWORD").optional);
+        assert!(union_field(&ir, "TOKEN").optional);
+    }
+
+    #[test]
     fn defaulted_secret_is_non_optional_because_resolution_guarantees_a_value() {
         let mut token = secret(None, None, None);
         token.default = Some("fallback".to_string());

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -415,7 +415,60 @@ fn validate_compiled_profile(
             ))
         })?;
     }
+    validate_profile_constraints(profile_name, profile)?;
     validate_composition_graph(profile_name, profile)?;
+    Ok(())
+}
+
+fn validate_profile_constraints(
+    profile_name: &str,
+    profile: &crate::manifest::CompiledProfile,
+) -> Result<(), ParseError> {
+    fn validate_groups(
+        profile_name: &str,
+        kind: &str,
+        groups: &[crate::manifest::CompiledConstraintGroup],
+    ) -> Result<(), ParseError> {
+        for group in groups {
+            if group.members.len() < 2 {
+                return Err(ParseError::Validation(format!(
+                    "Profile '{}': {} group '{}' must contain at least two secrets",
+                    profile_name, kind, group.name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    let at_least_names: HashSet<&str> = profile
+        .constraints
+        .at_least_one
+        .iter()
+        .map(|group| group.name.as_str())
+        .collect();
+    if let Some(group) = profile
+        .constraints
+        .exactly_one
+        .iter()
+        .find(|group| at_least_names.contains(group.name.as_str()))
+    {
+        return Err(ParseError::Validation(format!(
+            "Profile '{}': group '{}' cannot mix at_least_one and exactly_one membership",
+            profile_name, group.name
+        )));
+    }
+
+    validate_groups(
+        profile_name,
+        "at_least_one",
+        &profile.constraints.at_least_one,
+    )?;
+    validate_groups(
+        profile_name,
+        "exactly_one",
+        &profile.constraints.exactly_one,
+    )?;
+
     Ok(())
 }
 
@@ -1153,6 +1206,41 @@ fn ref_string_hint(s: &str) -> String {
     )
 }
 
+/// Deserialize a group membership as either `"name"` or `["name", ...]`.
+fn deserialize_group_names<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    Ok(Some(match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(name) => vec![name],
+        OneOrMany::Many(names) => names,
+    }))
+}
+
+/// Preserve the compact string form when a secret belongs to one group.
+fn serialize_group_names<S>(
+    groups: &Option<Vec<String>>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match groups.as_deref() {
+        Some([group]) => serializer.serialize_str(group),
+        Some(groups) => groups.serialize(serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
 impl<'de> Deserialize<'de> for NativeAddress {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
@@ -1190,34 +1278,92 @@ impl<'de> Deserialize<'de> for NativeAddress {
     }
 }
 
+/// The serialized form of `required`: either the existing boolean or a table
+/// of cross-secret presence groups.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum RequiredSetting {
+    Bool(bool),
+    Groups(RequiredGroups),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RequiredGroups {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_group_names",
+        serialize_with = "serialize_group_names",
+        skip_serializing_if = "Option::is_none"
+    )]
+    at_least_one: Option<Vec<String>>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_group_names",
+        serialize_with = "serialize_group_names",
+        skip_serializing_if = "Option::is_none"
+    )]
+    exactly_one: Option<Vec<String>>,
+}
+
+/// Serde proxy that keeps the established Rust `Secret` API while presenting
+/// requiredness as one boolean-or-table field in TOML.
+#[derive(Serialize, Deserialize)]
+struct SecretSerde {
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    required: Option<RequiredSetting>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    composed: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    providers: Option<Vec<String>>,
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+    reference: Option<NativeAddress>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    as_path: Option<bool>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    secret_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generate: Option<GenerateConfig>,
+}
+
 /// Configuration for an individual secret.
 ///
 /// Defines the properties of a secret including its documentation,
 /// whether it's required, an optional default value, and optionally
 /// which providers to use for retrieving this secret (in fallback order).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(try_from = "SecretSerde", into = "SecretSerde")]
 pub struct Secret {
     /// Human-readable description of what this secret is used for
     pub description: Option<String>,
     /// Whether this secret must be provided (no default value)
     /// If not specified, defaults to true unless overridden by profile defaults
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
+    /// Named groups in which at least one member must resolve. Serialized
+    /// inside the `required` table as either one string or an array of strings.
+    ///
+    /// Available since SecretSpec 0.17.
+    pub at_least_one: Option<Vec<String>>,
+    /// Named groups in which exactly one member must resolve. Serialized
+    /// inside the `required` table as either one string or an array of strings.
+    ///
+    /// Available since SecretSpec 0.17.
+    pub exactly_one: Option<Vec<String>>,
     /// Optional default value if the secret is not provided
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<String>,
     /// A strict template derived from other declared secrets. References use
     /// `${UPPERCASE_NAME}`; `$$` produces a literal dollar sign.
     ///
     /// Available since SecretSpec 0.16.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub composed: Option<String>,
     /// Optional list of provider aliases for retrieving this secret.
     /// Providers are tried in order until one has the secret.
     /// If not specified, uses the profile defaults.providers or global provider.
     /// Each alias is resolved against the providers map in GlobalConfig.
     /// Example: providers = ["keyring", "env"] will try keyring first, then env.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub providers: Option<Vec<String>>,
     /// Native coordinates naming one externally managed secret (see
     /// [`NativeAddress`]): `ref = { item = "db", field = "password" }`.
@@ -1230,20 +1376,72 @@ pub struct Secret {
     /// tests) without editing it, and composes with `providers`. Also composes
     /// with `generate`: a missing referenced secret is minted and written to
     /// its coordinates. Serialized as `ref` in TOML.
-    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<NativeAddress>,
     /// Whether to write the secret value to a temporary file and return the path.
     /// If true, the secret will be written to a temporary file and the field
     /// will contain the path to that file instead of the secret value.
     /// The temporary file will be cleaned up when the resolved secrets are dropped.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub as_path: Option<bool>,
     /// The type of secret, used for generation (e.g., "password", "hex", "base64", "uuid", "command", "rsa_private_key")
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub secret_type: Option<String>,
     /// Auto-generation configuration. Either `true` for defaults or a table with options.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub generate: Option<GenerateConfig>,
+}
+
+impl TryFrom<SecretSerde> for Secret {
+    type Error = String;
+
+    fn try_from(value: SecretSerde) -> Result<Self, Self::Error> {
+        let (required, at_least_one, exactly_one) = match value.required {
+            Some(RequiredSetting::Bool(required)) => (Some(required), None, None),
+            Some(RequiredSetting::Groups(groups)) => {
+                if groups.at_least_one.is_none() && groups.exactly_one.is_none() {
+                    return Err("`required` table must set `at_least_one` or `exactly_one`".into());
+                }
+                (None, groups.at_least_one, groups.exactly_one)
+            }
+            None => (None, None, None),
+        };
+
+        Ok(Self {
+            description: value.description,
+            required,
+            at_least_one,
+            exactly_one,
+            default: value.default,
+            composed: value.composed,
+            providers: value.providers,
+            reference: value.reference,
+            as_path: value.as_path,
+            secret_type: value.secret_type,
+            generate: value.generate,
+        })
+    }
+}
+
+impl From<Secret> for SecretSerde {
+    fn from(value: Secret) -> Self {
+        let required = if value.at_least_one.is_some() || value.exactly_one.is_some() {
+            Some(RequiredSetting::Groups(RequiredGroups {
+                at_least_one: value.at_least_one,
+                exactly_one: value.exactly_one,
+            }))
+        } else {
+            value.required.map(RequiredSetting::Bool)
+        };
+
+        Self {
+            description: value.description,
+            required,
+            default: value.default,
+            composed: value.composed,
+            providers: value.providers,
+            reference: value.reference,
+            as_path: value.as_path,
+            secret_type: value.secret_type,
+            generate: value.generate,
+        }
+    }
 }
 
 impl Secret {
@@ -1292,7 +1490,51 @@ impl Secret {
         self.generate.as_ref().is_some_and(|g| g.is_enabled())
     }
 
+    /// Whether this declaration supplies an individual or grouped requiredness
+    /// policy. The three Rust fields serialize as one TOML field and therefore
+    /// inherit as one unit.
+    fn has_required_setting(&self) -> bool {
+        self.required.is_some() || self.at_least_one.is_some() || self.exactly_one.is_some()
+    }
+
     fn validate_semantics(&self) -> Result<(), String> {
+        for (field, groups) in [
+            ("at_least_one", self.at_least_one.as_deref()),
+            ("exactly_one", self.exactly_one.as_deref()),
+        ] {
+            let Some(groups) = groups else {
+                continue;
+            };
+            if groups.is_empty() {
+                return Err(format!("`{field}` must name at least one group"));
+            }
+            let mut unique = HashSet::new();
+            for group in groups {
+                if group.trim().is_empty() {
+                    return Err(format!(
+                        "`{field}` group name cannot be empty or whitespace"
+                    ));
+                }
+                if !unique.insert(group) {
+                    return Err(format!("`{field}` contains duplicate group name '{group}'"));
+                }
+            }
+        }
+
+        // A presence group governs when its members' absence is an error, so an
+        // explicit `required = true` on a member is a contradiction: it demands
+        // the secret individually while the group offers it as one alternative.
+        // The value can be inherited from the `default` profile, so this runs on
+        // the merged view; drop `required` or set it to false to join a group.
+        if self.required == Some(true)
+            && (self.at_least_one.is_some() || self.exactly_one.is_some())
+        {
+            return Err(
+                "`required = true` cannot be combined with `at_least_one` or `exactly_one`; group membership governs the secret's presence, so drop `required` or set it to false"
+                    .into(),
+            );
+        }
+
         if let Some(composed) = &self.composed {
             Template::parse(composed)?;
             if self.default.is_some()
@@ -1417,13 +1659,26 @@ impl Secret {
         }
 
         let composed = inherit(current, default, |s| s.composed.clone());
+        let required_source = current
+            .filter(|secret| secret.has_required_setting())
+            .or_else(|| default.filter(|secret| secret.has_required_setting()));
+        let (required, at_least_one, exactly_one) = if let Some(secret) = required_source {
+            (
+                secret.required,
+                secret.at_least_one.clone(),
+                secret.exactly_one.clone(),
+            )
+        } else {
+            (defaults.and_then(|d| d.required), None, None)
+        };
         // A composed secret's source is its dependency graph, so the
         // `[defaults]` storage fields (`default`, `providers`) do not apply.
         let storage_defaults = if composed.is_some() { None } else { defaults };
         Some(Secret {
             description: inherit(current, default, |s| s.description.clone()),
-            required: inherit(current, default, |s| s.required)
-                .or(defaults.and_then(|d| d.required)),
+            required,
+            at_least_one,
+            exactly_one,
             default: inherit(current, default, |s| s.default.clone())
                 .or_else(|| storage_defaults.and_then(|d| d.default.clone())),
             composed,
@@ -2060,6 +2315,140 @@ ADMIN_PASSWORD = { description = "Password securing the admin page", required = 
         );
         assert_eq!(resolved.required, Some(true));
         assert_eq!(resolved.secret_type.as_deref(), Some("password"));
+    }
+
+    #[test]
+    fn config_validate_accepts_presence_constraints_and_default_inheritance() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "auth"
+revision = "1.0"
+
+[profiles.default]
+PASSWORD = { description = "Password", required = { at_least_one = ["auth", "fallback_auth"], exactly_one = "exclusive_auth" } }
+ACCESS_TOKEN = { description = "Access token", required = { at_least_one = ["auth", "fallback_auth"], exactly_one = "exclusive_auth" } }
+
+[profiles.production]
+"#,
+        )
+        .unwrap();
+
+        config.validate().unwrap();
+        let compiled = CompiledManifest::compile(&config);
+        let production = compiled.profile("production").unwrap();
+        assert_eq!(production.constraints.at_least_one[0].name, "auth");
+        assert_eq!(
+            production.constraints.at_least_one[0].members,
+            vec!["ACCESS_TOKEN".to_string(), "PASSWORD".to_string()]
+        );
+        assert_eq!(production.constraints.at_least_one[1].name, "fallback_auth");
+        assert_eq!(production.constraints.exactly_one[0].name, "exclusive_auth");
+        assert_eq!(production.constraints.exactly_one.len(), 1);
+
+        let rendered = toml::to_string(&config).unwrap();
+        assert!(
+            rendered.contains("[profiles.default.ACCESS_TOKEN.required]"),
+            "{rendered}"
+        );
+        assert!(rendered.contains(r#"at_least_one = ["auth", "fallback_auth"]"#));
+        assert!(rendered.contains(r#"exactly_one = "exclusive_auth""#));
+    }
+
+    #[test]
+    fn config_validate_rejects_invalid_presence_constraints() {
+        for (secrets, expected) in [
+            (
+                r#"PASSWORD = { description = "Password", required = { at_least_one = "auth" } }"#,
+                "at_least_one group 'auth' must contain at least two secrets",
+            ),
+            (
+                r#"
+PASSWORD = { description = "Password", required = { at_least_one = " " } }
+ACCESS_TOKEN = { description = "Access token", required = { at_least_one = " " } }
+"#,
+                "`at_least_one` group name cannot be empty or whitespace",
+            ),
+            (
+                r#"
+PASSWORD = { description = "Password", required = { at_least_one = [] } }
+ACCESS_TOKEN = { description = "Access token", required = { at_least_one = [] } }
+"#,
+                "`at_least_one` must name at least one group",
+            ),
+            (
+                r#"
+PASSWORD = { description = "Password", required = { at_least_one = ["auth", "auth"] } }
+ACCESS_TOKEN = { description = "Access token", required = { at_least_one = "auth" } }
+"#,
+                "`at_least_one` contains duplicate group name 'auth'",
+            ),
+            (
+                r#"
+PASSWORD = { description = "Password", required = { at_least_one = "auth" } }
+ACCESS_TOKEN = { description = "Access token", required = { exactly_one = "auth" } }
+"#,
+                "group 'auth' cannot mix at_least_one and exactly_one membership",
+            ),
+        ] {
+            let source = format!(
+                r#"
+[project]
+name = "auth"
+revision = "1.0"
+
+[profiles.default]
+{secrets}
+"#
+            );
+            let config: Config = toml::from_str(&source).unwrap();
+            let error = config.validate().unwrap_err().to_string();
+            assert!(error.contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn required_group_table_must_name_a_constraint() {
+        let error = toml::from_str::<Secret>(
+            r#"description = "d"
+required = {}"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("`required` table must set `at_least_one` or `exactly_one`"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn grouped_requiredness_replaces_inherited_boolean_requiredness() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "auth"
+revision = "1.0"
+
+[profiles.default]
+PASSWORD = { description = "Password", required = true }
+ACCESS_TOKEN = { description = "Access token" }
+
+[profiles.production]
+PASSWORD = { required = { at_least_one = "auth" } }
+ACCESS_TOKEN = { required = { at_least_one = "auth" } }
+"#,
+        )
+        .unwrap();
+
+        config.validate().unwrap();
+        let compiled = CompiledManifest::compile(&config);
+        let password = &compiled.profile("production").unwrap().secrets["PASSWORD"];
+        assert!(!password.declared_required);
+        assert_eq!(password.config.required, None);
+        assert_eq!(
+            password.config.at_least_one.as_deref(),
+            Some(&["auth".into()][..])
+        );
     }
 
     #[test]

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -84,7 +84,7 @@ pub use resolve::{
 };
 pub use secrets::ExportFormat;
 pub use secrets::Secrets;
-pub use validation::ValidatedSecrets;
+pub use validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
 
 #[cfg(test)]
 mod tests;

--- a/secretspec/src/manifest.rs
+++ b/secretspec/src/manifest.rs
@@ -45,11 +45,15 @@ pub(crate) struct CompiledSecret {
 }
 
 impl CompiledSecret {
-    fn new(config: Secret) -> Self {
+    fn new(config: Secret, conditionally_required: bool) -> Self {
         // An inline default makes an omitted `required` behave as false. This
         // preserves the manifest shorthand while keeping an explicit inherited
-        // `required = true` visible in reports.
-        let declared_required = config.required.unwrap_or(config.default.is_none());
+        // `required = true` visible in reports. Membership in a profile
+        // presence constraint likewise replaces the implicit per-secret
+        // requirement, while an explicit `required = true` remains independent.
+        let declared_required = config
+            .required
+            .unwrap_or(config.default.is_none() && !conditionally_required);
         let missing = if config.would_generate() {
             MissingPolicy::Generate
         } else if config.default.is_some() {
@@ -78,25 +82,35 @@ mod tests {
 
     #[test]
     fn missing_policy_compiles_presence_once() {
-        let required = CompiledSecret::new(Secret::default());
+        let required = CompiledSecret::new(Secret::default(), false);
         assert_eq!(required.missing, MissingPolicy::Error);
         assert!(required.declared_required);
         assert!(required.missing.guaranteed_on_success());
 
-        let defaulted = CompiledSecret::new(Secret {
-            default: Some("fallback".to_string()),
-            ..Default::default()
-        });
+        let defaulted = CompiledSecret::new(
+            Secret {
+                default: Some("fallback".to_string()),
+                ..Default::default()
+            },
+            false,
+        );
         assert_eq!(defaulted.missing, MissingPolicy::UseDefault);
         assert!(!defaulted.declared_required);
         assert!(defaulted.missing.guaranteed_on_success());
 
-        let optional = CompiledSecret::new(Secret {
-            required: Some(false),
-            ..Default::default()
-        });
+        let optional = CompiledSecret::new(
+            Secret {
+                required: Some(false),
+                ..Default::default()
+            },
+            false,
+        );
         assert_eq!(optional.missing, MissingPolicy::Omit);
         assert!(!optional.missing.guaranteed_on_success());
+
+        let alternative = CompiledSecret::new(Secret::default(), true);
+        assert_eq!(alternative.missing, MissingPolicy::Omit);
+        assert!(!alternative.declared_required);
     }
 }
 
@@ -104,6 +118,21 @@ mod tests {
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledProfile {
     pub(crate) secrets: BTreeMap<String, CompiledSecret>,
+    pub(crate) constraints: CompiledConstraints,
+}
+
+/// One named cross-secret presence group.
+#[derive(Debug, Clone)]
+pub(crate) struct CompiledConstraintGroup {
+    pub(crate) name: String,
+    pub(crate) members: Vec<String>,
+}
+
+/// Named presence groups compiled from each effective secret's membership.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CompiledConstraints {
+    pub(crate) at_least_one: Vec<CompiledConstraintGroup>,
+    pub(crate) exactly_one: Vec<CompiledConstraintGroup>,
 }
 
 /// A parsed manifest reduced to the semantics shared by runtime and codegen.
@@ -130,17 +159,70 @@ impl CompiledManifest {
                 names.extend(default.secrets.keys());
             }
 
-            let secrets = names
+            let effective: BTreeMap<String, Secret> = names
                 .into_iter()
                 .map(|name| {
                     let current = profile.secrets.get(name);
                     let default = inherited.and_then(|p| p.secrets.get(name));
                     let effective = Secret::resolved(current, default, profile.defaults.as_ref())
                         .expect("an effective name comes from current or default");
-                    (name.clone(), CompiledSecret::new(effective))
+                    (name.clone(), effective)
                 })
                 .collect();
-            profiles.insert(profile_name.clone(), CompiledProfile { secrets });
+
+            let mut at_least_one: BTreeMap<String, Vec<String>> = BTreeMap::new();
+            let mut exactly_one: BTreeMap<String, Vec<String>> = BTreeMap::new();
+            for (name, secret) in &effective {
+                if let Some(groups) = &secret.at_least_one {
+                    for group in groups {
+                        at_least_one
+                            .entry(group.clone())
+                            .or_default()
+                            .push(name.clone());
+                    }
+                }
+                if let Some(groups) = &secret.exactly_one {
+                    for group in groups {
+                        exactly_one
+                            .entry(group.clone())
+                            .or_default()
+                            .push(name.clone());
+                    }
+                }
+            }
+            fn groups(grouped: BTreeMap<String, Vec<String>>) -> Vec<CompiledConstraintGroup> {
+                grouped
+                    .into_iter()
+                    .map(|(name, members)| CompiledConstraintGroup { name, members })
+                    .collect()
+            }
+            let constraints = CompiledConstraints {
+                at_least_one: groups(at_least_one),
+                exactly_one: groups(exactly_one),
+            };
+
+            let secrets = effective
+                .into_iter()
+                .map(|(name, secret)| {
+                    let conditionally_required = secret
+                        .at_least_one
+                        .as_ref()
+                        .is_some_and(|groups| !groups.is_empty())
+                        || secret
+                            .exactly_one
+                            .as_ref()
+                            .is_some_and(|groups| !groups.is_empty());
+                    (name, CompiledSecret::new(secret, conditionally_required))
+                })
+                .collect();
+
+            profiles.insert(
+                profile_name.clone(),
+                CompiledProfile {
+                    secrets,
+                    constraints,
+                },
+            );
         }
 
         Self {

--- a/secretspec/src/report.rs
+++ b/secretspec/src/report.rs
@@ -12,6 +12,7 @@
 //! mismatched version rather than silently misparse. The canonical JSON Schema
 //! lives at `schema/resolution-report.schema.json` in the repository root.
 
+use crate::validation::ConstraintViolation;
 use serde::{Deserialize, Serialize};
 
 /// Version of the [`ResolutionReport`] wire format.
@@ -74,6 +75,11 @@ pub struct ResolutionReport {
     pub profile: String,
     /// One entry per declared secret, sorted by name for deterministic output.
     pub secrets: Vec<SecretResolution>,
+    /// Cross-secret presence constraints that failed.
+    ///
+    /// Available since SecretSpec 0.17. Omitted when all constraints pass.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraint_violations: Vec<ConstraintViolation>,
 }
 
 impl ResolutionReport {
@@ -87,15 +93,25 @@ impl ResolutionReport {
             provider,
             profile,
             secrets,
+            constraint_violations: Vec::new(),
         }
+    }
+
+    pub(crate) fn with_constraint_violations(
+        mut self,
+        violations: Vec<ConstraintViolation>,
+    ) -> Self {
+        self.constraint_violations = violations;
+        self
     }
 
     /// True when no required secret is missing (i.e. resolution would succeed).
     pub fn all_required_present(&self) -> bool {
-        !self
-            .secrets
-            .iter()
-            .any(|s| s.status == ResolutionStatus::MissingRequired)
+        self.constraint_violations.is_empty()
+            && !self
+                .secrets
+                .iter()
+                .any(|s| s.status == ResolutionStatus::MissingRequired)
     }
 
     /// Render a human-readable resolution trace. Value-free, word-based status
@@ -135,6 +151,9 @@ impl ResolutionReport {
                 path,
                 width = width
             ));
+        }
+        for violation in &self.constraint_violations {
+            out.push_str(&format!("  CONSTRAINT  FAILED    {}\n", violation));
         }
         out
     }

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -11,7 +11,7 @@ use crate::plan::{PlannedSecret, ResolutionPlan, Route};
 use crate::provider::{Address, Provider as ProviderTrait, ProviderCredentials};
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
-use crate::validation::{ValidatedSecrets, ValidationErrors};
+use crate::validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
 use colored::Colorize;
 use secrecy::{ExposeSecret, SecretString};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -36,6 +36,16 @@ fn format_secret_label(name: &str, description: Option<&str>) -> String {
             description.dimmed()
         ),
         None => name.cyan().bold().to_string(),
+    }
+}
+
+/// Preserve the established missing-secret error for ordinary required fields,
+/// while retaining structured group diagnostics for cross-secret constraints.
+fn validation_failure(errors: ValidationErrors) -> SecretSpecError {
+    if errors.constraint_violations.is_empty() {
+        SecretSpecError::RequiredSecretMissing(errors.missing_required.join(", "))
+    } else {
+        SecretSpecError::ValidationFailed(Box::new(errors))
     }
 }
 
@@ -1780,8 +1790,7 @@ impl Secrets {
                     Ok(())
                 }
                 Err(errors) => {
-                    let err =
-                        SecretSpecError::RequiredSecretMissing(errors.missing_required.join(", "));
+                    let err = validation_failure(errors);
                     self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
                     Err(err)
                 }
@@ -1930,17 +1939,13 @@ impl Secrets {
                 // If we're in interactive mode and have missing required secrets, prompt for them
                 if interactive && !validation_errors.missing_required.is_empty() {
                     if !io::stdin().is_terminal() {
-                        return Err(SecretSpecError::RequiredSecretMissing(
-                            validation_errors.missing_required.join(", "),
-                        ));
+                        return Err(validation_failure(validation_errors));
                     }
 
                     let missing =
                         self.promptable_missing_names(&validation_errors, &profile_display);
                     if missing.is_empty() {
-                        return Err(SecretSpecError::RequiredSecretMissing(
-                            validation_errors.missing_required.join(", "),
-                        ));
+                        return Err(validation_failure(validation_errors));
                     }
                     let total = missing.len();
                     // Name the provider without constructing it: this value is
@@ -2035,15 +2040,11 @@ impl Secrets {
                     // operation, so do not emit another `Check` event.
                     match self.validate_audited(false, Materialize::Values)? {
                         Ok(valid_secrets) => Ok(valid_secrets),
-                        Err(still_errors) => Err(SecretSpecError::RequiredSecretMissing(
-                            still_errors.missing_required.join(", "),
-                        )),
+                        Err(still_errors) => Err(validation_failure(still_errors)),
                     }
                 } else {
                     // Not interactive or no missing required secrets
-                    Err(SecretSpecError::RequiredSecretMissing(
-                        validation_errors.missing_required.join(", "),
-                    ))
+                    Err(validation_failure(validation_errors))
                 }
             }
         }
@@ -2167,6 +2168,9 @@ impl Secrets {
             "\n{}",
             Self::format_summary(found_count, missing_count, optional_count)
         );
+        for violation in &errors.constraint_violations {
+            eprintln!("{} {}", "Constraint failed:".red().bold(), violation);
+        }
 
         Ok(())
     }
@@ -2681,6 +2685,9 @@ impl Secrets {
                 })
             }
             Err(errors) => {
+                if !errors.constraint_violations.is_empty() {
+                    return Err(SecretSpecError::ValidationFailed(Box::new(errors)));
+                }
                 let mut missing_required = errors.missing_required.clone();
                 missing_required.sort();
                 let mut missing_optional = errors.missing_optional.clone();
@@ -3285,7 +3292,58 @@ impl Secrets {
             Some(&plan.profile),
         )?;
 
-        if !missing_required.is_empty() {
+        let resolved_names: HashSet<&str> = resolution
+            .iter()
+            .filter(|entry| entry.status == ResolutionStatus::Resolved)
+            .map(|entry| entry.name.as_str())
+            .collect();
+        let compiled_profile = self
+            .manifest
+            .profile(profile)
+            .expect("profile is validated before execution");
+        // `get` executes a deliberately partial plan for a composed secret and
+        // its dependencies. Profile constraints govern whole-profile
+        // validation (`check`, `run`, and SDK resolution), not that least-access
+        // read.
+        let constraints = (plan.secrets.len() == compiled_profile.secrets.len())
+            .then_some(&compiled_profile.constraints);
+        let mut constraint_violations = Vec::new();
+        if let Some(constraints) = constraints {
+            for group in &constraints.at_least_one {
+                let present: Vec<String> = group
+                    .members
+                    .iter()
+                    .filter(|name| resolved_names.contains(name.as_str()))
+                    .cloned()
+                    .collect();
+                if present.is_empty() {
+                    constraint_violations.push(ConstraintViolation {
+                        kind: ConstraintKind::AtLeastOne,
+                        group: group.name.clone(),
+                        secrets: group.members.clone(),
+                        present,
+                    });
+                }
+            }
+            for group in &constraints.exactly_one {
+                let present: Vec<String> = group
+                    .members
+                    .iter()
+                    .filter(|name| resolved_names.contains(name.as_str()))
+                    .cloned()
+                    .collect();
+                if present.len() != 1 {
+                    constraint_violations.push(ConstraintViolation {
+                        kind: ConstraintKind::ExactlyOne,
+                        group: group.name.clone(),
+                        secrets: group.members.clone(),
+                        present,
+                    });
+                }
+            }
+        }
+
+        if !missing_required.is_empty() || !constraint_violations.is_empty() {
             let mut errors = ValidationErrors::new(
                 missing_required,
                 missing_optional,
@@ -3294,6 +3352,7 @@ impl Secrets {
                 profile.to_string(),
             );
             errors.resolution = resolution;
+            errors.constraint_violations = constraint_violations;
             Ok(Err(errors))
         } else {
             Ok(Ok(ValidatedSecrets {

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -437,6 +437,114 @@ fn test_resolution_report_provenance() {
     assert!(stripe.required);
 }
 
+#[test]
+fn profile_presence_constraints_validate_resolved_values() {
+    use crate::validation::ConstraintKind;
+
+    fn app(env_contents: &str, kind: ConstraintKind, groups: &[&str]) -> (TempDir, Secrets) {
+        let temp_dir = TempDir::new().unwrap();
+        let env_path = temp_dir.path().join(".env");
+        fs::write(&env_path, env_contents).unwrap();
+
+        let member = || Secret {
+            description: Some("alternative credential".to_string()),
+            at_least_one: (kind == ConstraintKind::AtLeastOne)
+                .then(|| groups.iter().map(|group| (*group).to_string()).collect()),
+            exactly_one: (kind == ConstraintKind::ExactlyOne)
+                .then(|| groups.iter().map(|group| (*group).to_string()).collect()),
+            ..Default::default()
+        };
+        let config = Config {
+            project: Project {
+                name: "constraint-test".to_string(),
+                ..Default::default()
+            },
+            profiles: HashMap::from([(
+                "default".to_string(),
+                Profile {
+                    defaults: None,
+                    secrets: HashMap::from([
+                        ("PASSWORD".to_string(), member()),
+                        ("ACCESS_TOKEN".to_string(), member()),
+                    ]),
+                },
+            )]),
+            providers: None,
+        };
+        let provider = format!("dotenv://{}", env_path.display());
+        let app = Secrets::new(config, None, Some(provider), None);
+        (temp_dir, app)
+    }
+
+    fn validation_errors(spec: &Secrets) -> ValidationErrors {
+        match spec.validate().unwrap() {
+            Ok(_) => panic!("expected presence constraint to fail"),
+            Err(errors) => errors,
+        }
+    }
+
+    let (_temp_dir, spec) = app("", ConstraintKind::AtLeastOne, &["auth"]);
+    let errors = validation_errors(&spec);
+    assert!(errors.missing_required.is_empty());
+    assert_eq!(errors.constraint_violations.len(), 1);
+    assert_eq!(
+        errors.constraint_violations[0].kind,
+        ConstraintKind::AtLeastOne
+    );
+    assert_eq!(errors.constraint_violations[0].group, "auth");
+    assert!(errors.constraint_violations[0].present.is_empty());
+    let report = errors.report();
+    assert!(!report.all_required_present());
+    assert_eq!(
+        serde_json::to_value(&report).unwrap()["constraint_violations"][0]["kind"],
+        "at_least_one"
+    );
+    assert!(matches!(
+        spec.resolve(),
+        Err(SecretSpecError::ValidationFailed(_))
+    ));
+
+    let (_temp_dir, spec) = app(
+        "ACCESS_TOKEN=token\n",
+        ConstraintKind::AtLeastOne,
+        &["auth"],
+    );
+    assert!(spec.validate().unwrap().is_ok());
+
+    let (_temp_dir, spec) = app("", ConstraintKind::AtLeastOne, &["auth", "deploy"]);
+    let errors = validation_errors(&spec);
+    assert_eq!(
+        errors
+            .constraint_violations
+            .iter()
+            .map(|violation| violation.group.as_str())
+            .collect::<Vec<_>>(),
+        vec!["auth", "deploy"]
+    );
+
+    let (_temp_dir, spec) = app("", ConstraintKind::ExactlyOne, &["auth"]);
+    let errors = validation_errors(&spec);
+    assert_eq!(
+        errors.constraint_violations[0].kind,
+        ConstraintKind::ExactlyOne
+    );
+    assert!(errors.constraint_violations[0].present.is_empty());
+
+    let (_temp_dir, spec) = app(
+        "PASSWORD=p\nACCESS_TOKEN=t\n",
+        ConstraintKind::ExactlyOne,
+        &["auth"],
+    );
+    let errors = validation_errors(&spec);
+    assert_eq!(
+        errors.constraint_violations[0].present,
+        vec!["ACCESS_TOKEN".to_string(), "PASSWORD".to_string()]
+    );
+
+    let (_temp_dir, spec) = app("PASSWORD=p\n", ConstraintKind::ExactlyOne, &["auth"]);
+    assert!(spec.validate().unwrap().is_ok());
+}
+
 pub(crate) fn resolve_test_config(secrets: HashMap<String, Secret>) -> Config {
     let mut profiles = HashMap::new();
     profiles.insert(
@@ -5033,6 +5141,8 @@ fn test_resolve_secret_config_merges_type_and_generate() {
         Secret {
             description: Some("Database password".to_string()),
             required: None,
+            at_least_one: None,
+            exactly_one: None,
             default: None,
             composed: None,
             providers: None,

--- a/secretspec/src/validation.rs
+++ b/secretspec/src/validation.rs
@@ -3,6 +3,7 @@
 use crate::config::Resolved;
 use crate::report::{ResolutionReport, SecretResolution};
 use secrecy::SecretString;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use tempfile::NamedTempFile;
@@ -68,6 +69,67 @@ impl ValidatedSecrets {
     }
 }
 
+/// The kind of cross-secret presence constraint that failed.
+///
+/// Available since SecretSpec 0.17.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstraintKind {
+    /// None of a group whose rule requires at least one member resolved.
+    AtLeastOne,
+    /// Zero or multiple members of a group whose rule requires exactly one
+    /// member resolved.
+    ExactlyOne,
+}
+
+/// A failed cross-secret presence constraint.
+///
+/// `secrets` is the configured group and `present` is the subset that resolved.
+/// Values are never included.
+///
+/// Available since SecretSpec 0.17.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstraintViolation {
+    /// Which presence rule failed.
+    pub kind: ConstraintKind,
+    /// The group name declared by its member secrets.
+    pub group: String,
+    /// All secret names in the configured group.
+    pub secrets: Vec<String>,
+    /// Group members that resolved.
+    pub present: Vec<String>,
+}
+
+impl fmt::Display for ConstraintViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            ConstraintKind::AtLeastOne => {
+                write!(
+                    f,
+                    "at least one secret in group '{}' must be provided ({})",
+                    self.group,
+                    self.secrets.join(", ")
+                )
+            }
+            ConstraintKind::ExactlyOne if self.present.is_empty() => {
+                write!(
+                    f,
+                    "exactly one secret in group '{}' must be provided ({})",
+                    self.group,
+                    self.secrets.join(", ")
+                )
+            }
+            ConstraintKind::ExactlyOne => write!(
+                f,
+                "exactly one secret in group '{}' must be provided ({}); found {}",
+                self.group,
+                self.secrets.join(", "),
+                self.present.join(", ")
+            ),
+        }
+    }
+}
+
 /// Container for validation errors
 ///
 /// This struct contains all the validation errors that occurred when
@@ -88,6 +150,10 @@ pub struct ValidationErrors {
     /// required secrets that caused this error. Empty unless populated by the
     /// resolver; see [`ValidationErrors::report`].
     pub resolution: Vec<SecretResolution>,
+    /// Cross-secret presence constraints that failed.
+    ///
+    /// Available since SecretSpec 0.17.
+    pub constraint_violations: Vec<ConstraintViolation>,
 }
 
 impl ValidationErrors {
@@ -106,12 +172,13 @@ impl ValidationErrors {
             provider,
             profile,
             resolution: Vec::new(),
+            constraint_violations: Vec::new(),
         }
     }
 
     /// Check if there are any critical errors (missing required secrets)
     pub fn has_errors(&self) -> bool {
-        !self.missing_required.is_empty()
+        !self.missing_required.is_empty() || !self.constraint_violations.is_empty()
     }
 
     /// Build the value-free [`ResolutionReport`] for this failed resolution.
@@ -123,6 +190,7 @@ impl ValidationErrors {
             self.profile.clone(),
             self.resolution.clone(),
         )
+        .with_constraint_violations(self.constraint_violations.clone())
     }
 }
 
@@ -134,6 +202,17 @@ impl fmt::Display for ValidationErrors {
                 "Missing required secrets: {}",
                 self.missing_required.join(", ")
             )?;
+        }
+        if !self.constraint_violations.is_empty() {
+            if !self.missing_required.is_empty() {
+                write!(f, "; ")?;
+            }
+            let messages: Vec<String> = self
+                .constraint_violations
+                .iter()
+                .map(ToString::to_string)
+                .collect();
+            write!(f, "Secret constraints failed: {}", messages.join("; "))?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

- add named `at_least_one` and `exactly_one` presence groups through the existing `required` field
- accept one group name or a list of names, allowing a secret to participate in overlapping constraints
- validate group definitions and report value-free failures consistently across CLI and SDK resolution
- document the SecretSpec 0.17 syntax and extend the resolution report schema

## Configuration examples

Require at least one account credential:

```toml
[profiles.default]
PASSWORD = { description = "Account password", required = { at_least_one = "account_auth" } }
ACCESS_TOKEN = { description = "Access token", required = { at_least_one = "account_auth" } }
```

Require exactly one GitHub credential:

```toml
[profiles.default]
GITHUB_TOKEN = { description = "GitHub token", required = { exactly_one = "github_auth" } }
GITHUB_APP_KEY = { description = "GitHub App key", required = { exactly_one = "github_auth" } }
```

Group names may also be arrays when one secret belongs to overlapping constraints:

```toml
CI_ID_TOKEN = { description = "CI identity token", required = { at_least_one = ["automation_auth", "deploy_auth"] } }
```

Existing boolean declarations remain unchanged:

```toml
DATABASE_URL = { description = "Database URL", required = true }
SENTRY_DSN = { description = "Sentry DSN", required = false }
```

## Why

Applications commonly accept alternative credentials or require mutually exclusive authentication methods. Keeping these rules under `required` makes individual, optional, alternative, and exclusive requiredness one coherent configuration policy while named groups support constraints that overlap.

## User impact

Starting in SecretSpec 0.17, users can declare cross-secret presence constraints without marking every member individually required. A grouped policy replaces an inherited boolean `required` policy, and failed groups appear in human-readable and structured validation without exposing secret values.

## Validation

- `cargo test --all`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- repository Clippy and rustfmt commit hooks
- `git diff --check`
