### PR TITLE
Support systemd-credentials provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   direct X25519 and SSH key support, native tagged recipients, and
   non-interactive age plugins. Hybrid ML-KEM-768 + X25519 keys are recommended
   for new setups to protect stored ciphertext against future quantum attacks.
+- Read-only systemd credential provider (`systemd-credential://`) for resolving
+  secrets and provider authentication credentials from the current service's
+  `$CREDENTIALS_DIRECTORY`, including exact-name references and strict
+  filename, file-type, and text validation.
 - The `required` field accepts `at_least_one` and `exactly_one` group tables,
   supporting overlapping alternative and mutually exclusive credentials
   across `check`, `run`, and SDK resolution.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -119,7 +119,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), dotenv files, environment variables, 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), or age (0.17+).`,
+Secrets can be stored in: keyring (default), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), or age (0.17+).`,
         }),
       ],
       title: "SecretSpec",
@@ -196,6 +196,11 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
             { label: "Keyring", slug: "providers/keyring" },
             { label: "Dotenv", slug: "providers/dotenv" },
             { label: "Environment Variables", slug: "providers/env" },
+            {
+              label: "systemd Credentials",
+              slug: "providers/systemd-credential",
+              badge: { text: "0.17+", variant: "note" },
+            },
             { label: "Pass", slug: "providers/pass" },
             { label: "Proton Pass", slug: "providers/protonpass" },
             { label: "LastPass", slug: "providers/lastpass" },

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -42,6 +42,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [keyring](/providers/keyring/) | [macOS Keychain](https://support.apple.com/guide/security/keychain-data-protection-secb0694df1a/web), [Windows Credential Manager](https://learn.microsoft.com/windows/win32/secauthn/credentials-management), or [Linux Secret Service](https://gnome.pages.gitlab.gnome.org/libsecret/) | ✓ | ✓ | ✓ | — |
 | [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ | — |
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ | — |
+| [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |
 | [pass](/providers/pass/) | Unix `pass` password store | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [gopass](/providers/gopass/) (0.15+) | `gopass` password store (git-synced, GPG-encrypted) | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [protonpass](/providers/protonpass/) | Proton Pass | ✓ | ✓ | ✓ | — |
@@ -59,7 +60,10 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 “TPM-backed keys” means the local key used by the provider can be protected by
 a [TPM 2.0](https://trustedcomputinggroup.org/resource/tpm-library-specification/)
 through the provider path SecretSpec uses. Pass and Gopass inherit this
-capability from GnuPG when its encryption key is moved to the TPM.
+capability from GnuPG when its encryption key is moved to the TPM. systemd
+credentials inherit it from
+[systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html),
+which seals encrypted credentials to the TPM2 by default when the host has one.
 [libsecret has an optional TPM2-enabled file backend](https://gnome.pages.gitlab.gnome.org/libsecret/libsecret-tpm2.html),
 but SecretSpec's Linux keyring transport uses the Secret Service D-Bus API
 rather than that file backend. macOS Keychain uses Apple's Secure Enclave
@@ -68,7 +72,6 @@ rather than a TPM, and
 An em dash means SecretSpec has no documented TPM integration for that
 provider; it does not describe other hardware security used internally by the
 provider service.
-
 Each provider page starts with a minimal working example, then covers setup,
 project configuration, storage conventions, existing provider-native secrets,
 and CI/CD where applicable.

--- a/docs/src/content/docs/providers/systemd-credential.md
+++ b/docs/src/content/docs/providers/systemd-credential.md
@@ -1,0 +1,128 @@
+---
+title: systemd Credential Provider
+description: Read secrets passed to a service through systemd credentials
+---
+
+:::caution[Version compatibility]
+The `systemd-credential` provider is added in SecretSpec 0.17.
+:::
+
+The systemd credential provider reads credentials that the service manager
+passed to the current process. It is a read-only delivery provider: systemd
+selects and optionally decrypts each credential before SecretSpec starts, and
+SecretSpec reads the resulting file from `$CREDENTIALS_DIRECTORY`.
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `systemd-credential` (0.17+) |
+| URI | `systemd-credential://` |
+| Access | Read-only |
+| Best for | Services that receive application or provider credentials from systemd |
+| Authentication | Filesystem access granted by systemd to the service user |
+| Storage | Immutable runtime files managed by systemd |
+
+## Quick start
+
+Declare a secret that reads from the credential with the same name:
+
+```toml title="secretspec.toml"
+[profiles.production]
+DATABASE_PASSWORD = { description = "Production database password", providers = ["systemd-credential"] }
+```
+
+Pass that credential to the service:
+
+```ini title="/etc/systemd/system/myapp.service"
+[Service]
+LoadCredential=DATABASE_PASSWORD:/etc/myapp/database-password
+Environment=SECRETSPEC_PROFILE=production
+ExecStart=/usr/bin/secretspec --file /etc/myapp/secretspec.toml run -- /usr/bin/myapp
+```
+
+systemd copies the value into the service's private credential directory.
+SecretSpec reads it there and resolves `DATABASE_PASSWORD` normally.
+
+For confidential data stored in a unit or credential store, prefer
+`LoadCredentialEncrypted=` or `SetCredentialEncrypted=`. systemd decrypts the
+credential before SecretSpec reads it, so the provider behaves the same way for
+encrypted and plaintext sources.
+
+## Setup
+
+The process must be started by systemd with at least one service credential.
+systemd sets `$CREDENTIALS_DIRECTORY` to an absolute directory containing one
+immutable file per credential. Running the provider outside that execution
+context returns an error explaining that the variable is missing.
+
+The provider has no build feature and takes no URI configuration:
+
+```toml
+[providers]
+service = "systemd-credential://"
+```
+
+An authority, path, or query on the URI is rejected. Select a differently named
+credential with a secret reference instead.
+
+## Use an existing credential name
+
+Convention addresses use the SecretSpec key as the systemd credential name and
+do not include the project or profile. If the names differ, set `ref.item`:
+
+```toml
+[profiles.production]
+DATABASE_PASSWORD = { description = "Production database password", providers = ["systemd-credential"], ref = { item = "myapp.database-password" } }
+```
+
+```ini
+[Service]
+LoadCredential=myapp.database-password:/etc/myapp/database-password
+```
+
+Only the `item` coordinate is supported. Credential names must be a single
+filename; nested paths and traversal components are rejected.
+
+## Supply another provider's credential
+
+Because `systemd-credential` is a regular read-only SecretSpec provider, an
+alias can use it as a provider-credential source:
+
+```toml
+[providers]
+bootstrap = "systemd-credential://"
+remote = {
+  uri = "onepassword://Production",
+  credentials = { service_account_token = "bootstrap" }
+}
+```
+
+The service unit must pass a credential named `service_account_token`.
+SecretSpec reads it into memory and hands it directly to the target provider.
+
+:::caution[Service isolation]
+Every process in the same service runs under the same credential access
+boundary. If `secretspec run` starts the application in that service, the
+application can also access the service's credential directory. Put a
+high-value bootstrap credential in a separate SecretSpec broker or provisioning
+service when the application itself must not be able to read it.
+:::
+
+## Storage and security model
+
+This provider does not persist, encrypt, or decrypt values. Those properties
+come from the systemd unit:
+
+- `LoadCredential=` loads a file or socket source.
+- `LoadCredentialEncrypted=` loads a systemd-encrypted credential.
+- `SetCredentialEncrypted=` embeds encrypted credential data in the unit.
+- `$CREDENTIALS_DIRECTORY` contains the plaintext runtime value while the
+  service is active.
+
+SecretSpec refuses symlinks, directories, non-UTF-8 values, and credential
+names that could escape the credential directory. SecretSpec's provider API is
+text-based; binary systemd credentials are therefore not supported.
+
+Changing a source credential does not modify an already-running service's
+immutable runtime credential. Restart the service to load the new value.

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -103,6 +103,7 @@ $ secretspec config init
   onepassword: OnePassword password manager
   dotenv: Traditional .env files
   env: Read-only environment variables
+  systemd-credential: Read-only systemd service credentials (0.17+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
   protonpass: Proton Pass via official pass-cli

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -415,6 +415,7 @@ chain, and each provider is asked for the same coordinates.
 | [keyring](/providers/keyring/#use-existing-secrets) | Service | Account (defaults to the current system username) | Current user's entry | ✅ |
 | [dotenv](/providers/dotenv/#use-existing-secrets) | `.env` key | Rejected | Reads the key | ✅ |
 | [env](/providers/env/#use-existing-secrets) | Variable name | Rejected | Reads the variable | — (read-only) |
+| [systemd credentials (0.17+)](/providers/systemd-credential/#use-an-existing-credential-name) | Credential filename | Rejected | Reads the credential | — (read-only) |
 | [pass](/providers/pass/#use-existing-secrets) | Entry path | Rejected | Reads the entry | ✅ |
 | [Gopass (0.15+)](/providers/gopass/#use-existing-secrets) | Entry path, including any mount-point prefix | Rejected | Reads the entry | ✅ |
 | [LastPass](/providers/lastpass/#use-existing-secrets) | Item name | Rejected | Reads the item | ✅ |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -31,6 +31,27 @@ env://                       # Current process environment
 
 **Features**: Read-only, no setup required, no persistence
 
+## systemd Credential Provider (0.17+)
+
+:::caution[Version compatibility]
+The `systemd-credential` provider is added in SecretSpec 0.17.
+:::
+
+**URI**: `systemd-credential://` - Reads credentials passed to the current
+service by systemd
+
+```bash
+systemd-credential://          # $CREDENTIALS_DIRECTORY
+```
+
+**Features**: Read-only, flat credential names, immutable service-lifetime
+values, provider-credential source support
+**Prerequisites**: A process started by systemd with `LoadCredential=`,
+`LoadCredentialEncrypted=`, `SetCredential=`, or `SetCredentialEncrypted=`
+**Storage**: One runtime file per credential under `$CREDENTIALS_DIRECTORY`;
+convention addresses use the SecretSpec key as the filename, and `ref.item`
+selects a different credential name
+
 ## GoPass Provider
 
 Available starting with SecretSpec 0.15.
@@ -298,6 +319,7 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 |----------|------------|------------------|----------------|
 | DotEnv | ❌ Plain text | Local filesystem | ❌ No |
 | Environment | ❌ Plain text | Process memory | ❌ No |
+| systemd Credential (0.17+) | Depends on unit source | systemd-managed runtime memory | ❌ No |
 | Keyring | ✅ System encryption | System keychain | ❌ No |
 | Pass | ✅ GPG encryption | Local filesystem | ❌ No |
 | GoPass | ✅ GPG encryption | Local filesystem | ❌ No |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -51,6 +51,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },
   { slug: 'env', label: 'Environment variables' },
+  { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials (0.17+)' },
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
   { slug: 'keyring', label: 'Credential Manager' },
 ];
@@ -145,6 +146,7 @@ $ secretspec config init
   infisical: Infisical secret management
   openbao: OpenBao secret management (0.17+)
   age: age-encrypted file (0.17+)
+  systemd-credential: Read-only systemd service credentials (0.17+)
 <span class="tok-str">✓</span> Saved to ~/.config/secretspec/config.toml
 
 <span class="tok-com"># 3. Run your app with secrets injected</span>
@@ -213,7 +215,8 @@ $ secretspec run --profile production -- npm start
 > keyring: Uses system keychain (Recommended)
   infisical: Infisical secret management
   openbao: OpenBao secret management (0.17+)
-  age: age-encrypted file (0.17+)</code></pre>
+  age: age-encrypted file (0.17+)
+  systemd-credential: Read-only systemd service credentials (0.17+)</code></pre>
       </div>
 
       <div class="landing-step">
@@ -330,6 +333,7 @@ println<span class="tok-pun">!(</span><span class="tok-str">"{}"</span><span cla
           <button type="button" class="landing-provider-tab" data-provider="akv">Azure</button>
           <button type="button" class="landing-provider-tab" data-provider="dotenv">.env</button>
           <button type="button" class="landing-provider-tab" data-provider="env">env</button>
+          <button type="button" class="landing-provider-tab" data-provider="systemdCredential">systemd (0.17+)</button>
         </div>
 
         <div class="landing-terminal">
@@ -930,6 +934,7 @@ REDIS_URL=redis://…</code></pre>
       akv:         'Azure Key Vault',
       dotenv:      '.env file',
       env:         'Environment variables',
+      systemdCredential: 'systemd credentials (0.17+)',
     };
 
     tabs.forEach(function (tab) {

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -25,6 +25,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [Gopass](https://secretspec.dev/providers/gopass) (0.15+)
   - [Proton Pass](https://secretspec.dev/providers/protonpass)
   - [environment variables](https://secretspec.dev/providers/env)
+  - [systemd credentials](https://secretspec.dev/providers/systemd-credential) (0.17+)
   - [Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
   - [Vault](https://secretspec.dev/providers/vault)
@@ -60,6 +61,7 @@ $ secretspec config init
   onepassword: OnePassword password manager
   dotenv: Traditional .env files
   env: Read-only environment variables
+  systemd-credential: Read-only systemd service credentials (0.17+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
   protonpass: Proton Pass via official pass-cli
@@ -146,6 +148,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Keyring](https://secretspec.dev/providers/keyring)** - System credential store (recommended)
 - **[.env files](https://secretspec.dev/providers/dotenv)** - Traditional dotenv files
 - **[Environment variables](https://secretspec.dev/providers/env)** - Read-only for CI/CD
+- **[systemd credentials](https://secretspec.dev/providers/systemd-credential)** (0.17+) - Read-only credentials passed to the current service
 - **[Pass](https://secretspec.dev/providers/pass)** - Unix password manager with GPG encryption
 - **[Gopass](https://secretspec.dev/providers/gopass)** (0.15+) - GPG-based password manager with git-synced password store
 - **[Proton Pass](https://secretspec.dev/providers/protonpass)** - End-to-end encrypted via Proton's official pass-cli

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -20,6 +20,7 @@
 //! - [`env::EnvProvider`]: Environment variables (read-only)
 //! - [`pass::PassProvider`]: Pass integration
 //! - [`gopass::GoPassProvider`]: Gopass integration
+//! - [`systemd_credential::SystemdCredentialProvider`]: systemd service credentials (0.17+)
 //! - [`protonpass::ProtonPassProvider`]: Proton Pass integration
 //! - [`onepassword::OnePasswordProvider`]: 1Password integration
 //! - [`lastpass::LastPassProvider`]: LastPass integration
@@ -224,6 +225,12 @@ impl ProviderUrl {
             .filter(|v| !v.is_empty())
     }
 
+    /// Whether the provider URI contains a query component, including an
+    /// explicitly empty one.
+    pub(crate) fn has_query(&self) -> bool {
+        self.0.query().is_some()
+    }
+
     /// Percent-encode a value for use in a URI path or host component (e.g., in
     /// `uri()` methods).
     pub fn encode(value: &str) -> String {
@@ -279,6 +286,7 @@ pub mod onepassword;
 pub mod openbao;
 pub mod pass;
 pub mod protonpass;
+pub mod systemd_credential;
 #[cfg(feature = "vault")]
 pub mod vault;
 #[cfg(any(feature = "openbao", feature = "vault"))]

--- a/secretspec/src/provider/systemd_credential.rs
+++ b/secretspec/src/provider/systemd_credential.rs
@@ -1,0 +1,369 @@
+use super::{Address, Provider, ProviderUrl};
+use crate::{Result, SecretSpecError};
+use secrecy::SecretString;
+use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+const CREDENTIALS_DIRECTORY_ENV: &str = "CREDENTIALS_DIRECTORY";
+
+/// Configuration for the read-only systemd service-credential provider.
+///
+/// The provider takes no URI options. systemd supplies the credential
+/// directory through `$CREDENTIALS_DIRECTORY` when it starts the process.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SystemdCredentialConfig {}
+
+impl TryFrom<&ProviderUrl> for SystemdCredentialConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "systemd-credential" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for systemd-credential provider",
+                url.scheme()
+            )));
+        }
+
+        let host = url.host().filter(|host| !host.is_empty());
+        let path = url.path();
+        let path_item = path.trim_matches('/');
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || host.is_some()
+            || !path_item.is_empty()
+            || url.has_query()
+        {
+            let item = host
+                .as_deref()
+                .or((!path_item.is_empty()).then_some(path_item));
+            let hint = item
+                .map(|item| crate::config::ref_table_hint(None, item, None, None))
+                .unwrap_or_else(|| "ref = { item = \"CREDENTIAL_NAME\" }".to_string());
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "systemd-credential:// takes no authority, path, or query: to read one \
+                 specific credential, use {hint} on the secret instead"
+            )));
+        }
+
+        Ok(Self {})
+    }
+}
+
+/// Reads credentials systemd passed to the current service.
+///
+/// systemd exposes each credential as an immutable file beneath the absolute
+/// directory named by `$CREDENTIALS_DIRECTORY`. Convention addresses map
+/// directly to the secret key, while a native address reads the credential
+/// named by its `item` coordinate. The provider is read-only because the
+/// directory is owned and populated by the service manager.
+pub struct SystemdCredentialProvider {
+    credentials_directory: Option<PathBuf>,
+}
+
+crate::register_provider! {
+    struct: SystemdCredentialProvider,
+    config: SystemdCredentialConfig,
+    name: "systemd-credential",
+    description: "Read-only systemd service credentials (0.17+)",
+    schemes: ["systemd-credential"],
+    examples: ["systemd-credential://"],
+}
+
+impl SystemdCredentialProvider {
+    pub fn new(_config: SystemdCredentialConfig) -> Self {
+        Self {
+            credentials_directory: std::env::var_os(CREDENTIALS_DIRECTORY_ENV).map(PathBuf::from),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_directory(credentials_directory: Option<PathBuf>) -> Self {
+        Self {
+            credentials_directory,
+        }
+    }
+
+    fn directory(&self) -> Result<&Path> {
+        let directory = self.credentials_directory.as_deref().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "{CREDENTIALS_DIRECTORY_ENV} is not set; the systemd-credential provider \
+                 only works inside a service that systemd started with credentials"
+            ))
+        })?;
+
+        if !directory.is_absolute() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{CREDENTIALS_DIRECTORY_ENV} must contain an absolute path, got '{}'",
+                directory.display()
+            )));
+        }
+
+        Ok(directory)
+    }
+
+    fn credential_path(&self, name: &str) -> Result<PathBuf> {
+        let mut components = Path::new(name).components();
+        let is_one_normal_component = matches!(
+            (components.next(), components.next()),
+            (Some(Component::Normal(component)), None) if component == OsStr::new(name)
+        );
+        if name.is_empty()
+            || name.len() > 255
+            || name.contains(['/', '\\', '\0'])
+            || !is_one_normal_component
+        {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "invalid systemd credential name '{name}': expected one filename of at most 255 bytes"
+            )));
+        }
+
+        Ok(self.directory()?.join(name))
+    }
+}
+
+impl Provider for SystemdCredentialProvider {
+    /// systemd credentials form one flat namespace for the service, so project
+    /// and profile do not participate in the filename.
+    fn convention_address(
+        &self,
+        _project: &str,
+        _profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: key.to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let name = super::flat_item(self, addr)?;
+        let path = self.credential_path(&name)?;
+
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "failed to inspect systemd credential '{}': {error}",
+                    path.display()
+                )));
+            }
+        };
+
+        if !metadata.file_type().is_file() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "systemd credential '{}' is not a regular file",
+                path.display()
+            )));
+        }
+
+        let value = fs::read_to_string(&path).map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "failed to read systemd credential '{}': {error}",
+                path.display()
+            ))
+        })?;
+        Ok(Some(SecretString::new(value.into())))
+    }
+
+    fn set(&self, addr: Address<'_>, _value: &SecretString) -> Result<()> {
+        self.check_writable(addr)
+    }
+
+    fn check_writable(&self, _addr: Address<'_>) -> Result<()> {
+        Err(SecretSpecError::ProviderOperationFailed(
+            "systemd-credential provider is read-only; configure credentials with \
+             LoadCredential=, LoadCredentialEncrypted=, SetCredential=, or \
+             SetCredentialEncrypted= in the service unit"
+                .to_string(),
+        ))
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        "systemd-credential".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+    use tempfile::TempDir;
+    use url::Url;
+
+    fn provider(directory: &Path) -> SystemdCredentialProvider {
+        SystemdCredentialProvider::with_directory(Some(directory.to_path_buf()))
+    }
+
+    #[test]
+    fn convention_address_reads_exact_value_without_trimming() {
+        let directory = TempDir::new().unwrap();
+        fs::write(directory.path().join("API_TOKEN"), "line one\nline two\n").unwrap();
+
+        let value = provider(directory.path())
+            .get(Address::convention("project", "production", "API_TOKEN"))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(value.expose_secret(), "line one\nline two\n");
+    }
+
+    #[test]
+    fn native_address_reads_the_item_name() {
+        let directory = TempDir::new().unwrap();
+        fs::write(directory.path().join("op-token"), "ops_example").unwrap();
+        let address = crate::config::NativeAddress {
+            item: "op-token".to_string(),
+            ..Default::default()
+        };
+
+        let value = provider(directory.path())
+            .get(Address::Native(&address))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(value.expose_secret(), "ops_example");
+    }
+
+    #[test]
+    fn missing_credential_is_absent() {
+        let directory = TempDir::new().unwrap();
+        assert!(
+            provider(directory.path())
+                .get(Address::convention("project", "default", "MISSING"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn missing_directory_environment_is_actionable() {
+        let error = SystemdCredentialProvider::with_directory(None)
+            .get(Address::convention("project", "default", "TOKEN"))
+            .unwrap_err();
+        assert!(
+            error.to_string().contains(CREDENTIALS_DIRECTORY_ENV),
+            "{error}"
+        );
+        assert!(error.to_string().contains("systemd"), "{error}");
+    }
+
+    #[test]
+    fn relative_directory_is_rejected() {
+        let error =
+            SystemdCredentialProvider::with_directory(Some(PathBuf::from("relative/credentials")))
+                .get(Address::convention("project", "default", "TOKEN"))
+                .unwrap_err();
+        assert!(error.to_string().contains("absolute path"), "{error}");
+    }
+
+    #[test]
+    fn traversal_and_nested_paths_are_rejected() {
+        let directory = TempDir::new().unwrap();
+        for name in [
+            "../secret",
+            "nested/secret",
+            r"nested\secret",
+            ".",
+            "..",
+            "",
+        ] {
+            let address = crate::config::NativeAddress {
+                item: name.to_string(),
+                ..Default::default()
+            };
+            let error = provider(directory.path())
+                .get(Address::Native(&address))
+                .unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("invalid systemd credential name"),
+                "{name:?}: {error}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let directory = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let target = outside.path().join("target");
+        fs::write(&target, "must not be read").unwrap();
+        symlink(&target, directory.path().join("TOKEN")).unwrap();
+
+        let error = provider(directory.path())
+            .get(Address::convention("project", "default", "TOKEN"))
+            .unwrap_err();
+        assert!(error.to_string().contains("not a regular file"), "{error}");
+    }
+
+    #[test]
+    fn binary_credential_is_rejected_by_text_provider_api() {
+        let directory = TempDir::new().unwrap();
+        fs::write(directory.path().join("TOKEN"), [0xff, 0xfe]).unwrap();
+
+        let error = provider(directory.path())
+            .get(Address::convention("project", "default", "TOKEN"))
+            .unwrap_err();
+        assert!(error.to_string().contains("failed to read"), "{error}");
+        assert!(error.to_string().contains("UTF-8"), "{error}");
+    }
+
+    #[test]
+    fn unsupported_native_coordinate_is_rejected() {
+        let directory = TempDir::new().unwrap();
+        let address = crate::config::NativeAddress {
+            item: "TOKEN".to_string(),
+            field: Some("password".to_string()),
+            ..Default::default()
+        };
+
+        let error = provider(directory.path())
+            .get(Address::Native(&address))
+            .unwrap_err();
+        assert!(error.to_string().contains("`field`"), "{error}");
+    }
+
+    #[test]
+    fn provider_is_read_only() {
+        let directory = TempDir::new().unwrap();
+        let provider = provider(directory.path());
+        let address = Address::convention("project", "default", "TOKEN");
+        let check_error = provider.check_writable(address).unwrap_err().to_string();
+        let set_error = provider
+            .set(address, &SecretString::new("value".into()))
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(check_error, set_error);
+        assert!(check_error.contains("read-only"), "{check_error}");
+    }
+
+    #[test]
+    fn uri_must_not_select_a_credential() {
+        for uri in [
+            "systemd-credential://TOKEN",
+            "systemd-credential:///TOKEN",
+            "systemd-credential://?name=TOKEN",
+        ] {
+            let error =
+                SystemdCredentialConfig::try_from(&ProviderUrl::new(Url::parse(uri).unwrap()))
+                    .unwrap_err();
+            assert!(
+                error.to_string().contains("takes no authority"),
+                "{uri}: {error}"
+            );
+        }
+    }
+}

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -151,6 +151,7 @@ crate::register_provider! {
     description: "In-memory provider for tests",
     schemes: ["memtest"],
     examples: ["memtest://"],
+    credential_names: ["test_token"],
 }
 
 impl Provider for MemTestProvider {
@@ -297,6 +298,9 @@ fn test_create_from_string_with_plain_names() {
     // Test plain provider names
     let provider = Box::<dyn Provider>::try_from("env").unwrap();
     assert_eq!(provider.name(), "env");
+
+    let provider = Box::<dyn Provider>::try_from("systemd-credential").unwrap();
+    assert_eq!(provider.name(), "systemd-credential");
 
     let provider = Box::<dyn Provider>::try_from("keyring").unwrap();
     assert_eq!(provider.name(), "keyring");

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6658,6 +6658,37 @@ fn sourced_credential_reaches_target_provider_end_to_end() {
 }
 
 #[test]
+fn provider_credentials_read_from_systemd_credential_source() {
+    let _guard = scrub_resolution_env();
+    let directory = TempDir::new().unwrap();
+    std::fs::write(
+        directory.path().join("test_token"),
+        "systemd-delivered-token",
+    )
+    .unwrap();
+    let _credentials_directory =
+        EnvVarGuard::set("CREDENTIALS_DIRECTORY", directory.path().to_str().unwrap());
+
+    let secrets = secrets_with_credential_alias(
+        "memtest://",
+        HashMap::from([(
+            "test_token".to_string(),
+            CredentialSource::from("systemd-credential"),
+        )]),
+    );
+
+    let credentials = secrets
+        .resolve_provider_credentials("target", "default")
+        .expect("the systemd credential source should resolve");
+    assert_eq!(
+        credentials
+            .get("test_token")
+            .map(|value| value.expose_secret().to_string()),
+        Some("systemd-delivered-token".to_string()),
+    );
+}
+
+#[test]
 fn provider_credentials_read_ref_addressed_credential() {
     let _guard = scrub_resolution_env();
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- add a read-only `systemd-credential://` provider that reads credentials from systemd's `$CREDENTIALS_DIRECTORY`
- support convention-based credential names and explicit `ref.item` mappings
- reject unsafe names, symlinks, non-regular files, binary values, and URI-scoped credential names
- allow systemd credentials to bootstrap another provider's authentication
- document the provider and mark it as available starting with SecretSpec 0.17

## Why

systemd credentials provide a standard way to deliver secrets to services,
including credentials encrypted with machine- or TPM-backed keys. SecretSpec
should be able to consume those service-scoped runtime credentials directly
without first copying them into another provider.

Closes #41

## Testing

- `devenv shell cargo test --all`
- `devenv shell cargo clippy --package secretspec --lib --all-features -- -D warnings`
- `devenv shell cargo fmt --all -- --check`
- `npm run build` in `docs/`
- `git diff --check`

The provider-credential pipeline test uses a test-only in-memory target provider
and a temporary credential directory, so it requires no external password
manager, network access, or authentication.
