### PR TITLE
Add KeePass KDBX provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   secrets and provider authentication credentials from the current service's
   `$CREDENTIALS_DIRECTORY`, including exact-name references and strict
   filename, file-type, and text validation.
+- KeePass KDBX provider (`kdbx:`, `kdbx` build feature) for local encrypted
+  databases. It reads KDBX 3 and KDBX 4, writes KDBX 4 with atomic file
+  replacement, supports master passwords and key files, and can address
+  standard or custom entry fields through secret references.
 - The `required` field accepts `at_least_one` and `exactly_one` group tables,
   supporting overlapping alternative and mutually exclusive credentials
   across `check`, `run`, and SDK resolution.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -76,7 +76,7 @@ dependencies = [
  "base64",
  "bcrypt-pbkdf",
  "bech32",
- "cbc",
+ "cbc 0.1.2",
  "chacha20poly1305",
  "cipher 0.4.4",
  "cookie-factory",
@@ -221,6 +221,18 @@ dependencies = [
  "password-hash",
  "zeroize",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-compression"
@@ -911,7 +923,7 @@ dependencies = [
  "argon2",
  "bitwarden-encoding",
  "bitwarden-error",
- "cbc",
+ "cbc 0.1.2",
  "chacha20poly1305",
  "ciborium",
  "coset",
@@ -1072,6 +1084,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,12 +1114,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-modes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2211b0817f061502a8dd9f11a37e879e79763e3c698d2418cf824d8cb2f21e"
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array 0.4.8",
 ]
 
 [[package]]
@@ -1196,6 +1234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
@@ -1323,11 +1371,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.2.1",
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -1666,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array 0.4.8",
 ]
@@ -1961,7 +2010,7 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
  "zeroize",
 ]
@@ -2790,6 +2839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,7 +3337,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -3292,6 +3347,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding 0.4.2",
  "hybrid-array 0.4.8",
 ]
 
@@ -3519,6 +3575,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keepass"
+version = "0.13.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2765eb6c9966956f5b421f44657140856accd7a769151dd47811d81ff2d8e8df"
+dependencies = [
+ "aes 0.9.1",
+ "base64",
+ "block-modes",
+ "byteorder",
+ "cbc 0.2.1",
+ "chacha20 0.10.0",
+ "chrono",
+ "cipher 0.5.2",
+ "flate2",
+ "getrandom 0.4.2",
+ "hex",
+ "hex-literal",
+ "hmac 0.13.0",
+ "hybrid-array 0.4.8",
+ "indexmap 2.13.0",
+ "js-sys",
+ "quick-xml",
+ "rust-argon2",
+ "salsa20 0.11.0",
+ "secrecy",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "twofish",
+ "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -4431,6 +4521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4798,6 +4898,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-argon2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae76b7506744d254fd0eb2c0ff5c5d108201ccbb083111ac04a44eeda105680"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4987,6 +5099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5062,7 +5184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2 0.12.2",
- "salsa20",
+ "salsa20 0.10.2",
  "sha2 0.10.9",
 ]
 
@@ -5119,6 +5241,7 @@ dependencies = [
  "google-cloud-secretmanager-v1",
  "inquire",
  "jiff",
+ "keepass",
  "keyring",
  "linkme",
  "miette",
@@ -6122,6 +6245,15 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn",
+]
+
+[[package]]
+name = "twofish"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0218ef702a91e18ba84dd516edf8df33a9f9fb4431d6ada13e6f9502c3bcb6fc"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ keyring = { version = "3.6.2", features = [
   "windows-native",
   "apple-native",
 ] }
+keepass = { version = "0.13.17", features = ["save_kdbx4"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9"
 toml_edit = "0.23"

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -119,7 +119,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), or age (0.17+).`,
+Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), or age (0.17+).`,
         }),
       ],
       title: "SecretSpec",
@@ -194,6 +194,11 @@ Secrets can be stored in: keyring (default), dotenv files, environment variables
           label: "Providers",
           items: [
             { label: "Keyring", slug: "providers/keyring" },
+            {
+              label: "KeePass KDBX",
+              slug: "providers/kdbx",
+              badge: { text: "0.17+", variant: "note" },
+            },
             { label: "Dotenv", slug: "providers/dotenv" },
             { label: "Environment Variables", slug: "providers/env" },
             {

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -40,6 +40,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | Provider | Storage backend | Read | Write | Encrypted at rest | TPM-backed keys |
 |----------|-----------------|------|-------|-------------------|-----------------|
 | [keyring](/providers/keyring/) | [macOS Keychain](https://support.apple.com/guide/security/keychain-data-protection-secb0694df1a/web), [Windows Credential Manager](https://learn.microsoft.com/windows/win32/secauthn/credentials-management), or [Linux Secret Service](https://gnome.pages.gitlab.gnome.org/libsecret/) | ✓ | ✓ | ✓ | — |
+| [kdbx](/providers/kdbx/) (0.17+) | KeePass KDBX file (requires the `kdbx` build feature) | ✓ | KDBX 4 | ✓ | — |
 | [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ | — |
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ | — |
 | [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |

--- a/docs/src/content/docs/providers/kdbx.md
+++ b/docs/src/content/docs/providers/kdbx.md
@@ -1,0 +1,178 @@
+---
+title: KeePass KDBX Provider
+description: Store SecretSpec values in an encrypted KeePass database
+---
+
+The KDBX provider reads and writes encrypted [KeePass](https://keepass.info/)
+databases directly, without requiring KeePass or KeePassXC to be installed.
+
+:::caution[Version compatibility]
+The KDBX provider is an upcoming SecretSpec 0.17 feature.
+:::
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `kdbx` |
+| URI | `kdbx:PATH[?keyfile=PATH][&prefix=TEMPLATE]` |
+| Access | KDBX 3 read; KDBX 4 read and write |
+| Best for | Local, portable KeePass-compatible encrypted storage |
+| Authentication | Master password, key file, or both |
+| Build feature | `kdbx` (0.17+) |
+| Default storage | Entry `secretspec/{project}/{profile}/{key}`, field `Password` |
+
+## Quick start
+
+```toml title="secretspec.toml"
+[providers]
+kdbx = {
+  uri = "kdbx:./secrets.kdbx",
+  credentials = { password = "keyring" }
+}
+```
+
+```bash
+# Store the database master password in the bootstrap provider.
+$ secretspec config provider login kdbx
+Enter password for provider 'kdbx' (source: keyring): ****
+
+# Set a secret in an existing KDBX 4 database, or create a new KDBX 4 database.
+$ secretspec set DATABASE_URL --provider kdbx
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret DATABASE_URL saved to kdbx
+
+$ secretspec get DATABASE_URL --provider kdbx
+postgresql://localhost/mydb
+
+$ secretspec run --provider kdbx -- npm start
+```
+
+## Setup
+
+The provider is built into standard SecretSpec 0.17 binaries. Custom builds
+must enable the `kdbx` feature.
+
+### Authentication
+
+Load the semantic `password`
+[provider credential](/concepts/providers/#provider-credentials) from a
+bootstrap provider such as the system keyring. This keeps the KDBX master
+password out of shell profiles and child-process environments:
+
+```toml title="secretspec.toml"
+[providers]
+kdbx = {
+  uri = "kdbx:./secrets.kdbx",
+  credentials = { password = "keyring" }
+}
+```
+
+Store the declared credential once:
+
+```bash
+$ secretspec config provider login kdbx
+Enter password for provider 'kdbx' (source: keyring): ****
+```
+
+`SECRETSPEC_KDBX_PASSWORD` is available as a fallback for environments without
+a suitable bootstrap provider. Avoid it for normal interactive use, and do not
+persist the master password in a shell profile.
+
+Use `?keyfile=PATH` for a KeePass key file. When both a password and key file
+are configured, both are required to unlock the database, matching KeePass.
+Relative database and key-file paths resolve from the directory containing
+`secretspec.toml`.
+
+## Configuration
+
+### URI format
+
+```text
+kdbx:PATH[?keyfile=PATH][&prefix=TEMPLATE]
+```
+
+- `PATH` is the KDBX database. Use `./` for a relative path so its spelling and
+  case are preserved as a URI path.
+- `keyfile` is an optional KeePass key file.
+- `prefix` changes the convention entry path. It accepts `{project}`,
+  `{profile}`, and `{key}` placeholders and defaults to
+  `secretspec/{project}/{profile}/{key}`.
+
+### URI examples
+
+```text
+kdbx:./secrets.kdbx
+kdbx:/var/lib/myapp/secrets.kdbx
+kdbx:./secrets.kdbx?keyfile=./secrets.key
+kdbx:./shared.kdbx?prefix=teams/{project}/{profile}/{key}
+```
+
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+local_vault = {
+  uri = "kdbx:./secrets.kdbx?keyfile=./secrets.key",
+  credentials = { password = "keyring" }
+}
+
+[profiles.default]
+DATABASE_URL = { description = "Database URL", providers = ["local_vault"] }
+```
+
+## Storage model
+
+The default convention address creates groups for `secretspec`, the project,
+and the profile. The final path component is the entry title, and the value is
+stored as its protected `Password` field:
+
+```text
+secretspec/myapp/production/DATABASE_URL
+└── Password = <secret value>
+```
+
+Reads open KDBX 3 and KDBX 4 databases. Writes create KDBX 4 databases and
+atomically replace an existing KDBX 4 file only after the complete encrypted
+replacement has been flushed. KDBX 3 databases must be upgraded with KeePass
+or KeePassXC before SecretSpec can write them.
+
+## Use existing secrets
+
+Use [`ref`](/reference/configuration/#secret-references) to name an existing
+entry by its complete group path and title. The optional `field` selects a
+standard or custom entry field; it defaults to `Password`.
+
+```toml
+[profiles.production]
+DATABASE_PASSWORD = {
+  description = "Existing KeePass entry",
+  ref = { item = "Infrastructure/PostgreSQL", field = "Password" },
+  providers = ["local_vault"]
+}
+DATABASE_USERNAME = {
+  description = "Username from the same entry",
+  ref = { item = "Infrastructure/PostgreSQL", field = "UserName" },
+  providers = ["local_vault"]
+}
+```
+
+Entry and group names are matched exactly. Duplicate titles within one group,
+or duplicate group names under one parent, are rejected as ambiguous instead
+of selecting an arbitrary value. Empty path components are not supported.
+The `Title` field is readable but not writable because it forms part of the
+entry address; rename entries in KeePass or KeePassXC.
+
+## Security considerations and limitations
+
+- Never place the master password in the URI. Use the `password` provider
+  credential from a bootstrap provider. `SECRETSPEC_KDBX_PASSWORD` is a
+  discouraged fallback for environments without one; reported provider URIs
+  never contain the password.
+- Keep key files separate from the KDBX database when possible. Possessing both
+  removes the extra protection a key file provides.
+- SecretSpec serializes KDBX operations within one process and replaces files
+  atomically, but KDBX is still a local file rather than a multi-writer service.
+  Avoid editing the same database simultaneously in SecretSpec and KeePass.
+- Writing uses the `keepass` crate's KDBX 4 writer. Back up important databases
+  before first use with a new SecretSpec or `keepass` version.

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -100,6 +100,7 @@ Configure your preferred secrets storage backend:
 $ secretspec config init
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
+  kdbx: KeePass KDBX databases (0.17+)
   onepassword: OnePassword password manager
   dotenv: Traditional .env files
   env: Read-only environment variables

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -81,6 +81,33 @@ keyring://                   # System default keychain
 **Storage**: Service `secretspec/{project}/{profile}/{key}`, with the current
 operating-system username as the account
 
+## KeePass KDBX Provider (0.17+)
+
+:::caution[Version compatibility]
+The `kdbx` provider is added in SecretSpec 0.17.
+:::
+
+**URI**: `kdbx:PATH[?keyfile=PATH][&prefix=TEMPLATE]` - Stores secrets in a
+KeePass-compatible encrypted database
+
+```bash
+kdbx:./secrets.kdbx
+kdbx:/var/lib/myapp/secrets.kdbx
+kdbx:./secrets.kdbx?keyfile=./secrets.key
+kdbx:./shared.kdbx?prefix=teams/{project}/{profile}/{key}
+```
+
+**Features**: KDBX 3 read, KDBX 4 read/write, password and key-file
+authentication, standard and custom entry fields, profiles
+**Prerequisites**: Master password, key file, or both; build with
+`--features kdbx` (0.17+)
+**Authentication**: `password` provider credential from a bootstrap provider
+(recommended), or the discouraged `SECRETSPEC_KDBX_PASSWORD` fallback; optional
+`?keyfile=PATH`
+**Storage**: Entry path `secretspec/{project}/{profile}/{key}`, field `Password`
+by default. A secret `ref` uses `item` for the complete group path and entry
+title, and optional `field` for a standard or custom field.
+
 ## LastPass Provider
 
 **URI**: `lastpass://[item_template]` - Integrates with LastPass via `lpass` CLI
@@ -321,6 +348,7 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Environment | ❌ Plain text | Process memory | ❌ No |
 | systemd Credential (0.17+) | Depends on unit source | systemd-managed runtime memory | ❌ No |
 | Keyring | ✅ System encryption | System keychain | ❌ No |
+| KeePass KDBX (0.17+) | ✅ KDBX encryption | Local filesystem | ❌ No |
 | Pass | ✅ GPG encryption | Local filesystem | ❌ No |
 | GoPass | ✅ GPG encryption | Local filesystem | ❌ No |
 | Proton Pass | ✅ End-to-end | Cloud (Proton) | ✅ Yes |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -36,6 +36,7 @@ type ProviderMetadata = {
 
 const providerMetadata: ProviderMetadata[] = [
   { icon: 'apple', slug: 'keyring', label: 'macOS Keychain' },
+  { slug: 'kdbx', label: 'KeePass KDBX (0.17+)' },
   { icon: '1password', slug: 'onepassword', label: '1Password' },
   { icon: 'lastpass', slug: 'lastpass', label: 'LastPass' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden' },
@@ -143,6 +144,7 @@ $ secretspec init --from dotenv
 $ secretspec config init
 ? Select your preferred provider backend:
 <span class="tok-pun">›</span> keyring: Uses system keychain (Recommended)
+  kdbx: KeePass KDBX databases (0.17+)
   infisical: Infisical secret management
   openbao: OpenBao secret management (0.17+)
   age: age-encrypted file (0.17+)
@@ -213,6 +215,7 @@ $ secretspec run --profile production -- npm start
         <pre is:raw class="landing-step-code"><code>$ secretspec config init
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
+  kdbx: KeePass KDBX databases (0.17+)
   infisical: Infisical secret management
   openbao: OpenBao secret management (0.17+)
   age: age-encrypted file (0.17+)

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -18,6 +18,7 @@ required-features = ["cli"]
 [dependencies]
 clap.workspace = true
 keyring = { workspace = true, optional = true }
+keepass = { workspace = true, optional = true }
 serde.workspace = true
 toml.workspace = true
 toml_edit = { workspace = true, optional = true }
@@ -53,9 +54,10 @@ detect-coding-agent.workspace = true
 age = { workspace = true, optional = true }
 
 [features]
-default = ["cli", "keyring", "gcsm", "awssm", "vault", "openbao", "bws", "akv", "infisical", "age"]
+default = ["cli", "keyring", "kdbx", "gcsm", "awssm", "vault", "openbao", "bws", "akv", "infisical", "age"]
 cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
+kdbx = ["dep:keepass"]
 # Compile libdbus from source into the binary instead of linking the system
 # library at runtime (keyring's secret-service transport on Linux). Used by
 # prebuilt release artifacts that must run on distros we don't build on.

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -18,6 +18,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
 - **[Declarative Configuration](https://secretspec.dev/reference/configuration/)**: Define your secrets in `secretspec.toml` with descriptions and requirements
 - **[Multiple Provider Backends](https://secretspec.dev/concepts/providers/)**:
   - [Keyring](https://secretspec.dev/providers/keyring)
+  - [KeePass KDBX](https://secretspec.dev/providers/kdbx) (0.17+)
   - [.env](https://secretspec.dev/providers/dotenv)
   - [OnePassword](https://secretspec.dev/providers/onepassword)
   - [LastPass](https://secretspec.dev/providers/lastpass)
@@ -58,6 +59,7 @@ Next steps:
 $ secretspec config init
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
+  kdbx: KeePass KDBX databases (0.17+)
   onepassword: OnePassword password manager
   dotenv: Traditional .env files
   env: Read-only environment variables
@@ -146,6 +148,7 @@ Learn more about [profiles](https://secretspec.dev/concepts/profiles) and [profi
 SecretSpec supports multiple storage backends for secrets:
 
 - **[Keyring](https://secretspec.dev/providers/keyring)** - System credential store (recommended)
+- **[KeePass KDBX](https://secretspec.dev/providers/kdbx)** (0.17+) - Local KeePass-compatible encrypted database
 - **[.env files](https://secretspec.dev/providers/dotenv)** - Traditional dotenv files
 - **[Environment variables](https://secretspec.dev/providers/env)** - Read-only for CI/CD
 - **[systemd credentials](https://secretspec.dev/providers/systemd-credential)** (0.17+) - Read-only credentials passed to the current service

--- a/secretspec/src/provider/kdbx.rs
+++ b/secretspec/src/provider/kdbx.rs
@@ -1,0 +1,939 @@
+//! KeePass KDBX provider.
+//!
+//! Entries are addressed by their group path and title. SecretSpec's convention
+//! stores an entry at `secretspec/{project}/{profile}/{key}`; a native `ref`
+//! supplies that complete path as `item`. The entry's `Password` field is used
+//! by default, while `field` can select another standard or custom field.
+
+use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
+use crate::config::NativeAddress;
+use crate::{Result, SecretSpecError};
+use keepass::DatabaseKey;
+use keepass::config::DatabaseVersion;
+use keepass::db::{Database, EntryId, GroupId, fields};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+const DEFAULT_PREFIX: &str = "secretspec/{project}/{profile}/{key}";
+const PASSWORD_CREDENTIAL: &str = "password";
+const PASSWORD_ENV: &str = "SECRETSPEC_KDBX_PASSWORD";
+
+/// Serializes access across provider instances in this process.
+///
+/// Secret resolution constructs multiple instances for one alias. Without one
+/// shared lock, concurrent setters could both read the same database and let
+/// the last atomic replacement discard the other's change.
+static KDBX_IO_LOCK: Mutex<()> = Mutex::new(());
+
+/// Configuration for a KeePass KDBX database.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KdbxConfig {
+    /// Path to the `.kdbx` database.
+    pub path: PathBuf,
+    /// Optional KeePass key file, combined with the password when both exist.
+    pub keyfile: Option<PathBuf>,
+    /// Entry path template used for convention addresses.
+    pub prefix: String,
+}
+
+impl TryFrom<&ProviderUrl> for KdbxConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> Result<Self> {
+        if url.scheme() != "kdbx" {
+            return Err(operation_error(format!(
+                "Invalid scheme '{}' for kdbx provider",
+                url.scheme()
+            )));
+        }
+
+        let uri_path = url.path();
+        let path = match url.host() {
+            Some(host) => format!("{host}{uri_path}"),
+            None => uri_path,
+        };
+        if path.is_empty() || path == "/" {
+            return Err(operation_error(
+                "No KDBX database path given. Use kdbx:./secrets.kdbx or \
+                 kdbx:/absolute/path/secrets.kdbx.",
+            ));
+        }
+
+        let mut keyfile = None;
+        let mut prefix = None;
+        for (name, value) in url.query_pairs() {
+            let value = value.into_owned();
+            match name.as_ref() {
+                "keyfile" => {
+                    if keyfile.is_some() {
+                        return Err(operation_error(
+                            "The KDBX `keyfile` query parameter may only be specified once.",
+                        ));
+                    }
+                    if value.is_empty() {
+                        return Err(operation_error(
+                            "The KDBX `keyfile` query parameter cannot be empty.",
+                        ));
+                    }
+                    keyfile = Some(PathBuf::from(value));
+                }
+                "prefix" => {
+                    if prefix.is_some() {
+                        return Err(operation_error(
+                            "The KDBX `prefix` query parameter may only be specified once.",
+                        ));
+                    }
+                    if value.is_empty() {
+                        return Err(operation_error(
+                            "The KDBX `prefix` query parameter cannot be empty.",
+                        ));
+                    }
+                    prefix = Some(value);
+                }
+                other => {
+                    return Err(operation_error(format!(
+                        "Unknown KDBX query parameter `{other}`. Supported parameters are \
+                         `keyfile` and `prefix`."
+                    )));
+                }
+            }
+        }
+
+        Ok(Self {
+            path: PathBuf::from(path),
+            keyfile,
+            prefix: prefix.unwrap_or_else(|| DEFAULT_PREFIX.to_string()),
+        })
+    }
+}
+
+/// A provider backed by a KeePass KDBX 3 or KDBX 4 database.
+///
+/// Reads support both KDBX 3 and KDBX 4. Writes create KDBX 4 databases and
+/// update existing KDBX 4 databases; the `keepass` crate cannot save KDBX 3.
+pub struct KdbxProvider {
+    config: KdbxConfig,
+    credentials: ProviderCredentials,
+}
+
+crate::register_provider! {
+    struct: KdbxProvider,
+    config: KdbxConfig,
+    name: "kdbx",
+    description: "KeePass KDBX databases (0.17+)",
+    schemes: ["kdbx"],
+    examples: [
+        "kdbx:./secrets.kdbx",
+        "kdbx:./secrets.kdbx?keyfile=./secrets.key",
+    ],
+    credential_names: [PASSWORD_CREDENTIAL],
+}
+
+impl KdbxProvider {
+    pub fn new(config: KdbxConfig) -> Self {
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+        }
+    }
+
+    fn location(&self, addr: Address<'_>) -> Result<Location> {
+        let coords = self.resolve_coords(addr)?;
+        Location::parse(
+            &coords.item,
+            coords.field.as_deref().unwrap_or(fields::PASSWORD),
+        )
+    }
+
+    fn key(&self) -> Result<DatabaseKey> {
+        let password = credential_or_env(&self.credentials, PASSWORD_CREDENTIAL, PASSWORD_ENV);
+        if password.is_none() && self.config.keyfile.is_none() {
+            return Err(operation_error(format!(
+                "The KDBX database needs a master password or key file. Configure the \
+                 `{PASSWORD_CREDENTIAL}` provider credential, set {PASSWORD_ENV}, or add \
+                 `?keyfile=PATH` to the provider URI."
+            )));
+        }
+
+        let mut key = DatabaseKey::new();
+        if let Some(password) = password.as_deref() {
+            key = key.with_password(password);
+        }
+        if let Some(path) = self.config.keyfile.as_deref() {
+            let mut file = File::open(path).map_err(|error| {
+                operation_error(format!(
+                    "Failed to open KDBX key file '{}': {error}",
+                    path.display()
+                ))
+            })?;
+            key = key.with_keyfile(&mut file).map_err(|error| {
+                operation_error(format!(
+                    "Failed to read KDBX key file '{}': {error}",
+                    path.display()
+                ))
+            })?;
+        }
+        Ok(key)
+    }
+
+    fn load(&self) -> Result<Option<Database>> {
+        let mut file = match File::open(&self.config.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(operation_error(format!(
+                    "Failed to open KDBX database '{}': {error}",
+                    self.config.path.display()
+                )));
+            }
+        };
+
+        Database::open(&mut file, self.key()?)
+            .map(Some)
+            .map_err(|error| {
+                operation_error(format!(
+                    "Failed to unlock KDBX database '{}': {error}",
+                    self.config.path.display()
+                ))
+            })
+    }
+
+    fn save(&self, database: &Database) -> Result<()> {
+        if !matches!(database.config.version, DatabaseVersion::KDB4(_)) {
+            return Err(write_version_error());
+        }
+
+        let parent = self
+            .config
+            .path
+            .parent()
+            .filter(|path| !path.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let mut temporary = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
+            operation_error(format!(
+                "Failed to create a temporary KDBX database next to '{}': {error}",
+                self.config.path.display()
+            ))
+        })?;
+
+        database
+            .save(temporary.as_file_mut(), self.key()?)
+            .map_err(|error| {
+                operation_error(format!("Failed to encrypt KDBX database: {error}"))
+            })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            operation_error(format!(
+                "Failed to flush KDBX database '{}': {error}",
+                self.config.path.display()
+            ))
+        })?;
+        temporary.persist(&self.config.path).map_err(|error| {
+            operation_error(format!(
+                "Failed to atomically replace KDBX database '{}': {}",
+                self.config.path.display(),
+                error.error
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn get_from_database(
+        &self,
+        database: &Database,
+        addr: Address<'_>,
+    ) -> Result<Option<SecretString>> {
+        let location = self.location(addr)?;
+        let Some(entry_id) = find_entry(database, &location)? else {
+            return Ok(None);
+        };
+        Ok(database
+            .entry(entry_id)
+            .and_then(|entry| entry.get(&location.field).map(str::to_owned))
+            .map(|value| SecretString::new(value.into())))
+    }
+}
+
+impl Provider for KdbxProvider {
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        let item = self
+            .config
+            .prefix
+            .replace("{project}", project)
+            .replace("{profile}", profile)
+            .replace("{key}", key);
+        Location::parse(&item, fields::PASSWORD)?;
+        Ok(NativeAddress {
+            item,
+            ..Default::default()
+        })
+    }
+
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field"]
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let _guard = KDBX_IO_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match self.load()? {
+            Some(database) => self.get_from_database(&database, addr),
+            None => Ok(None),
+        }
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let location = self.location(addr)?;
+        let _guard = KDBX_IO_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut database = self.load()?.unwrap_or_else(|| {
+            let mut database = Database::new();
+            database.meta.database_name = Some("SecretSpec".to_string());
+            database
+        });
+
+        if !matches!(database.config.version, DatabaseVersion::KDB4(_)) {
+            return Err(write_version_error());
+        }
+
+        let group_id = find_or_create_group(&mut database, &location.groups)?;
+        match find_entry_in_group(&database, group_id, &location.title)? {
+            Some(entry_id) => {
+                let mut entry = database.entry_mut(entry_id).ok_or_else(|| {
+                    operation_error("KDBX entry disappeared while it was being updated.")
+                })?;
+                entry.edit_tracking(|entry| {
+                    entry.set_protected(&location.field, value.expose_secret());
+                });
+            }
+            None => {
+                let mut group = database.group_mut(group_id).ok_or_else(|| {
+                    operation_error("KDBX group disappeared while an entry was being created.")
+                })?;
+                group.add_entry().edit(|entry| {
+                    entry.set_unprotected(fields::TITLE, &location.title);
+                    entry.set_protected(&location.field, value.expose_secret());
+                });
+            }
+        }
+
+        self.save(&database)
+    }
+
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        let location = self.location(addr)?;
+        if location.field.eq_ignore_ascii_case(fields::TITLE) {
+            return Err(operation_error(
+                "The kdbx provider cannot write the `Title` field because the title is \
+                 part of the entry address. Change `ref.item` to rename an entry in KeePass.",
+            ));
+        }
+
+        let mut file = match File::open(&self.config.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(operation_error(format!(
+                    "Failed to open KDBX database '{}': {error}",
+                    self.config.path.display()
+                )));
+            }
+        };
+        let version = Database::get_version(&mut file).map_err(|error| {
+            operation_error(format!(
+                "Failed to inspect KDBX database '{}': {error}",
+                self.config.path.display()
+            ))
+        })?;
+        if !matches!(version, DatabaseVersion::KDB4(_)) {
+            return Err(write_version_error());
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let mut uri = format!(
+            "kdbx:{}",
+            ProviderUrl::encode(&self.config.path.display().to_string())
+        );
+        let mut separator = '?';
+        if let Some(keyfile) = self.config.keyfile.as_deref() {
+            uri.push(separator);
+            separator = '&';
+            uri.push_str("keyfile=");
+            uri.push_str(&ProviderUrl::encode_query(&keyfile.display().to_string()));
+        }
+        if self.config.prefix != DEFAULT_PREFIX {
+            uri.push(separator);
+            uri.push_str("prefix=");
+            uri.push_str(&ProviderUrl::encode_query(&self.config.prefix));
+        }
+        uri
+    }
+
+    fn with_base_dir(&mut self, base_dir: &Path) {
+        if self.config.path.is_relative() {
+            self.config.path = base_dir.join(&self.config.path);
+        }
+        if let Some(keyfile) = self.config.keyfile.as_mut()
+            && keyfile.is_relative()
+        {
+            *keyfile = base_dir.join(&*keyfile);
+        }
+    }
+
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        let _guard = KDBX_IO_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(database) = self.load()? else {
+            return Ok(HashMap::new());
+        };
+
+        let mut results = HashMap::new();
+        for (name, addr) in requests {
+            if let Some(value) = self.get_from_database(&database, *addr)? {
+                results.insert((*name).to_string(), value);
+            }
+        }
+        Ok(results)
+    }
+}
+
+#[derive(Debug)]
+struct Location {
+    groups: Vec<String>,
+    title: String,
+    field: String,
+}
+
+impl Location {
+    fn parse(item: &str, field: &str) -> Result<Self> {
+        if item.is_empty() {
+            return Err(operation_error("A KDBX entry path cannot be empty."));
+        }
+        if field.is_empty() {
+            return Err(operation_error("A KDBX field name cannot be empty."));
+        }
+
+        let mut parts: Vec<&str> = item.split('/').collect();
+        if parts.iter().any(|part| part.is_empty()) {
+            return Err(operation_error(format!(
+                "Invalid KDBX entry path `{item}`: group and entry names cannot be empty."
+            )));
+        }
+        let title = parts
+            .pop()
+            .expect("a non-empty split always contains an entry title")
+            .to_string();
+        Ok(Self {
+            groups: parts.into_iter().map(str::to_owned).collect(),
+            title,
+            field: field.to_string(),
+        })
+    }
+}
+
+fn find_entry(database: &Database, location: &Location) -> Result<Option<EntryId>> {
+    let mut group_id = database.root().id();
+    for name in &location.groups {
+        let Some(next) = unique_group(database, group_id, name)? else {
+            return Ok(None);
+        };
+        group_id = next;
+    }
+    find_entry_in_group(database, group_id, &location.title)
+}
+
+fn unique_group(database: &Database, parent: GroupId, name: &str) -> Result<Option<GroupId>> {
+    let group = database
+        .group(parent)
+        .ok_or_else(|| operation_error("KDBX group tree contains a missing group."))?;
+    let matches: Vec<GroupId> = group
+        .groups()
+        .filter(|group| group.name == name)
+        .map(|group| group.id())
+        .collect();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [id] => Ok(Some(*id)),
+        _ => Err(operation_error(format!(
+            "KDBX group `{name}` is ambiguous: its parent contains multiple groups with that name."
+        ))),
+    }
+}
+
+fn find_entry_in_group(
+    database: &Database,
+    group_id: GroupId,
+    title: &str,
+) -> Result<Option<EntryId>> {
+    let group = database
+        .group(group_id)
+        .ok_or_else(|| operation_error("KDBX group tree contains a missing group."))?;
+    let matches: Vec<EntryId> = group
+        .entries()
+        .filter(|entry| entry.get_title() == Some(title))
+        .map(|entry| entry.id())
+        .collect();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [id] => Ok(Some(*id)),
+        _ => Err(operation_error(format!(
+            "KDBX entry `{title}` is ambiguous: its group contains multiple entries with that title."
+        ))),
+    }
+}
+
+fn find_or_create_group(database: &mut Database, groups: &[String]) -> Result<GroupId> {
+    let mut current = database.root().id();
+    for name in groups {
+        current = match unique_group(database, current, name)? {
+            Some(id) => id,
+            None => {
+                let mut parent = database
+                    .group_mut(current)
+                    .ok_or_else(|| operation_error("KDBX group tree contains a missing group."))?;
+                let mut group = parent.add_group();
+                group.name = name.clone();
+                group.id()
+            }
+        };
+    }
+    Ok(current)
+}
+
+fn operation_error(message: impl Into<String>) -> SecretSpecError {
+    SecretSpecError::ProviderOperationFailed(message.into())
+}
+
+fn write_version_error() -> SecretSpecError {
+    operation_error(
+        "The kdbx provider can read KDBX 3 databases but cannot write them. \
+         Upgrade the database to KDBX 4 with KeePass or KeePassXC first.",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keepass::db::Value;
+    use secrecy::ExposeSecret;
+    use tempfile::TempDir;
+    use url::Url;
+
+    fn provider_url(value: &str) -> ProviderUrl {
+        ProviderUrl::new(Url::parse(value).unwrap())
+    }
+
+    fn config(path: PathBuf) -> KdbxConfig {
+        KdbxConfig {
+            path,
+            keyfile: None,
+            prefix: DEFAULT_PREFIX.to_string(),
+        }
+    }
+
+    fn provider(path: PathBuf, password: &str) -> KdbxProvider {
+        let mut provider = KdbxProvider::new(config(path));
+        let mut credentials = ProviderCredentials::new();
+        credentials.insert(
+            PASSWORD_CREDENTIAL.to_string(),
+            SecretString::new(password.to_string().into()),
+        );
+        provider.with_credentials(credentials);
+        provider
+    }
+
+    fn convention<'a>(key: &'a str) -> Address<'a> {
+        Address::convention("project", "production", key)
+    }
+
+    #[test]
+    fn config_parses_relative_and_absolute_paths() {
+        let relative = KdbxConfig::try_from(&provider_url("kdbx://./vault.kdbx")).unwrap();
+        assert_eq!(relative.path, PathBuf::from("./vault.kdbx"));
+
+        let absolute = KdbxConfig::try_from(&provider_url("kdbx:///var/lib/vault.kdbx")).unwrap();
+        assert_eq!(absolute.path, PathBuf::from("/var/lib/vault.kdbx"));
+    }
+
+    #[test]
+    fn config_parses_keyfile_and_prefix() {
+        let config = KdbxConfig::try_from(&provider_url(
+            "kdbx://./vault.kdbx?keyfile=keys/team.key&prefix=team/{profile}/{key}",
+        ))
+        .unwrap();
+        assert_eq!(config.keyfile, Some(PathBuf::from("keys/team.key")));
+        assert_eq!(config.prefix, "team/{profile}/{key}");
+    }
+
+    #[test]
+    fn registry_builds_documented_uri_and_advertises_password_credential() {
+        let provider = Box::<dyn Provider>::try_from(
+            "kdbx:./vault.kdbx?keyfile=keys/team.key&prefix=team/{profile}/{key}",
+        )
+        .unwrap();
+        assert_eq!(provider.name(), "kdbx");
+        assert_eq!(
+            crate::provider::credential_names_for_spec("kdbx:./vault.kdbx"),
+            &[PASSWORD_CREDENTIAL]
+        );
+    }
+
+    #[test]
+    fn config_rejects_missing_path_unknown_and_duplicate_parameters() {
+        for uri in [
+            "kdbx://",
+            "kdbx://./vault.kdbx?typo=value",
+            "kdbx://./vault.kdbx?keyfile=a&keyfile=b",
+            "kdbx://./vault.kdbx?prefix=",
+        ] {
+            assert!(KdbxConfig::try_from(&provider_url(uri)).is_err(), "{uri}");
+        }
+    }
+
+    #[test]
+    fn convention_and_native_addresses_map_to_entry_fields() {
+        let provider = KdbxProvider::new(config(PathBuf::from("vault.kdbx")));
+        let coords = provider
+            .convention_address("app", "prod", "DATABASE_URL")
+            .unwrap();
+        assert_eq!(coords.item, "secretspec/app/prod/DATABASE_URL");
+        assert_eq!(
+            provider
+                .location(Address::Native(&NativeAddress {
+                    item: "shared/database".into(),
+                    field: Some("UserName".into()),
+                    ..Default::default()
+                }))
+                .unwrap()
+                .field,
+            "UserName"
+        );
+    }
+
+    #[test]
+    fn invalid_entry_paths_and_title_writes_are_rejected() {
+        let provider = KdbxProvider::new(config(PathBuf::from("vault.kdbx")));
+        for item in ["", "/entry", "group/", "group//entry"] {
+            let addr = NativeAddress {
+                item: item.into(),
+                ..Default::default()
+            };
+            assert!(provider.location(Address::Native(&addr)).is_err(), "{item}");
+        }
+        let title = NativeAddress {
+            item: "group/entry".into(),
+            field: Some("Title".into()),
+            ..Default::default()
+        };
+        assert!(provider.check_writable(Address::Native(&title)).is_err());
+    }
+
+    #[test]
+    fn writable_check_rejects_kdbx3_before_requesting_a_value() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("vault.kdbx");
+        let provider = provider(path.clone(), "master");
+        provider
+            .set(convention("TOKEN"), &SecretString::new("value".into()))
+            .unwrap();
+
+        // KDBX stores its little-endian major version in header bytes 10..12.
+        // Changing only that header is enough for the value-free pre-check to
+        // identify this as KDBX 3; it deliberately does not try to decrypt it.
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes[10] = 3;
+        std::fs::write(path, bytes).unwrap();
+
+        let error = provider
+            .check_writable(convention("TOKEN"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("read KDBX 3"), "{error}");
+    }
+
+    #[test]
+    fn base_dir_rebases_database_and_keyfile_paths() {
+        let mut provider = KdbxProvider::new(KdbxConfig {
+            path: "data/vault.kdbx".into(),
+            keyfile: Some("keys/vault.key".into()),
+            prefix: DEFAULT_PREFIX.into(),
+        });
+        provider.with_base_dir(Path::new("/project"));
+        assert_eq!(
+            provider.config.path,
+            PathBuf::from("/project/data/vault.kdbx")
+        );
+        assert_eq!(
+            provider.config.keyfile,
+            Some(PathBuf::from("/project/keys/vault.key"))
+        );
+    }
+
+    #[test]
+    fn uri_round_trips_without_password() {
+        let mut provider = provider(PathBuf::from("./my vault.kdbx"), "do-not-leak");
+        provider.config.keyfile = Some(PathBuf::from("./my key.key"));
+        provider.config.prefix = "team/{profile}/{key}".into();
+        let uri = provider.uri();
+        assert_eq!(
+            uri,
+            "kdbx:./my%20vault.kdbx?keyfile=./my%20key.key&prefix=team/{profile}/{key}"
+        );
+        assert!(!uri.contains("do-not-leak"));
+    }
+
+    #[test]
+    fn set_creates_database_and_get_reads_secret() {
+        let temp = TempDir::new().unwrap();
+        let provider = provider(temp.path().join("vault.kdbx"), "master password");
+
+        assert!(provider.get(convention("API_KEY")).unwrap().is_none());
+        provider
+            .set(
+                convention("API_KEY"),
+                &SecretString::new("first value".into()),
+            )
+            .unwrap();
+        assert_eq!(
+            provider
+                .get(convention("API_KEY"))
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "first value"
+        );
+    }
+
+    #[test]
+    fn set_updates_existing_entry_and_preserves_other_fields() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("vault.kdbx");
+        let provider = provider(path.clone(), "master");
+        provider
+            .set(convention("API_KEY"), &SecretString::new("old".into()))
+            .unwrap();
+
+        let custom = NativeAddress {
+            item: "secretspec/project/production/API_KEY".into(),
+            field: Some("Account".into()),
+            ..Default::default()
+        };
+        provider
+            .set(
+                Address::Native(&custom),
+                &SecretString::new("service-user".into()),
+            )
+            .unwrap();
+        provider
+            .set(convention("API_KEY"), &SecretString::new("new".into()))
+            .unwrap();
+
+        assert_eq!(
+            provider
+                .get(convention("API_KEY"))
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "new"
+        );
+        assert_eq!(
+            provider
+                .get(Address::Native(&custom))
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "service-user"
+        );
+
+        let mut file = File::open(path).unwrap();
+        let database =
+            Database::open(&mut file, DatabaseKey::new().with_password("master")).unwrap();
+        let location = provider.location(convention("API_KEY")).unwrap();
+        let entry = database
+            .entry(find_entry(&database, &location).unwrap().unwrap())
+            .unwrap();
+        assert!(
+            entry
+                .history
+                .as_ref()
+                .is_some_and(|history| !history.get_entries().is_empty())
+        );
+    }
+
+    #[test]
+    fn keyfile_only_database_round_trips() {
+        let temp = TempDir::new().unwrap();
+        let keyfile = temp.path().join("vault.key");
+        std::fs::write(&keyfile, b"test key material").unwrap();
+        let mut provider = KdbxProvider::new(KdbxConfig {
+            path: temp.path().join("vault.kdbx"),
+            keyfile: Some(keyfile),
+            prefix: DEFAULT_PREFIX.into(),
+        });
+        provider.with_credentials(ProviderCredentials::new());
+
+        provider
+            .set(convention("TOKEN"), &SecretString::new("value".into()))
+            .unwrap();
+        assert_eq!(
+            provider
+                .get(convention("TOKEN"))
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "value"
+        );
+    }
+
+    #[test]
+    fn wrong_password_and_missing_credentials_are_actionable() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("vault.kdbx");
+        provider(path.clone(), "right")
+            .set(convention("TOKEN"), &SecretString::new("value".into()))
+            .unwrap();
+
+        let error = provider(path.clone(), "wrong")
+            .get(convention("TOKEN"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("Failed to unlock KDBX database"), "{error}");
+        assert!(!error.contains("wrong"), "{error}");
+
+        let error = KdbxProvider::new(config(path))
+            .get(convention("TOKEN"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(PASSWORD_ENV), "{error}");
+    }
+
+    #[test]
+    fn get_many_reads_fields_and_omits_missing_entries() {
+        let temp = TempDir::new().unwrap();
+        let provider = provider(temp.path().join("vault.kdbx"), "master");
+        provider
+            .set(convention("ONE"), &SecretString::new("one".into()))
+            .unwrap();
+        provider
+            .set(convention("TWO"), &SecretString::new("two".into()))
+            .unwrap();
+
+        let results = provider
+            .get_many(&[
+                ("FIRST", convention("ONE")),
+                ("SECOND", convention("TWO")),
+                ("MISSING", convention("THREE")),
+            ])
+            .unwrap();
+        assert_eq!(results["FIRST"].expose_secret(), "one");
+        assert_eq!(results["SECOND"].expose_secret(), "two");
+        assert!(!results.contains_key("MISSING"));
+    }
+
+    #[test]
+    fn duplicate_entry_titles_are_rejected_as_ambiguous() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("vault.kdbx");
+        let provider = provider(path.clone(), "master");
+        let mut database = Database::new();
+        {
+            let mut root = database.root_mut();
+            for password in ["one", "two"] {
+                root.add_entry().edit(|entry| {
+                    entry.set_unprotected(fields::TITLE, "duplicate");
+                    entry.set_protected(fields::PASSWORD, password);
+                });
+            }
+        }
+        provider.save(&database).unwrap();
+
+        let address = NativeAddress {
+            item: "duplicate".into(),
+            ..Default::default()
+        };
+        let error = provider
+            .get(Address::Native(&address))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("ambiguous"), "{error}");
+    }
+
+    #[test]
+    fn concurrent_writes_preserve_both_entries() {
+        let temp = TempDir::new().unwrap();
+        let provider = std::sync::Arc::new(provider(temp.path().join("vault.kdbx"), "master"));
+        std::thread::scope(|scope| {
+            for (name, value) in [("ONE", "one"), ("TWO", "two")] {
+                let provider = std::sync::Arc::clone(&provider);
+                scope.spawn(move || {
+                    provider
+                        .set(convention(name), &SecretString::new(value.into()))
+                        .unwrap();
+                });
+            }
+        });
+        assert_eq!(
+            provider
+                .get(convention("ONE"))
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "one"
+        );
+        assert_eq!(
+            provider
+                .get(convention("TWO"))
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "two"
+        );
+    }
+
+    #[test]
+    fn existing_non_secret_fields_survive_updates() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("vault.kdbx");
+        let provider = provider(path, "master");
+        let mut database = Database::new();
+        database.root_mut().add_entry().edit(|entry| {
+            entry.set_unprotected(fields::TITLE, "existing");
+            entry.set_unprotected(fields::URL, "https://example.com");
+            entry.set(fields::PASSWORD, Value::protected("old"));
+        });
+        provider.save(&database).unwrap();
+
+        let address = NativeAddress {
+            item: "existing".into(),
+            ..Default::default()
+        };
+        provider
+            .set(Address::Native(&address), &SecretString::new("new".into()))
+            .unwrap();
+        let loaded = provider.load().unwrap().unwrap();
+        let location = provider.location(Address::Native(&address)).unwrap();
+        let entry = loaded
+            .entry(find_entry(&loaded, &location).unwrap().unwrap())
+            .unwrap();
+        assert_eq!(entry.get_url(), Some("https://example.com"));
+        assert_eq!(entry.get_password(), Some("new"));
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -16,6 +16,7 @@
 //! ## Available Providers
 //!
 //! - [`keyring::KeyringProvider`]: System keyring integration (default)
+//! - [`kdbx::KdbxProvider`]: KeePass KDBX database integration (0.17+)
 //! - [`dotenv::DotEnvProvider`]: `.env` file support
 //! - [`env::EnvProvider`]: Environment variables (read-only)
 //! - [`pass::PassProvider`]: Pass integration
@@ -206,6 +207,7 @@ impl ProviderUrl {
     #[cfg(any(
         feature = "awssm",
         feature = "infisical",
+        feature = "kdbx",
         feature = "openbao",
         feature = "vault",
         test
@@ -278,6 +280,8 @@ pub mod gcsm;
 pub mod gopass;
 #[cfg(feature = "infisical")]
 pub mod infisical;
+#[cfg(feature = "kdbx")]
+pub mod kdbx;
 #[cfg(feature = "keyring")]
 pub mod keyring;
 pub mod lastpass;


### PR DESCRIPTION
Closes #130.

## What changed

- add a `kdbx:` provider backed by the `keepass` crate
- support KDBX 3 reads and KDBX 4 reads/writes
- support password, key-file-only, and combined authentication
- support convention addresses plus native entry paths and standard/custom fields
- use atomic file replacement, preserve entry history and unrelated fields, batch reads, and serialize in-process writes
- include the `kdbx` feature in standard builds
- document the provider throughout the site and README as an upcoming 0.17 feature

## User impact

SecretSpec users can store and retrieve secrets directly from KeePass-compatible databases without requiring KeePass or KeePassXC to be installed. Existing KDBX 3 databases are readable; writes require KDBX 4.

## Validation

- `cargo test --all`
- focused KDBX provider tests: 17 passed
- `cargo clippy -p secretspec --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check -p secretspec --no-default-features`
- documentation production build
- commit hooks: Clippy and rustfmt passed
- `git diff --check`