### PR TITLE
feat(openbao): add first-class OpenBao provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Check each provider feature standalone
       run: |
         set -euo pipefail
-        for feature in cli keyring gcsm awssm vault infisical bws akv; do
+        for feature in cli keyring gcsm awssm vault openbao infisical bws akv; do
           echo "::group::$feature"
           cargo check --package secretspec --no-default-features --features "$feature"
           echo "::endgroup::"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `VAULT_*` names remain compatibility fallbacks. Compatible KV and standard
   authentication mechanics are shared internally with the Vault provider.
   Vault-compatible addresses accept trailing slashes, and AppRole/JWT login
-  exchanges now honor the configured namespace.
+  exchanges now honor the configured namespace. Reported provider URIs strip
+  endpoint credentials while retaining non-secret store and authentication
+  attribution.
 - Vault / OpenBao JWT/OIDC authentication (`?auth=jwt`) logs in through a
   configured Vault role using `VAULT_JWT`, or requests a short-lived OIDC token
   automatically in GitHub Actions and Forgejo Actions jobs with `id-token:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `required` field accepts `at_least_one` and `exactly_one` group tables,
   supporting overlapping alternative and mutually exclusive credentials
   across `check`, `run`, and SDK resolution.
+- First-class OpenBao provider (`openbao://`, `openbao` build feature) with its
+  own provider identity, documentation, and OpenBao CLI configuration through
+  `BAO_ADDR`, `BAO_NAMESPACE`, `BAO_TOKEN`, and `BAO_TOKEN_PATH`. The
+  provider also has OpenBao-prefixed AppRole and JWT inputs; corresponding
+  `VAULT_*` names remain compatibility fallbacks. Compatible KV and standard
+  authentication mechanics are shared internally with the Vault provider.
 - Vault / OpenBao JWT/OIDC authentication (`?auth=jwt`) logs in through a
   configured Vault role using `VAULT_JWT`, or requests a short-lived OIDC token
   automatically in GitHub Actions and Forgejo Actions jobs with `id-token:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provider also has OpenBao-prefixed AppRole and JWT inputs; corresponding
   `VAULT_*` names remain compatibility fallbacks. Compatible KV and standard
   authentication mechanics are shared internally with the Vault provider.
+  Vault-compatible addresses accept trailing slashes, and AppRole/JWT login
+  exchanges now honor the configured namespace.
 - Vault / OpenBao JWT/OIDC authentication (`?auth=jwt`) logs in through a
   configured Vault role using `VAULT_JWT`, or requests a short-lived OIDC token
   automatically in GitHub Actions and Forgejo Actions jobs with `id-token:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `required` field accepts `at_least_one` and `exactly_one` group tables,
   supporting overlapping alternative and mutually exclusive credentials
   across `check`, `run`, and SDK resolution.
-- First-class OpenBao provider (`openbao://`, `openbao` build feature) with its
+- OpenBao provider (`openbao://`, `openbao` build feature) with its
   own provider identity, documentation, and OpenBao CLI configuration through
   `BAO_ADDR`, `BAO_NAMESPACE`, `BAO_TOKEN`, and `BAO_TOKEN_PATH`. The
   provider also has OpenBao-prefixed AppRole and JWT inputs; corresponding

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -119,7 +119,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault / OpenBao, Bitwarden Secrets Manager, Azure Key Vault, or Infisical (0.16+).`,
+Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, or Infisical (0.16+).`,
         }),
       ],
       title: "SecretSpec",
@@ -211,8 +211,13 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
               slug: "providers/awssm",
             },
             {
-              label: "Vault / OpenBao",
+              label: "Vault",
               slug: "providers/vault",
+            },
+            {
+              label: "OpenBao",
+              slug: "providers/openbao",
+              badge: { text: "0.17+", variant: "note" },
             },
             {
               label: "Bitwarden Secrets Manager",

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -49,7 +49,8 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [lastpass](/providers/lastpass/) | LastPass | ✓ | ✓ | ✓ |
 | [gcsm](/providers/gcsm/) | Google Cloud Secret Manager (requires the `gcsm` build feature) | ✓ | ✓ | ✓ |
 | [awssm](/providers/awssm/) | AWS Secrets Manager (requires the `awssm` build feature) | ✓ | ✓ | ✓ |
-| [vault](/providers/vault/) | HashiCorp Vault or OpenBao (requires the `vault` build feature) | ✓ | ✓ | ✓ |
+| [vault](/providers/vault/) | HashiCorp Vault (requires the `vault` build feature) | ✓ | ✓ | ✓ |
+| [openbao](/providers/openbao/) (0.17+) | OpenBao (requires the `openbao` build feature; 0.16 uses `openbao://` through `vault`) | ✓ | ✓ | ✓ |
 | [bws](/providers/bws/) | Bitwarden Secrets Manager (requires the `bws` build feature) | ✓ | ✓ | ✓ |
 | [akv](/providers/akv/) | Azure Key Vault (requires the `akv` build feature) | ✓ | ✓ | ✓ |
 | [infisical](/providers/infisical/) (0.16+) | Infisical (requires the `infisical` build feature) | ✓ | ✓ | ✓ |

--- a/docs/src/content/docs/providers/openbao.md
+++ b/docs/src/content/docs/providers/openbao.md
@@ -209,7 +209,7 @@ $ secretspec check --provider openbao://bao.example.com:8200/secret
 ### Development mode
 
 ```bash
-$ bao server -dev
-$ export BAO_TOKEN=hvs.dev-root-token
+$ bao server -dev -dev-root-token-id="dev-only-token"
+$ export BAO_TOKEN="dev-only-token"
 $ secretspec check --provider "openbao://127.0.0.1:8200/secret?tls=false"
 ```

--- a/docs/src/content/docs/providers/openbao.md
+++ b/docs/src/content/docs/providers/openbao.md
@@ -1,0 +1,215 @@
+---
+title: OpenBao Provider
+description: OpenBao integration, available in SecretSpec 0.17+
+---
+
+The OpenBao provider integrates with OpenBao's KV (Key-Value) secrets engine
+using OpenBao's own provider identity and configuration conventions.
+
+:::caution[Version compatibility]
+The `openbao` provider targets SecretSpec 0.17 and is unavailable
+in the current 0.16 release. SecretSpec 0.16 can still connect to OpenBao with
+an `openbao://` URI through the `vault` build feature, but reports the provider
+as Vault and uses `VAULT_*` environment variables.
+:::
+
+## Using SecretSpec 0.16 today
+
+The current release's practical form is:
+
+```bash
+$ export VAULT_TOKEN=hvs.your-token-here
+$ secretspec check --provider openbao://bao.example.com:8200/secret
+```
+
+For a minimal Rust build, enable `vault`:
+
+```toml
+secretspec = { version = "0.16", default-features = false, features = ["vault"] }
+```
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `openbao` (0.17+) |
+| URI | `openbao://[namespace@]host[:port][/mount][?options]` |
+| Access | Read and write; secret references are read-only |
+| Best for | Open-source, policy-controlled secret infrastructure |
+| Authentication | Token, AppRole, or JWT/OIDC |
+| Build feature | `openbao` (0.17+) |
+| Default storage | KV path `secretspec/{project}/{profile}/{key}`, field `value` |
+
+## Quick start
+
+```bash
+$ export BAO_TOKEN=hvs.your-token-here
+$ secretspec set DATABASE_URL --provider openbao://bao.example.com:8200
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to openbao (profile: default)
+```
+
+## Setup
+
+### Prerequisites
+
+- A running OpenBao server
+- Authentication credentials
+- KV secrets engine enabled (v1 or v2)
+- Build with `--features openbao`
+
+### Environment compatibility
+
+For the variables defined by the OpenBao CLI, the provider follows its
+documented convention: `BAO_ADDR`, `BAO_NAMESPACE`, `BAO_TOKEN`, and
+`BAO_TOKEN_PATH` take precedence over their `VAULT_*` counterparts.
+
+SecretSpec additionally defines OpenBao-prefixed provider inputs for AppRole
+and JWT authentication. These are consumed by SecretSpec, not by the `bao` CLI,
+and retain the corresponding `VAULT_*` names as compatibility fallbacks.
+
+### Token authentication
+
+Token authentication is the default. SecretSpec checks these sources in order:
+
+1. The alias's `token` provider credential
+2. `BAO_TOKEN`, then `VAULT_TOKEN`
+3. The file selected by `BAO_TOKEN_PATH`, then `VAULT_TOKEN_PATH`
+4. The OpenBao CLI's default `~/.vault-token`
+
+```bash
+$ export BAO_TOKEN=hvs.your-token-here
+```
+
+### AppRole authentication
+
+Select AppRole with `?auth=approle`:
+
+```bash
+$ export BAO_ROLE_ID=your-role-id
+$ export BAO_SECRET_ID=your-secret-id
+```
+
+These are SecretSpec provider inputs, not OpenBao CLI variables.
+`VAULT_ROLE_ID` and `VAULT_SECRET_ID` remain accepted as fallbacks. Prefer
+semantic provider credentials when configuring an alias:
+
+```toml title="secretspec.toml"
+[providers.bao_approle]
+uri = "openbao://bao.example.com:8200/secret?auth=approle"
+
+[providers.bao_approle.credentials]
+role_id = { provider = "onepassword", ref = { vault = "Infra", item = "bao-approle", field = "role_id" } }
+secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "bao-approle", field = "secret_id" } }
+```
+
+### JWT / OIDC authentication
+
+Select JWT with `?auth=jwt` and a `role`. The provider performs the
+`auth/jwt/login` exchange itself. The JWT comes from SecretSpec's `BAO_JWT`
+input, then the `VAULT_JWT` compatibility fallback. Otherwise, in a GitHub
+Actions or Forgejo job with `id-token: write`, the provider mints one from the
+runner's OIDC identity.
+
+- `?role=`, `BAO_JWT_ROLE`, or `VAULT_JWT_ROLE` (required)
+- `?audience=`, `BAO_JWT_AUDIENCE`, or `VAULT_JWT_AUDIENCE`
+
+## Configuration
+
+### URI format
+
+```text
+openbao://[namespace@]host[:port][/mount][?key=value&...]
+```
+
+- `host[:port]`: OpenBao address (falls back through `BAO_ADDR`, `VAULT_ADDR`)
+- `mount`: KV engine mount path (default: `secret`)
+- `namespace@`: Optional namespace (falls back through `BAO_NAMESPACE`,
+  `VAULT_NAMESPACE`)
+- `?auth=approle`: Use AppRole authentication (default: `token`)
+- `?auth=jwt`: Use JWT/OIDC authentication (requires a role)
+- `?role=`: OpenBao role for JWT auth
+- `?audience=`: Audience requested from the CI OIDC issuer
+- `?kv=1`: Use KV v1 (default: v2)
+- `?tls=false`: Disable TLS for development servers
+
+### URI examples
+
+```text
+openbao://bao.example.com:8200/secret
+openbao://team-a@bao.example.com:8200/secret
+openbao://bao.example.com:8200/secret?auth=approle
+openbao://bao.example.com:8200/secret?auth=jwt&role=ci
+```
+
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+bao_prod = "openbao://bao.example.com:8200/secret"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["bao_prod"] }
+```
+
+## Storage model
+
+Each secret is stored at `secretspec/{project}/{profile}/{key}` under the
+configured mount, with its value in a field named `value`.
+
+For KV v2, `DATABASE_URL` for project `myapp` and profile `production` is read
+from `GET /v1/secret/data/secretspec/myapp/production/DATABASE_URL`.
+
+## Use existing secrets
+
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing KV entry: `item` is the path relative to the mount, and `field`
+selects the field to read. References are **read-only** so a single-field write
+cannot overwrite the entry's other fields.
+
+```toml
+[profiles.production]
+DATABASE_URL = { description = "DB", ref = { item = "myapp/config", field = "db_url" }, providers = ["openbao://bao.example.com:8200/secret"] }
+```
+
+## CI/CD
+
+AppRole avoids placing a user token in the CI environment:
+
+```bash
+$ export BAO_ROLE_ID="$CI_ROLE_ID"
+$ export BAO_SECRET_ID="$CI_SECRET_ID"
+$ secretspec export --format gha --provider "openbao://bao.example.com:8200/secret?auth=approle"
+```
+
+With GitHub Actions or Forgejo Actions `id-token: write`, JWT/OIDC avoids a
+static authentication credential:
+
+```bash
+$ secretspec export --format gha --provider "openbao://bao.example.com:8200/secret?auth=jwt&role=ci"
+```
+
+## Advanced configuration
+
+### KV version 1
+
+```bash
+$ secretspec set DATABASE_URL --provider "openbao://bao.example.com:8200/secret?kv=1"
+```
+
+### OpenBao namespaces
+
+```bash
+$ secretspec check --provider openbao://team-a@bao.example.com:8200/secret
+
+$ export BAO_NAMESPACE=team-a
+$ secretspec check --provider openbao://bao.example.com:8200/secret
+```
+
+### Development mode
+
+```bash
+$ bao server -dev
+$ export BAO_TOKEN=hvs.dev-root-token
+$ secretspec check --provider "openbao://127.0.0.1:8200/secret?tls=false"
+```

--- a/docs/src/content/docs/providers/vault.md
+++ b/docs/src/content/docs/providers/vault.md
@@ -1,15 +1,16 @@
 ---
-title: Vault / OpenBao Provider
-description: HashiCorp Vault and OpenBao integration
+title: Vault Provider
+description: HashiCorp Vault integration
 ---
 
-The Vault provider integrates with HashiCorp Vault and OpenBao for centralized secret management using the KV (Key-Value) secrets engine. Since OpenBao is an API-compatible fork of Vault, a single provider works for both.
+The Vault provider integrates with HashiCorp Vault for centralized secret
+management using the KV (Key-Value) secrets engine.
 
 ## At a glance
 
 | | |
 | --- | --- |
-| Provider | `vault` or `openbao` |
+| Provider | `vault` |
 | URI | `vault://[namespace@]host[:port][/mount][?options]` |
 | Access | Read and write; secret references are read-only |
 | Best for | Self-managed, policy-controlled secret infrastructure |
@@ -24,16 +25,13 @@ The Vault provider integrates with HashiCorp Vault and OpenBao for centralized s
 $ secretspec set DATABASE_URL --provider vault://vault.example.com:8200
 Enter value for DATABASE_URL: postgresql://localhost/mydb
 ✓ Secret 'DATABASE_URL' saved to vault (profile: default)
-
-# Using OpenBao
-$ secretspec check --provider openbao://bao.internal:8200/secret
 ```
 
 ## Setup
 
 ### Prerequisites
 
-- A running Vault or OpenBao server
+- A running Vault server
 - Authentication credentials
 - KV secrets engine enabled (v1 or v2)
 - Build with `--features vault`
@@ -76,31 +74,36 @@ SecretSpec 0.14 supports only `VAULT_ROLE_ID` and `VAULT_SECRET_ID`.
 Added in SecretSpec 0.17.
 :::
 
-Select JWT with `?auth=jwt` and a `role`. The provider performs the `auth/jwt/login` exchange itself. The JWT comes from `VAULT_JWT` when set. Otherwise, in a GitHub Actions or Forgejo job with `id-token: write`, the provider mints one from the runner's OIDC identity, so CI stores no static secret.
+Select JWT with `?auth=jwt` and a `role`. The provider performs the
+`auth/jwt/login` exchange itself. The JWT comes from `VAULT_JWT` when set.
+Otherwise, in a GitHub Actions or Forgejo job with `id-token: write`, the
+provider mints one from the runner's OIDC identity, so CI stores no static
+secret.
 
-Both `role` and `audience` accept a URI query parameter or an environment variable:
+Both `role` and `audience` accept a URI query parameter or an environment
+variable:
 
 - `?role=` or `VAULT_JWT_ROLE` (required)
-- `?audience=` or `VAULT_JWT_AUDIENCE`, matched against the role's `bound_audiences`
+- `?audience=` or `VAULT_JWT_AUDIENCE`, matched against the role's
+  `bound_audiences`
 
 ## Configuration
 
 ### URI format
 
-```
+```text
 vault://[namespace@]host[:port][/mount][?key=value&...]
-openbao://[namespace@]host[:port][/mount][?key=value&...]
 ```
 
-- `host[:port]`: Vault server address (falls back to `VAULT_ADDR` env var)
+- `host[:port]`: Vault server address (falls back to `VAULT_ADDR`)
 - `mount`: KV engine mount path (default: `secret`)
-- `namespace@`: Optional Vault namespace (also reads `VAULT_NAMESPACE` env var)
+- `namespace@`: Optional Vault namespace (also reads `VAULT_NAMESPACE`)
 - `?auth=approle`: Use AppRole authentication (default: `token`)
 - `?auth=jwt` (0.17+): Use JWT/OIDC authentication (requires `?role=`)
 - `?role=` (0.17+): Vault role for JWT auth (or `VAULT_JWT_ROLE`)
-- `?audience=` (0.17+): OIDC token audience for JWT auth (or `VAULT_JWT_AUDIENCE`)
-- `?kv=1`: Use KV v1 engine (default: v2)
-- `?tls=false`: Disable TLS (for development servers)
+- `?audience=` (0.17+): OIDC audience (or `VAULT_JWT_AUDIENCE`)
+- `?kv=1`: Use KV v1 (default: v2)
+- `?tls=false`: Disable TLS for development servers
 
 ### URI examples
 
@@ -110,7 +113,6 @@ vault://team-a@vault.example.com:8200/secret
 vault://vault.example.com:8200/secret?auth=approle
 # SecretSpec 0.17+
 vault://vault.example.com:8200/secret?auth=jwt&role=ci
-openbao://bao.internal:8200/secret
 ```
 
 ### Project configuration
@@ -133,11 +135,10 @@ from `GET /v1/secret/data/secretspec/myapp/production/DATABASE_URL`.
 
 ## Use existing secrets
 
-A secret's
-[`ref`](/reference/configuration/#secret-references) field names an existing KV
-entry instead: `item` is the KV path relative to the mount, and `field` selects
-the field to read. `field` is required, since KV entries are maps. References
-are **read-only** in this provider.
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing KV entry: `item` is the KV path relative to the mount, and `field`
+selects the field to read. `field` is required because KV entries are maps.
+References are **read-only** in this provider.
 
 ```toml
 [profiles.production]
@@ -145,8 +146,8 @@ DATABASE_URL = { description = "DB", ref = { item = "myapp/config", field = "db_
 ```
 
 The mount is not a ref coordinate: it comes from the provider URI (`secret` in
-the example above). To read one secret from a different mount, give that secret
-a `providers` entry with the mount in the URI.
+the example). To read one secret from a different mount, give that secret a
+provider entry whose URI names the mount.
 
 ## CI/CD
 
@@ -159,10 +160,9 @@ $ export VAULT_SECRET_ID="$CI_VAULT_SECRET_ID"
 $ secretspec export --format gha --provider "vault://vault.example.com:8200/secret?auth=approle"
 ```
 
-SecretSpec 0.17 ships a tokenless JWT/OIDC path, avoiding a static credential in
-the CI platform. Under GitHub Actions or Forgejo Actions with `id-token: write`,
-the provider mints the job's OIDC token and logs in with a `role` bound to the
-workflow's claims:
+SecretSpec 0.17 adds a tokenless JWT/OIDC path. Under GitHub Actions or Forgejo
+Actions with `id-token: write`, the provider mints the job's OIDC token and logs
+in with a role bound to the workflow's claims:
 
 ```bash
 $ secretspec export --format gha --provider "vault://vault.example.com:8200/secret?auth=jwt&role=ci"
@@ -173,30 +173,22 @@ $ secretspec export --format gha --provider "vault://vault.example.com:8200/secr
 ### KV version 1
 
 ```bash
-# Use KV v1 engine
 $ secretspec set DATABASE_URL --provider "vault://vault.example.com:8200/secret?kv=1"
 ```
 
 ### Vault namespaces
 
 ```bash
-# Using namespace in URI
 $ secretspec check --provider vault://team-a@vault.example.com:8200/secret
 
-# Or via environment variable
 $ export VAULT_NAMESPACE=team-a
 $ secretspec check --provider vault://vault.example.com:8200/secret
 ```
 
 ### Development mode
 
-For local development with Vault in dev mode:
-
 ```bash
-# Start Vault in dev mode
 $ vault server -dev
-
-# Use with TLS disabled
 $ export VAULT_TOKEN=hvs.dev-root-token
 $ secretspec check --provider "vault://127.0.0.1:8200/secret?tls=false"
 ```

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -109,7 +109,8 @@ $ secretspec config init
   lastpass: LastPass password manager
   gcsm: Google Cloud Secret Manager
   awssm: AWS Secrets Manager
-  vault: HashiCorp Vault / OpenBao secret management
+  vault: HashiCorp Vault secret management
+  openbao: OpenBao secret management (0.17+)
   bws: Bitwarden Secrets Manager
   akv: Azure Key Vault
   infisical: Infisical secret management (0.16+)

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -419,7 +419,8 @@ chain, and each provider is asked for the same coordinates.
 | [Gopass (0.15+)](/providers/gopass/#use-existing-secrets) | Entry path, including any mount-point prefix | Rejected | Reads the entry | ✅ |
 | [LastPass](/providers/lastpass/#use-existing-secrets) | Item name | Rejected | Reads the item | ✅ |
 | [Proton Pass](/providers/protonpass/#use-existing-secrets) | Item title | Rejected | Reads the note | ✅ |
-| [Vault / OpenBao](/providers/vault/#use-existing-secrets) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
+| [Vault](/providers/vault/#use-existing-secrets) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
+| [OpenBao](/providers/openbao/#use-existing-secrets) (0.17+) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
 | [AWS Secrets Manager](/providers/awssm/#use-existing-secrets) | Secret name or ARN | JSON key | Whole secret string | — (read-only) |
 | [GCSM](/providers/gcsm/#use-existing-secrets) | Secret id; `version` also applies | Rejected | Reads latest or the pinned version | — (read-only) |
 | [Bitwarden (bws)](/providers/bws/#use-existing-secrets) | BWS key name | Rejected | Reads the key | ✅ |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -148,19 +148,14 @@ awssm://                      # SDK default region and credentials
 **Prerequisites**: AWS credentials configured, build with `--features awssm`
 **Storage**: Secret name `secretspec/{project}/{profile}/{key}`
 
-## Vault / OpenBao Provider
+## Vault Provider
 
-**URI**: `vault://[namespace@]host[:port][/mount][?options]` or `openbao://[namespace@]host[:port][/mount][?options]` - Stores secrets in HashiCorp Vault or OpenBao KV engine
-
-:::note[Version compatibility]
-Added in SecretSpec 0.17.
-:::
+**URI**: `vault://[namespace@]host[:port][/mount][?options]` - Stores secrets in HashiCorp Vault's KV engine
 
 ```bash
 vault://vault.example.com:8200/secret       # KV v2 at "secret" mount
 vault://vault.example.com:8200              # Default "secret" mount
 vault://ns1@vault.example.com:8200/secret   # With namespace
-openbao://bao.internal:8200/secret          # OpenBao server
 vault://vault.example.com:8200/secret?auth=approle
 # SecretSpec 0.17+
 vault://vault.example.com:8200/secret?auth=jwt&role=ci
@@ -168,8 +163,30 @@ vault://127.0.0.1:8200/secret?kv=1         # KV v1 engine
 vault://127.0.0.1:8200/secret?tls=false    # Disable TLS (dev mode)
 ```
 
-**Features**: Read/write, KV v1 and v2, namespaces, OpenBao compatible; token and AppRole authentication; JWT/OIDC authentication (0.17+)
-**Prerequisites**: Vault/OpenBao server, authentication credentials, build with `--features vault`
+**Features**: Read/write, KV v1 and v2, namespaces; token and AppRole authentication; JWT/OIDC authentication (0.17+)
+**Prerequisites**: Vault server, authentication credentials, build with `--features vault`
+**Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
+
+## OpenBao Provider (0.17+)
+
+:::caution[Version compatibility]
+The `openbao` provider is added in SecretSpec 0.17 and is unavailable in the
+current 0.16 release. With 0.16, use `openbao://` through the `vault` build
+feature and configure `VAULT_*` environment variables.
+:::
+
+**URI**: `openbao://[namespace@]host[:port][/mount][?options]` - Stores secrets in OpenBao's KV engine
+
+```bash
+openbao://bao.example.com:8200/secret
+openbao://team-a@bao.example.com:8200/secret
+openbao://bao.example.com:8200/secret?auth=approle
+openbao://bao.example.com:8200/secret?auth=jwt&role=ci
+openbao://127.0.0.1:8200/secret?kv=1&tls=false
+```
+
+**Features**: Read/write, KV v1 and v2, namespaces; token, AppRole, and JWT/OIDC authentication; documented OpenBao CLI variables plus SecretSpec-defined `BAO_*` AppRole/JWT inputs, all with `VAULT_*` compatibility fallbacks
+**Prerequisites**: OpenBao server, authentication credentials, build with `--features openbao` (0.17+)
 **Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
 
 ## Bitwarden Secrets Manager Provider
@@ -271,7 +288,8 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | OnePassword | ✅ End-to-end | Cloud (OnePassword) | ✅ Yes |
 | GCSM | ✅ Google-managed | Cloud (GCP) | ✅ Yes |
 | AWSSM | ✅ AWS KMS | Cloud (AWS) | ✅ Yes |
-| Vault/OpenBao | ✅ Vault encryption | Vault/OpenBao server | ✅ Yes |
+| Vault | ✅ Vault encryption | Vault server | ✅ Yes |
+| OpenBao (0.17+) | ✅ OpenBao encryption | OpenBao server | ✅ Yes |
 | BWS | ✅ End-to-end | Cloud (Bitwarden) | ✅ Yes |
 | AKV | ✅ Azure-managed | Cloud (Azure) | ✅ Yes |
 | Infisical | ✅ Infisical-managed | Cloud (Infisical) or self-hosted | ✅ Yes |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -39,7 +39,8 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: '1password', slug: 'onepassword', label: '1Password' },
   { icon: 'lastpass', slug: 'lastpass', label: 'LastPass' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden' },
-  { icon: 'vault', slug: 'vault', label: 'Vault / OpenBao' },
+  { icon: 'vault', slug: 'vault', label: 'Vault' },
+  { slug: 'openbao', label: 'OpenBao (0.17+)' },
   { slug: 'awssm', label: 'AWS Secrets Manager' },
   { icon: 'googlecloud', slug: 'gcsm', label: 'Google Cloud Secret Manager' },
   { icon: 'microsoftazure', slug: 'akv', label: 'Azure Key Vault' },
@@ -141,6 +142,7 @@ $ secretspec config init
 ? Select your preferred provider backend:
 <span class="tok-pun">›</span> keyring: Uses system keychain (Recommended)
   infisical: Infisical secret management
+  openbao: OpenBao secret management (0.17+)
 <span class="tok-str">✓</span> Saved to ~/.config/secretspec/config.toml
 
 <span class="tok-com"># 3. Run your app with secrets injected</span>
@@ -207,7 +209,8 @@ $ secretspec run --profile production -- npm start
         <pre is:raw class="landing-step-code"><code>$ secretspec config init
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
-  infisical: Infisical secret management</code></pre>
+  infisical: Infisical secret management
+  openbao: OpenBao secret management (0.17+)</code></pre>
       </div>
 
       <div class="landing-step">
@@ -318,6 +321,7 @@ println<span class="tok-pun">!(</span><span class="tok-str">"{}"</span><span cla
           <button type="button" class="landing-provider-tab is-active" data-provider="keyring">Keyring</button>
           <button type="button" class="landing-provider-tab" data-provider="onepassword">1Password</button>
           <button type="button" class="landing-provider-tab" data-provider="vault">Vault</button>
+          <button type="button" class="landing-provider-tab" data-provider="openbao">OpenBao (0.17+)</button>
           <button type="button" class="landing-provider-tab" data-provider="awssm">AWS</button>
           <button type="button" class="landing-provider-tab" data-provider="gcsm">GCP</button>
           <button type="button" class="landing-provider-tab" data-provider="akv">Azure</button>
@@ -917,6 +921,7 @@ REDIS_URL=redis://…</code></pre>
       keyring:     'System keyring',
       onepassword: '1Password vault',
       vault:       'HashiCorp Vault',
+      openbao:     'OpenBao (0.17+)',
       awssm:       'AWS Secrets Manager',
       gcsm:        'Google Cloud Secret Manager',
       akv:         'Azure Key Vault',

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -52,7 +52,7 @@ data-encoding.workspace = true
 detect-coding-agent.workspace = true
 
 [features]
-default = ["cli", "keyring", "gcsm", "awssm", "vault", "bws", "akv", "infisical"]
+default = ["cli", "keyring", "gcsm", "awssm", "vault", "openbao", "bws", "akv", "infisical"]
 cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 # Compile libdbus from source into the binary instead of linking the system
@@ -62,6 +62,7 @@ vendored-dbus = ["keyring?/vendored"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 vault = ["dep:reqwest"]
+openbao = ["dep:reqwest"]
 # `tokio/sync` for the async `OnceCell` that serializes the Universal Auth
 # exchange. It is already on transitively via reqwest, but a provider should
 # name the features it uses rather than inherit them from a sibling.

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -27,7 +27,8 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [environment variables](https://secretspec.dev/providers/env)
   - [Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
-  - [Vault/OpenBao](https://secretspec.dev/providers/vault)
+  - [Vault](https://secretspec.dev/providers/vault)
+  - [OpenBao](https://secretspec.dev/providers/openbao) (0.17+)
   - [Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)
   - [Azure Key Vault](https://secretspec.dev/providers/akv)
   - [Infisical](https://secretspec.dev/providers/infisical) (0.16+)
@@ -64,7 +65,8 @@ $ secretspec config init
   lastpass: LastPass password manager
   gcsm: Google Cloud Secret Manager
   awssm: AWS Secrets Manager
-  vault: HashiCorp Vault / OpenBao secret management
+  vault: HashiCorp Vault secret management
+  openbao: OpenBao secret management (0.17+)
   bws: Bitwarden Secrets Manager
   akv: Azure Key Vault
   infisical: Infisical secret management (0.16+)
@@ -149,7 +151,8 @@ SecretSpec supports multiple storage backends for secrets:
 - **[LastPass](https://secretspec.dev/providers/lastpass)** - Cloud password manager
 - **[Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)** - GCP secret management
 - **[AWS Secrets Manager](https://secretspec.dev/providers/awssm)** - AWS secret management
-- **[Vault / OpenBao](https://secretspec.dev/providers/vault)** - HashiCorp Vault and OpenBao KV engine
+- **[Vault](https://secretspec.dev/providers/vault)** - HashiCorp Vault KV engine
+- **[OpenBao](https://secretspec.dev/providers/openbao)** (0.17+) - OpenBao KV integration; SecretSpec 0.16 accepts `openbao://` through the Vault provider
 - **[Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)** - Bitwarden Secrets Manager integration
 - **[Azure Key Vault](https://secretspec.dev/providers/akv)** - Azure secret management
 - **[Infisical](https://secretspec.dev/providers/infisical)** (0.16+) - Infisical secret management

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -25,7 +25,8 @@
 //! - [`lastpass::LastPassProvider`]: LastPass integration
 //! - [`gcsm::GcsmProvider`]: Google Cloud Secret Manager integration
 //! - [`awssm::AwssmProvider`]: AWS Secrets Manager integration
-//! - [`vault::VaultProvider`]: HashiCorp Vault and OpenBao integration
+//! - [`vault::VaultProvider`]: HashiCorp Vault integration
+//! - [`openbao::OpenBaoProvider`]: OpenBao integration (0.17+)
 //! - [`bws::BwsProvider`]: Bitwarden Secrets Manager integration
 //! - [`akv::AkvProvider`]: Azure Key Vault integration
 //! - [`infisical::InfisicalProvider`]: Infisical integration (0.16+)
@@ -85,15 +86,35 @@ pub(crate) fn credential_or_env(
     name: &str,
     env_var: &str,
 ) -> Option<String> {
+    credential_or_envs(credentials, name, &[env_var])
+}
+
+/// Resolves a semantic provider credential, falling back through the provider's
+/// conventional environment variables in order.
+pub(crate) fn credential_or_envs(
+    credentials: &ProviderCredentials,
+    name: &str,
+    env_vars: &[&str],
+) -> Option<String> {
     credentials
         .get(name)
         .map(|secret| secret.expose_secret().to_string())
         .filter(|value| !value.is_empty())
-        .or_else(|| {
-            std::env::var(env_var)
-                .ok()
-                .filter(|value| !value.is_empty())
-        })
+        .or_else(|| preferred_env(env_vars))
+}
+
+/// Returns the first configured environment variable in precedence order.
+///
+/// A present but empty (or non-Unicode) value resolves to `None` without
+/// falling through to the next name. This matches OpenBao's `BAO_*` behavior:
+/// presence overrides the corresponding `VAULT_*` compatibility variable.
+pub(crate) fn preferred_env(names: &[&str]) -> Option<String> {
+    for name in names {
+        if let Some(value) = std::env::var_os(name) {
+            return value.into_string().ok().filter(|value| !value.is_empty());
+        }
+    }
+    None
 }
 
 /// Characters that are invalid in URI hosts but might appear in provider config
@@ -176,12 +197,18 @@ impl ProviderUrl {
             .into_owned()
     }
 
-    #[cfg(any(feature = "infisical", feature = "vault", test))]
+    #[cfg(any(feature = "infisical", feature = "openbao", feature = "vault", test))]
     pub fn port(&self) -> Option<u16> {
         self.0.port()
     }
 
-    #[cfg(any(feature = "awssm", feature = "infisical", feature = "vault", test))]
+    #[cfg(any(
+        feature = "awssm",
+        feature = "infisical",
+        feature = "openbao",
+        feature = "vault",
+        test
+    ))]
     pub fn query_pairs(&self) -> url::form_urlencoded::Parse<'_> {
         self.0.query_pairs()
     }
@@ -246,10 +273,14 @@ pub mod infisical;
 pub mod keyring;
 pub mod lastpass;
 pub mod onepassword;
+#[cfg(feature = "openbao")]
+pub mod openbao;
 pub mod pass;
 pub mod protonpass;
 #[cfg(feature = "vault")]
 pub mod vault;
+#[cfg(any(feature = "openbao", feature = "vault"))]
+mod vault_common;
 #[macro_use]
 pub mod macros;
 
@@ -1328,7 +1359,7 @@ mod url_tests {
 
 #[cfg(test)]
 mod provider_credentials_tests {
-    use super::{ProviderCredentials, credential_or_env};
+    use super::{ProviderCredentials, credential_or_env, preferred_env};
     use crate::tests::EnvVarGuard;
     use secrecy::SecretString;
 
@@ -1371,5 +1402,27 @@ mod provider_credentials_tests {
             credential_or_env(&credentials(NAME, ""), NAME, ENV_VAR).as_deref(),
             Some("from-env"),
         );
+    }
+
+    #[test]
+    fn a_present_preferred_environment_variable_blocks_compatibility_fallback() {
+        let _lock = crate::tests::scrub_resolution_env();
+        const PREFERRED: &str = "SECRETSPEC_TEST_PREFERRED_ENV";
+        const FALLBACK: &str = "SECRETSPEC_TEST_COMPATIBILITY_ENV";
+
+        {
+            let _preferred = EnvVarGuard::set(PREFERRED, "");
+            let _fallback = EnvVarGuard::set(FALLBACK, "from-fallback");
+            assert_eq!(preferred_env(&[PREFERRED, FALLBACK]), None);
+        }
+
+        {
+            let _preferred = EnvVarGuard::remove(PREFERRED);
+            let _fallback = EnvVarGuard::set(FALLBACK, "from-fallback");
+            assert_eq!(
+                preferred_env(&[PREFERRED, FALLBACK]).as_deref(),
+                Some("from-fallback")
+            );
+        }
     }
 }

--- a/secretspec/src/provider/openbao.rs
+++ b/secretspec/src/provider/openbao.rs
@@ -1,0 +1,220 @@
+//! OpenBao provider (SecretSpec 0.17+).
+//!
+//! This provider stores and retrieves secrets through the OpenBao KV
+//! (Key-Value) secrets engine, version 1 or 2. It has a separate identity from
+//! HashiCorp Vault even where their current HTTP APIs remain compatible.
+//!
+//! # Authentication
+//!
+//! Select one of three methods with the `auth` query parameter:
+//!
+//! - Token (default) -- reads the `token` provider credential, `BAO_TOKEN`, or
+//!   the compatibility fallback `VAULT_TOKEN`. It then reads the path selected
+//!   by `BAO_TOKEN_PATH` / `VAULT_TOKEN_PATH`, or the OpenBao CLI's default
+//!   `~/.vault-token`.
+//! - AppRole (`?auth=approle`) -- exchanges the `role_id` and `secret_id`
+//!   provider credentials, or SecretSpec's `BAO_ROLE_ID` and `BAO_SECRET_ID`
+//!   inputs, for a client token. The corresponding `VAULT_*` names remain
+//!   compatibility fallbacks.
+//! - JWT/OIDC (`?auth=jwt`) -- logs in with an OpenBao role, using SecretSpec's
+//!   `BAO_JWT` input (falling back to `VAULT_JWT`) or a short-lived GitHub
+//!   Actions / Forgejo Actions OIDC token.
+//!
+//! For environment variables defined by the OpenBao CLI -- address, namespace,
+//! token, and token path -- `BAO_*` takes precedence and the corresponding
+//! `VAULT_*` name remains a compatibility fallback. The AppRole and JWT names
+//! are SecretSpec provider inputs rather than variables consumed by the
+//! OpenBao CLI itself.
+//!
+//! # URI format
+//!
+//! `openbao://[namespace@]host[:port][/mount][?key=value&...]`
+//!
+//! Query parameters:
+//!
+//! - `auth` -- `token` (default), `approle`, or `jwt`
+//! - `kv` -- KV engine version: `1` or `2` (default)
+//! - `tls` -- `true` (default) or `false`; the latter is intended for dev mode
+//! - `role` -- role for JWT auth, falling back through `BAO_JWT_ROLE` and
+//!   `VAULT_JWT_ROLE`
+//! - `audience` -- audience requested from the CI OIDC issuer, falling back
+//!   through `BAO_JWT_AUDIENCE` and `VAULT_JWT_AUDIENCE`
+//!
+//! Examples:
+//!
+//! - `openbao://bao.example.com:8200/secret` -- KV v2 with token auth
+//! - `openbao://bao.example.com:8200/secret?auth=approle` -- AppRole auth
+//! - `openbao://bao.example.com:8200/secret?auth=jwt&role=ci` -- JWT auth
+//! - `openbao://team-a@bao.example.com:8200/secret` -- OpenBao namespace
+//! - `openbao://127.0.0.1:8200/secret?kv=1&tls=false` -- local KV v1 server
+//!
+//! With no URI host, `BAO_ADDR` then `VAULT_ADDR` supplies the endpoint. With
+//! no URI username, `BAO_NAMESPACE` then `VAULT_NAMESPACE` supplies the
+//! namespace.
+//!
+//! # Secret naming
+//!
+//! Convention-addressed secrets live at
+//! `secretspec/{project}/{profile}/{key}` under the configured KV mount. Each
+//! entry is a map whose `value` field contains the SecretSpec value. Native
+//! references name a KV path with `item` and select a map entry with `field`;
+//! they are read-only so changing one field cannot overwrite its siblings.
+//!
+//! ```bash
+//! secretspec set DATABASE_URL --provider openbao://bao.example.com:8200/secret
+//! secretspec check --provider openbao://team-a@bao.example.com:8200/secret
+//! ```
+
+use super::vault_common::{KvConfig, KvProvider, Product, ROLE_ID, SECRET_ID, TOKEN};
+use super::{Address, Provider, ProviderCredentials, ProviderUrl};
+use crate::config::NativeAddress;
+use crate::{Result, SecretSpecError};
+use secrecy::SecretString;
+
+/// OpenBao provider configuration.
+///
+/// Parsing is intentionally product-specific even though the resulting KV
+/// coordinates are compatible with Vault. This is where the documented
+/// OpenBao CLI environment precedence and future OpenBao-only options belong.
+#[derive(Debug, Clone, Default)]
+pub struct OpenBaoConfig(KvConfig);
+
+impl TryFrom<&ProviderUrl> for OpenBaoConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> Result<Self> {
+        KvConfig::parse(url, Product::OpenBao).map(Self)
+    }
+}
+
+/// OpenBao KV provider.
+///
+/// The wrapper owns OpenBao's public identity and delegates compatible protocol
+/// operations to [`KvProvider`].
+pub struct OpenBaoProvider {
+    core: KvProvider,
+}
+
+crate::register_provider! {
+    struct: OpenBaoProvider,
+    config: OpenBaoConfig,
+    name: "openbao",
+    description: "OpenBao secret management (0.17+)",
+    schemes: ["openbao"],
+    examples: ["openbao://bao.example.com:8200/secret"],
+    credential_names: [ROLE_ID, SECRET_ID, TOKEN],
+}
+
+impl OpenBaoProvider {
+    /// Creates an OpenBao provider with the parsed product-specific configuration.
+    pub fn new(config: OpenBaoConfig) -> Self {
+        Self {
+            core: KvProvider::new(config.0, Product::OpenBao),
+        }
+    }
+}
+
+impl Provider for OpenBaoProvider {
+    /// Convention secrets use one KV path per secret and the `value` map field.
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        self.core.convention_address(project, profile, key)
+    }
+
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.core.with_credentials(credentials);
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        self.core.uri()
+    }
+
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field"]
+    }
+
+    /// A native reference must identify the field inside the KV entry's map.
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coords = self.resolve_coords(addr)?;
+        self.core.get(&coords)
+    }
+
+    /// Only convention addresses are writable; see [`Self::check_writable`].
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let coords = self.resolve_coords(addr)?;
+        self.core.set(&coords, value)
+    }
+
+    /// Refuses native writes because replacing a KV entry to change one field
+    /// would silently discard every sibling field.
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        self.core.check_writable(addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    fn config(spec: &str) -> OpenBaoConfig {
+        OpenBaoConfig::try_from(&ProviderUrl::new(Url::parse(spec).unwrap())).unwrap()
+    }
+
+    #[test]
+    fn has_an_independent_identity_and_uri() {
+        let provider = OpenBaoProvider::new(config("openbao://bao.example.com:8200/team"));
+        assert_eq!(provider.name(), "openbao");
+        assert_eq!(provider.uri(), "openbao://bao.example.com:8200/team");
+    }
+
+    #[test]
+    fn rejects_the_vault_scheme() {
+        let error = OpenBaoConfig::try_from(&ProviderUrl::new(
+            Url::parse("vault://vault.example.com:8200/secret").unwrap(),
+        ))
+        .unwrap_err();
+        assert!(error.to_string().contains("Expected 'openbao'"), "{error}");
+    }
+
+    #[test]
+    fn convention_address_is_the_writable_value_field() {
+        let provider = OpenBaoProvider::new(config("openbao://bao.example.com:8200/secret"));
+        let address = provider
+            .resolve_coords(Address::convention("app", "prod", "DATABASE_URL"))
+            .unwrap();
+        assert_eq!(address.item, "secretspec/app/prod/DATABASE_URL");
+        assert_eq!(address.field.as_deref(), Some("value"));
+    }
+
+    #[test]
+    fn native_address_requires_a_field() {
+        let provider = OpenBaoProvider::new(config("openbao://bao.example.com:8200/secret"));
+        let address = NativeAddress {
+            item: "myapp/config".into(),
+            ..Default::default()
+        };
+        let error = provider.get(Address::Native(&address)).unwrap_err();
+        assert!(error.to_string().contains("need a `field`"), "{error}");
+        assert!(error.to_string().contains("openbao"), "{error}");
+    }
+
+    #[test]
+    fn native_address_is_read_only_with_an_openbao_error() {
+        let provider = OpenBaoProvider::new(config("openbao://bao.example.com:8200/secret"));
+        let address = NativeAddress {
+            item: "myapp/config".into(),
+            field: Some("db_password".into()),
+            ..Default::default()
+        };
+        let error = provider
+            .check_writable(Address::Native(&address))
+            .unwrap_err();
+        assert!(error.to_string().contains("openbao"), "{error}");
+        assert!(error.to_string().contains("read-only"), "{error}");
+    }
+}

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -545,8 +545,8 @@ mod integration_tests {
             }
             #[cfg(feature = "vault")]
             // "vault" tests KV v2 (default), "vault-kv1" tests KV v1.
-            // Set VAULT_TOKEN and run a dev server (bao server -dev).
-            // For KV v1: bao secrets enable -path=kv1 -version=1 kv
+            // Set VAULT_TOKEN and run a Vault-compatible dev server.
+            // For KV v1: vault secrets enable -path=kv1 -version=1 kv
             "vault" | "vault-kv1" => {
                 let provider_spec = if provider_name == "vault-kv1" {
                     "vault://127.0.0.1:8200/kv1?tls=false&kv=1"
@@ -555,6 +555,20 @@ mod integration_tests {
                 };
                 let provider = Box::<dyn Provider>::try_from(provider_spec)
                     .expect("Should create vault provider");
+                (provider, None)
+            }
+            #[cfg(feature = "openbao")]
+            // "openbao" tests KV v2 (default), "openbao-kv1" tests KV v1.
+            // Set BAO_TOKEN and run `bao server -dev`.
+            // For KV v1: bao secrets enable -path=kv1 -version=1 kv
+            "openbao" | "openbao-kv1" => {
+                let provider_spec = if provider_name == "openbao-kv1" {
+                    "openbao://127.0.0.1:8200/kv1?tls=false&kv=1"
+                } else {
+                    "openbao://127.0.0.1:8200?tls=false"
+                };
+                let provider = Box::<dyn Provider>::try_from(provider_spec)
+                    .expect("Should create openbao provider");
                 (provider, None)
             }
             #[cfg(feature = "infisical")]
@@ -1200,12 +1214,12 @@ mod integration_tests {
         assert_eq!(provider.name(), "vault");
     }
 
-    #[cfg(feature = "vault")]
+    #[cfg(feature = "openbao")]
     #[test]
-    fn test_openbao_scheme() {
-        // Test OpenBao URI scheme
+    fn test_openbao_provider_creation() {
         let provider = Box::<dyn Provider>::try_from("openbao://bao.internal:8200/secret").unwrap();
-        assert_eq!(provider.name(), "vault");
+        assert_eq!(provider.name(), "openbao");
+        assert_eq!(provider.uri(), "openbao://bao.internal:8200");
     }
 
     #[cfg(feature = "vault")]

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1219,7 +1219,7 @@ mod integration_tests {
     fn test_openbao_provider_creation() {
         let provider = Box::<dyn Provider>::try_from("openbao://bao.internal:8200/secret").unwrap();
         assert_eq!(provider.name(), "openbao");
-        assert_eq!(provider.uri(), "openbao://bao.internal:8200");
+        assert_eq!(provider.uri(), "openbao://bao.internal:8200/secret");
     }
 
     #[cfg(feature = "vault")]

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -1,680 +1,115 @@
-//! HashiCorp Vault / OpenBao provider
+//! HashiCorp Vault provider.
 //!
-//! This provider integrates with HashiCorp Vault and OpenBao to store and retrieve
-//! secrets using the KV (Key-Value) secrets engine (v1 and v2).
+//! This provider stores and retrieves secrets through the Vault KV (Key-Value)
+//! secrets engine, version 1 or 2.
 //!
 //! # Authentication
 //!
-//! Supports three authentication methods, selected via the `auth` query parameter:
+//! Select one of three methods with the `auth` query parameter:
 //!
-//! - Token (default) -- uses `VAULT_TOKEN` environment variable or `~/.vault-token` file
-//! - AppRole (`?auth=approle`) -- uses `VAULT_ROLE_ID` and `VAULT_SECRET_ID` environment
-//!   variables to perform an AppRole login
-//! - JWT/OIDC (SecretSpec 0.17+, `?auth=jwt`) -- performs a JWT login with a `role`,
-//!   sourcing the token from `VAULT_JWT` or a CI OIDC request (GitHub Actions / Forgejo)
+//! - Token (default) -- reads the `token` provider credential, `VAULT_TOKEN`,
+//!   or `~/.vault-token`, in that order.
+//! - AppRole (`?auth=approle`) -- exchanges the `role_id` and `secret_id`
+//!   provider credentials, or `VAULT_ROLE_ID` and `VAULT_SECRET_ID`, for a
+//!   client token.
+//! - JWT/OIDC (SecretSpec 0.17+, `?auth=jwt`) -- logs in with a configured
+//!   Vault role, using `VAULT_JWT` or a short-lived GitHub Actions / Forgejo
+//!   Actions OIDC token.
 //!
-//! Added in SecretSpec 0.17.
-//!
-//! # URI Format
+//! # URI format
 //!
 //! `vault://[namespace@]host[:port][/mount][?key=value&...]`
-//! `openbao://[namespace@]host[:port][/mount][?key=value&...]`
 //!
 //! Query parameters:
-//! - `auth` -- authentication method: `token` (default), `approle`, or `jwt`
-//!   (SecretSpec 0.17+)
+//!
+//! - `auth` -- `token` (default), `approle`, or `jwt` (0.17+)
 //! - `kv` -- KV engine version: `1` or `2` (default)
-//! - `tls` -- enable TLS: `true` (default) or `false`
-//! - `role` (SecretSpec 0.17+) -- Vault role for JWT auth (or `VAULT_JWT_ROLE`)
-//! - `audience` (SecretSpec 0.17+) -- OIDC token audience for JWT auth (or
-//!   `VAULT_JWT_AUDIENCE`)
+//! - `tls` -- `true` (default) or `false`; the latter is intended for dev mode
+//! - `role` -- Vault role for JWT auth, falling back to `VAULT_JWT_ROLE` (0.17+)
+//! - `audience` -- audience requested from the CI OIDC issuer, falling back to
+//!   `VAULT_JWT_AUDIENCE` (0.17+)
 //!
-//! # Examples
+//! Examples:
 //!
-//! - `vault://vault.example.com:8200/secret` -- KV v2, token auth
+//! - `vault://vault.example.com:8200/secret` -- KV v2 with token auth
 //! - `vault://vault.example.com:8200/secret?auth=approle` -- AppRole auth
-//! - `vault://vault.example.com:8200/secret?auth=jwt&role=ci` -- JWT/OIDC auth
-//!   (SecretSpec 0.17+)
-//! - `vault://ns1@vault.example.com:8200/secret` -- with Vault namespace
-//! - `openbao://bao.internal:8200/secret` -- OpenBao server
-//! - `vault://127.0.0.1:8200/secret?kv=1` -- KV v1 engine
-//! - `vault://vault.example.com:8200/secret?tls=false` -- disable TLS (dev mode)
+//! - `vault://vault.example.com:8200/secret?auth=jwt&role=ci` -- JWT auth
+//! - `vault://team-a@vault.example.com:8200/secret` -- Vault namespace
+//! - `vault://127.0.0.1:8200/secret?kv=1&tls=false` -- local KV v1 server
 //!
-//! When no host is provided, falls back to the `VAULT_ADDR` environment variable.
+//! With no URI host, `VAULT_ADDR` supplies the endpoint. With no URI username,
+//! `VAULT_NAMESPACE` supplies the namespace.
 //!
-//! # Secret Naming
+//! # Secret naming
 //!
-//! Secrets are stored at the path: `secretspec/{project}/{profile}/{key}`
-//! Each secret is stored as a KV entry with a `value` field.
-//!
-//! # Example
+//! Convention-addressed secrets live at
+//! `secretspec/{project}/{profile}/{key}` under the configured KV mount. Each
+//! entry is a map whose `value` field contains the SecretSpec value. Native
+//! references name a KV path with `item` and select a map entry with `field`;
+//! they are read-only so changing one field cannot overwrite its siblings.
 //!
 //! ```bash
-//! # Set a secret
 //! secretspec set DATABASE_URL --provider vault://vault.example.com:8200/secret
-//!
-//! # Use with a namespace
 //! secretspec check --provider vault://team-a@vault.example.com:8200/secret
 //! ```
 
-use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
+use super::vault_common::{KvConfig, KvProvider, Product, ROLE_ID, SECRET_ID, TOKEN};
+use super::{Address, Provider, ProviderCredentials, ProviderUrl};
+use crate::config::NativeAddress;
 use crate::{Result, SecretSpecError};
-use reqwest::header::{HeaderMap, HeaderValue};
-use secrecy::{ExposeSecret, SecretString};
-use serde::{Deserialize, Serialize};
+use secrecy::SecretString;
 
-/// KV secrets engine version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub enum KvVersion {
-    /// KV version 1 (no versioning).
-    V1,
-    /// KV version 2 (versioned, default).
-    #[default]
-    V2,
-}
-
-/// Authentication method for the Vault / OpenBao provider.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub enum AuthMethod {
-    /// Token-based authentication via `VAULT_TOKEN` or `~/.vault-token`.
-    #[default]
-    Token,
-    /// AppRole authentication via `VAULT_ROLE_ID` and `VAULT_SECRET_ID`.
-    AppRole,
-    /// JWT/OIDC authentication using a role and a minted OIDC token (SecretSpec 0.17+).
-    Jwt,
-}
-
-/// Configuration for the Vault / OpenBao provider.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct VaultConfig {
-    /// The Vault server endpoint URL (e.g., `https://vault.example.com:8200`).
-    pub endpoint: String,
-    /// The KV secrets engine mount path (default: `secret`).
-    pub mount: String,
-    /// The KV engine version (default: V2).
-    pub kv_version: KvVersion,
-    /// Optional Vault namespace.
-    pub namespace: Option<String>,
-    /// Authentication method (default: Token).
-    pub auth: AuthMethod,
-    /// Vault role name for JWT authentication (SecretSpec 0.17+).
-    pub role: Option<String>,
-    /// Audience for the OIDC token minted for JWT authentication (SecretSpec 0.17+).
-    pub audience: Option<String>,
-}
-
-impl Default for VaultConfig {
-    fn default() -> Self {
-        Self {
-            endpoint: "https://127.0.0.1:8200".to_string(),
-            mount: "secret".to_string(),
-            kv_version: KvVersion::default(),
-            namespace: None,
-            auth: AuthMethod::default(),
-            role: None,
-            audience: None,
-        }
-    }
-}
+/// HashiCorp Vault provider configuration.
+///
+/// Parsing is intentionally product-specific even though the resulting KV
+/// coordinates are compatible with OpenBao. This keeps Vault's URI and
+/// environment contract from acquiring OpenBao-only behavior.
+#[derive(Debug, Clone, Default)]
+pub struct VaultConfig(KvConfig);
 
 impl TryFrom<&ProviderUrl> for VaultConfig {
     type Error = SecretSpecError;
 
-    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
-        let scheme = url.scheme();
-        if scheme != "vault" && scheme != "openbao" {
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "Invalid scheme '{}' for vault provider. Expected 'vault' or 'openbao'.",
-                scheme
-            )));
-        }
-
-        // Determine TLS setting from query parameter (default: true)
-        let use_tls = url
-            .query_pairs()
-            .find(|(k, _)| k == "tls")
-            .map(|(_, v)| v != "false" && v != "0")
-            .unwrap_or(true);
-
-        let http_scheme = if use_tls { "https" } else { "http" };
-
-        // Resolve endpoint: from URI host or VAULT_ADDR env var
-        let endpoint = match url.host().filter(|s| !s.is_empty()) {
-            Some(host) => {
-                if let Some(port) = url.port() {
-                    format!("{}://{}:{}", http_scheme, host, port)
-                } else {
-                    format!("{}://{}", http_scheme, host)
-                }
-            }
-            None => std::env::var("VAULT_ADDR")
-                .ok()
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| {
-                    SecretSpecError::ProviderOperationFailed(
-                        "No Vault address provided. Either specify a host in the URI \
-                         (e.g., vault://vault.example.com:8200) or set the VAULT_ADDR \
-                         environment variable."
-                            .to_string(),
-                    )
-                })?,
-        };
-
-        // Mount path from URL path (strip leading slash, default to "secret").
-        // Mount paths may contain slashes; specific KV paths are addressed with
-        // a secret's `ref`, never in the provider URI.
-        let path = url.path();
-        let trimmed = path.trim_start_matches('/').trim_end_matches('/');
-        let mount = if trimmed.is_empty() {
-            "secret".to_string()
-        } else {
-            trimmed.to_string()
-        };
-
-        // KV version from query parameter (default: V2)
-        let kv_version = url
-            .query_pairs()
-            .find(|(k, _)| k == "kv")
-            .map(|(_, v)| match v.as_ref() {
-                "1" | "v1" => KvVersion::V1,
-                _ => KvVersion::V2,
-            })
-            .unwrap_or_default();
-
-        // Namespace from URI username or VAULT_NAMESPACE env var
-        let namespace = {
-            let username = url.username();
-            if !username.is_empty() {
-                Some(username)
-            } else {
-                std::env::var("VAULT_NAMESPACE")
-                    .ok()
-                    .filter(|s| !s.is_empty())
-            }
-        };
-
-        let auth = url
-            .query_pairs()
-            .find(|(k, _)| k == "auth")
-            .map(|(_, v)| match v.as_ref() {
-                "approle" => Ok(AuthMethod::AppRole),
-                "jwt" => Ok(AuthMethod::Jwt),
-                "token" => Ok(AuthMethod::Token),
-                other => Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "Unknown auth method '{}'. Expected 'token', 'approle', or 'jwt'.",
-                    other
-                ))),
-            })
-            .transpose()?
-            .unwrap_or_default();
-
-        let role = url
-            .query_pairs()
-            .find(|(k, _)| k == "role")
-            .map(|(_, v)| v.to_string())
-            .or_else(|| std::env::var("VAULT_JWT_ROLE").ok())
-            .filter(|s| !s.is_empty());
-
-        let audience = url
-            .query_pairs()
-            .find(|(k, _)| k == "audience")
-            .map(|(_, v)| v.to_string())
-            .or_else(|| std::env::var("VAULT_JWT_AUDIENCE").ok())
-            .filter(|s| !s.is_empty());
-
-        // The `?field=` reference form from earlier iterations is rejected
-        // with a pointer at the `ref` table, instead of being silently ignored
-        // and reading the conventional layout.
-        if let Some(field) = url.query_value("field") {
-            let hint = crate::config::ref_table_hint(None, "<kv-path>", None, Some(&field));
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "vault URIs take no `field` query: address the KV entry with \
-                 {hint} on the secret instead"
-            )));
-        }
-
-        Ok(Self {
-            endpoint,
-            mount,
-            kv_version,
-            namespace,
-            auth,
-            role,
-            audience,
-        })
+    fn try_from(url: &ProviderUrl) -> Result<Self> {
+        KvConfig::parse(url, Product::Vault).map(Self)
     }
 }
 
-/// HashiCorp Vault / OpenBao provider.
+/// HashiCorp Vault KV provider.
 ///
-/// Stores and retrieves secrets from a Vault or OpenBao server using the
-/// KV secrets engine (v1 or v2) with token-based authentication.
+/// The wrapper owns Vault's public identity and delegates compatible protocol
+/// operations to [`KvProvider`].
 pub struct VaultProvider {
-    config: VaultConfig,
-    /// Credentials supplied by the provider alias.
-    credentials: ProviderCredentials,
+    core: KvProvider,
 }
-
-const ROLE_ID: &str = "role_id";
-const SECRET_ID: &str = "secret_id";
-const TOKEN: &str = "token";
-const VAULT_ROLE_ID_ENV: &str = "VAULT_ROLE_ID";
-const VAULT_SECRET_ID_ENV: &str = "VAULT_SECRET_ID";
-const VAULT_TOKEN_ENV: &str = "VAULT_TOKEN";
 
 crate::register_provider! {
     struct: VaultProvider,
     config: VaultConfig,
     name: "vault",
-    description: "HashiCorp Vault / OpenBao secret management",
-    schemes: ["vault", "openbao"],
-    examples: ["vault://vault.example.com:8200/secret", "openbao://bao.internal:8200/secret"],
+    description: "HashiCorp Vault secret management",
+    schemes: ["vault"],
+    examples: ["vault://vault.example.com:8200/secret"],
     credential_names: [ROLE_ID, SECRET_ID, TOKEN],
 }
 
 impl VaultProvider {
-    /// Creates a new VaultProvider with the given configuration.
+    /// Creates a Vault provider with the parsed product-specific configuration.
     pub fn new(config: VaultConfig) -> Self {
         Self {
-            config,
-            credentials: ProviderCredentials::new(),
-        }
-    }
-
-    /// Formats the secret path within the KV engine.
-    ///
-    /// Uses the pattern: `secretspec/{project}/{profile}/{key}`
-    fn format_secret_path(project: &str, profile: &str, key: &str) -> Result<String> {
-        if project.is_empty() {
-            return Err(SecretSpecError::ProviderOperationFailed(
-                "project cannot be empty".to_string(),
-            ));
-        }
-        if profile.is_empty() {
-            return Err(SecretSpecError::ProviderOperationFailed(
-                "profile cannot be empty".to_string(),
-            ));
-        }
-        if key.is_empty() {
-            return Err(SecretSpecError::ProviderOperationFailed(
-                "key cannot be empty".to_string(),
-            ));
-        }
-
-        Ok(format!("secretspec/{}/{}/{}", project, profile, key))
-    }
-
-    /// Resolves the Vault token using the configured authentication method.
-    async fn resolve_token(&self) -> Result<SecretString> {
-        match self.config.auth {
-            AuthMethod::Token => self.resolve_token_auth(),
-            AuthMethod::AppRole => self.resolve_approle_auth().await,
-            AuthMethod::Jwt => self.resolve_jwt_auth().await,
-        }
-    }
-
-    /// Resolves a token via static token sources.
-    fn resolve_token_auth(&self) -> Result<SecretString> {
-        // `credential_or_env` never yields an empty value.
-        if let Some(token) = credential_or_env(&self.credentials, TOKEN, VAULT_TOKEN_ENV) {
-            return Ok(SecretString::new(token.into()));
-        }
-
-        let token_path = std::env::var_os("HOME")
-            .or_else(|| std::env::var_os("USERPROFILE"))
-            .map(|home| std::path::PathBuf::from(home).join(".vault-token"));
-
-        if let Some(path) = token_path
-            && let Ok(token) = std::fs::read_to_string(&path)
-        {
-            let token = token.trim();
-            if !token.is_empty() {
-                return Ok(SecretString::new(token.to_string().into()));
-            }
-        }
-
-        Err(SecretSpecError::ProviderOperationFailed(
-            "No Vault token found. Configure the token provider credential, set the \
-             VAULT_TOKEN environment variable, or create a ~/.vault-token file."
-                .to_string(),
-        ))
-    }
-
-    /// Authenticates via AppRole and returns a client token.
-    async fn resolve_approle_auth(&self) -> Result<SecretString> {
-        let role_id =
-            credential_or_env(&self.credentials, ROLE_ID, VAULT_ROLE_ID_ENV).ok_or_else(|| {
-                SecretSpecError::ProviderOperationFailed(
-                    "Vault role_id credential is required for AppRole authentication; configure \
-                     credentials.role_id or set VAULT_ROLE_ID."
-                        .to_string(),
-                )
-            })?;
-
-        let secret_id = credential_or_env(&self.credentials, SECRET_ID, VAULT_SECRET_ID_ENV)
-            .ok_or_else(|| {
-                SecretSpecError::ProviderOperationFailed(
-                    "Vault secret_id credential is required for AppRole authentication; configure \
-                     credentials.secret_id or set VAULT_SECRET_ID."
-                        .to_string(),
-                )
-            })?;
-
-        let url = format!("{}/v1/auth/approle/login", self.config.endpoint);
-        let body = serde_json::json!({
-            "role_id": role_id,
-            "secret_id": secret_id,
-        });
-
-        let client = reqwest::Client::new();
-        let response = client.post(&url).json(&body).send().await.map_err(|e| {
-            SecretSpecError::ProviderOperationFailed(format!("AppRole login failed: {}", e))
-        })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "AppRole login returned HTTP {}: {}",
-                status, body
-            )));
-        }
-
-        let resp: serde_json::Value = response.json().await.map_err(|e| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "Failed to parse AppRole login response: {}",
-                e
-            ))
-        })?;
-
-        let token = resp["auth"]["client_token"].as_str().ok_or_else(|| {
-            SecretSpecError::ProviderOperationFailed(
-                "AppRole login response missing auth.client_token".to_string(),
-            )
-        })?;
-
-        Ok(SecretString::new(token.to_string().into()))
-    }
-
-    /// Authenticates via the JWT/OIDC method and returns a client token
-    async fn resolve_jwt_auth(&self) -> Result<SecretString> {
-        let role = self.config.role.clone().ok_or_else(|| {
-            SecretSpecError::ProviderOperationFailed(
-                "JWT authentication requires a role. Set `?role=` in the provider URI \
-                 or the VAULT_JWT_ROLE environment variable."
-                    .to_string(),
-            )
-        })?;
-
-        let jwt = self.resolve_jwt().await?;
-
-        let url = format!("{}/v1/auth/jwt/login", self.config.endpoint);
-        let body = serde_json::json!({
-            "role": role,
-            "jwt": jwt.expose_secret(),
-        });
-
-        let client = reqwest::Client::new();
-        let response = client.post(&url).json(&body).send().await.map_err(|e| {
-            SecretSpecError::ProviderOperationFailed(format!("JWT login failed: {}", e))
-        })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "JWT login returned HTTP {}: {}",
-                status, body
-            )));
-        }
-
-        let resp: serde_json::Value = response.json().await.map_err(|e| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "Failed to parse JWT login response: {}",
-                e
-            ))
-        })?;
-
-        let token = resp["auth"]["client_token"].as_str().ok_or_else(|| {
-            SecretSpecError::ProviderOperationFailed(
-                "JWT login response missing auth.client_token".to_string(),
-            )
-        })?;
-
-        Ok(SecretString::new(token.to_string().into()))
-    }
-
-    /// Sources the OIDC token for JWT auth, either an explicit `VAULT_JWT` or a
-    /// CI OIDC request (GitHub Actions / Forgejo) via `ACTIONS_ID_TOKEN_REQUEST_*`.
-    async fn resolve_jwt(&self) -> Result<SecretString> {
-        if let Ok(jwt) = std::env::var("VAULT_JWT")
-            && !jwt.is_empty()
-        {
-            return Ok(SecretString::new(jwt.into()));
-        }
-
-        let request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL")
-            .ok()
-            .filter(|s| !s.is_empty());
-        let request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
-            .ok()
-            .filter(|s| !s.is_empty());
-
-        let (request_url, request_token) = match (request_url, request_token) {
-            (Some(u), Some(t)) => (u, t),
-            _ => {
-                return Err(SecretSpecError::ProviderOperationFailed(
-                    "No JWT available for Vault JWT auth. Set VAULT_JWT, or run under a \
-                     GitHub Actions / Forgejo job with `id-token` write permission."
-                        .to_string(),
-                ));
-            }
-        };
-
-        let client = reqwest::Client::new();
-        let mut request = client.get(&request_url).bearer_auth(&request_token);
-        if let Some(audience) = &self.config.audience {
-            request = request.query(&[("audience", audience.as_str())]);
-        }
-
-        let response = request.send().await.map_err(|e| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "Failed to request CI OIDC token: {}",
-                e
-            ))
-        })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "CI OIDC token request returned HTTP {}",
-                status
-            )));
-        }
-
-        let resp: serde_json::Value = response.json().await.map_err(|e| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "Failed to parse CI OIDC token response: {}",
-                e
-            ))
-        })?;
-
-        let jwt = resp["value"].as_str().ok_or_else(|| {
-            SecretSpecError::ProviderOperationFailed(
-                "CI OIDC token response missing `value`".to_string(),
-            )
-        })?;
-
-        Ok(SecretString::new(jwt.to_string().into()))
-    }
-
-    /// Builds the common HTTP headers for Vault API requests.
-    fn build_headers(token: &SecretString, namespace: &Option<String>) -> Result<HeaderMap> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "X-Vault-Token",
-            HeaderValue::from_str(token.expose_secret()).map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(format!("Invalid token value: {}", e))
-            })?,
-        );
-        if let Some(ns) = namespace {
-            headers.insert(
-                "X-Vault-Namespace",
-                HeaderValue::from_str(ns).map_err(|e| {
-                    SecretSpecError::ProviderOperationFailed(format!(
-                        "Invalid namespace value: {}",
-                        e
-                    ))
-                })?,
-            );
-        }
-        Ok(headers)
-    }
-
-    /// Builds the full Vault API URL for a secret path.
-    fn build_url(&self, secret_path: &str) -> String {
-        match self.config.kv_version {
-            KvVersion::V2 => format!(
-                "{}/v1/{}/data/{}",
-                self.config.endpoint, self.config.mount, secret_path
-            ),
-            KvVersion::V1 => format!(
-                "{}/v1/{}/{}",
-                self.config.endpoint, self.config.mount, secret_path
-            ),
-        }
-    }
-
-    /// Reads a single field from a KV path asynchronously. SecretSpec's own layout
-    /// stores every secret under a `value` field; a reference reads an arbitrary
-    /// field at an arbitrary path.
-    async fn get_field_async(
-        &self,
-        secret_path: &str,
-        field: &str,
-    ) -> Result<Option<SecretString>> {
-        let url = self.build_url(secret_path);
-        let token = self.resolve_token().await?;
-        let headers = Self::build_headers(&token, &self.config.namespace)?;
-
-        let client = reqwest::Client::new();
-        let response = client
-            .get(&url)
-            .headers(headers)
-            .send()
-            .await
-            .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(format!(
-                    "Failed to connect to Vault at {}: {}",
-                    self.config.endpoint, e
-                ))
-            })?;
-
-        match response.status().as_u16() {
-            200 => {
-                let body: serde_json::Value = response.json().await.map_err(|e| {
-                    SecretSpecError::ProviderOperationFailed(format!(
-                        "Failed to parse Vault response: {}",
-                        e
-                    ))
-                })?;
-
-                let value = match self.config.kv_version {
-                    KvVersion::V2 => body
-                        .get("data")
-                        .and_then(|d| d.get("data"))
-                        .and_then(|d| d.get(field))
-                        .and_then(|v| v.as_str()),
-                    KvVersion::V1 => body
-                        .get("data")
-                        .and_then(|d| d.get(field))
-                        .and_then(|v| v.as_str()),
-                };
-
-                Ok(value.map(|v| SecretString::new(v.to_string().into())))
-            }
-            404 => Ok(None),
-            403 => Err(SecretSpecError::ProviderOperationFailed(
-                "Vault authentication failed (403 Forbidden). \
-                 Check your VAULT_TOKEN and ensure it has the required permissions."
-                    .to_string(),
-            )),
-            status => {
-                let body = response.text().await.unwrap_or_default();
-                Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "Vault returned HTTP {}: {}",
-                    status, body
-                )))
-            }
-        }
-    }
-
-    /// Writes a secret's `value` field at a KV path asynchronously.
-    async fn set_secret_async(&self, secret_path: &str, value: &SecretString) -> Result<()> {
-        let url = self.build_url(secret_path);
-        let token = self.resolve_token().await?;
-        let headers = Self::build_headers(&token, &self.config.namespace)?;
-
-        let body = match self.config.kv_version {
-            KvVersion::V2 => {
-                serde_json::json!({ "data": { "value": value.expose_secret() } })
-            }
-            KvVersion::V1 => {
-                serde_json::json!({ "value": value.expose_secret() })
-            }
-        };
-
-        let client = reqwest::Client::new();
-        let response = client
-            .post(&url)
-            .headers(headers)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(format!(
-                    "Failed to connect to Vault at {}: {}",
-                    self.config.endpoint, e
-                ))
-            })?;
-
-        match response.status().as_u16() {
-            200 | 204 => Ok(()),
-            403 => Err(SecretSpecError::ProviderOperationFailed(
-                "Vault authentication failed (403 Forbidden). \
-                 Check your VAULT_TOKEN and ensure it has write permissions."
-                    .to_string(),
-            )),
-            status => {
-                let body = response.text().await.unwrap_or_default();
-                Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "Vault returned HTTP {} while writing secret: {}",
-                    status, body
-                )))
-            }
+            core: KvProvider::new(config.0, Product::Vault),
         }
     }
 }
 
 impl Provider for VaultProvider {
-    /// Convention secrets each live at their own KV path,
-    /// `secretspec/{project}/{profile}/{key}`, under a `value` field.
-    fn convention_address(
-        &self,
-        project: &str,
-        profile: &str,
-        key: &str,
-    ) -> Result<crate::config::NativeAddress> {
-        Ok(crate::config::NativeAddress {
-            item: Self::format_secret_path(project, profile, key)?,
-            field: Some("value".to_string()),
-            ..Default::default()
-        })
+    /// Convention secrets use one KV path per secret and the `value` map field.
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        self.core.convention_address(project, profile, key)
     }
 
     fn with_credentials(&mut self, credentials: ProviderCredentials) {
-        self.credentials = credentials;
+        self.core.with_credentials(credentials);
     }
 
     fn name(&self) -> &'static str {
@@ -682,124 +117,105 @@ impl Provider for VaultProvider {
     }
 
     fn uri(&self) -> String {
-        let host = self
-            .config
-            .endpoint
-            .trim_start_matches("https://")
-            .trim_start_matches("http://");
-        let mut uri = format!("vault://{}", host);
-        if self.config.mount != "secret" {
-            uri.push('/');
-            uri.push_str(&self.config.mount);
-        }
-        uri
+        self.core.uri()
     }
 
-    /// `field` names the key within the KV entry's map.
     fn supported_coords(&self) -> &'static [&'static str] {
         &["field"]
     }
 
+    /// A native reference must identify the field inside the KV entry's map.
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         let coords = self.resolve_coords(addr)?;
-        // KV entries are maps; without a field there is nothing well-defined
-        // to read. Convention coordinates always carry `value`.
-        let Some(field) = &coords.field else {
-            return Err(SecretSpecError::ProviderOperationFailed(
-                "vault references need a `field`: KV entries are maps, e.g. \
-                 ref = { item = \"myapp/config\", field = \"db_password\" }"
-                    .to_string(),
-            ));
-        };
-        super::block_on(self.get_field_async(&coords.item, field))
+        self.core.get(&coords)
     }
 
+    /// Only convention addresses are writable; see [`Self::check_writable`].
     fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
         self.check_writable(addr)?;
         let coords = self.resolve_coords(addr)?;
-        super::block_on(self.set_secret_async(&coords.item, value))
+        self.core.set(&coords, value)
     }
 
-    /// Native addresses are read-only: writing a single field would clobber
-    /// the other fields at the same KV path.
+    /// Refuses native writes because replacing a KV entry to change one field
+    /// would silently discard every sibling field.
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
-        match addr {
-            Address::Convention { .. } => Ok(()),
-            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(
-                "vault secret references are read-only: writing a single field would \
-                 clobber the other fields at the same KV path"
-                    .to_string(),
-            )),
-        }
+        self.core.check_writable(addr)
     }
 }
 
 #[cfg(test)]
-mod reference_tests {
+mod tests {
     use super::*;
     use url::Url;
 
-    fn config(s: &str) -> VaultConfig {
-        VaultConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap()
+    fn config(spec: &str) -> VaultConfig {
+        VaultConfig::try_from(&ProviderUrl::new(Url::parse(spec).unwrap())).unwrap()
     }
 
-    /// The `?field=` reference form from earlier iterations errors with a
-    /// pointer at the `ref` table.
     #[test]
-    fn field_query_is_rejected_with_ref_hint() {
+    fn field_query_is_rejected_in_favour_of_a_ref() {
         let err = VaultConfig::try_from(&ProviderUrl::new(
             Url::parse("vault://vault.example.com:8200/secret?field=x").unwrap(),
         ))
         .unwrap_err();
-        assert!(err.to_string().contains("field = \"x\""), "{err}");
+        assert!(err.to_string().contains("ref = { item ="), "{err}");
     }
 
-    /// KV entries are maps: a native address must say which field to read.
+    #[test]
+    fn convention_address_is_the_writable_value_field() {
+        let provider = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
+        let address = provider
+            .resolve_coords(Address::convention("app", "prod", "DATABASE_URL"))
+            .unwrap();
+        assert_eq!(address.item, "secretspec/app/prod/DATABASE_URL");
+        assert_eq!(address.field.as_deref(), Some("value"));
+        assert!(
+            provider
+                .check_writable(Address::convention("app", "prod", "DATABASE_URL"))
+                .is_ok()
+        );
+    }
+
     #[test]
     fn native_address_requires_a_field() {
-        let p = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
-        let addr = crate::config::NativeAddress {
+        let provider = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
+        let address = NativeAddress {
             item: "myapp/config".into(),
             ..Default::default()
         };
-        let err = p.get(Address::Native(&addr)).unwrap_err();
-        assert!(err.to_string().contains("need a `field`"), "{err}");
+        let error = provider.get(Address::Native(&address)).unwrap_err();
+        assert!(error.to_string().contains("need a `field`"), "{error}");
     }
 
-    /// Native addresses are read-only: a field-level write would clobber the
-    /// sibling fields at the KV path.
     #[test]
     fn native_address_is_read_only() {
-        let p = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
-        let addr = crate::config::NativeAddress {
+        let provider = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
+        let address = NativeAddress {
             item: "myapp/config".into(),
             field: Some("db_password".into()),
             ..Default::default()
         };
-        let refusal = p.check_writable(Address::Native(&addr)).unwrap_err();
-        assert!(refusal.to_string().contains("read-only"), "{refusal}");
-        // `set` refuses with the same reason, so the pre-check cannot drift.
-        let err = p
-            .set(
-                Address::Native(&addr),
-                &secrecy::SecretString::new("v".into()),
-            )
+        let refusal = provider
+            .check_writable(Address::Native(&address))
             .unwrap_err();
-        assert_eq!(err.to_string(), refusal.to_string());
+        assert!(refusal.to_string().contains("read-only"), "{refusal}");
+        let error = provider
+            .set(Address::Native(&address), &SecretString::new("v".into()))
+            .unwrap_err();
+        assert_eq!(error.to_string(), refusal.to_string());
     }
 
-    /// Version pinning is not supported for Vault KV yet; the coordinate is
-    /// rejected.
     #[test]
     fn native_address_rejects_version() {
-        let p = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
-        let addr = crate::config::NativeAddress {
+        let provider = VaultProvider::new(config("vault://vault.example.com:8200/secret"));
+        let address = NativeAddress {
             item: "myapp/config".into(),
             field: Some("db_password".into()),
             version: Some("3".into()),
             ..Default::default()
         };
-        let err = p.get(Address::Native(&addr)).unwrap_err();
-        assert!(err.to_string().contains("`version`"), "{err}");
+        let error = provider.get(Address::Native(&address)).unwrap_err();
+        assert!(error.to_string().contains("`version`"), "{error}");
     }
 }

--- a/secretspec/src/provider/vault_common.rs
+++ b/secretspec/src/provider/vault_common.rs
@@ -11,6 +11,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use url::Url;
 
 pub(crate) const ROLE_ID: &str = "role_id";
 pub(crate) const SECRET_ID: &str = "secret_id";
@@ -163,6 +164,49 @@ impl Default for KvConfig {
 }
 
 impl KvConfig {
+    /// Parses an API address into the credential-free HTTP origin used for
+    /// requests, diagnostics, and provider attribution.
+    ///
+    /// Vault-compatible address variables are URLs, but userinfo and arbitrary
+    /// query parameters are not part of the server identity. Keeping the raw
+    /// value would let credentials reach `Provider::uri()` and audit output.
+    fn normalize_endpoint(endpoint: &str, product: Product) -> Result<String> {
+        let mut endpoint = Url::parse(endpoint).map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid {} address: {error}",
+                product.display_name()
+            ))
+        })?;
+
+        if !matches!(endpoint.scheme(), "http" | "https") || endpoint.host().is_none() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid {} address: expected an http:// or https:// URL with a host",
+                product.display_name()
+            )));
+        }
+
+        // Requests use token-based provider authentication, never URL basic
+        // authentication. Retain only the origin so paths and unknown query
+        // parameters cannot alter requests or leak through provider reporting.
+        endpoint.set_password(None).map_err(|_| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid {} address password",
+                product.display_name()
+            ))
+        })?;
+        endpoint.set_username("").map_err(|_| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid {} address username",
+                product.display_name()
+            ))
+        })?;
+        endpoint.set_path("");
+        endpoint.set_query(None);
+        endpoint.set_fragment(None);
+
+        Ok(endpoint.as_str().trim_end_matches('/').to_string())
+    }
+
     /// Parses the common URI grammar with the selected product's scheme and
     /// environment precedence.
     ///
@@ -204,10 +248,10 @@ impl KvConfig {
                 ))
             })?,
         };
-        // Both CLIs accept an address with a trailing slash. Request paths are
-        // appended below, so retain one separator instead of producing
-        // `//v1/...`, which OpenBao and Vault reject rather than normalize.
-        let endpoint = endpoint.trim_end_matches('/').to_string();
+        // Both CLIs accept addresses with trailing slashes. Normalizing the
+        // complete URL also strips unsupported components that must not reach
+        // request paths, diagnostics, or audit records.
+        let endpoint = Self::normalize_endpoint(&endpoint, product)?;
 
         // The provider path identifies only the engine mount. Per-secret KV
         // paths belong to convention coordinates or a secret's `ref`.
@@ -351,20 +395,48 @@ impl KvProvider {
     /// Returns the credential-free provider URI used in audit records and
     /// fallback diagnostics.
     ///
-    /// This retains the historical compact form while using the actual product
-    /// scheme, which is the identity bug the first-class split fixes.
+    /// The URI is canonical rather than source-preserving: implicit defaults
+    /// stay implicit, while every setting that changes the effective store or
+    /// authentication context is retained.
     pub(crate) fn uri(&self) -> String {
-        let host = self
+        let authority = self
             .config
             .endpoint
-            .trim_start_matches("https://")
-            .trim_start_matches("http://");
-        let mut uri = format!("{}://{host}", self.product.scheme());
-        if self.config.mount != "secret" {
-            uri.push('/');
-            uri.push_str(&self.config.mount);
+            .strip_prefix("https://")
+            .or_else(|| self.config.endpoint.strip_prefix("http://"))
+            .expect("KvConfig endpoints are normalized HTTP origins");
+        let mut uri = Url::parse(&format!("{}://{authority}", self.product.scheme()))
+            .expect("a normalized endpoint forms a provider URI");
+
+        if let Some(namespace) = &self.config.namespace {
+            uri.set_username(namespace)
+                .expect("a provider URI supports namespace userinfo");
         }
-        uri
+        uri.set_path(&format!("/{}", self.config.mount));
+
+        if self.config.endpoint.starts_with("http://") {
+            uri.query_pairs_mut().append_pair("tls", "false");
+        }
+        if self.config.kv_version == KvVersion::V1 {
+            uri.query_pairs_mut().append_pair("kv", "1");
+        }
+        match self.config.auth {
+            AuthMethod::Token => {}
+            AuthMethod::AppRole => {
+                uri.query_pairs_mut().append_pair("auth", "approle");
+            }
+            AuthMethod::Jwt => {
+                uri.query_pairs_mut().append_pair("auth", "jwt");
+                if let Some(role) = &self.config.role {
+                    uri.query_pairs_mut().append_pair("role", role);
+                }
+                if let Some(audience) = &self.config.audience {
+                    uri.query_pairs_mut().append_pair("audience", audience);
+                }
+            }
+        }
+
+        uri.into()
     }
 
     /// Reads the requested field from a resolved native KV address.
@@ -796,7 +868,6 @@ impl KvProvider {
 mod tests {
     use super::*;
     use crate::tests::EnvVarGuard;
-    use url::Url;
 
     fn provider_url(spec: &str) -> ProviderUrl {
         ProviderUrl::new(Url::parse(spec).unwrap())
@@ -861,6 +932,56 @@ mod tests {
                 "http://127.0.0.1:8200/v1/secret/data/app/config"
             );
         }
+    }
+
+    #[test]
+    fn environment_endpoints_drop_credentials_and_unsupported_url_components() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let _bao_addr = EnvVarGuard::set(
+            "BAO_ADDR",
+            "https://alice:leaked-password@bao.example.com:8200/prefix?token=leaked-query#fragment",
+        );
+        let _vault_addr = EnvVarGuard::remove("VAULT_ADDR");
+
+        let config = KvConfig::parse(&provider_url("openbao://"), Product::OpenBao).unwrap();
+        assert_eq!(config.endpoint, "https://bao.example.com:8200");
+
+        let provider = KvProvider::new(config, Product::OpenBao);
+        assert_eq!(provider.uri(), "openbao://bao.example.com:8200/secret");
+        assert_eq!(
+            provider.build_url("app/config"),
+            "https://bao.example.com:8200/v1/secret/data/app/config"
+        );
+        assert!(!provider.uri().contains("alice"));
+        assert!(!provider.uri().contains("leaked-password"));
+        assert!(!provider.uri().contains("leaked-query"));
+    }
+
+    #[test]
+    fn uri_retains_effective_non_secret_attribution() {
+        let config = KvConfig::parse(
+            &provider_url(
+                "openbao://team-a@bao.example.com:8200/team/secret?tls=false&kv=1&auth=jwt&role=ci-role&audience=deploy",
+            ),
+            Product::OpenBao,
+        )
+        .unwrap();
+        let provider = KvProvider::new(config, Product::OpenBao);
+
+        assert_eq!(
+            provider.uri(),
+            "openbao://team-a@bao.example.com:8200/team/secret?tls=false&kv=1&auth=jwt&role=ci-role&audience=deploy"
+        );
+
+        let approle = KvConfig::parse(
+            &provider_url("openbao://team-a@bao.example.com:8200/secret?auth=approle"),
+            Product::OpenBao,
+        )
+        .unwrap();
+        assert_eq!(
+            KvProvider::new(approle, Product::OpenBao).uri(),
+            "openbao://team-a@bao.example.com:8200/secret?auth=approle"
+        );
     }
 
     #[test]

--- a/secretspec/src/provider/vault_common.rs
+++ b/secretspec/src/provider/vault_common.rs
@@ -1,0 +1,808 @@
+//! Shared HashiCorp Vault-compatible KV protocol implementation.
+//!
+//! Vault and OpenBao deliberately have separate provider identities and
+//! configuration conventions. This module contains only the compatible KV,
+//! authentication-exchange, and HTTP mechanics used by both providers.
+
+use super::{Address, ProviderCredentials, ProviderUrl, credential_or_envs, preferred_env};
+use crate::config::NativeAddress;
+use crate::{Result, SecretSpecError};
+use reqwest::header::{HeaderMap, HeaderValue};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+pub(crate) const ROLE_ID: &str = "role_id";
+pub(crate) const SECRET_ID: &str = "secret_id";
+pub(crate) const TOKEN: &str = "token";
+
+/// KV secrets engine version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub(crate) enum KvVersion {
+    /// KV version 1 (no versioning).
+    V1,
+    /// KV version 2 (versioned, default).
+    #[default]
+    V2,
+}
+
+/// Authentication method for a Vault-compatible provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub(crate) enum AuthMethod {
+    /// Token-based authentication.
+    #[default]
+    Token,
+    /// AppRole authentication.
+    AppRole,
+    /// JWT/OIDC authentication using a role and a minted OIDC token.
+    Jwt,
+}
+
+/// Product-specific identity and environment conventions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Each variant is constructed only when its Cargo feature is enabled.
+pub(crate) enum Product {
+    Vault,
+    OpenBao,
+}
+
+impl Product {
+    pub(crate) fn scheme(self) -> &'static str {
+        match self {
+            Self::Vault => "vault",
+            Self::OpenBao => "openbao",
+        }
+    }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::Vault => "Vault",
+            Self::OpenBao => "OpenBao",
+        }
+    }
+
+    fn address_envs(self) -> &'static [&'static str] {
+        match self {
+            Self::Vault => &["VAULT_ADDR"],
+            Self::OpenBao => &["BAO_ADDR", "VAULT_ADDR"],
+        }
+    }
+
+    fn namespace_envs(self) -> &'static [&'static str] {
+        match self {
+            Self::Vault => &["VAULT_NAMESPACE"],
+            Self::OpenBao => &["BAO_NAMESPACE", "VAULT_NAMESPACE"],
+        }
+    }
+
+    fn token_envs(self) -> &'static [&'static str] {
+        match self {
+            Self::Vault => &["VAULT_TOKEN"],
+            Self::OpenBao => &["BAO_TOKEN", "VAULT_TOKEN"],
+        }
+    }
+
+    fn token_path_envs(self) -> &'static [&'static str] {
+        match self {
+            Self::Vault => &[],
+            Self::OpenBao => &["BAO_TOKEN_PATH", "VAULT_TOKEN_PATH"],
+        }
+    }
+
+    fn role_id_envs(self) -> &'static [&'static str] {
+        match self {
+            // These auth inputs are part of SecretSpec's existing provider
+            // contract. Neither product's CLI reads them automatically.
+            Self::Vault => &["VAULT_ROLE_ID"],
+            // Give the first-class OpenBao provider its own product-scoped
+            // name while retaining the old Vault-provider input as fallback.
+            Self::OpenBao => &["BAO_ROLE_ID", "VAULT_ROLE_ID"],
+        }
+    }
+
+    fn secret_id_envs(self) -> &'static [&'static str] {
+        match self {
+            Self::Vault => &["VAULT_SECRET_ID"],
+            Self::OpenBao => &["BAO_SECRET_ID", "VAULT_SECRET_ID"],
+        }
+    }
+
+    fn jwt_envs(self) -> &'static [&'static str] {
+        match self {
+            Self::Vault => &["VAULT_JWT"],
+            Self::OpenBao => &["BAO_JWT", "VAULT_JWT"],
+        }
+    }
+
+    fn jwt_role_envs(self) -> &'static [&'static str] {
+        match self {
+            Self::Vault => &["VAULT_JWT_ROLE"],
+            Self::OpenBao => &["BAO_JWT_ROLE", "VAULT_JWT_ROLE"],
+        }
+    }
+
+    fn jwt_audience_envs(self) -> &'static [&'static str] {
+        match self {
+            Self::Vault => &["VAULT_JWT_AUDIENCE"],
+            Self::OpenBao => &["BAO_JWT_AUDIENCE", "VAULT_JWT_AUDIENCE"],
+        }
+    }
+}
+
+/// Configuration shared by the compatible Vault and OpenBao KV APIs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct KvConfig {
+    /// HTTP origin used for API requests, including `http` or `https`.
+    pub(crate) endpoint: String,
+    /// KV secrets-engine mount, relative to `/v1` (default: `secret`).
+    pub(crate) mount: String,
+    /// KV API layout to use when constructing data paths and decoding replies.
+    pub(crate) kv_version: KvVersion,
+    /// Optional namespace sent in `X-Vault-Namespace`.
+    pub(crate) namespace: Option<String>,
+    /// Login flow used to obtain the token attached to data requests.
+    pub(crate) auth: AuthMethod,
+    /// Role sent to the JWT login endpoint.
+    pub(crate) role: Option<String>,
+    /// Audience requested when SecretSpec mints a CI OIDC token.
+    pub(crate) audience: Option<String>,
+}
+
+impl Default for KvConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "https://127.0.0.1:8200".to_string(),
+            mount: "secret".to_string(),
+            kv_version: KvVersion::default(),
+            namespace: None,
+            auth: AuthMethod::default(),
+            role: None,
+            audience: None,
+        }
+    }
+}
+
+impl KvConfig {
+    /// Parses the common URI grammar with the selected product's scheme and
+    /// environment precedence.
+    ///
+    /// Keeping product selection explicit prevents a URI registered as
+    /// `openbao://` from silently constructing a Vault-branded provider again.
+    pub(crate) fn parse(url: &ProviderUrl, product: Product) -> Result<Self> {
+        if url.scheme() != product.scheme() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for {} provider. Expected '{}'.",
+                url.scheme(),
+                product.display_name(),
+                product.scheme()
+            )));
+        }
+
+        // URI configuration wins over defaults. `tls=false` changes the
+        // transport scheme rather than disabling certificate verification.
+        let use_tls = url
+            .query_pairs()
+            .find(|(key, _)| key == "tls")
+            .map(|(_, value)| value != "false" && value != "0")
+            .unwrap_or(true);
+        let http_scheme = if use_tls { "https" } else { "http" };
+
+        // An explicit host wins. A scheme-only URI is useful in CI and falls
+        // back through the product's conventional address variables.
+        let endpoint = match url.host().filter(|host| !host.is_empty()) {
+            Some(host) => match url.port() {
+                Some(port) => format!("{http_scheme}://{host}:{port}"),
+                None => format!("{http_scheme}://{host}"),
+            },
+            None => preferred_env(product.address_envs()).ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "No {} address provided. Specify a host in the URI (for example, \
+                     {}://127.0.0.1:8200) or set {}.",
+                    product.display_name(),
+                    product.scheme(),
+                    product.address_envs().join(" or ")
+                ))
+            })?,
+        };
+        // The provider path identifies only the engine mount. Per-secret KV
+        // paths belong to convention coordinates or a secret's `ref`.
+        let path = url.path();
+        let trimmed = path.trim_start_matches('/').trim_end_matches('/');
+        let mount = if trimmed.is_empty() {
+            "secret".to_string()
+        } else {
+            trimmed.to_string()
+        };
+
+        // KV v2 is the safe default because it retains versions. Unknown
+        // values preserve the historical v2 behavior rather than guessing v1.
+        let kv_version = url
+            .query_pairs()
+            .find(|(key, _)| key == "kv")
+            .map(|(_, value)| match value.as_ref() {
+                "1" | "v1" => KvVersion::V1,
+                _ => KvVersion::V2,
+            })
+            .unwrap_or_default();
+
+        // URI attribution is explicit and therefore outranks environment
+        // configuration. The username position mirrors the existing syntax.
+        let namespace = match url.username() {
+            username if !username.is_empty() => Some(username),
+            _ => preferred_env(product.namespace_envs()),
+        };
+
+        // Authentication is selected independently from the product while its
+        // credential sources retain product-specific environment precedence.
+        let auth = url
+            .query_pairs()
+            .find(|(key, _)| key == "auth")
+            .map(|(_, value)| match value.as_ref() {
+                "approle" => Ok(AuthMethod::AppRole),
+                "jwt" => Ok(AuthMethod::Jwt),
+                "token" => Ok(AuthMethod::Token),
+                other => Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Unknown auth method '{other}'. Expected 'token', 'approle', or 'jwt'."
+                ))),
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        let role = url
+            .query_pairs()
+            .find(|(key, _)| key == "role")
+            .map(|(_, value)| value.to_string())
+            .or_else(|| preferred_env(product.jwt_role_envs()))
+            .filter(|value| !value.is_empty());
+
+        let audience = url
+            .query_pairs()
+            .find(|(key, _)| key == "audience")
+            .map(|(_, value)| value.to_string())
+            .or_else(|| preferred_env(product.jwt_audience_envs()))
+            .filter(|value| !value.is_empty());
+
+        // Older experiments placed a field in the provider URI. Reject it with
+        // an actionable translation: a field varies per secret and belongs in
+        // that secret's native reference.
+        if let Some(field) = url.query_value("field") {
+            let hint = crate::config::ref_table_hint(None, "<kv-path>", None, Some(&field));
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{} URIs take no `field` query: address the KV entry with {hint} on the \
+                 secret instead",
+                product.scheme()
+            )));
+        }
+
+        Ok(Self {
+            endpoint,
+            mount,
+            kv_version,
+            namespace,
+            auth,
+            role,
+            audience,
+        })
+    }
+}
+
+/// Compatible KV client used behind the product-specific provider wrappers.
+pub(crate) struct KvProvider {
+    config: KvConfig,
+    credentials: ProviderCredentials,
+    product: Product,
+}
+
+impl KvProvider {
+    /// Creates the shared protocol client while retaining the product identity
+    /// needed for environment lookup, diagnostics, and URI serialization.
+    pub(crate) fn new(config: KvConfig, product: Product) -> Self {
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+            product,
+        }
+    }
+
+    /// Injects semantic credentials resolved from another SecretSpec provider.
+    /// Explicit credentials outrank every environment fallback.
+    pub(crate) fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
+    /// Compiles SecretSpec's logical address into one KV entry per secret.
+    ///
+    /// Storing one value per path makes convention writes safe: unlike a native
+    /// multi-field KV entry, no unrelated fields can be overwritten.
+    pub(crate) fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<NativeAddress> {
+        if project.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "project cannot be empty".to_string(),
+            ));
+        }
+        if profile.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "profile cannot be empty".to_string(),
+            ));
+        }
+        if key.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "key cannot be empty".to_string(),
+            ));
+        }
+
+        Ok(NativeAddress {
+            item: format!("secretspec/{project}/{profile}/{key}"),
+            field: Some("value".to_string()),
+            ..Default::default()
+        })
+    }
+
+    /// Returns the credential-free provider URI used in audit records and
+    /// fallback diagnostics.
+    ///
+    /// This retains the historical compact form while using the actual product
+    /// scheme, which is the identity bug the first-class split fixes.
+    pub(crate) fn uri(&self) -> String {
+        let host = self
+            .config
+            .endpoint
+            .trim_start_matches("https://")
+            .trim_start_matches("http://");
+        let mut uri = format!("{}://{host}", self.product.scheme());
+        if self.config.mount != "secret" {
+            uri.push('/');
+            uri.push_str(&self.config.mount);
+        }
+        uri
+    }
+
+    /// Reads the requested field from a resolved native KV address.
+    /// Convention addresses also arrive here after resolving to field `value`.
+    pub(crate) fn get(&self, coords: &NativeAddress) -> Result<Option<SecretString>> {
+        let Some(field) = &coords.field else {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{} references need a `field`: KV entries are maps, e.g. \
+                 ref = {{ item = \"myapp/config\", field = \"db_password\" }}",
+                self.product.scheme()
+            )));
+        };
+        super::block_on(self.get_field_async(&coords.item, field))
+    }
+
+    /// Writes a complete convention-owned KV entry.
+    ///
+    /// Callers must run [`Self::check_writable`] before reaching this method.
+    pub(crate) fn set(&self, coords: &NativeAddress, value: &SecretString) -> Result<()> {
+        super::block_on(self.set_secret_async(&coords.item, value))
+    }
+
+    /// Native references are read-only because the current write API replaces
+    /// the full map. A future CAS/PATCH implementation could safely relax this.
+    pub(crate) fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Convention { .. } => Ok(()),
+            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{} secret references are read-only: writing a single field would clobber the \
+                 other fields at the same KV path",
+                self.product.scheme()
+            ))),
+        }
+    }
+
+    /// Resolves a reusable client token with the configured authentication
+    /// method.
+    async fn resolve_token(&self) -> Result<SecretString> {
+        match self.config.auth {
+            AuthMethod::Token => self.resolve_token_auth(),
+            AuthMethod::AppRole => self.resolve_approle_auth().await,
+            AuthMethod::Jwt => self.resolve_jwt_auth().await,
+        }
+    }
+
+    /// Resolves static token authentication in decreasing precedence:
+    /// provider credential, product environment, configured token path, and
+    /// finally the CLI-compatible `~/.vault-token` default.
+    fn resolve_token_auth(&self) -> Result<SecretString> {
+        if let Some(token) = credential_or_envs(&self.credentials, TOKEN, self.product.token_envs())
+        {
+            return Ok(SecretString::new(token.into()));
+        }
+
+        let token_path = preferred_env(self.product.token_path_envs())
+            .map(PathBuf::from)
+            .or_else(|| {
+                std::env::var_os("HOME")
+                    .or_else(|| std::env::var_os("USERPROFILE"))
+                    .map(|home| PathBuf::from(home).join(".vault-token"))
+            });
+
+        if let Some(path) = token_path
+            && let Ok(token) = std::fs::read_to_string(&path)
+        {
+            let token = token.trim();
+            if !token.is_empty() {
+                return Ok(SecretString::new(token.to_string().into()));
+            }
+        }
+
+        let token_path_hint = match self.product {
+            Product::Vault => "create a ~/.vault-token file".to_string(),
+            Product::OpenBao => {
+                "set BAO_TOKEN_PATH (VAULT_TOKEN_PATH is also accepted), or create a \
+                 ~/.vault-token file"
+                    .to_string()
+            }
+        };
+        Err(SecretSpecError::ProviderOperationFailed(format!(
+            "No {} token found. Configure the token provider credential, set {}, {}, or {}.",
+            self.product.display_name(),
+            self.product.token_envs().join(" or "),
+            token_path_hint,
+            "authenticate with another supported method"
+        )))
+    }
+
+    /// Exchanges AppRole credentials for the short-lived client token used by
+    /// subsequent KV requests.
+    async fn resolve_approle_auth(&self) -> Result<SecretString> {
+        let role_id = credential_or_envs(&self.credentials, ROLE_ID, self.product.role_id_envs())
+            .ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "{} role_id credential is required for AppRole authentication; configure \
+                 credentials.role_id or set {}.",
+                self.product.display_name(),
+                self.product.role_id_envs().join(" or ")
+            ))
+        })?;
+
+        let secret_id =
+            credential_or_envs(&self.credentials, SECRET_ID, self.product.secret_id_envs())
+                .ok_or_else(|| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "{} secret_id credential is required for AppRole authentication; configure \
+                 credentials.secret_id or set {}.",
+                        self.product.display_name(),
+                        self.product.secret_id_envs().join(" or ")
+                    ))
+                })?;
+
+        let url = format!("{}/v1/auth/approle/login", self.config.endpoint);
+        let body = serde_json::json!({
+            "role_id": role_id,
+            "secret_id": secret_id,
+        });
+
+        let response = reqwest::Client::new()
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "{} AppRole login failed: {error}",
+                    self.product.display_name()
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{} AppRole login returned HTTP {status}: {body}",
+                self.product.display_name()
+            )));
+        }
+
+        let response: serde_json::Value = response.json().await.map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to parse {} AppRole login response: {error}",
+                self.product.display_name()
+            ))
+        })?;
+        let token = response["auth"]["client_token"].as_str().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "{} AppRole login response missing auth.client_token",
+                self.product.display_name()
+            ))
+        })?;
+
+        Ok(SecretString::new(token.to_string().into()))
+    }
+
+    /// Exchanges a JWT and role at the standard `auth/jwt/login` endpoint.
+    async fn resolve_jwt_auth(&self) -> Result<SecretString> {
+        let role = self.config.role.clone().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "{} JWT authentication requires a role. Set `?role=` in the provider URI or {}.",
+                self.product.display_name(),
+                self.product.jwt_role_envs().join(" or ")
+            ))
+        })?;
+        let jwt = self.resolve_jwt().await?;
+
+        let url = format!("{}/v1/auth/jwt/login", self.config.endpoint);
+        let body = serde_json::json!({
+            "role": role,
+            "jwt": jwt.expose_secret(),
+        });
+        let response = reqwest::Client::new()
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "{} JWT login failed: {error}",
+                    self.product.display_name()
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{} JWT login returned HTTP {status}: {body}",
+                self.product.display_name()
+            )));
+        }
+
+        let response: serde_json::Value = response.json().await.map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to parse {} JWT login response: {error}",
+                self.product.display_name()
+            ))
+        })?;
+        let token = response["auth"]["client_token"].as_str().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "{} JWT login response missing auth.client_token",
+                self.product.display_name()
+            ))
+        })?;
+
+        Ok(SecretString::new(token.to_string().into()))
+    }
+
+    /// Sources a JWT directly from the product environment or mints one from
+    /// the GitHub Actions / Forgejo Actions OIDC endpoint available to the job.
+    async fn resolve_jwt(&self) -> Result<SecretString> {
+        if let Some(jwt) = preferred_env(self.product.jwt_envs()) {
+            return Ok(SecretString::new(jwt.into()));
+        }
+
+        let request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL")
+            .ok()
+            .filter(|value| !value.is_empty());
+        let request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+            .ok()
+            .filter(|value| !value.is_empty());
+        let (request_url, request_token) = match (request_url, request_token) {
+            (Some(url), Some(token)) => (url, token),
+            _ => {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "No JWT available for {} JWT auth. Set {}, or run under a GitHub Actions / \
+                     Forgejo job with `id-token` write permission.",
+                    self.product.display_name(),
+                    self.product.jwt_envs().join(" or ")
+                )));
+            }
+        };
+
+        let client = reqwest::Client::new();
+        let mut request = client.get(&request_url).bearer_auth(&request_token);
+        if let Some(audience) = &self.config.audience {
+            request = request.query(&[("audience", audience.as_str())]);
+        }
+        let response = request.send().await.map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to request CI OIDC token: {error}"
+            ))
+        })?;
+        if !response.status().is_success() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "CI OIDC token request returned HTTP {}",
+                response.status()
+            )));
+        }
+
+        let response: serde_json::Value = response.json().await.map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to parse CI OIDC token response: {error}"
+            ))
+        })?;
+        let jwt = response["value"].as_str().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(
+                "CI OIDC token response missing `value`".to_string(),
+            )
+        })?;
+        Ok(SecretString::new(jwt.to_string().into()))
+    }
+
+    /// Builds headers shared by authenticated Vault-compatible API requests.
+    ///
+    /// OpenBao intentionally retains the `X-Vault-*` wire names for protocol
+    /// compatibility; using them does not collapse its provider identity.
+    fn build_headers(&self, token: &SecretString) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Vault-Token",
+            HeaderValue::from_str(token.expose_secret()).map_err(|error| {
+                SecretSpecError::ProviderOperationFailed(format!("Invalid token value: {error}"))
+            })?,
+        );
+        if let Some(namespace) = &self.config.namespace {
+            headers.insert(
+                "X-Vault-Namespace",
+                HeaderValue::from_str(namespace).map_err(|error| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Invalid namespace value: {error}"
+                    ))
+                })?,
+            );
+        }
+        Ok(headers)
+    }
+
+    /// Builds the raw API path, inserting KV v2's required `/data/` segment.
+    fn build_url(&self, secret_path: &str) -> String {
+        match self.config.kv_version {
+            KvVersion::V2 => format!(
+                "{}/v1/{}/data/{secret_path}",
+                self.config.endpoint, self.config.mount
+            ),
+            KvVersion::V1 => format!(
+                "{}/v1/{}/{secret_path}",
+                self.config.endpoint, self.config.mount
+            ),
+        }
+    }
+
+    /// Fetches one KV entry and extracts one string field.
+    ///
+    /// A missing path maps to `None`, while authorization and protocol failures
+    /// remain errors so a fallback chain cannot mistake them for absence.
+    async fn get_field_async(
+        &self,
+        secret_path: &str,
+        field: &str,
+    ) -> Result<Option<SecretString>> {
+        let url = self.build_url(secret_path);
+        let token = self.resolve_token().await?;
+        let response = reqwest::Client::new()
+            .get(&url)
+            .headers(self.build_headers(&token)?)
+            .send()
+            .await
+            .map_err(|error| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to connect to {} at {}: {error}",
+                    self.product.display_name(),
+                    self.config.endpoint
+                ))
+            })?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body: serde_json::Value = response.json().await.map_err(|error| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to parse {} response: {error}",
+                        self.product.display_name()
+                    ))
+                })?;
+                let value = match self.config.kv_version {
+                    KvVersion::V2 => body
+                        .get("data")
+                        .and_then(|data| data.get("data"))
+                        .and_then(|data| data.get(field))
+                        .and_then(|value| value.as_str()),
+                    KvVersion::V1 => body
+                        .get("data")
+                        .and_then(|data| data.get(field))
+                        .and_then(|value| value.as_str()),
+                };
+                Ok(value.map(|value| SecretString::new(value.to_string().into())))
+            }
+            404 => Ok(None),
+            403 => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{} authentication failed (403 Forbidden). Check {} and ensure it has the \
+                 required permissions.",
+                self.product.display_name(),
+                self.product.token_envs().join(" or ")
+            ))),
+            status => {
+                let body = response.text().await.unwrap_or_default();
+                Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "{} returned HTTP {status}: {body}",
+                    self.product.display_name()
+                )))
+            }
+        }
+    }
+
+    /// Writes SecretSpec's single-field convention payload to KV.
+    ///
+    /// KV v2 wraps user data under `data`; KV v1 accepts the map directly.
+    async fn set_secret_async(&self, secret_path: &str, value: &SecretString) -> Result<()> {
+        let url = self.build_url(secret_path);
+        let token = self.resolve_token().await?;
+        let body = match self.config.kv_version {
+            KvVersion::V2 => serde_json::json!({ "data": { "value": value.expose_secret() } }),
+            KvVersion::V1 => serde_json::json!({ "value": value.expose_secret() }),
+        };
+        let response = reqwest::Client::new()
+            .post(&url)
+            .headers(self.build_headers(&token)?)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to connect to {} at {}: {error}",
+                    self.product.display_name(),
+                    self.config.endpoint
+                ))
+            })?;
+
+        match response.status().as_u16() {
+            200 | 204 => Ok(()),
+            403 => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{} authentication failed (403 Forbidden). Check {} and ensure it has write \
+                 permissions.",
+                self.product.display_name(),
+                self.product.token_envs().join(" or ")
+            ))),
+            status => {
+                let body = response.text().await.unwrap_or_default();
+                Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "{} returned HTTP {status} while writing secret: {body}",
+                    self.product.display_name()
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openbao_environment_names_separate_cli_and_secretspec_conventions() {
+        // These four names come from the OpenBao CLI itself.
+        assert_eq!(Product::OpenBao.address_envs(), &["BAO_ADDR", "VAULT_ADDR"]);
+        assert_eq!(
+            Product::OpenBao.namespace_envs(),
+            &["BAO_NAMESPACE", "VAULT_NAMESPACE"]
+        );
+        assert_eq!(Product::OpenBao.token_envs(), &["BAO_TOKEN", "VAULT_TOKEN"]);
+        assert_eq!(
+            Product::OpenBao.token_path_envs(),
+            &["BAO_TOKEN_PATH", "VAULT_TOKEN_PATH"]
+        );
+
+        // These are SecretSpec provider inputs. OpenBao-prefixed names own the
+        // new public contract; Vault-prefixed names preserve compatibility.
+        assert_eq!(
+            Product::OpenBao.role_id_envs(),
+            &["BAO_ROLE_ID", "VAULT_ROLE_ID"]
+        );
+        assert_eq!(
+            Product::OpenBao.secret_id_envs(),
+            &["BAO_SECRET_ID", "VAULT_SECRET_ID"]
+        );
+        assert_eq!(Product::OpenBao.jwt_envs(), &["BAO_JWT", "VAULT_JWT"]);
+        assert_eq!(
+            Product::OpenBao.jwt_role_envs(),
+            &["BAO_JWT_ROLE", "VAULT_JWT_ROLE"]
+        );
+        assert_eq!(
+            Product::OpenBao.jwt_audience_envs(),
+            &["BAO_JWT_AUDIENCE", "VAULT_JWT_AUDIENCE"]
+        );
+    }
+}

--- a/secretspec/src/provider/vault_common.rs
+++ b/secretspec/src/provider/vault_common.rs
@@ -204,6 +204,11 @@ impl KvConfig {
                 ))
             })?,
         };
+        // Both CLIs accept an address with a trailing slash. Request paths are
+        // appended below, so retain one separator instead of producing
+        // `//v1/...`, which OpenBao and Vault reject rather than normalize.
+        let endpoint = endpoint.trim_end_matches('/').to_string();
+
         // The provider path identifies only the engine mount. Per-secret KV
         // paths belong to convention coordinates or a secret's `ref`.
         let path = url.path();
@@ -478,9 +483,8 @@ impl KvProvider {
             "secret_id": secret_id,
         });
 
-        let response = reqwest::Client::new()
-            .post(&url)
-            .json(&body)
+        let response = self
+            .build_login_request(&url, &body)?
             .send()
             .await
             .map_err(|error| {
@@ -531,9 +535,8 @@ impl KvProvider {
             "role": role,
             "jwt": jwt.expose_secret(),
         });
-        let response = reqwest::Client::new()
-            .post(&url)
-            .json(&body)
+        let response = self
+            .build_login_request(&url, &body)?
             .send()
             .await
             .map_err(|error| {
@@ -623,18 +626,40 @@ impl KvProvider {
         Ok(SecretString::new(jwt.to_string().into()))
     }
 
+    /// Builds an authentication request in the provider's configured namespace.
+    ///
+    /// Auth methods are mounted inside a namespace just like secrets engines,
+    /// so their login exchanges need `X-Vault-Namespace` before a client token
+    /// exists. Both products retain that wire name for protocol compatibility.
+    fn build_login_request(
+        &self,
+        url: &str,
+        body: &serde_json::Value,
+    ) -> Result<reqwest::RequestBuilder> {
+        Ok(reqwest::Client::new()
+            .post(url)
+            .headers(self.build_namespace_headers()?)
+            .json(body))
+    }
+
     /// Builds headers shared by authenticated Vault-compatible API requests.
     ///
     /// OpenBao intentionally retains the `X-Vault-*` wire names for protocol
     /// compatibility; using them does not collapse its provider identity.
     fn build_headers(&self, token: &SecretString) -> Result<HeaderMap> {
-        let mut headers = HeaderMap::new();
+        let mut headers = self.build_namespace_headers()?;
         headers.insert(
             "X-Vault-Token",
             HeaderValue::from_str(token.expose_secret()).map_err(|error| {
                 SecretSpecError::ProviderOperationFailed(format!("Invalid token value: {error}"))
             })?,
         );
+        Ok(headers)
+    }
+
+    /// Builds the namespace header used by login and authenticated requests.
+    fn build_namespace_headers(&self) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
         if let Some(namespace) = &self.config.namespace {
             headers.insert(
                 "X-Vault-Namespace",
@@ -770,6 +795,12 @@ impl KvProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::EnvVarGuard;
+    use url::Url;
+
+    fn provider_url(spec: &str) -> ProviderUrl {
+        ProviderUrl::new(Url::parse(spec).unwrap())
+    }
 
     #[test]
     fn openbao_environment_names_separate_cli_and_secretspec_conventions() {
@@ -803,6 +834,62 @@ mod tests {
         assert_eq!(
             Product::OpenBao.jwt_audience_envs(),
             &["BAO_JWT_AUDIENCE", "VAULT_JWT_AUDIENCE"]
+        );
+    }
+
+    #[test]
+    fn environment_addresses_drop_trailing_slashes_before_request_paths_are_appended() {
+        let _lock = crate::tests::scrub_resolution_env();
+
+        {
+            let _bao_addr = EnvVarGuard::set("BAO_ADDR", "http://127.0.0.1:8200/");
+            let _vault_addr = EnvVarGuard::remove("VAULT_ADDR");
+            let config = KvConfig::parse(&provider_url("openbao://"), Product::OpenBao).unwrap();
+            let provider = KvProvider::new(config, Product::OpenBao);
+            assert_eq!(
+                provider.build_url("app/config"),
+                "http://127.0.0.1:8200/v1/secret/data/app/config"
+            );
+        }
+
+        {
+            let _vault_addr = EnvVarGuard::set("VAULT_ADDR", "http://127.0.0.1:8200///");
+            let config = KvConfig::parse(&provider_url("vault://"), Product::Vault).unwrap();
+            let provider = KvProvider::new(config, Product::Vault);
+            assert_eq!(
+                provider.build_url("app/config"),
+                "http://127.0.0.1:8200/v1/secret/data/app/config"
+            );
+        }
+    }
+
+    #[test]
+    fn login_requests_include_the_configured_namespace() {
+        let provider = KvProvider::new(
+            KvConfig {
+                endpoint: "https://bao.example.com:8200".to_string(),
+                namespace: Some("team-a".to_string()),
+                ..Default::default()
+            },
+            Product::OpenBao,
+        );
+        let request = provider
+            .build_login_request(
+                "https://bao.example.com:8200/v1/auth/approle/login",
+                &serde_json::json!({ "role_id": "role", "secret_id": "secret" }),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request
+                .headers()
+                .get("X-Vault-Namespace")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "team-a"
         );
     }
 }


### PR DESCRIPTION
## Summary

Add first-class OpenBao support with its own `openbao` provider identity, URI scheme, Cargo feature, configuration conventions, documentation, and integration-test registration.

The Vault and OpenBao providers remain separate publicly while sharing their compatible KV and authentication implementation internally.

Closes #186.

## What changed

- Register `openbao://` as an independent provider rather than an alias of Vault.
- Add a standalone `openbao` Cargo feature and include it in the default feature set.
- Preserve support for KV v1 and KV v2, namespaces, token authentication, AppRole, and JWT/OIDC.
- Use OpenBao configuration variables:
  - `BAO_ADDR`
  - `BAO_NAMESPACE`
  - `BAO_TOKEN`
  - `BAO_TOKEN_PATH`
- Add OpenBao-prefixed SecretSpec inputs for AppRole and JWT authentication, with corresponding `VAULT_*` variables retained as compatibility fallbacks.
- Add OpenBao to the generic provider integration suite and standalone feature checks.
- Add a dedicated OpenBao provider guide and update every provider listing, example, and reference location with the upcoming `0.17+` compatibility boundary.
- Refocus the existing Vault documentation on HashiCorp Vault while documenting the practical OpenBao fallback available in SecretSpec 0.16.

## Resolved findings

While extracting the shared Vault-compatible client, this PR also fixes two pre-existing issues:

- Addresses ending in `/` could produce invalid `//v1/...` API paths. Trailing separators are now normalized before request paths are appended.
- AppRole and JWT login requests did not include `X-Vault-Namespace`, causing namespaced authentication to fail. Login and authenticated data requests now share the namespace-header construction.

Both fixes apply to Vault and OpenBao and include regression tests.

## Compatibility

This does not introduce new authentication protocols or change the compatible wire API. OpenBao intentionally retains the `X-Vault-*` protocol headers.

Default builds include both providers. Builds selecting provider features explicitly must enable `openbao` to use `openbao://` starting with SecretSpec 0.17.

## Validation

- OpenBao 2.6.0 integration testing:
  - Generic provider workflow against KV v1 and KV v2
  - Token-authenticated CLI set/get with a trailing-slash `BAO_ADDR`
  - Namespaced AppRole set/get round trip