### PR TITLE
Use the official BWS CLI instead of the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,12 +53,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Linux and macOS builds on each release.
 
 ### Changed
+- The Bitwarden Secrets Manager provider now invokes the separately installed
+  official `bws` CLI instead of linking the Bitwarden SDK. This removes the
+  SDK's restricted-license dependency from SecretSpec distributions while
+  preserving project-scoped reads, writes, access-token credentials, and
+  EU/self-hosted server selection.
 - Secret status output now emphasizes secret names, de-emphasizes descriptions,
   and omits placeholder text when a description is unavailable, making long
   `check` and `import` results easier to scan.
   ([#139](https://github.com/cachix/secretspec/issues/139))
 
 ### Fixed
+- BWS CLI writes preserve secret keys and values that begin with `-`, and
+  hostless BWS provider URIs stay pinned to Bitwarden's default server even
+  when ambient BWS profiles or server settings are configured.
 - The dotenv provider rejects variable names its parser cannot read back
   (anything outside `[A-Za-z_][A-Za-z0-9_.]*`, for example a `ref` item
   containing a dash) instead of writing a line that made every later read and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,6 @@ dependencies = [
  "cfg-if",
  "cipher 0.4.4",
  "cpufeatures 0.2.17",
- "zeroize",
 ]
 
 [[package]]
@@ -207,19 +206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "argon2"
-version = "0.6.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a213fe583d472f454ae47407edc78848bebd950493528b1d4f7327a7dc335f"
-dependencies = [
- "base64ct",
- "blake2",
- "cpufeatures 0.2.17",
- "password-hash",
- "zeroize",
 ]
 
 [[package]]
@@ -816,272 +802,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "bitwarden"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eef4531792ef05e9230aae8e05a18dbb24b95cef6cdf29aece0afa6abe5fc1"
-dependencies = [
- "bitwarden-core",
- "bitwarden-generators",
- "bitwarden-sm",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bitwarden-api-api"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd58354043028b24c83fa3d8f1572dd6c8a5ac6d35a30434be36eddf51116bd"
-dependencies = [
- "async-trait",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_repr",
- "serde_with",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "bitwarden-api-identity"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be00c3af1405c120ebf212224b7dadc8ff0a9764728785273489be0e2129232d"
-dependencies = [
- "async-trait",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_repr",
- "serde_with",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "bitwarden-core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27846f2b01681661896b80b61ff3f423eb6ff8a9fa237bb7445e6a1d75af1fa3"
-dependencies = [
- "async-trait",
- "bitwarden-api-api",
- "bitwarden-api-identity",
- "bitwarden-crypto",
- "bitwarden-encoding",
- "bitwarden-error",
- "bitwarden-state",
- "bitwarden-uuid",
- "chrono",
- "getrandom 0.2.17",
- "rand 0.8.5",
- "reqwest 0.12.28",
- "rustls 0.23.37",
- "rustls-platform-verifier",
- "schemars 1.2.1",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_qs",
- "serde_repr",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
- "zeroize",
- "zxcvbn",
-]
-
-[[package]]
-name = "bitwarden-crypto"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b8689df316d423b62aade5e0f55cd6de8d2eebbb90a38cf50cd8f3485fbb1b"
-dependencies = [
- "aes 0.8.4",
- "argon2",
- "bitwarden-encoding",
- "bitwarden-error",
- "cbc 0.1.2",
- "chacha20poly1305",
- "ciborium",
- "coset",
- "ed25519-dalek",
- "generic-array",
- "hkdf",
- "hmac 0.12.1",
- "num-bigint",
- "num-traits",
- "pbkdf2 0.12.2",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rayon",
- "rsa",
- "schemars 1.2.1",
- "serde",
- "serde_bytes",
- "serde_repr",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "subtle",
- "thiserror 2.0.18",
- "tracing",
- "typenum",
- "uuid",
- "zeroize",
- "zeroizing-alloc",
-]
-
-[[package]]
-name = "bitwarden-encoding"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb1c2139a7ead11ad4891282d1fa7492bcc48052c37764972397bc4f16d32ce"
-dependencies = [
- "data-encoding",
- "data-encoding-macro",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bitwarden-error"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d1d0cef07f2895613a758a96b71f7217ed6518631d5945c28781c7ea035ffa"
-dependencies = [
- "bitwarden-error-macro",
-]
-
-[[package]]
-name = "bitwarden-error-macro"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264b4e0f626d477a2b627916a413b0f87fb86d107bcfe2d2459f0c0947a13c9"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "bitwarden-generators"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fdd34d0b795242a9fbf6a7cdf1d71cab17a5c3c43aaab4508affcfcea63b8b4"
-dependencies = [
- "bitwarden-core",
- "bitwarden-crypto",
- "bitwarden-error",
- "rand 0.8.5",
- "reqwest 0.12.28",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "bitwarden-sm"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f52d1bf993d2c580549a108afa9db324e0f94219c1b5cca86f72beb763143e"
-dependencies = [
- "bitwarden-api-api",
- "bitwarden-core",
- "bitwarden-crypto",
- "chrono",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
- "validator",
-]
-
-[[package]]
-name = "bitwarden-state"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0ef7fc06daa6cfe6ba6e6a8a288b6610585b74344b410ba7abaae1434f8b14"
-dependencies = [
- "async-trait",
- "bitwarden-error",
- "bitwarden-threading",
- "indexed-db",
- "js-sys",
- "rusqlite",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tsify",
-]
-
-[[package]]
-name = "bitwarden-threading"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b372360be78619bafcb9914cc4ade356cbffaf29a95b52ba6ef6cd15e5ac9691"
-dependencies = [
- "bitwarden-error",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "bitwarden-uuid"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621f8978a373727746803771ed415b8d2dc4bd4e7c4d0ee39803b07658bd955b"
-dependencies = [
- "bitwarden-uuid-macro",
-]
-
-[[package]]
-name = "bitwarden-uuid-macro"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4773816a659edc3db0fc5b9a90fc870adf67910ff106c7fe4f8ce2810c732037"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "blake2"
-version = "0.11.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52965399b470437fc7f4d4b51134668dbc96573fea6f1b83318a420e4605745"
-dependencies = [
- "digest 0.11.2",
-]
 
 [[package]]
 name = "blake2b_simd"
@@ -1324,38 +1048,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -1590,16 +1285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "coset"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
-dependencies = [
- "ciborium",
- "ciborium-io",
-]
-
-[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,25 +1315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1683,12 +1349,6 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1759,7 +1419,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1779,36 +1438,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1826,22 +1461,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1851,26 +1475,6 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "data-encoding-macro"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
-dependencies = [
- "data-encoding",
- "syn",
-]
 
 [[package]]
 name = "dbus"
@@ -1929,37 +1533,6 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn",
 ]
 
 [[package]]
@@ -2052,31 +1625,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "either"
@@ -2196,7 +1744,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2223,34 +1771,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f57a075f878ad51bcc56745fb21efe601429a509204f8a385bbe526566597320"
 dependencies = [
  "convert_case 0.11.0",
- "darling 0.23.0",
- "itertools 0.14.0",
+ "darling",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fancy-regex"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -2786,17 +2311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,15 +2330,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "heck"
@@ -3295,20 +2800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexed-db"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f4ecbb6cd50773303683617a93fc2782267d2c94546e9545ec4190eb69aa1a"
-dependencies = [
- "futures-channel",
- "futures-util",
- "pin-project-lite",
- "scoped-tls",
- "thiserror 2.0.18",
- "web-sys",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,15 +2929,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3697,17 +3179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3964,16 +3435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4191,15 +3652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbd25f71dd5249dba9ed843d52500c8757a25511560d01a94f4abf56b52a1d5"
-dependencies = [
- "phc",
-]
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,16 +3694,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "phc"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
-dependencies = [
- "base64ct",
- "ctutils",
-]
 
 [[package]]
 name = "pin-project"
@@ -4400,16 +3842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro-error-attr3"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4417,18 +3849,6 @@ checksum = "be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4684,26 +4104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4776,8 +4176,6 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
- "futures-util",
- "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4786,7 +4184,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4881,20 +4278,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]
@@ -5144,32 +4527,11 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
- "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive",
  "serde",
  "serde_json",
- "uuid",
 ]
-
-[[package]]
-name = "schemars_derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5231,7 +4593,6 @@ dependencies = [
  "azure_core",
  "azure_identity",
  "azure_security_keyvault_secrets",
- "bitwarden",
  "clap",
  "colored",
  "data-encoding",
@@ -5249,7 +4610,6 @@ dependencies = [
  "rand 0.9.2",
  "reqwest 0.12.28",
  "rsa",
- "rustls 0.23.37",
  "secrecy",
  "serde",
  "serde_json",
@@ -5389,27 +4749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5430,17 +4769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5451,28 +4779,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3faaf9e727533a19351a43cc5a8de957372163c7d35cc48c90b75cdda13c352"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -5521,7 +4827,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -6224,30 +5530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tsify"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
-dependencies = [
- "serde",
- "serde-wasm-bindgen",
- "tsify-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-macros"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
 name = "twofish"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6481,36 +5763,6 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "validator"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
-dependencies = [
- "idna",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_derive",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
-dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -7288,12 +6540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroizing-alloc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebff5e6b81c1c7dca2d0bd333b2006da48cb37dbcae5a8da888f31fcb3c19934"
-
-[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7404,21 +6650,4 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zxcvbn"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad76e35b00ad53688d6b90c431cabe3cbf51f7a4a154739e04b63004ab1c736c"
-dependencies = [
- "chrono",
- "derive_builder",
- "fancy-regex",
- "itertools 0.13.0",
- "lazy_static",
- "regex",
- "time",
- "wasm-bindgen",
- "web-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,6 @@ insta = "1.34"
 linkme = "0.3"
 jiff = "0.2"
 secrecy = { version = "0.10.3", features = ["serde"] }
-bitwarden = { version = "2.0.0", features = ["secrets"] }
-rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 google-cloud-secretmanager-v1 = "1.2"
 aws-config = "1"
 aws-sdk-secretsmanager = "1"
@@ -59,7 +57,7 @@ secretspec-derive = { version = "0.16.0", path = "./secretspec-derive" }
 secretspec = { version = "0.16.0", path = "./secretspec" }
 rand = "0.9"
 rsa = { version = "0.9", features = ["pem"] }
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["serde", "v4"] }
 data-encoding = "2"
 detect-coding-agent = "0.1"
 age = { version = "0.12", features = ["armor", "plugin", "ssh"] }

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -53,7 +53,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [awssm](/providers/awssm/) | AWS Secrets Manager (requires the `awssm` build feature) | ✓ | ✓ | ✓ | — |
 | [vault](/providers/vault/) | HashiCorp Vault (requires the `vault` build feature) | ✓ | ✓ | ✓ | — |
 | [openbao](/providers/openbao/) (0.17+) | OpenBao (requires the `openbao` build feature; 0.16 uses `openbao://` through `vault`) | ✓ | ✓ | ✓ | — |
-| [bws](/providers/bws/) | Bitwarden Secrets Manager (requires the `bws` build feature) | ✓ | ✓ | ✓ | — |
+| [bws](/providers/bws/) | Bitwarden Secrets Manager (official `bws` CLI in SecretSpec 0.17+; requires the `bws` build feature) | ✓ | ✓ | ✓ | — |
 | [akv](/providers/akv/) | Azure Key Vault (requires the `akv` build feature) | ✓ | ✓ | ✓ | — |
 | [infisical](/providers/infisical/) (0.16+) | Infisical (requires the `infisical` build feature) | ✓ | ✓ | ✓ | — |
 | [age](/providers/age/) (0.17+) | An age-encrypted file (requires the `age` build feature) | ✓ | ✓ | ✓ | — |

--- a/docs/src/content/docs/providers/bws.md
+++ b/docs/src/content/docs/providers/bws.md
@@ -3,7 +3,29 @@ title: Bitwarden Secrets Manager Provider
 description: Bitwarden Secrets Manager integration
 ---
 
-The Bitwarden Secrets Manager (BWS) provider integrates with Bitwarden for centralized, end-to-end encrypted secret management.
+:::caution[Why SecretSpec 0.17+ uses the CLI]
+Bitwarden publishes a Rust SDK, but its
+[SDK license](https://github.com/bitwarden/sdk-sm/blob/main/LICENSE) does not
+permit a compatible application built with it to be offered, licensed, or sold
+to third parties, and it prohibits redistribution of the SDK. Those terms mean
+SecretSpec cannot link the SDK while remaining a distributable open-source
+crate and CLI.
+
+SecretSpec therefore invokes an independently installed official `bws`
+executable. This process boundary lets users opt into Bitwarden's software
+under Bitwarden's terms without embedding or redistributing its SDK in
+SecretSpec.
+
+This is unfortunate: a normal Rust library integration would be faster,
+simpler to install, and would not need to pass new secret values as process
+arguments. If Bitwarden provides SDK terms that allow third-party
+redistribution, we would prefer to use the SDK directly.
+:::
+
+The Bitwarden Secrets Manager (BWS) provider integrates with Bitwarden for
+centralized, end-to-end encrypted secret management. SecretSpec 0.17 and later
+invoke the separately installed official `bws` CLI instead of linking the
+Bitwarden SDK.
 
 ## At a glance
 
@@ -13,7 +35,7 @@ The Bitwarden Secrets Manager (BWS) provider integrates with Bitwarden for centr
 | URI | `bws://[SERVER_BASE@]PROJECT_UUID` |
 | Access | Read and write |
 | Best for | Machine and CI/CD secrets managed in Bitwarden |
-| Authentication | A machine-account access token |
+| Authentication | Machine-account access token; official `bws` CLI in SecretSpec 0.17+ |
 | Build feature | `bws` |
 | Default storage | Flat key names in the selected BWS project |
 
@@ -34,8 +56,13 @@ $ secretspec run --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c -- npm st
 ### Prerequisites
 
 - Bitwarden Secrets Manager subscription
+- SecretSpec 0.17+: official [`bws` CLI](https://bitwarden.com/help/secrets-manager-cli/)
+  0.3.0 or later installed and available on `PATH`
 - Machine account access token (`BWS_ACCESS_TOKEN` environment variable)
 - Build with `--features bws`
+
+Set `SECRETSPEC_BWS_CLI_PATH` to the executable path if `bws` is not on
+`PATH` (SecretSpec 0.17+).
 
 ### Authentication
 
@@ -72,12 +99,12 @@ bws://[SERVER_BASE@]PROJECT_UUID
 - `SERVER_BASE` (optional): Hostname of the Bitwarden instance for EU cloud or
   self hosted deployments. Defaults to `bitwarden.com` (US cloud) when omitted.
 
-When `SERVER_BASE` is set, the identity and API endpoints are derived as
-`https://SERVER_BASE/identity` and `https://SERVER_BASE/api`, matching the
-`bws config server-base` behavior described in the
-[Bitwarden Secrets Manager CLI docs](https://bitwarden.com/help/secrets-manager-cli/#server).
-Use the web vault hostname here, for example `vault.bitwarden.eu` for the EU
-cloud. Only a bare hostname is supported (no scheme prefix or custom port).
+In SecretSpec 0.17 and later, `SERVER_BASE` is passed to each CLI invocation as
+`--server-url https://SERVER_BASE`, overriding the CLI's saved server
+configuration. Use the web vault hostname here, for example
+`vault.bitwarden.eu` for the EU cloud. Only a bare hostname is supported (no
+scheme prefix or custom port). SecretSpec 0.16 and earlier configured the same
+derived `/identity` and `/api` endpoints directly through the SDK.
 
 ### URI examples
 
@@ -123,3 +150,11 @@ $ export BWS_ACCESS_TOKEN="$BWS_TOKEN"
 # Run command
 $ secretspec run --provider bws://a9230ec4-5507-4870-b8b5-b3f500587e4c -- deploy
 ```
+
+## Security considerations
+
+SecretSpec passes the access token to `bws` through `BWS_ACCESS_TOKEN`, not the
+CLI's `--access-token` argument. The official CLI requires new or updated
+secret values as command-line arguments, however, so during `secretspec set`
+the value may briefly be visible to process-inspection tools available to the
+same user. This applies to the CLI-backed provider in SecretSpec 0.17 and later.

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -245,13 +245,20 @@ bws://vault.bitwarden.eu@a9230ec4-5507-4870-b8b5-b3f500587e4c # EU cloud
 bws://bw.example.com@a9230ec4-5507-4870-b8b5-b3f500587e4c     # Self hosted
 ```
 
-`SERVER_BASE` is the bare hostname of the Bitwarden instance; the identity and
-API endpoints are derived as `https://SERVER_BASE/identity` and
-`https://SERVER_BASE/api`. Omit it to use the `bitwarden.com` US cloud.
+`SERVER_BASE` is the bare hostname of the Bitwarden instance. SecretSpec 0.17+
+passes `https://SERVER_BASE` to `bws --server-url`; SecretSpec 0.16 and earlier
+derive the `https://SERVER_BASE/identity` and `https://SERVER_BASE/api`
+endpoints through the SDK. Omit it to use the `bitwarden.com` US cloud.
 
 **Features**: Read/write, cloud sync, project-scoped, end-to-end encryption
 **Prerequisites**: BWS subscription, machine account access token, build with `--features bws`
 **Storage**: Flat key names in the specified BWS project
+
+SecretSpec 0.17 and later require the official `bws` CLI 0.3.0 or later on
+`PATH` and invoke it for all reads and writes; set `SECRETSPEC_BWS_CLI_PATH` to
+use another executable path. The access token is supplied through the child
+process environment. Secret values passed to the CLI for creation or editing
+may briefly be visible to same-user process-inspection tools.
 
 ## Azure Key Vault Provider
 

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -36,8 +36,6 @@ whoami = { workspace = true, optional = true }
 linkme.workspace = true
 jiff.workspace = true
 secrecy.workspace = true
-bitwarden = { workspace = true, optional = true }
-rustls = { workspace = true, optional = true }
 google-cloud-secretmanager-v1 = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-secretsmanager = { workspace = true, optional = true }
@@ -70,6 +68,6 @@ openbao = ["dep:reqwest"]
 # exchange. It is already on transitively via reqwest, but a provider should
 # name the features it uses rather than inherit them from a sibling.
 infisical = ["dep:reqwest", "tokio/sync"]
-bws = ["dep:bitwarden", "dep:rustls"]
+bws = []
 akv = ["dep:azure_core", "dep:azure_identity", "dep:azure_security_keyvault_secrets"]
 age = ["dep:age"]

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -31,7 +31,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
   - [Vault](https://secretspec.dev/providers/vault)
   - [OpenBao](https://secretspec.dev/providers/openbao) (0.17+)
-  - [Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)
+  - [Bitwarden Secrets Manager](https://secretspec.dev/providers/bws) (official `bws` CLI required in SecretSpec 0.17+)
   - [Azure Key Vault](https://secretspec.dev/providers/akv)
   - [Infisical](https://secretspec.dev/providers/infisical) (0.16+)
   - [age](https://secretspec.dev/providers/age) (0.17+)
@@ -164,7 +164,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[AWS Secrets Manager](https://secretspec.dev/providers/awssm)** - AWS secret management
 - **[Vault](https://secretspec.dev/providers/vault)** - HashiCorp Vault KV engine
 - **[OpenBao](https://secretspec.dev/providers/openbao)** (0.17+) - OpenBao KV integration; SecretSpec 0.16 accepts `openbao://` through the Vault provider
-- **[Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)** - Bitwarden Secrets Manager integration
+- **[Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)** - Bitwarden Secrets Manager integration (official `bws` CLI required in SecretSpec 0.17+)
 - **[Azure Key Vault](https://secretspec.dev/providers/akv)** - Azure secret management
 - **[Infisical](https://secretspec.dev/providers/infisical)** (0.16+) - Infisical secret management
 - **[age](https://secretspec.dev/providers/age)** (0.17+) - age-encrypted file

--- a/secretspec/src/provider/bws.rs
+++ b/secretspec/src/provider/bws.rs
@@ -1,12 +1,14 @@
 //! Bitwarden Secrets Manager (BWS) provider
 //!
-//! This provider integrates with Bitwarden Secrets Manager to store and retrieve secrets.
+//! This provider integrates with Bitwarden Secrets Manager to store and retrieve secrets
+//! through the official `bws` command-line interface in SecretSpec 0.17 and later.
 //!
 //! # Authentication
 //!
 //! Uses a machine account access token supplied as a provider credential or via
 //! the `BWS_ACCESS_TOKEN` environment variable.
 //! Generate access tokens from the Bitwarden Secrets Manager web interface.
+//! The `bws` executable must be installed and available on `PATH`.
 //!
 //! # URI Format
 //!
@@ -39,16 +41,11 @@
 
 use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
 use crate::{Result, SecretSpecError};
-use bitwarden::auth::login::AccessTokenLoginRequest;
-use bitwarden::secrets_manager::ClientSecretsExt;
-use bitwarden::secrets_manager::secrets::{
-    SecretCreateRequest, SecretIdentifiersByProjectRequest, SecretPutRequest, SecretResponse,
-    SecretsGetRequest,
-};
-use bitwarden::{Client, ClientSettings};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io;
+use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
 /// Configuration for the Bitwarden Secrets Manager provider.
@@ -109,20 +106,31 @@ impl TryFrom<&ProviderUrl> for BwsConfig {
 /// the BWS project ID specified in the provider URI.
 pub struct BwsProvider {
     config: BwsConfig,
-    client: OnceLock<Client>,
-    secrets_cache: OnceLock<Vec<SecretResponse>>,
+    secrets_cache: OnceLock<Vec<BwsSecret>>,
     /// Credentials supplied by the provider alias.
     credentials: ProviderCredentials,
+    /// Path to the official Bitwarden Secrets Manager CLI.
+    cli_binary_path: String,
 }
 
 const ACCESS_TOKEN: &str = "access_token";
 const BWS_ACCESS_TOKEN_ENV: &str = "BWS_ACCESS_TOKEN";
+const BWS_CLI_PATH_ENV: &str = "SECRETSPEC_BWS_CLI_PATH";
+const DEFAULT_SERVER_URL: &str = "https://bitwarden.com";
+
+/// Fields consumed from `bws secret list --output json`.
+#[derive(Debug, Clone, Deserialize)]
+struct BwsSecret {
+    id: String,
+    key: String,
+    value: String,
+}
 
 crate::register_provider! {
     struct: BwsProvider,
     config: BwsConfig,
     name: "bws",
-    description: "Bitwarden Secrets Manager",
+    description: "Bitwarden Secrets Manager via official bws CLI",
     schemes: ["bws"],
     examples: ["bws://a9230ec4-5507-4870-b8b5-b3f500587e4c"],
     credential_names: [ACCESS_TOKEN],
@@ -133,9 +141,9 @@ impl BwsProvider {
     pub fn new(config: BwsConfig) -> Self {
         Self {
             config,
-            client: OnceLock::new(),
             secrets_cache: OnceLock::new(),
             credentials: ProviderCredentials::new(),
+            cli_binary_path: std::env::var(BWS_CLI_PATH_ENV).unwrap_or_else(|_| "bws".to_string()),
         }
     }
 
@@ -155,15 +163,8 @@ impl BwsProvider {
         message.to_string()
     }
 
-    /// Returns a reference to the authenticated Client, creating it if needed.
-    ///
-    /// Resolves an access token and authenticates on first call.
-    /// Subsequent calls return the cached client.
-    async fn ensure_client(&self) -> Result<&Client> {
-        if let Some(client) = self.client.get() {
-            return Ok(client);
-        }
-
+    /// Builds an authenticated `bws` command without exposing the token in its arguments.
+    fn command(&self) -> Result<Command> {
         let token = self.access_token().ok_or_else(|| {
             SecretSpecError::ProviderOperationFailed(
                 "BWS access_token credential is not set. Configure \
@@ -180,91 +181,89 @@ impl BwsProvider {
             ));
         }
 
-        // The bitwarden crate uses rustls for TLS but doesn't install a crypto
-        // provider. Install the aws-lc-rs provider (already a transitive dependency)
-        // before creating the client. ok() ignores if already installed.
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let mut command = Command::new(&self.cli_binary_path);
+        command
+            .env(BWS_ACCESS_TOKEN_ENV, token)
+            .arg("--color")
+            .arg("no")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
 
-        // Set the API and Identity URLs based on server base URL if set
-        let settings = self.config.server_base.as_ref().map(|it| ClientSettings {
-            identity_url: format!("https://{it}/identity"),
-            api_url: format!("https://{it}/api"),
-            ..Default::default()
-        });
+        let server_url = self.config.server_base.as_ref().map_or_else(
+            || DEFAULT_SERVER_URL.to_string(),
+            |base| format!("https://{base}"),
+        );
+        command.arg("--server-url").arg(server_url);
 
-        let client = Client::new(settings);
+        Ok(command)
+    }
 
-        client
-            .auth()
-            .login_access_token(&AccessTokenLoginRequest {
-                access_token: token,
-                state_file: None,
-            })
-            .await
-            .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
-                    "Failed to authenticate with Bitwarden Secrets Manager: {}",
-                    e
-                )))
+    /// Runs the official BWS CLI and returns its UTF-8 stdout.
+    fn run_bws(&self, args: &[&str], action: &str) -> Result<String> {
+        let output = self
+            .command()?
+            .args(args)
+            .output()
+            .map_err(|error| match error.kind() {
+                io::ErrorKind::NotFound => SecretSpecError::ProviderOperationFailed(format!(
+                    "Bitwarden Secrets Manager CLI (bws) is not installed or was not found at \
+                     '{}'. Install it from https://bitwarden.com/help/secrets-manager-cli/ \
+                     and ensure it is on PATH.",
+                    self.cli_binary_path
+                )),
+                _ => SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to start Bitwarden Secrets Manager CLI (bws): {error}"
+                )),
             })?;
 
-        Ok(self.client.get_or_init(|| client))
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let detail = if stderr.trim().is_empty() {
+                format!("bws exited with status {}", output.status)
+            } else {
+                stderr.trim().to_string()
+            };
+            return Err(SecretSpecError::ProviderOperationFailed(
+                self.sanitize_error(&format!("Failed to {action} using BWS CLI: {detail}")),
+            ));
+        }
+
+        String::from_utf8(output.stdout).map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "BWS CLI returned non-UTF-8 output while attempting to {action}: {error}"
+            ))
+        })
     }
 
     /// Returns a reference to the cached list of secrets in the project, fetching if needed.
-    ///
-    /// Uses a two-step process: first lists secret identifiers by project (which only returns
-    /// IDs and key names), then fetches full secret values by IDs.
-    async fn ensure_secrets(&self) -> Result<&Vec<SecretResponse>> {
+    fn ensure_secrets(&self) -> Result<&Vec<BwsSecret>> {
         if let Some(secrets) = self.secrets_cache.get() {
             return Ok(secrets);
         }
 
-        let secrets = self.fetch_secrets().await?;
+        let secrets = self.fetch_secrets()?;
         Ok(self.secrets_cache.get_or_init(|| secrets))
     }
 
-    /// Fetches all secrets from the BWS project (always makes API calls, no caching).
-    async fn fetch_secrets(&self) -> Result<Vec<SecretResponse>> {
-        let client = self.ensure_client().await?;
+    /// Fetches all secrets from the BWS project (always invokes the CLI, no caching).
+    fn fetch_secrets(&self) -> Result<Vec<BwsSecret>> {
+        let project_id = self.config.project_id.to_string();
+        let output = self.run_bws(
+            &["secret", "list", &project_id, "--output", "json"],
+            &format!("list secrets in BWS project '{}'", self.config.project_id),
+        )?;
 
-        // Step 1: List secret identifiers in the project
-        let identifiers = client
-            .secrets()
-            .list_by_project(&SecretIdentifiersByProjectRequest {
-                project_id: self.config.project_id,
-            })
-            .await
-            .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
-                    "Failed to list secrets in BWS project '{}': {}",
-                    self.config.project_id, e
-                )))
-            })?;
-
-        if identifiers.data.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Step 2: Fetch full secret values by IDs
-        let ids: Vec<uuid::Uuid> = identifiers.data.iter().map(|s| s.id).collect();
-        let secrets = client
-            .secrets()
-            .get_by_ids(SecretsGetRequest { ids })
-            .await
-            .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
-                    "Failed to fetch secret values from BWS project '{}': {}",
-                    self.config.project_id, e
-                )))
-            })?;
-
-        Ok(secrets.data)
+        serde_json::from_str(&output).map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to parse JSON returned by BWS CLI while listing project '{}': {error}",
+                self.config.project_id
+            ))
+        })
     }
 
     /// Retrieves a secret value from BWS by its resolved key name.
-    async fn get_secret_async(&self, target: &str) -> Result<Option<SecretString>> {
-        let secrets = self.ensure_secrets().await?;
+    fn get_secret(&self, target: &str) -> Result<Option<SecretString>> {
+        let secrets = self.ensure_secrets()?;
 
         // BWS uses flat key names -- match directly.
         for secret in secrets {
@@ -277,67 +276,44 @@ impl BwsProvider {
     }
 
     /// Creates or updates a secret in BWS at its resolved key name.
-    async fn set_secret_async(&self, key: &str, value: &SecretString) -> Result<()> {
-        let client = self.ensure_client().await?;
-
-        // get_access_token_organization() is not part of the public stable API surface
-        // of bitwarden-core, but it is the only way to retrieve the organization ID
-        // from the access token after authentication.
-        // See: https://github.com/bitwarden/sdk-sm/issues/944
-        let org_id = client
-            .internal
-            .get_access_token_organization()
-            .ok_or_else(|| {
-                SecretSpecError::ProviderOperationFailed(
-                    "Failed to determine organization ID from BWS access token. \
-                     Ensure the access token is valid."
-                        .to_string(),
-                )
-            })?;
-
+    fn set_secret(&self, key: &str, value: &SecretString) -> Result<()> {
         // Fetch fresh secrets list (not cached) to avoid stale data when writing
-        let fresh_secrets = self.fetch_secrets().await?;
+        let fresh_secrets = self.fetch_secrets()?;
 
         // Look for an existing secret with the same key name
         let existing = fresh_secrets.iter().find(|s| s.key == key);
+        let secret_value = value.expose_secret();
 
         if let Some(existing_secret) = existing {
-            // Update existing secret
-            client
-                .secrets()
-                .update(&SecretPutRequest {
-                    id: existing_secret.id,
-                    organization_id: org_id.into(),
-                    key: key.to_string(),
-                    value: value.expose_secret().to_string(),
-                    note: existing_secret.note.clone(),
-                    project_ids: existing_secret.project_id.map(|id| vec![id]),
-                })
-                .await
-                .map_err(|e| {
-                    SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
-                        "Failed to update secret '{}' in BWS: {}",
-                        key, e
-                    )))
-                })?;
+            // Keep option-like values attached to the option so clap cannot
+            // interpret them as another flag.
+            let value_arg = format!("--value={secret_value}");
+            self.run_bws(
+                &[
+                    "secret",
+                    "edit",
+                    &existing_secret.id,
+                    &value_arg,
+                    "--output",
+                    "none",
+                ],
+                &format!("update secret '{key}' in BWS"),
+            )?;
         } else {
-            // Create new secret
-            client
-                .secrets()
-                .create(&SecretCreateRequest {
-                    organization_id: org_id.into(),
-                    key: key.to_string(),
-                    value: value.expose_secret().to_string(),
-                    note: String::new(),
-                    project_ids: Some(vec![self.config.project_id]),
-                })
-                .await
-                .map_err(|e| {
-                    SecretSpecError::ProviderOperationFailed(self.sanitize_error(&format!(
-                        "Failed to create secret '{}' in BWS: {}",
-                        key, e
-                    )))
-                })?;
+            let project_id = self.config.project_id.to_string();
+            self.run_bws(
+                &[
+                    "secret",
+                    "create",
+                    "--output",
+                    "none",
+                    "--",
+                    key,
+                    secret_value,
+                    &project_id,
+                ],
+                &format!("create secret '{key}' in BWS"),
+            )?;
         }
 
         Ok(())
@@ -376,12 +352,12 @@ impl Provider for BwsProvider {
 
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         let target = super::flat_item(self, addr)?;
-        super::block_on(self.get_secret_async(&target))
+        self.get_secret(&target)
     }
 
     fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
         let target = super::flat_item(self, addr)?;
-        super::block_on(self.set_secret_async(&target, value))
+        self.set_secret(&target, value)
     }
 
     /// Serves every request, convention or `ref`, from one cached listing of
@@ -395,7 +371,7 @@ impl Provider for BwsProvider {
             targets.push((*name, super::flat_item(self, *addr)?));
         }
 
-        let secrets = super::block_on(self.ensure_secrets())?;
+        let secrets = self.ensure_secrets()?;
         let by_key: HashMap<&str, &str> = secrets
             .iter()
             .map(|s| (s.key.as_str(), s.value.as_str()))
@@ -417,10 +393,25 @@ impl Provider for BwsProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use secrecy::ExposeSecret;
     use url::Url;
 
     fn provider_url(s: &str) -> ProviderUrl {
         ProviderUrl::new(Url::parse(s).unwrap())
+    }
+
+    fn provider_with_credentials(server_base: Option<&str>) -> BwsProvider {
+        let mut provider = BwsProvider::new(BwsConfig {
+            project_id: uuid::Uuid::parse_str("a9230ec4-5507-4870-b8b5-b3f500587e4c").unwrap(),
+            server_base: server_base.map(str::to_string),
+        });
+        let mut credentials = ProviderCredentials::new();
+        credentials.insert(
+            ACCESS_TOKEN.to_string(),
+            SecretString::new("token-from-provider".to_string().into()),
+        );
+        provider.with_credentials(credentials);
+        provider
     }
 
     #[test]
@@ -551,6 +542,192 @@ mod tests {
             "Error should mention BWS_ACCESS_TOKEN, got: {}",
             err_msg
         );
+    }
+
+    #[test]
+    fn command_passes_token_via_environment_and_server_as_argument() {
+        let provider = provider_with_credentials(Some("vault.bitwarden.eu"));
+        let command = provider.command().unwrap();
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        let token = command
+            .get_envs()
+            .find(|(name, _)| *name == BWS_ACCESS_TOKEN_ENV)
+            .and_then(|(_, value)| value)
+            .unwrap();
+
+        assert_eq!(token, "token-from-provider");
+        assert!(!args.iter().any(|arg| arg == "token-from-provider"));
+        assert_eq!(
+            args,
+            [
+                "--color",
+                "no",
+                "--server-url",
+                "https://vault.bitwarden.eu"
+            ]
+        );
+    }
+
+    #[test]
+    fn command_pins_default_server_as_argument() {
+        let provider = provider_with_credentials(None);
+        let command = provider.command().unwrap();
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            ["--color", "no", "--server-url", "https://bitwarden.com"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn get_reads_json_from_bws_cli_and_caches_the_project_listing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let cli = temp.path().join("bws");
+        let count = temp.path().join("count");
+        let script = format!(
+            "#!/bin/sh\n\
+             test \"$BWS_ACCESS_TOKEN\" = token-from-provider || exit 41\n\
+             printf x >> '{}'\n\
+             printf '%s' '[{{\"id\":\"11111111-1111-1111-1111-111111111111\",\
+             \"key\":\"DATABASE_URL\",\"value\":\"postgres://db\"}}]'\n",
+            count.display()
+        );
+        std::fs::write(&cli, script).unwrap();
+        let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&cli, permissions).unwrap();
+
+        let mut provider = provider_with_credentials(None);
+        provider.cli_binary_path = cli.to_string_lossy().into_owned();
+
+        let first = provider
+            .get(Address::convention("project", "default", "DATABASE_URL"))
+            .unwrap()
+            .unwrap();
+        let second = provider
+            .get(Address::convention("project", "default", "DATABASE_URL"))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(first.expose_secret(), "postgres://db");
+        assert_eq!(second.expose_secret(), "postgres://db");
+        assert_eq!(std::fs::read_to_string(count).unwrap(), "x");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_updates_an_existing_secret_through_bws_cli() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let cli = temp.path().join("bws");
+        let args_log = temp.path().join("args");
+        let script = format!(
+            "#!/bin/sh\n\
+             case \" $* \" in\n\
+             *' secret list '*)\n\
+               printf '%s' '[{{\"id\":\"11111111-1111-1111-1111-111111111111\",\
+               \"key\":\"DATABASE_URL\",\"value\":\"old\"}}]'\n\
+               ;;\n\
+             *)\n\
+               for argument in \"$@\"; do printf '%s\\n' \"$argument\"; done > '{}'\n\
+               ;;\n\
+             esac\n",
+            args_log.display()
+        );
+        std::fs::write(&cli, script).unwrap();
+        let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&cli, permissions).unwrap();
+
+        let mut provider = provider_with_credentials(None);
+        provider.cli_binary_path = cli.to_string_lossy().into_owned();
+        provider
+            .set(
+                Address::convention("project", "default", "DATABASE_URL"),
+                &SecretString::new("--password".to_string().into()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(args_log).unwrap(),
+            "--color\nno\n--server-url\nhttps://bitwarden.com\nsecret\nedit\n\
+             11111111-1111-1111-1111-111111111111\n--value=--password\n--output\nnone\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_creates_a_missing_secret_through_bws_cli() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let cli = temp.path().join("bws");
+        let args_log = temp.path().join("args");
+        let script = format!(
+            "#!/bin/sh\n\
+             case \" $* \" in\n\
+             *' secret list '*) printf '%s' '[]' ;;\n\
+             *) for argument in \"$@\"; do printf '%s\\n' \"$argument\"; done > '{}' ;;\n\
+             esac\n",
+            args_log.display()
+        );
+        std::fs::write(&cli, script).unwrap();
+        let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&cli, permissions).unwrap();
+
+        let mut provider = provider_with_credentials(None);
+        provider.cli_binary_path = cli.to_string_lossy().into_owned();
+        provider
+            .set(
+                Address::convention("project", "default", "--API_KEY"),
+                &SecretString::new("--password".to_string().into()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(args_log).unwrap(),
+            "--color\nno\n--server-url\nhttps://bitwarden.com\nsecret\ncreate\n--output\nnone\n--\n\
+             --API_KEY\n--password\na9230ec4-5507-4870-b8b5-b3f500587e4c\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cli_errors_redact_the_access_token() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let cli = temp.path().join("bws");
+        std::fs::write(
+            &cli,
+            "#!/bin/sh\nprintf 'rejected %s\\n' \"$BWS_ACCESS_TOKEN\" >&2\nexit 1\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&cli, permissions).unwrap();
+
+        let mut provider = provider_with_credentials(None);
+        provider.cli_binary_path = cli.to_string_lossy().into_owned();
+
+        let error = provider
+            .get(Address::convention("project", "default", "DATABASE_URL"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("[REDACTED]"), "{error}");
+        assert!(!error.contains("token-from-provider"), "{error}");
     }
 
     /// BWS secrets are flat key/value pairs; a `field` coordinate is rejected.


### PR DESCRIPTION
## Summary

- replace the in-process Bitwarden SDK integration with `bws secret list`, `bws secret create`, and `bws secret edit`
- pass the machine-account token through `BWS_ACCESS_TOKEN`, preserve per-provider credentials and server selection, and support `SECRETSPEC_BWS_CLI_PATH`
- remove the restricted `bitwarden` dependency and its transitive packages from the workspace lockfile
- add mocked CLI coverage for reads, caching, creates, updates, server routing, and error redaction
- document the SecretSpec 0.17+ CLI prerequisite, process-argument caveat, and the licensing reason for not using the Rust SDK

## Why

The Bitwarden SDK license does not permit a compatible application built with the SDK to be offered, licensed, or sold to third parties, and prohibits SDK redistribution. That makes linking the SDK unsuitable for a publicly distributed SecretSpec crate and CLI. Invoking the separately installed official CLI keeps Bitwarden software outside SecretSpec's distribution boundary.

This is an unfortunate compromise: an SDK integration would be faster and simpler to install, while the CLI requires write values as process arguments. The provider page now calls this out prominently.

## User impact

Starting with SecretSpec 0.17, the BWS provider requires the official `bws` CLI 0.3.0 or later on `PATH` (or at `SECRETSPEC_BWS_CLI_PATH`). Provider URIs, access-token credentials, project-scoped behavior, EU/self-hosted routing, and read/write support remain intact.

## Validation

- `cargo test --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run build` in `docs/`
- commit-time Clippy and rustfmt hooks
