### PR TITLE
Add Scaleway Secret Manager provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Scaleway Secret Manager provider (`scaleway://`, `scaleway` build feature) for
+  storing secrets in Scaleway's Secret Manager over its v1beta1 REST API.
+  Authenticates with an API secret key (`secret_key` credential or
+  `SCW_SECRET_KEY`), targets a region (URI host or `SCW_DEFAULT_REGION`, default
+  `fr-par`) and project (`?project_id=` or `SCW_DEFAULT_PROJECT_ID`), and stores
+  convention secrets under the folder path `secretspec/{project}/{profile}` with
+  the key as the secret name. Native `ref` references may select a JSON key with
+  `field` and a revision with `version`, and are read-only.
 - `secretspec config global init --provider <PROVIDER> --profile <PROFILE>`
   can save explicitly user-global defaults without interactive prompts,
   including `--profile none` to clear the default profile. The `global`

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -120,7 +120,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), or age (0.17+).`,
+Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), or age (0.17+).`,
         }),
       ],
       title: "SecretSpec",
@@ -223,6 +223,11 @@ Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files,
             {
               label: "AWS Secrets Manager",
               slug: "providers/awssm",
+            },
+            {
+              label: "Scaleway Secret Manager",
+              slug: "providers/scaleway",
+              badge: { text: "0.17+", variant: "note" },
             },
             {
               label: "Vault",

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -51,6 +51,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [lastpass](/providers/lastpass/) | LastPass | ✓ | ✓ | ✓ | — |
 | [gcsm](/providers/gcsm/) | Google Cloud Secret Manager (requires the `gcsm` build feature) | ✓ | ✓ | ✓ | — |
 | [awssm](/providers/awssm/) | AWS Secrets Manager (requires the `awssm` build feature) | ✓ | ✓ | ✓ | — |
+| [scaleway](/providers/scaleway/) (0.17+) | Scaleway Secret Manager (requires the `scaleway` build feature) | ✓ | ✓ | ✓ | — |
 | [vault](/providers/vault/) | HashiCorp Vault (requires the `vault` build feature) | ✓ | ✓ | ✓ | — |
 | [openbao](/providers/openbao/) (0.17+) | OpenBao (requires the `openbao` build feature; 0.16 uses `openbao://` through `vault`) | ✓ | ✓ | ✓ | — |
 | [bws](/providers/bws/) | Bitwarden Secrets Manager (official `bws` CLI in SecretSpec 0.17+; requires the `bws` build feature) | ✓ | ✓ | ✓ | — |

--- a/docs/src/content/docs/providers/scaleway.md
+++ b/docs/src/content/docs/providers/scaleway.md
@@ -1,0 +1,140 @@
+---
+title: Scaleway Secret Manager Provider
+description: Scaleway Secret Manager integration
+---
+
+:::note
+The Scaleway Secret Manager provider is available in SecretSpec 0.17+.
+:::
+
+The Scaleway Secret Manager provider stores secrets in [Scaleway Secret
+Manager](https://www.scaleway.com/en/secret-manager/) through its `v1beta1`
+REST API.
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `scaleway` |
+| URI | `scaleway://[REGION][?project_id=UUID&path=/folder]` |
+| Access | Read and write; secret references are read-only |
+| Best for | Workloads and teams on Scaleway |
+| Authentication | API secret key (`X-Auth-Token`) |
+| Build feature | `scaleway` |
+| Default storage | folder `[{base}/]secretspec/{project}/{profile}`, name `{key}` |
+
+## Quick start
+
+```bash
+$ export SCW_SECRET_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+$ export SCW_DEFAULT_PROJECT_ID=11111111-2222-3333-4444-555555555555
+
+# Set a secret
+$ secretspec set DATABASE_URL --provider scaleway://fr-par
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to scaleway (profile: default)
+
+# Run with secrets
+$ secretspec run --provider scaleway://fr-par -- npm start
+```
+
+## Setup
+
+### Prerequisites
+
+- A Scaleway account with Secret Manager enabled
+- An API key (access key + secret key) with Secret Manager permissions
+- Build with `--features scaleway`
+
+### Authentication
+
+The provider authenticates with a Scaleway API **secret key**, sent in the
+`X-Auth-Token` header. It is read from, in order:
+
+1. The `secret_key` provider credential
+2. The `SCW_SECRET_KEY` environment variable
+
+The target project is read from `?project_id=` in the URI, falling back to
+`SCW_DEFAULT_PROJECT_ID`. The region is the URI host, falling back to
+`SCW_DEFAULT_REGION`, and finally `fr-par`. Secret Manager is available in the
+`fr-par`, `nl-ams`, and `pl-waw` regions.
+
+## Configuration
+
+### URI format
+
+```
+scaleway://[REGION][?project_id=UUID][&path=/folder]
+```
+
+- `REGION`: Scaleway region (e.g. `fr-par`). If omitted, `SCW_DEFAULT_REGION`
+  is used, then `fr-par`.
+- `project_id`: Target project UUID. If omitted, `SCW_DEFAULT_PROJECT_ID` is
+  used.
+- `path`: Optional base folder prepended to the convention hierarchy. Defaults
+  to `/` (root).
+
+### URI examples
+
+```text
+scaleway://fr-par
+scaleway://nl-ams?project_id=11111111-2222-3333-4444-555555555555
+scaleway://fr-par?project_id=11111111-2222-3333-4444-555555555555&path=/myteam
+scaleway://
+```
+
+### Project configuration
+
+The region and project usually vary per environment, so they are a natural fit
+for a checked-in [provider alias](/reference/configuration/) in
+`secretspec.toml` (the secret key stays in the environment, never the URI):
+
+```toml
+[providers]
+scw = "scaleway://fr-par?project_id=11111111-2222-3333-4444-555555555555"
+```
+
+```toml title="secretspec.toml"
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["scw"] }
+```
+
+## Storage model
+
+Scaleway secret names may not contain `/` — that character separates folders —
+so the SecretSpec convention lives in the folder hierarchy rather than the
+name. A secret is stored in the folder `[{base}/]secretspec/{project}/{profile}`
+with the key as its name.
+
+For example, `DATABASE_URL` in project `myapp` and profile `production` is
+stored at folder `/secretspec/myapp/production` with name `DATABASE_URL`. With
+`?path=/myteam`, the folder becomes `/myteam/secretspec/myapp/production`.
+
+Each write appends a new secret version; reads return the latest enabled
+version.
+
+## Use existing secrets
+
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing Scaleway secret instead. `item` is the secret's absolute path
+(folder + name, e.g. `/prod/db-url`); the optional `field` selects one key of a
+JSON (`key_value`) secret, and the optional `version` pins a revision number
+(default: latest enabled). References are **read-only** in this provider.
+
+```toml
+[profiles.production]
+# Whole secret value, latest enabled revision
+DATABASE_URL = { description = "DB", ref = { item = "/prod/database-url" }, providers = ["scaleway://fr-par"] }
+# One key of a JSON secret, pinned to revision 3
+DB_PASSWORD = { description = "DB pw", ref = { item = "/prod/db-credentials", field = "password", version = "3" }, providers = ["scaleway://fr-par"] }
+```
+
+## CI/CD
+
+```bash
+$ export SCW_SECRET_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+$ export SCW_DEFAULT_PROJECT_ID=11111111-2222-3333-4444-555555555555
+$ export SCW_DEFAULT_REGION=fr-par
+
+$ secretspec run --provider scaleway://fr-par -- deploy
+```

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -111,6 +111,7 @@ $ secretspec config global init  # 0.17+
   lastpass: LastPass password manager
   gcsm: Google Cloud Secret Manager
   awssm: AWS Secrets Manager
+  scaleway: Scaleway Secret Manager (0.17+)
   vault: HashiCorp Vault secret management
   openbao: OpenBao secret management (0.17+)
   bws: Bitwarden Secrets Manager

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -196,6 +196,21 @@ awssm://                      # SDK default region and credentials
 **Prerequisites**: AWS credentials configured, build with `--features awssm`
 **Storage**: Secret name `secretspec/{project}/{profile}/{key}`
 
+## Scaleway Secret Manager Provider (0.17+)
+
+**URI**: `scaleway://[REGION][?project_id=UUID&path=/folder]` - Stores secrets in Scaleway Secret Manager
+
+```bash
+scaleway://fr-par                                    # Region, project from SCW_DEFAULT_PROJECT_ID
+scaleway://nl-ams?project_id=PROJECT_UUID            # Region and project
+scaleway://fr-par?project_id=PROJECT_UUID&path=/team # Nest under a folder
+scaleway://                                          # Region from SCW_DEFAULT_REGION, else fr-par
+```
+
+**Features**: Read/write, cloud sync, profiles via folders, version-pinned refs, JSON-key refs
+**Prerequisites**: Scaleway API secret key (`secret_key` credential or `SCW_SECRET_KEY`), build with `--features scaleway`
+**Storage**: Folder `[{base}/]secretspec/{project}/{profile}`, secret name `{key}`
+
 ## Vault Provider
 
 **URI**: `vault://[namespace@]host[:port][/mount][?options]` - Stores secrets in HashiCorp Vault's KV engine
@@ -360,6 +375,7 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | OnePassword | ✅ End-to-end | Cloud (OnePassword) | ✅ Yes |
 | GCSM | ✅ Google-managed | Cloud (GCP) | ✅ Yes |
 | AWSSM | ✅ AWS KMS | Cloud (AWS) | ✅ Yes |
+| Scaleway (0.17+) | ✅ Scaleway-managed | Cloud (Scaleway) | ✅ Yes |
 | Vault | ✅ Vault encryption | Vault server | ✅ Yes |
 | OpenBao (0.17+) | ✅ OpenBao encryption | OpenBao server | ✅ Yes |
 | BWS | ✅ End-to-end | Cloud (Bitwarden) | ✅ Yes |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -43,6 +43,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'vault', slug: 'vault', label: 'Vault' },
   { slug: 'openbao', label: 'OpenBao (0.17+)' },
   { slug: 'awssm', label: 'AWS Secrets Manager' },
+  { slug: 'scaleway', label: 'Scaleway Secret Manager (0.17+)' },
   { icon: 'googlecloud', slug: 'gcsm', label: 'Google Cloud Secret Manager' },
   { icon: 'microsoftazure', slug: 'akv', label: 'Azure Key Vault' },
   { slug: 'infisical', label: 'Infisical' },

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -150,6 +150,7 @@ $ secretspec config global init
   openbao: OpenBao secret management (0.17+)
   age: age-encrypted file (0.17+)
   systemd-credential: Read-only systemd service credentials (0.17+)
+  scaleway: Scaleway Secret Manager (0.17+)
 <span class="tok-str">✓</span> Saved to ~/.config/secretspec/config.toml
 
 <span class="tok-com"># 3. Run your app with secrets injected</span>
@@ -220,7 +221,8 @@ $ secretspec run --profile production -- npm start
   infisical: Infisical secret management
   openbao: OpenBao secret management (0.17+)
   age: age-encrypted file (0.17+)
-  systemd-credential: Read-only systemd service credentials (0.17+)</code></pre>
+  systemd-credential: Read-only systemd service credentials (0.17+)
+  scaleway: Scaleway Secret Manager (0.17+)</code></pre>
       </div>
 
       <div class="landing-step">

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -52,7 +52,7 @@ detect-coding-agent.workspace = true
 age = { workspace = true, optional = true }
 
 [features]
-default = ["cli", "keyring", "kdbx", "gcsm", "awssm", "vault", "openbao", "bws", "akv", "infisical", "age"]
+default = ["cli", "keyring", "kdbx", "gcsm", "awssm", "vault", "openbao", "bws", "akv", "infisical", "age", "scaleway"]
 cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
@@ -63,6 +63,9 @@ vendored-dbus = ["keyring?/vendored"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 vault = ["dep:reqwest"]
+# Scaleway Secret Manager talks to the v1beta1 REST API directly; base64
+# payloads use data-encoding, which is already a non-optional dependency.
+scaleway = ["dep:reqwest"]
 openbao = ["dep:reqwest"]
 # `tokio/sync` for the async `OnceCell` that serializes the Universal Auth
 # exchange. It is already on transitively via reqwest, but a provider should

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -29,6 +29,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [systemd credentials](https://secretspec.dev/providers/systemd-credential) (0.17+)
   - [Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
+  - [Scaleway Secret Manager](https://secretspec.dev/providers/scaleway) (0.17+)
   - [Vault](https://secretspec.dev/providers/vault)
   - [OpenBao](https://secretspec.dev/providers/openbao) (0.17+)
   - [Bitwarden Secrets Manager](https://secretspec.dev/providers/bws) (official `bws` CLI required in SecretSpec 0.17+)
@@ -162,6 +163,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[LastPass](https://secretspec.dev/providers/lastpass)** - Cloud password manager
 - **[Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)** - GCP secret management
 - **[AWS Secrets Manager](https://secretspec.dev/providers/awssm)** - AWS secret management
+- **[Scaleway Secret Manager](https://secretspec.dev/providers/scaleway)** (0.17+) - Scaleway secret management
 - **[Vault](https://secretspec.dev/providers/vault)** - HashiCorp Vault KV engine
 - **[OpenBao](https://secretspec.dev/providers/openbao)** (0.17+) - OpenBao KV integration; SecretSpec 0.16 accepts `openbao://` through the Vault provider
 - **[Bitwarden Secrets Manager](https://secretspec.dev/providers/bws)** - Bitwarden Secrets Manager integration (official `bws` CLI required in SecretSpec 0.17+)

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -71,6 +71,7 @@ $ secretspec config global init  # 0.17+
   lastpass: LastPass password manager
   gcsm: Google Cloud Secret Manager
   awssm: AWS Secrets Manager
+  scaleway: Scaleway Secret Manager (0.17+)
   vault: HashiCorp Vault secret management
   openbao: OpenBao secret management (0.17+)
   bws: Bitwarden Secrets Manager

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -290,6 +290,8 @@ pub mod onepassword;
 pub mod openbao;
 pub mod pass;
 pub mod protonpass;
+#[cfg(feature = "scaleway")]
+pub mod scaleway;
 pub mod systemd_credential;
 #[cfg(feature = "vault")]
 pub mod vault;

--- a/secretspec/src/provider/scaleway.rs
+++ b/secretspec/src/provider/scaleway.rs
@@ -1,0 +1,721 @@
+//! Scaleway Secret Manager provider.
+//!
+//! Stores and retrieves secrets through Scaleway's Secret Manager
+//! (`v1beta1`) REST API.
+//!
+//! # Authentication
+//!
+//! Requests are authenticated with an API secret key sent in the
+//! `X-Auth-Token` header. It is read from the `secret_key` provider credential
+//! or the `SCW_SECRET_KEY` environment variable.
+//!
+//! # URI format
+//!
+//! `scaleway://[region][?project_id=UUID][&path=/folder]`
+//!
+//! - `scaleway://fr-par` — Paris region, project from `SCW_DEFAULT_PROJECT_ID`
+//! - `scaleway://nl-ams?project_id=11111111-2222-3333-4444-555555555555`
+//! - `scaleway://fr-par?project_id=…&path=/myteam` — nest secrets under a folder
+//! - `scaleway://` — region from `SCW_DEFAULT_REGION`, else `fr-par`
+//!
+//! With no region in the URI, `SCW_DEFAULT_REGION` supplies it, falling back to
+//! `fr-par`. The project id is not part of the server identity, so it is taken
+//! from the URI or `SCW_DEFAULT_PROJECT_ID` and never treated as a secret.
+//!
+//! # Secret naming
+//!
+//! Scaleway secret names may not contain `/` (that is the folder separator), so
+//! the SecretSpec convention lives in the folder hierarchy rather than the
+//! name: convention secrets are stored at path
+//! `[{base}/]secretspec/{project}/{profile}` with name `{key}`. A native `ref`
+//! names an absolute Scaleway path in `item` (e.g.
+//! `ref = { item = "/prod/db-url" }`), optionally selecting a JSON key with
+//! `field` and a revision with `version`. Native references are read-only.
+//!
+//! ```bash
+//! secretspec set DATABASE_URL --provider scaleway://fr-par?project_id=…
+//! secretspec check --provider scaleway://fr-par?project_id=…
+//! ```
+
+use super::{
+    Address, Provider, ProviderCredentials, ProviderUrl, credential_or_envs, preferred_env,
+};
+use crate::config::NativeAddress;
+use crate::{Result, SecretSpecError};
+use data_encoding::BASE64;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+
+/// Semantic credential name for the Scaleway API secret key.
+const SECRET_KEY: &str = "secret_key";
+/// Environment fallback for the API secret key.
+const SECRET_KEY_ENV: &str = "SCW_SECRET_KEY";
+/// Environment fallback for the target project id.
+const PROJECT_ID_ENV: &str = "SCW_DEFAULT_PROJECT_ID";
+/// Environment fallback for the region.
+const REGION_ENV: &str = "SCW_DEFAULT_REGION";
+/// Region used when neither the URI nor the environment specifies one.
+const DEFAULT_REGION: &str = "fr-par";
+/// Revision read when a native reference does not pin `version`.
+const DEFAULT_REVISION: &str = "latest_enabled";
+
+/// Configuration for the Scaleway Secret Manager provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScalewayConfig {
+    /// Effective region (URI host, else `SCW_DEFAULT_REGION`, else `fr-par`).
+    pub region: String,
+    /// Target project id from the URI. `None` falls back to
+    /// `SCW_DEFAULT_PROJECT_ID` at call time; it is not part of `uri()`.
+    pub project_id: Option<String>,
+    /// Base folder prepended to the convention hierarchy. Normalized to a
+    /// leading slash with no trailing slash; `/` (root) is the default.
+    pub path: String,
+}
+
+impl TryFrom<&ProviderUrl> for ScalewayConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "scaleway" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for scaleway provider. Expected 'scaleway'.",
+                url.scheme()
+            )));
+        }
+
+        let region = url
+            .host()
+            .filter(|s| !s.is_empty())
+            .or_else(|| preferred_env(&[REGION_ENV]))
+            .unwrap_or_else(|| DEFAULT_REGION.to_string());
+
+        let project_id = url.query_value("project_id").filter(|s| !s.is_empty());
+
+        let path = normalize_path(url.query_value("path").as_deref().unwrap_or("/"));
+
+        Ok(Self {
+            region,
+            project_id,
+            path,
+        })
+    }
+}
+
+/// Normalizes a folder path to a single leading slash and no trailing slash.
+/// Root collapses to `/`.
+fn normalize_path(path: &str) -> String {
+    let trimmed = path.trim_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+/// Scaleway Secret Manager provider.
+pub struct ScalewayProvider {
+    config: ScalewayConfig,
+    credentials: ProviderCredentials,
+}
+
+crate::register_provider! {
+    struct: ScalewayProvider,
+    config: ScalewayConfig,
+    name: "scaleway",
+    description: "Scaleway Secret Manager",
+    schemes: ["scaleway"],
+    examples: ["scaleway://fr-par", "scaleway://nl-ams?project_id=PROJECT_UUID", "scaleway://fr-par?project_id=PROJECT_UUID&path=/myteam"],
+    credential_names: [SECRET_KEY],
+}
+
+/// One secret in a `ListSecrets` response (only the fields we consume).
+#[derive(Deserialize)]
+struct ListedSecret {
+    id: String,
+    name: String,
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct ListSecretsResponse {
+    #[serde(default)]
+    secrets: Vec<ListedSecret>,
+}
+
+#[derive(Deserialize)]
+struct CreatedSecret {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct AccessResponse {
+    /// Base64-encoded payload.
+    data: String,
+}
+
+impl ScalewayProvider {
+    pub fn new(config: ScalewayConfig) -> Self {
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+        }
+    }
+
+    /// Builds the convention item as an absolute Scaleway path
+    /// `[{base}/]secretspec/{project}/{profile}/{key}`. The folder is
+    /// everything up to the last segment; the name is `{key}`.
+    fn format_item(base: &str, project: &str, profile: &str, key: &str) -> Result<String> {
+        for (label, value) in [("project", project), ("profile", profile), ("key", key)] {
+            if value.is_empty() {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "{label} cannot be empty"
+                )));
+            }
+        }
+        // `base` is already normalized ("/" or "/prefix"); trim its slash so we
+        // never emit a double slash when composing the hierarchy.
+        let base = base.trim_end_matches('/');
+        Ok(format!("{base}/secretspec/{project}/{profile}/{key}"))
+    }
+
+    /// Splits an absolute item path into `(secret_path, secret_name)`. The path
+    /// is the folder (at least `/`); the name is the final segment.
+    fn split_item(item: &str) -> Result<(String, String)> {
+        let item = item.trim_end_matches('/');
+        match item.rsplit_once('/') {
+            Some((folder, name)) if !name.is_empty() => {
+                let folder = if folder.is_empty() { "/" } else { folder };
+                Ok((folder.to_string(), name.to_string()))
+            }
+            // No slash, or a trailing-only slash: not an addressable secret.
+            _ => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "scaleway secret path '{item}' has no name segment; \
+                 use an absolute path like /folder/NAME"
+            ))),
+        }
+    }
+
+    fn secret_key(&self) -> Result<SecretString> {
+        credential_or_envs(&self.credentials, SECRET_KEY, &[SECRET_KEY_ENV])
+            .map(|k| SecretString::new(k.into()))
+            .ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "No Scaleway secret key found. Configure the {SECRET_KEY} provider \
+                     credential or set {SECRET_KEY_ENV}."
+                ))
+            })
+    }
+
+    fn project_id(&self) -> Result<String> {
+        self.config
+            .project_id
+            .clone()
+            .or_else(|| preferred_env(&[PROJECT_ID_ENV]))
+            .ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "No Scaleway project id found. Add ?project_id=… to the provider URI \
+                     or set {PROJECT_ID_ENV}."
+                ))
+            })
+    }
+
+    fn region_base(&self) -> String {
+        format!(
+            "https://api.scaleway.com/secret-manager/v1beta1/regions/{}",
+            self.config.region
+        )
+    }
+
+    fn client(secret_key: &SecretString) -> Result<reqwest::Client> {
+        use reqwest::header::{HeaderMap, HeaderValue};
+        let mut headers = HeaderMap::new();
+        let mut token = HeaderValue::from_str(secret_key.expose_secret()).map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!("Invalid Scaleway secret key: {e}"))
+        })?;
+        token.set_sensitive(true);
+        headers.insert("X-Auth-Token", token);
+        reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to build Scaleway HTTP client: {e}"
+                ))
+            })
+    }
+
+    /// Extracts one key from a JSON secret value (for `key_value` secrets),
+    /// mirroring the AWS provider's `field` semantics.
+    fn extract_json_key(name: &str, value: &str, json_key: &str) -> Result<Option<SecretString>> {
+        let json: serde_json::Value = serde_json::from_str(value).map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "secret '{name}' is not JSON, cannot extract key '{json_key}': {e}"
+            ))
+        })?;
+        match json.get(json_key) {
+            Some(serde_json::Value::String(s)) => Ok(Some(SecretString::new(s.clone().into()))),
+            Some(other) => Ok(Some(SecretString::new(other.to_string().into()))),
+            None => Ok(None),
+        }
+    }
+
+    async fn get_async(
+        &self,
+        item: &str,
+        field: Option<&str>,
+        version: Option<&str>,
+    ) -> Result<Option<SecretString>> {
+        let (secret_path, secret_name) = Self::split_item(item)?;
+        let project_id = self.project_id()?;
+        let secret_key = self.secret_key()?;
+        let revision = version.unwrap_or(DEFAULT_REVISION);
+
+        let url = format!(
+            "{}/secrets-by-path/versions/{}/access",
+            self.region_base(),
+            revision
+        );
+        let response = Self::client(&secret_key)?
+            .get(&url)
+            .query(&[
+                ("project_id", project_id.as_str()),
+                ("secret_name", secret_name.as_str()),
+                ("secret_path", secret_path.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to reach Scaleway Secret Manager: {e}"
+                ))
+            })?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body: AccessResponse = response.json().await.map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to parse Scaleway access response: {e}"
+                    ))
+                })?;
+                let decoded = decode_payload(item, &body.data)?;
+                match field {
+                    None => Ok(Some(SecretString::new(decoded.into()))),
+                    Some(json_key) => Self::extract_json_key(item, &decoded, json_key),
+                }
+            }
+            404 => Ok(None),
+            401 | 403 => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Scaleway authentication failed (HTTP {}). Check {SECRET_KEY_ENV} and its \
+                 permissions.",
+                response.status().as_u16()
+            ))),
+            status => Err(http_error("reading secret", status, response).await),
+        }
+    }
+
+    async fn set_async(&self, item: &str, value: &SecretString) -> Result<()> {
+        let (secret_path, secret_name) = Self::split_item(item)?;
+        let project_id = self.project_id()?;
+        let secret_key = self.secret_key()?;
+        let client = Self::client(&secret_key)?;
+
+        let secret_id = self
+            .ensure_secret(&client, &project_id, &secret_path, &secret_name)
+            .await?;
+
+        // Payloads are transmitted base64-encoded.
+        let data = BASE64.encode(value.expose_secret().as_bytes());
+        let url = format!("{}/secrets/{}/versions", self.region_base(), secret_id);
+        let response = client
+            .post(&url)
+            .json(&serde_json::json!({ "data": data }))
+            .send()
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to reach Scaleway Secret Manager: {e}"
+                ))
+            })?;
+
+        match response.status().as_u16() {
+            200 | 201 => Ok(()),
+            status => Err(http_error("writing secret version", status, response).await),
+        }
+    }
+
+    /// Resolves the secret id for `path`/`name`, creating the secret if it does
+    /// not yet exist. Create-first mirrors the AWS provider; a `409 Conflict`
+    /// means it already exists, so we look the id up.
+    async fn ensure_secret(
+        &self,
+        client: &reqwest::Client,
+        project_id: &str,
+        secret_path: &str,
+        secret_name: &str,
+    ) -> Result<String> {
+        let create_url = format!("{}/secrets", self.region_base());
+        let response = client
+            .post(&create_url)
+            .json(&serde_json::json!({
+                "project_id": project_id,
+                "name": secret_name,
+                "path": secret_path,
+            }))
+            .send()
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to reach Scaleway Secret Manager: {e}"
+                ))
+            })?;
+
+        match response.status().as_u16() {
+            200 | 201 => {
+                let created: CreatedSecret = response.json().await.map_err(|e| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to parse Scaleway create-secret response: {e}"
+                    ))
+                })?;
+                Ok(created.id)
+            }
+            409 => {
+                self.lookup_secret_id(client, project_id, secret_path, secret_name)
+                    .await
+            }
+            status => Err(http_error("creating secret", status, response).await),
+        }
+    }
+
+    async fn lookup_secret_id(
+        &self,
+        client: &reqwest::Client,
+        project_id: &str,
+        secret_path: &str,
+        secret_name: &str,
+    ) -> Result<String> {
+        let url = format!("{}/secrets", self.region_base());
+        let response = client
+            .get(&url)
+            .query(&[
+                ("project_id", project_id),
+                ("name", secret_name),
+                ("path", secret_path),
+                // Required by the API; deletion-scheduled secrets are excluded.
+                ("scheduled_for_deletion", "false"),
+            ])
+            .send()
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to reach Scaleway Secret Manager: {e}"
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            return Err(http_error("listing secrets", status, response).await);
+        }
+
+        let body: ListSecretsResponse = response.json().await.map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to parse Scaleway list-secrets response: {e}"
+            ))
+        })?;
+
+        // The `name`/`path` filters are not guaranteed exact, so match both.
+        body.secrets
+            .into_iter()
+            .find(|s| s.name == secret_name && s.path == secret_path)
+            .map(|s| s.id)
+            .ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Scaleway reported secret '{secret_name}' at '{secret_path}' exists but it \
+                     was not found when listing"
+                ))
+            })
+    }
+}
+
+/// Decodes a base64 payload into a UTF-8 string.
+fn decode_payload(item: &str, data: &str) -> Result<String> {
+    let bytes = BASE64.decode(data.as_bytes()).map_err(|e| {
+        SecretSpecError::ProviderOperationFailed(format!(
+            "Scaleway secret '{item}' payload is not valid base64: {e}"
+        ))
+    })?;
+    String::from_utf8(bytes).map_err(|e| {
+        SecretSpecError::ProviderOperationFailed(format!(
+            "Scaleway secret '{item}' payload is not valid UTF-8: {e}"
+        ))
+    })
+}
+
+/// Builds an error for a non-success HTTP response, including the body.
+async fn http_error(action: &str, status: u16, response: reqwest::Response) -> SecretSpecError {
+    let body = response.text().await.unwrap_or_default();
+    SecretSpecError::ProviderOperationFailed(format!(
+        "Scaleway returned HTTP {status} while {action}: {body}"
+    ))
+}
+
+impl Provider for ScalewayProvider {
+    /// Convention secrets live at `[{base}/]secretspec/{project}/{profile}/{key}`.
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        Ok(NativeAddress {
+            item: Self::format_item(&self.config.path, project, profile, key)?,
+            ..Default::default()
+        })
+    }
+
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let mut params: Vec<String> = Vec::new();
+        if let Some(project_id) = &self.config.project_id {
+            params.push(format!(
+                "project_id={}",
+                ProviderUrl::encode_query(project_id)
+            ));
+        }
+        if self.config.path != "/" {
+            params.push(format!(
+                "path={}",
+                ProviderUrl::encode_query(&self.config.path)
+            ));
+        }
+        if params.is_empty() {
+            format!("scaleway://{}", self.config.region)
+        } else {
+            format!("scaleway://{}?{}", self.config.region, params.join("&"))
+        }
+    }
+
+    /// `field` extracts a key from a JSON (`key_value`) secret; `version` pins a
+    /// revision (default `latest_enabled`).
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field", "version"]
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.get_async(
+            &coords.item,
+            coords.field.as_deref(),
+            coords.version.as_deref(),
+        ))
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let coords = self.resolve_coords(addr)?;
+        super::block_on(self.set_async(&coords.item, value))
+    }
+
+    /// Native references name secrets managed outside SecretSpec and are
+    /// read-only: a `field` write would append a version that discards the
+    /// other JSON keys, and the revision is server-assigned.
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Convention { .. } => Ok(()),
+            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(
+                "scaleway secret references are read-only and cannot be written".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    fn config(spec: &str) -> ScalewayConfig {
+        ScalewayConfig::try_from(&ProviderUrl::new(Url::parse(spec).unwrap())).unwrap()
+    }
+
+    #[test]
+    fn region_from_uri_or_default() {
+        // An explicit host is used verbatim regardless of the environment.
+        assert_eq!(config("scaleway://nl-ams").region, "nl-ams");
+
+        // With no host and no SCW_DEFAULT_REGION, the region falls back to fr-par.
+        let _guard = crate::tests::EnvVarGuard::remove(REGION_ENV);
+        assert_eq!(config("scaleway://").region, "fr-par");
+    }
+
+    #[test]
+    fn path_is_normalized() {
+        assert_eq!(config("scaleway://fr-par").path, "/");
+        assert_eq!(config("scaleway://fr-par?path=/myteam/").path, "/myteam");
+        assert_eq!(config("scaleway://fr-par?path=myteam").path, "/myteam");
+        assert_eq!(config("scaleway://fr-par?path=/a/b").path, "/a/b");
+    }
+
+    #[test]
+    fn wrong_scheme_is_rejected() {
+        let err = ScalewayConfig::try_from(&ProviderUrl::new(Url::parse("awssm://x").unwrap()))
+            .unwrap_err();
+        assert!(err.to_string().contains("Invalid scheme"), "{err}");
+    }
+
+    #[test]
+    fn format_item_root_and_prefix() {
+        assert_eq!(
+            ScalewayProvider::format_item("/", "app", "prod", "DB_URL").unwrap(),
+            "/secretspec/app/prod/DB_URL"
+        );
+        assert_eq!(
+            ScalewayProvider::format_item("/myteam", "app", "prod", "DB_URL").unwrap(),
+            "/myteam/secretspec/app/prod/DB_URL"
+        );
+    }
+
+    #[test]
+    fn format_item_rejects_empty_components() {
+        assert!(ScalewayProvider::format_item("/", "", "prod", "K").is_err());
+        assert!(ScalewayProvider::format_item("/", "app", "", "K").is_err());
+        assert!(ScalewayProvider::format_item("/", "app", "prod", "").is_err());
+    }
+
+    #[test]
+    fn split_item_separates_folder_and_name() {
+        assert_eq!(
+            ScalewayProvider::split_item("/secretspec/app/prod/DB_URL").unwrap(),
+            ("/secretspec/app/prod".to_string(), "DB_URL".to_string())
+        );
+        assert_eq!(
+            ScalewayProvider::split_item("/DB_URL").unwrap(),
+            ("/".to_string(), "DB_URL".to_string())
+        );
+    }
+
+    #[test]
+    fn split_item_rejects_nameless_paths() {
+        assert!(ScalewayProvider::split_item("/").is_err());
+        assert!(ScalewayProvider::split_item("no-leading-slash").is_err());
+    }
+
+    #[test]
+    fn convention_address_uses_the_folder_hierarchy() {
+        let p = ScalewayProvider::new(config("scaleway://fr-par?path=/myteam"));
+        let addr = p.convention_address("app", "default", "A").unwrap();
+        assert_eq!(addr.item, "/myteam/secretspec/app/default/A");
+        assert_eq!(addr.field, None);
+        assert_eq!(addr.version, None);
+    }
+
+    #[test]
+    fn uri_round_trips() {
+        let p = ScalewayProvider::new(config(
+            "scaleway://nl-ams?project_id=11111111-2222-3333-4444-555555555555&path=/myteam",
+        ));
+        assert_eq!(
+            p.uri(),
+            "scaleway://nl-ams?project_id=11111111-2222-3333-4444-555555555555&path=/myteam"
+        );
+        // Bare region, default path: no query string.
+        assert_eq!(
+            ScalewayProvider::new(config("scaleway://fr-par")).uri(),
+            "scaleway://fr-par"
+        );
+    }
+
+    #[test]
+    fn uri_omits_no_secret_material() {
+        // The secret key comes from a credential/env, never the URI, so uri()
+        // cannot leak it regardless of config.
+        let p = ScalewayProvider::new(config("scaleway://fr-par?project_id=abc"));
+        assert!(!p.uri().contains("SCW_SECRET_KEY"));
+    }
+
+    #[test]
+    fn extract_json_key_reads_string_and_renders_scalars() {
+        let v = r#"{"user":"admin","port":5432,"tls":true}"#;
+        assert_eq!(
+            ScalewayProvider::extract_json_key("s", v, "user")
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "admin"
+        );
+        assert_eq!(
+            ScalewayProvider::extract_json_key("s", v, "port")
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "5432"
+        );
+        assert!(
+            ScalewayProvider::extract_json_key("s", v, "missing")
+                .unwrap()
+                .is_none()
+        );
+        assert!(ScalewayProvider::extract_json_key("s", "not-json", "user").is_err());
+    }
+
+    #[test]
+    fn decode_payload_round_trips() {
+        let encoded = BASE64.encode(b"s3cret");
+        assert_eq!(decode_payload("s", &encoded).unwrap(), "s3cret");
+        assert!(decode_payload("s", "!!!not-base64!!!").is_err());
+    }
+
+    #[test]
+    fn native_reference_is_read_only() {
+        let p = ScalewayProvider::new(config("scaleway://fr-par?project_id=abc"));
+        let addr = NativeAddress {
+            item: "/prod/db-url".into(),
+            ..Default::default()
+        };
+        let refusal = p.check_writable(Address::Native(&addr)).unwrap_err();
+        assert!(refusal.to_string().contains("read-only"), "{refusal}");
+        let err = p
+            .set(Address::Native(&addr), &SecretString::new("v".into()))
+            .unwrap_err();
+        assert_eq!(err.to_string(), refusal.to_string());
+    }
+
+    /// The registry factory path the CLI uses: a `scaleway://` spec resolves to
+    /// this provider, proving it is registered and wired end-to-end.
+    #[test]
+    fn scheme_resolves_through_the_registry() {
+        let provider = <Box<dyn Provider>>::try_from(
+            "scaleway://nl-ams?project_id=11111111-2222-3333-4444-555555555555",
+        )
+        .expect("scaleway scheme should resolve");
+        assert_eq!(provider.name(), "scaleway");
+        assert_eq!(
+            provider.uri(),
+            "scaleway://nl-ams?project_id=11111111-2222-3333-4444-555555555555"
+        );
+    }
+
+    /// The provider appears in the enumerated registry that `config init` lists.
+    #[test]
+    fn registered_in_provider_list() {
+        assert!(
+            super::super::PROVIDER_REGISTRY
+                .iter()
+                .any(|r| r.info.name == "scaleway"),
+            "scaleway missing from PROVIDER_REGISTRY"
+        );
+    }
+
+    #[test]
+    fn native_reference_rejects_unsupported_coordinate() {
+        let p = ScalewayProvider::new(config("scaleway://fr-par?project_id=abc"));
+        let addr = NativeAddress {
+            item: "/prod/db-url".into(),
+            section: Some("x".into()),
+            ..Default::default()
+        };
+        let err = p.get(Address::Native(&addr)).unwrap_err();
+        assert!(err.to_string().contains("`section`"), "{err}");
+    }
+}

--- a/secretspec/src/provider/scaleway.rs
+++ b/secretspec/src/provider/scaleway.rs
@@ -83,6 +83,19 @@ impl TryFrom<&ProviderUrl> for ScalewayConfig {
             )));
         }
 
+        // The URI path is not part of the provider identity: only the host
+        // (region) and query (`project_id`, `path`) are honored, and `uri()`
+        // reconstructs the provider without it. Reject a non-root path rather
+        // than silently ignoring it and falling back to the root hierarchy —
+        // folders are configured through `?path=...`.
+        if !url.path().trim_matches('/').is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "scaleway provider URI must not contain a path ('{}'); \
+                 configure a folder with '?path=/folder' instead",
+                url.path()
+            )));
+        }
+
         let region = url
             .host()
             .filter(|s| !s.is_empty())
@@ -562,6 +575,18 @@ mod tests {
         let err = ScalewayConfig::try_from(&ProviderUrl::new(Url::parse("awssm://x").unwrap()))
             .unwrap_err();
         assert!(err.to_string().contains("Invalid scheme"), "{err}");
+    }
+
+    #[test]
+    fn non_root_path_is_rejected() {
+        // `scaleway://fr-par/team` parses, but the path is not part of the
+        // provider identity and `uri()` would drop it, so accepting it would
+        // silently read/write the root hierarchy. Folders go through `?path=`.
+        let err = ScalewayConfig::try_from(&ProviderUrl::new(
+            Url::parse("scaleway://fr-par/team").unwrap(),
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("must not contain a path"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
Adds a `scaleway://` provider backed by [Scaleway Secret Manager](https://www.scaleway.com/en/secret-manager/) via its `v1beta1` REST API. Gated behind a `scaleway` build feature (on by default).

## Behavior

- **Auth:** API secret key in the `X-Auth-Token` header, from the `secret_key` credential or `SCW_SECRET_KEY`.
- **Targeting:** region from the URI host / `SCW_DEFAULT_REGION` / `fr-par`; project from `?project_id=` / `SCW_DEFAULT_PROJECT_ID`.
- **Storage:** Scaleway secret names can't contain `/`, so the SecretSpec convention lives in the folder hierarchy: convention secrets are stored at path `[{base}/]secretspec/{project}/{profile}` with the key as the secret name. `set` creates the secret if needed, then appends a version; `get` reads the latest enabled version and base64-decodes it.
- **Native refs:** `item` is an absolute Scaleway path; optional `field` extracts one key of a JSON (`key_value`) secret and `version` pins a revision. Native refs are read-only (a single-field write would append a version discarding sibling keys).

URI: `scaleway://[REGION][?project_id=UUID&path=/folder]`

## Docs

Updated every listing in the provider checklist: dedicated provider page, concepts + reference tables, security-considerations table, sidebar + LLM summary, landing-page grid, quick-start output, and both READMEs. New provider is version-gated as `(0.17+)`.

## Testing

- Unit tests for URI/config parsing, path normalization, convention/native addressing, `uri()` round-trip, JSON-key extraction, base64 decode, read-only refs, and registry resolution.
- Verified end-to-end against the live Scaleway API: `set` → `get` round-trips the exact value (exercising create-secret → add-version → access-by-path → base64 decode); a bogus key surfaces a clean `401`. Test secrets were created under a throwaway folder and deleted afterward.