### PR TITLE
Remove unavailable-version wording

### DIFF
--- a/docs/src/content/docs/blog/secrets-dont-belong-in-config.md
+++ b/docs/src/content/docs/blog/secrets-dont-belong-in-config.md
@@ -105,7 +105,7 @@ boundary into the client through the SecretSpec Haskell SDK. It resolves
 `CACHIX_AUTH_TOKEN` and `CACHIX_SIGNING_KEY` from SecretSpec and can store them
 in the user's chosen provider instead of `cachix.dhall`. Existing environment
 variables and config files remain higher-priority fallbacks for compatibility.
-The PR is still open and is not available in a released Cachix version yet.
+The PR is still open.
 
 That is the problem SecretSpec is designed to solve: configuration declares the
 requirement, while each environment chooses where the value lives.

--- a/docs/src/content/docs/development/adding-providers.md
+++ b/docs/src/content/docs/development/adding-providers.md
@@ -118,18 +118,15 @@ When adding a provider for an upcoming release:
 
    ```md
    :::note[Version compatibility]
-   The MyBackend provider is an upcoming SecretSpec 0.16 feature and is not
-   available in SecretSpec 0.15.
+   The MyBackend provider is added in SecretSpec 0.16.
    :::
    ```
 
 2. Mark the provider as `(0.16+)` anywhere it appears in a provider list,
    table, selector example, sidebar, landing page, README, or generated
    documentation description.
-3. If the provider changes authentication or configuration syntax, show the
-   latest released version's working form first, then label the upcoming form
-   explicitly. Include a practical fallback such as the environment variable
-   used by the released version.
+3. If the provider changes authentication or configuration syntax, label the
+   new form explicitly with its target version.
 4. Add the provider under the existing `Unreleased` section in `CHANGELOG.md`.
 
 Update every provider location; names otherwise drift out of sync:
@@ -144,10 +141,8 @@ Update every provider location; names otherwise drift out of sync:
 6. `docs/src/content/docs/quick-start.mdx` — provider selector example
 7. `README.md` — provider lists and provider selector example
 
-When the release is published, replace temporary wording such as “upcoming”
-and “not available in 0.15” with durable wording such as “Available since
-SecretSpec 0.16.” The `(0.16+)` labels may remain where knowing the minimum
-version is useful.
+Use durable wording such as “Added in SecretSpec 0.16.” The `(0.16+)` labels
+may remain where knowing the minimum version is useful.
 
 Apply the same rule to unreleased CLI commands and configuration fields:
 place a version notice beside the command or field, not only on a separate

--- a/docs/src/content/docs/development/sdks.md
+++ b/docs/src/content/docs/development/sdks.md
@@ -53,8 +53,7 @@ platform and publishes on a version tag:
 ## Platform support
 
 Platforms each released artifact covers. Windows support for the Python wheel,
-the Ruby gem, and the PHP extension binaries targets SecretSpec 0.17 and is not
-available in the current release.
+the Ruby gem, and the PHP extension binaries is added in SecretSpec 0.17.
 
 | SDK | Linux x64 | Linux arm64 | macOS Intel | macOS Apple silicon | Windows x64 | Windows arm64 |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/src/content/docs/providers/age.md
+++ b/docs/src/content/docs/providers/age.md
@@ -4,7 +4,7 @@ description: Store secrets in an age-encrypted file committed alongside code
 ---
 
 :::note[Version compatibility]
-The age provider is an upcoming SecretSpec 0.17 feature and is not available in SecretSpec 0.16.
+The age provider is added in SecretSpec 0.17.
 :::
 
 The age provider keeps secrets in a single [age](https://age-encryption.org)-encrypted file that you can commit to your repository. The plaintext inside is a dotenv-style `KEY=value` blob that SecretSpec encrypts to one or more age recipients and decrypts with your age identity. A read decrypts the blob; a write decrypts it, updates one key, and re-encrypts the whole blob to the current recipients.

--- a/docs/src/content/docs/providers/openbao.md
+++ b/docs/src/content/docs/providers/openbao.md
@@ -7,26 +7,8 @@ The OpenBao provider integrates with OpenBao's KV (Key-Value) secrets engine
 using OpenBao's own provider identity and configuration conventions.
 
 :::caution[Version compatibility]
-The `openbao` provider targets SecretSpec 0.17 and is unavailable
-in the current 0.16 release. SecretSpec 0.16 can still connect to OpenBao with
-an `openbao://` URI through the `vault` build feature, but reports the provider
-as Vault and uses `VAULT_*` environment variables.
+The `openbao` provider is added in SecretSpec 0.17.
 :::
-
-## Using SecretSpec 0.16 today
-
-The current release's practical form is:
-
-```bash
-$ export VAULT_TOKEN=hvs.your-token-here
-$ secretspec check --provider openbao://bao.example.com:8200/secret
-```
-
-For a minimal Rust build, enable `vault`:
-
-```toml
-secretspec = { version = "0.16", default-features = false, features = ["vault"] }
-```
 
 ## At a glance
 

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -218,9 +218,7 @@ vault://127.0.0.1:8200/secret?tls=false    # Disable TLS (dev mode)
 ## OpenBao Provider (0.17+)
 
 :::caution[Version compatibility]
-The `openbao` provider is added in SecretSpec 0.17 and is unavailable in the
-current 0.16 release. With 0.16, use `openbao://` through the `vault` build
-feature and configure `VAULT_*` environment variables.
+The `openbao` provider is added in SecretSpec 0.17.
 :::
 
 **URI**: `openbao://[namespace@]host[:port][/mount][?options]` - Stores secrets in OpenBao's KV engine
@@ -302,8 +300,7 @@ Values are read with Infisical's secret references expanded, matching its own CL
 
 ## age Provider (0.17+)
 
-> **Version compatibility:** The age provider is upcoming in SecretSpec 0.17
-> and is unavailable in the current SecretSpec 0.16 release.
+> **Version compatibility:** The age provider is added in SecretSpec 0.17.
 
 **URI**: `age://PATH[?identity=FILE][&recipients-file=FILE][&armor=false]` - Stores secrets in a single age-encrypted file committed alongside code
 

--- a/docs/src/content/docs/sdk/overview.md
+++ b/docs/src/content/docs/sdk/overview.md
@@ -106,8 +106,8 @@ where `SECRETSPEC_FFI_LIB` can point at a specific library build.
 ## Platform support
 
 Prebuilt packages cover the following platforms. Windows support for the
-Python wheel, the Ruby gem, and the PHP extension binaries targets SecretSpec
-0.17 and is not available in the current release.
+Python wheel, the Ruby gem, and the PHP extension binaries is added in
+SecretSpec 0.17.
 
 | SDK | Linux x64 | Linux arm64 | macOS Intel | macOS Apple silicon | Windows x64 | Windows arm64 |
 | --- | --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION
## Summary

- replace negative “unavailable in …” compatibility notices with durable added-in version wording
- remove the obsolete SecretSpec 0.16 OpenBao workaround from the 0.17 provider guide
- update contributor guidance to avoid temporary negative availability phrasing
- simplify related SDK and blog wording

## Why

Version-specific negative availability notices become stale and distract from
the durable minimum-version labels already shown throughout the documentation.

## Impact

Provider and SDK documentation keeps its minimum supported version markers
while no longer describing features in terms of older releases where they were
unavailable.

## Validation

- `npm run build` in `docs/`
- tracked docs/code search for version-specific `unavailable` / `not available` wording
- `git diff --check`
