### PR TITLE
Add an explicit global config namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `secretspec config --global init --provider <PROVIDER> --profile <PROFILE>`
+- `secretspec config global init --provider <PROVIDER> --profile <PROFILE>`
   can save explicitly user-global defaults without interactive prompts,
-  including `--profile none` to clear the default profile. `--global` is also
-  accepted by global config inspection and provider-alias commands; existing
-  invocations without the scope marker remain compatible.
+  including `--profile none` to clear the default profile. The `global`
+  namespace also supports config inspection and provider-alias commands;
+  existing invocations without the namespace remain compatible.
   ([#171](https://github.com/cachix/secretspec/issues/171))
 - age provider (`age://`) for storing dotenv-style secret sets in an
   age-encrypted file, with ASCII armor by default, team recipient rosters,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `secretspec config init --provider <PROVIDER> --profile <PROFILE>` can save
-  global defaults without interactive prompts, including `--profile none` to
-  clear the default profile.
+- `secretspec config --global init --provider <PROVIDER> --profile <PROFILE>`
+  can save explicitly user-global defaults without interactive prompts,
+  including `--profile none` to clear the default profile. `--global` is also
+  accepted by global config inspection and provider-alias commands; existing
+  invocations without the scope marker remain compatible.
   ([#171](https://github.com/cachix/secretspec/issues/171))
 - age provider (`age://`) for storing dotenv-style secret sets in an
   age-encrypted file, with ASCII armor by default, team recipient rosters,

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -124,17 +124,19 @@ convention-based secrets.
 
 ## Configure the default provider
 
-Run the interactive configuration command to select the provider SecretSpec
-uses when a secret has no provider-specific configuration:
+Run the interactive configuration command to select the user-global provider
+SecretSpec uses when a secret has no provider-specific configuration.
+SecretSpec 0.17+ accepts an explicit `--global` scope marker; the legacy
+spelling without it remains supported:
 
 ```bash
-$ secretspec config init
+$ secretspec config --global init # 0.17+
 ```
 
 SecretSpec 0.17+ can persist the provider and profile non-interactively:
 
 ```bash
-$ secretspec config init --provider env --profile default
+$ secretspec config --global init --provider env --profile default
 ```
 
 The resulting user configuration contains a default provider:
@@ -201,9 +203,10 @@ DATABASE_URL = { description = "Production database", providers = ["onepassword:
 Use the CLI to manage user-level aliases:
 
 ```bash
-$ secretspec config provider add prod_vault "onepassword://Production"
-$ secretspec config provider list
-$ secretspec config provider remove prod_vault
+# SecretSpec 0.17+
+$ secretspec config --global provider add prod_vault "onepassword://Production"
+$ secretspec config --global provider list
+$ secretspec config --global provider remove prod_vault
 ```
 
 These commands modify only `~/.config/secretspec/config.toml`. Edit the
@@ -273,7 +276,7 @@ You can also create a user-level alias with a convention-address credential
 source from the CLI:
 
 ```bash
-$ secretspec config provider add bws "bws://project-uuid" --credential access_token=keyring
+$ secretspec config --global provider add bws "bws://project-uuid" --credential access_token=keyring # 0.17+
 $ secretspec config provider login bws
 ```
 

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -126,17 +126,17 @@ convention-based secrets.
 
 Run the interactive configuration command to select the user-global provider
 SecretSpec uses when a secret has no provider-specific configuration.
-SecretSpec 0.17+ accepts an explicit `--global` scope marker; the legacy
-spelling without it remains supported:
+SecretSpec 0.17+ provides an explicit `global` namespace; the legacy spelling
+without it remains supported:
 
 ```bash
-$ secretspec config --global init # 0.17+
+$ secretspec config global init # 0.17+
 ```
 
 SecretSpec 0.17+ can persist the provider and profile non-interactively:
 
 ```bash
-$ secretspec config --global init --provider env --profile default
+$ secretspec config global init --provider env --profile default
 ```
 
 The resulting user configuration contains a default provider:
@@ -204,9 +204,9 @@ Use the CLI to manage user-level aliases:
 
 ```bash
 # SecretSpec 0.17+
-$ secretspec config --global provider add prod_vault "onepassword://Production"
-$ secretspec config --global provider list
-$ secretspec config --global provider remove prod_vault
+$ secretspec config global provider add prod_vault "onepassword://Production"
+$ secretspec config global provider list
+$ secretspec config global provider remove prod_vault
 ```
 
 These commands modify only `~/.config/secretspec/config.toml`. Edit the
@@ -276,7 +276,7 @@ You can also create a user-level alias with a convention-address credential
 source from the CLI:
 
 ```bash
-$ secretspec config --global provider add bws "bws://project-uuid" --credential access_token=keyring # 0.17+
+$ secretspec config global provider add bws "bws://project-uuid" --credential access_token=keyring # 0.17+
 $ secretspec config provider login bws
 ```
 

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -63,7 +63,7 @@ $ secretspec init
 ✓ Created secretspec.toml with 0 secrets
 
 Next steps:
-  1. secretspec config --global init    # Set up user defaults (0.17+)
+  1. secretspec config global init    # Set up user defaults (0.17+)
   2. secretspec check          # Verify all secrets are set
   3. secretspec run -- your-command  # Run with secrets
 ```
@@ -97,7 +97,7 @@ REDIS_URL = { required = true }
 Configure your preferred secrets storage backend:
 
 ```bash
-$ secretspec config --global init  # 0.17+
+$ secretspec config global init  # 0.17+
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -63,7 +63,7 @@ $ secretspec init
 ✓ Created secretspec.toml with 0 secrets
 
 Next steps:
-  1. secretspec config init    # Set up user configuration
+  1. secretspec config --global init    # Set up user defaults (0.17+)
   2. secretspec check          # Verify all secrets are set
   3. secretspec run -- your-command  # Run with secrets
 ```
@@ -97,7 +97,7 @@ REDIS_URL = { required = true }
 Configure your preferred secrets storage backend:
 
 ```bash
-$ secretspec config init
+$ secretspec config --global init  # 0.17+
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -36,26 +36,26 @@ $ secretspec init --from .env.example
 ✓ Created secretspec.toml with 5 secrets
 ```
 
-### config --global init
-Initialize user-global configuration. SecretSpec 0.17+ accepts the explicit
-`--global` scope marker; without options, it prompts for the provider and
-profile.
+### config global init
+Initialize user-global configuration. The explicit `global` namespace is
+available in SecretSpec 0.17+; without options, the command prompts for the
+provider and profile.
 
 ```bash
-secretspec config [--global] init [--provider <PROVIDER>] [--profile <PROFILE>]
+secretspec config global init [--provider <PROVIDER>] [--profile <PROFILE>] # 0.17+
 ```
 
 SecretSpec 0.17+ accepts `--provider` and `--profile` so installations can save
 both defaults without interaction. Each omitted option still prompts; use
 `--profile none` to clear the saved default profile. The corresponding
 `SECRETSPEC_PROVIDER` and `SECRETSPEC_PROFILE` environment variables are also
-accepted. Project requirements remain in `secretspec.toml`; `--global` makes it
-clear that this command writes user-wide defaults. The legacy spelling without
-`--global` remains supported.
+accepted. Project requirements remain in `secretspec.toml`; the namespace makes
+it clear that this command writes user-wide defaults. The legacy
+`secretspec config init` spelling remains supported as a hidden alias.
 
 **Example:**
 ```bash
-$ secretspec config --global init  # 0.17+
+$ secretspec config global init  # 0.17+
 ? Select your preferred provider backend:
 > keyring: System keychain
 ? Select your default profile:
@@ -65,26 +65,26 @@ $ secretspec config --global init  # 0.17+
 
 ```bash
 # SecretSpec 0.17+: save both defaults without prompting
-$ secretspec config --global init --provider env --profile default
+$ secretspec config global init --provider env --profile default
 ✓ Configuration saved to ~/.config/secretspec/config.toml
 ```
 
-### config --global show
-Display current user-global configuration. SecretSpec 0.17+ accepts the
-explicit `--global` scope marker; the legacy spelling remains supported.
+### config global show
+Display current user-global configuration. The explicit namespace is available
+in SecretSpec 0.17+; `secretspec config show` remains a hidden alias.
 
 ```bash
-secretspec config [--global] show
+secretspec config global show # 0.17+
 ```
 
 **Example:**
 ```bash
-$ secretspec config --global show  # 0.17+
+$ secretspec config global show  # 0.17+
 Provider: keyring
 Profile:  development
 ```
 
-### config --global provider add
+### config global provider add
 Add a provider alias to your user-level configuration (`~/.config/secretspec/config.toml`).
 
 To share aliases with your team, declare them in a top-level `[providers]` table in `secretspec.toml` instead — they take precedence over user-level aliases on name conflict.
@@ -92,12 +92,12 @@ To share aliases with your team, declare them in a top-level `[providers]` table
 :::note[Version compatibility]
 SecretSpec 0.14 supports adding aliases with `<ALIAS>` and `<URI>`.
 The `--credential` option is available starting with SecretSpec 0.15.
-The explicit `--global` scope marker is accepted starting with SecretSpec 0.17;
-the legacy spelling remains supported.
+The explicit `global` namespace is available starting with SecretSpec 0.17;
+the legacy `config provider add` spelling remains a hidden alias.
 :::
 
 ```bash
-secretspec config [--global] provider add <ALIAS> <URI> [--credential NAME=PROVIDER]...
+secretspec config global provider add <ALIAS> <URI> [--credential NAME=PROVIDER]... # 0.17+
 ```
 
 **Arguments:**
@@ -109,35 +109,35 @@ secretspec config [--global] provider add <ALIAS> <URI> [--credential NAME=PROVI
 
 **Example:**
 ```bash
-$ secretspec config --global provider add prod_vault "onepassword://Production" # 0.17+
+$ secretspec config global provider add prod_vault "onepassword://Production" # 0.17+
 ✓ Provider alias 'prod_vault' added: 'onepassword://Production'
 
-$ secretspec config --global provider add bws "bws://project-uuid" --credential access_token=keyring # 0.17+
+$ secretspec config global provider add bws "bws://project-uuid" --credential access_token=keyring # 0.17+
 ✓ Provider alias 'bws' added: 'bws://project-uuid'
   credentials: access_token=keyring
   run 'secretspec config provider login bws' to store the credentials
 ```
 
-### config --global provider list
+### config global provider list
 List all configured user-level provider aliases. Project-level aliases declared in `secretspec.toml` are not shown by this command.
 
 ```bash
-secretspec config [--global] provider list
+secretspec config global provider list # 0.17+
 ```
 
 **Example:**
 ```bash
-$ secretspec config --global provider list  # 0.17+
+$ secretspec config global provider list  # 0.17+
 prod_vault  → onepassword://Production
 shared      → onepassword://Shared
 env         → env://
 ```
 
-### config --global provider remove
+### config global provider remove
 Remove a provider alias from your user-level configuration. To remove a project-level alias, edit the `[providers]` table in `secretspec.toml` directly.
 
 ```bash
-secretspec config [--global] provider remove <ALIAS>
+secretspec config global provider remove <ALIAS> # 0.17+
 ```
 
 **Arguments:**
@@ -145,7 +145,7 @@ secretspec config [--global] provider remove <ALIAS>
 
 **Example:**
 ```bash
-$ secretspec config --global provider remove prod_vault  # 0.17+
+$ secretspec config global provider remove prod_vault  # 0.17+
 ✓ Provider alias 'prod_vault' removed
 ```
 
@@ -467,7 +467,7 @@ $ secretspec audit --json | jq 'select(.outcome == "missing")'
 $ secretspec init --from .env
 
 # Set up user-global defaults (0.17+)
-$ secretspec config --global init
+$ secretspec config global init
 
 # Import existing secrets (optional)
 $ secretspec import env  # or: secretspec import dotenv:.env.old

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -36,23 +36,26 @@ $ secretspec init --from .env.example
 ✓ Created secretspec.toml with 5 secrets
 ```
 
-### config init
-Initialize user configuration. Without options, SecretSpec prompts for the
-provider and profile.
+### config --global init
+Initialize user-global configuration. SecretSpec 0.17+ accepts the explicit
+`--global` scope marker; without options, it prompts for the provider and
+profile.
 
 ```bash
-secretspec config init [--provider <PROVIDER>] [--profile <PROFILE>]
+secretspec config [--global] init [--provider <PROVIDER>] [--profile <PROFILE>]
 ```
 
 SecretSpec 0.17+ accepts `--provider` and `--profile` so installations can save
 both defaults without interaction. Each omitted option still prompts; use
 `--profile none` to clear the saved default profile. The corresponding
 `SECRETSPEC_PROVIDER` and `SECRETSPEC_PROFILE` environment variables are also
-accepted.
+accepted. Project requirements remain in `secretspec.toml`; `--global` makes it
+clear that this command writes user-wide defaults. The legacy spelling without
+`--global` remains supported.
 
 **Example:**
 ```bash
-$ secretspec config init
+$ secretspec config --global init  # 0.17+
 ? Select your preferred provider backend:
 > keyring: System keychain
 ? Select your default profile:
@@ -62,25 +65,26 @@ $ secretspec config init
 
 ```bash
 # SecretSpec 0.17+: save both defaults without prompting
-$ secretspec config init --provider env --profile default
+$ secretspec config --global init --provider env --profile default
 ✓ Configuration saved to ~/.config/secretspec/config.toml
 ```
 
-### config show
-Display current configuration.
+### config --global show
+Display current user-global configuration. SecretSpec 0.17+ accepts the
+explicit `--global` scope marker; the legacy spelling remains supported.
 
 ```bash
-secretspec config show
+secretspec config [--global] show
 ```
 
 **Example:**
 ```bash
-$ secretspec config show
+$ secretspec config --global show  # 0.17+
 Provider: keyring
 Profile:  development
 ```
 
-### config provider add
+### config --global provider add
 Add a provider alias to your user-level configuration (`~/.config/secretspec/config.toml`).
 
 To share aliases with your team, declare them in a top-level `[providers]` table in `secretspec.toml` instead — they take precedence over user-level aliases on name conflict.
@@ -88,10 +92,12 @@ To share aliases with your team, declare them in a top-level `[providers]` table
 :::note[Version compatibility]
 SecretSpec 0.14 supports adding aliases with `<ALIAS>` and `<URI>`.
 The `--credential` option is available starting with SecretSpec 0.15.
+The explicit `--global` scope marker is accepted starting with SecretSpec 0.17;
+the legacy spelling remains supported.
 :::
 
 ```bash
-secretspec config provider add <ALIAS> <URI> [--credential NAME=PROVIDER]...
+secretspec config [--global] provider add <ALIAS> <URI> [--credential NAME=PROVIDER]...
 ```
 
 **Arguments:**
@@ -103,35 +109,35 @@ secretspec config provider add <ALIAS> <URI> [--credential NAME=PROVIDER]...
 
 **Example:**
 ```bash
-$ secretspec config provider add prod_vault "onepassword://Production"
+$ secretspec config --global provider add prod_vault "onepassword://Production" # 0.17+
 ✓ Provider alias 'prod_vault' added: 'onepassword://Production'
 
-$ secretspec config provider add bws "bws://project-uuid" --credential access_token=keyring
+$ secretspec config --global provider add bws "bws://project-uuid" --credential access_token=keyring # 0.17+
 ✓ Provider alias 'bws' added: 'bws://project-uuid'
   credentials: access_token=keyring
   run 'secretspec config provider login bws' to store the credentials
 ```
 
-### config provider list
+### config --global provider list
 List all configured user-level provider aliases. Project-level aliases declared in `secretspec.toml` are not shown by this command.
 
 ```bash
-secretspec config provider list
+secretspec config [--global] provider list
 ```
 
 **Example:**
 ```bash
-$ secretspec config provider list
+$ secretspec config --global provider list  # 0.17+
 prod_vault  → onepassword://Production
 shared      → onepassword://Shared
 env         → env://
 ```
 
-### config provider remove
+### config --global provider remove
 Remove a provider alias from your user-level configuration. To remove a project-level alias, edit the `[providers]` table in `secretspec.toml` directly.
 
 ```bash
-secretspec config provider remove <ALIAS>
+secretspec config [--global] provider remove <ALIAS>
 ```
 
 **Arguments:**
@@ -139,7 +145,7 @@ secretspec config provider remove <ALIAS>
 
 **Example:**
 ```bash
-$ secretspec config provider remove prod_vault
+$ secretspec config --global provider remove prod_vault  # 0.17+
 ✓ Provider alias 'prod_vault' removed
 ```
 
@@ -460,8 +466,8 @@ $ secretspec audit --json | jq 'select(.outcome == "missing")'
 # Initialize from existing .env
 $ secretspec init --from .env
 
-# Set up user configuration
-$ secretspec config init
+# Set up user-global defaults (0.17+)
+$ secretspec config --global init
 
 # Import existing secrets (optional)
 $ secretspec import env  # or: secretspec import dotenv:.env.old

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -258,13 +258,13 @@ Manage user-level aliases via CLI:
 
 ```bash
 # SecretSpec 0.17+: add a provider alias to your user config
-$ secretspec config --global provider add prod_vault "onepassword://Production"
+$ secretspec config global provider add prod_vault "onepassword://Production"
 
 # SecretSpec 0.17+: list all aliases known to your user config
-$ secretspec config --global provider list
+$ secretspec config global provider list
 
 # SecretSpec 0.17+: remove an alias from your user config
-$ secretspec config --global provider remove prod_vault
+$ secretspec config global provider remove prod_vault
 ```
 
 These explicitly scoped CLI commands operate on the user-global config only —

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -257,17 +257,18 @@ env = "env://"
 Manage user-level aliases via CLI:
 
 ```bash
-# Add a provider alias to your user config
-$ secretspec config provider add prod_vault "onepassword://Production"
+# SecretSpec 0.17+: add a provider alias to your user config
+$ secretspec config --global provider add prod_vault "onepassword://Production"
 
-# List all aliases known to your user config
-$ secretspec config provider list
+# SecretSpec 0.17+: list all aliases known to your user config
+$ secretspec config --global provider list
 
-# Remove an alias from your user config
-$ secretspec config provider remove prod_vault
+# SecretSpec 0.17+: remove an alias from your user config
+$ secretspec config --global provider remove prod_vault
 ```
 
-The CLI commands operate on the user-global config only — edit `secretspec.toml` by hand to change project-level aliases.
+These explicitly scoped CLI commands operate on the user-global config only —
+edit `secretspec.toml` by hand to change project-level aliases.
 
 #### SecretSpec 0.15 alias values
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -141,7 +141,7 @@ $ secretspec init --from dotenv
 <span class="tok-str">✓</span> Created secretspec.toml with 5 secrets
 
 <span class="tok-com"># 2. Pick a user-global default (0.17+)</span>
-$ secretspec config --global init
+$ secretspec config global init
 ? Select your preferred provider backend:
 <span class="tok-pun">›</span> keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)
@@ -212,7 +212,7 @@ $ secretspec run --profile production -- npm start
           <p class="landing-step-title">Provider</p>
         </div>
         <p class="landing-step-desc">Choose where this machine looks for values: a system keyring, password manager, cloud secret store, or one of {providerCount} providers.</p>
-        <pre is:raw class="landing-step-code"><code>$ secretspec config --global init <span class="tok-com"># 0.17+</span>
+        <pre is:raw class="landing-step-code"><code>$ secretspec config global init <span class="tok-com"># 0.17+</span>
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -140,8 +140,8 @@ const dup = <T,>(arr: T[]) => [...arr, ...arr];
 $ secretspec init --from dotenv
 <span class="tok-str">✓</span> Created secretspec.toml with 5 secrets
 
-<span class="tok-com"># 2. Pick a storage backend (one-time)</span>
-$ secretspec config init
+<span class="tok-com"># 2. Pick a user-global default (0.17+)</span>
+$ secretspec config --global init
 ? Select your preferred provider backend:
 <span class="tok-pun">›</span> keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)
@@ -212,7 +212,7 @@ $ secretspec run --profile production -- npm start
           <p class="landing-step-title">Provider</p>
         </div>
         <p class="landing-step-desc">Choose where this machine looks for values: a system keyring, password manager, cloud secret store, or one of {providerCount} providers.</p>
-        <pre is:raw class="landing-step-code"><code>$ secretspec config init
+        <pre is:raw class="landing-step-code"><code>$ secretspec config --global init <span class="tok-com"># 0.17+</span>
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -51,12 +51,12 @@ $ secretspec init
 ✓ Created secretspec.toml with 0 secrets
 
 Next steps:
-  1. secretspec config --global init    # Set up user defaults (0.17+)
+  1. secretspec config global init    # Set up user defaults (0.17+)
   2. secretspec check          # Verify all secrets are set
   3. secretspec run -- your-command  # Run with secrets
 
 # 2. Set up provider backend
-$ secretspec config --global init  # 0.17+
+$ secretspec config global init  # 0.17+
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)
@@ -138,10 +138,10 @@ $ secretspec run --profile development -- npm start
 $ secretspec run --profile production -- npm start
 
 # Set a user-global default profile (0.17+)
-$ secretspec config --global init
+$ secretspec config global init
 
 # SecretSpec 0.17+: set provider and profile defaults without prompting
-$ secretspec config --global init --provider env --profile default
+$ secretspec config global init --provider env --profile default
 ```
 
 Learn more about [profiles](https://secretspec.dev/concepts/profiles) and [profile selection](https://secretspec.dev/concepts/profiles#profile-selection).
@@ -174,7 +174,7 @@ $ secretspec run --provider keyring -- npm start
 $ secretspec run --provider dotenv -- npm start
 
 # Configure a user-global default provider (0.17+)
-$ secretspec config --global init
+$ secretspec config global init
 ```
 
 See [provider concepts](https://secretspec.dev/concepts/providers) and [provider reference](https://secretspec.dev/reference/providers) for details.
@@ -236,7 +236,7 @@ Common commands:
 ```bash
 # Initialize and configure
 secretspec init                    # Create secretspec.toml
-secretspec config --global init   # Set up user defaults (0.17+)
+secretspec config global init    # Set up user defaults (0.17+)
 
 # Manage secrets
 secretspec check                  # Verify all secrets are set

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -51,12 +51,12 @@ $ secretspec init
 ✓ Created secretspec.toml with 0 secrets
 
 Next steps:
-  1. secretspec config init    # Set up user configuration
+  1. secretspec config --global init    # Set up user defaults (0.17+)
   2. secretspec check          # Verify all secrets are set
   3. secretspec run -- your-command  # Run with secrets
 
 # 2. Set up provider backend
-$ secretspec config init
+$ secretspec config --global init  # 0.17+
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)
@@ -137,11 +137,11 @@ Profiles allow you to define different secret requirements for each environment 
 $ secretspec run --profile development -- npm start
 $ secretspec run --profile production -- npm start
 
-# Set default profile
-$ secretspec config init
+# Set a user-global default profile (0.17+)
+$ secretspec config --global init
 
 # SecretSpec 0.17+: set provider and profile defaults without prompting
-$ secretspec config init --provider env --profile default
+$ secretspec config --global init --provider env --profile default
 ```
 
 Learn more about [profiles](https://secretspec.dev/concepts/profiles) and [profile selection](https://secretspec.dev/concepts/profiles#profile-selection).
@@ -173,8 +173,8 @@ SecretSpec supports multiple storage backends for secrets:
 $ secretspec run --provider keyring -- npm start
 $ secretspec run --provider dotenv -- npm start
 
-# Configure default provider
-$ secretspec config init
+# Configure a user-global default provider (0.17+)
+$ secretspec config --global init
 ```
 
 See [provider concepts](https://secretspec.dev/concepts/providers) and [provider reference](https://secretspec.dev/reference/providers) for details.
@@ -236,7 +236,7 @@ Common commands:
 ```bash
 # Initialize and configure
 secretspec init                    # Create secretspec.toml
-secretspec config init            # Set up user configuration
+secretspec config --global init   # Set up user defaults (0.17+)
 
 # Manage secrets
 secretspec check                  # Verify all secrets are set

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -134,9 +134,6 @@ enum Commands {
     },
     /// Manage SecretSpec configuration
     Config {
-        /// Use the user-global configuration at ~/.config/secretspec/config.toml (0.17+)
-        #[arg(long)]
-        global: bool,
         #[command(subcommand)]
         action: ConfigAction,
     },
@@ -164,11 +161,17 @@ enum Commands {
 
 /// Configuration-related subcommands.
 ///
-/// Configuration actions. All actions except `provider login` operate on the
-/// user-global configuration. `--global` makes that scope explicit.
+/// User-global configuration has an explicit `global` namespace. Legacy
+/// spellings remain hidden aliases for backwards compatibility.
 #[derive(Subcommand)]
 enum ConfigAction {
+    /// Manage user-global configuration (0.17+)
+    Global {
+        #[command(subcommand)]
+        action: GlobalConfigAction,
+    },
     /// Initialize user configuration
+    #[command(hide = true)]
     Init {
         /// Provider backend to save without prompting (0.17+)
         #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
@@ -178,17 +181,35 @@ enum ConfigAction {
         profile: Option<String>,
     },
     /// Show current configuration
+    #[command(hide = true)]
     Show,
-    /// Manage provider aliases
+    /// Store project-scoped provider credentials
     #[command(subcommand)]
     Provider(ProviderAction),
 }
 
-/// Provider alias management subcommands.
-///
-/// These actions manage named provider aliases or store their credentials.
+/// User-global configuration subcommands.
 #[derive(Subcommand)]
-enum ProviderAction {
+enum GlobalConfigAction {
+    /// Initialize user-global defaults
+    Init {
+        /// Provider backend to save without prompting
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        provider: Option<String>,
+        /// Default profile to save without prompting; use "none" to clear it
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        profile: Option<String>,
+    },
+    /// Show user-global configuration
+    Show,
+    /// Manage user-global provider aliases
+    #[command(subcommand)]
+    Provider(GlobalProviderAction),
+}
+
+/// User-global provider alias management subcommands.
+#[derive(Subcommand)]
+enum GlobalProviderAction {
     /// Add or update a provider alias
     Add {
         /// Name of the provider alias
@@ -209,11 +230,79 @@ enum ProviderAction {
     },
     /// List all configured provider aliases
     List,
+}
+
+/// Legacy provider alias commands plus project-scoped credential login.
+///
+/// Alias mutation commands remain hidden for backwards compatibility; new
+/// invocations should use `config global provider`.
+#[derive(Subcommand)]
+enum ProviderAction {
+    /// Add or update a provider alias
+    #[command(hide = true)]
+    Add {
+        /// Name of the provider alias
+        name: String,
+        /// Provider URI (e.g., "keyring://", "onepassword://Shared", "dotenv://.env.local")
+        uri: String,
+        /// Provider credential binding `NAME=PROVIDER` (repeatable). `NAME` is
+        /// semantic and provider-specific, such as `access_token` or `role_id`.
+        /// Only the bare-string source form is expressible here; add a `ref` by
+        /// editing the config.
+        #[arg(long = "credential", value_name = "NAME=PROVIDER")]
+        credential: Vec<String>,
+    },
+    /// Remove a provider alias
+    #[command(hide = true)]
+    Remove {
+        /// Name of the provider alias to remove
+        name: String,
+    },
+    /// List all configured provider aliases
+    #[command(hide = true)]
+    List,
     /// Store the credentials declared by a provider alias
     Login {
         /// Name of the provider alias to store credentials for
         name: String,
     },
+}
+
+impl From<GlobalConfigAction> for ConfigAction {
+    fn from(action: GlobalConfigAction) -> Self {
+        match action {
+            GlobalConfigAction::Init { provider, profile } => Self::Init { provider, profile },
+            GlobalConfigAction::Show => Self::Show,
+            GlobalConfigAction::Provider(action) => Self::Provider(action.into()),
+        }
+    }
+}
+
+impl From<GlobalProviderAction> for ProviderAction {
+    fn from(action: GlobalProviderAction) -> Self {
+        match action {
+            GlobalProviderAction::Add {
+                name,
+                uri,
+                credential,
+            } => Self::Add {
+                name,
+                uri,
+                credential,
+            },
+            GlobalProviderAction::Remove { name } => Self::Remove { name },
+            GlobalProviderAction::List => Self::List,
+        }
+    }
+}
+
+/// Maps the explicit `config global` namespace onto the legacy internal action
+/// variants so both CLI spellings share exactly one implementation.
+fn normalize_config_action(action: ConfigAction) -> ConfigAction {
+    match action {
+        ConfigAction::Global { action } => action.into(),
+        action => action,
+    }
 }
 
 /// Returns an example TOML configuration string
@@ -523,14 +612,15 @@ pub fn main() -> Result<()> {
             }
 
             println!("\nNext steps:");
-            println!("  1. secretspec config --global init    # Set up user defaults (0.17+)");
+            println!("  1. secretspec config global init    # Set up user defaults (0.17+)");
             println!("  2. secretspec check          # Verify all secrets and set them");
             println!("  3. secretspec run -- your-command  # Run with secrets");
 
             Ok(())
         }
         // Handle configuration management commands
-        Commands::Config { global, action } => match action {
+        Commands::Config { action } => match normalize_config_action(action) {
+            ConfigAction::Global { .. } => unreachable!("global action was normalized"),
             // Initialize user configuration, prompting only for omitted values.
             ConfigAction::Init { provider, profile } => {
                 let provider = select_config_init_provider(provider)?;
@@ -580,7 +670,7 @@ pub fn main() -> Result<()> {
                     }
                     None => {
                         println!(
-                            "No configuration found. Run 'secretspec config --global init' to create one."
+                            "No configuration found. Run 'secretspec config global init' to create one."
                         );
                     }
                 }
@@ -668,7 +758,7 @@ pub fn main() -> Result<()> {
                             }
                             None => {
                                 println!(
-                                    "✗ No configuration found. Run 'secretspec config --global init' first."
+                                    "✗ No configuration found. Run 'secretspec config global init' first."
                                 );
                             }
                         }
@@ -694,18 +784,13 @@ pub fn main() -> Result<()> {
                             }
                             None => {
                                 println!(
-                                    "No configuration found. Run 'secretspec config --global init' first."
+                                    "No configuration found. Run 'secretspec config global init' first."
                                 );
                             }
                         }
                         Ok(())
                     }
                     ProviderAction::Login { name } => {
-                        if global {
-                            return Err(miette!(
-                                "'secretspec config provider login' is project-scoped and does not accept '--global'"
-                            ));
-                        }
                         let app = load_secrets(&cli.file, &cli.reason)?;
                         let credentials =
                             app.declared_provider_credentials(&name).into_diagnostic()?;
@@ -1430,7 +1515,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "secretspec",
             "config",
-            "--global",
+            "global",
             "init",
             "--provider",
             "env",
@@ -1441,10 +1526,11 @@ mod tests {
 
         match cli.command {
             Commands::Config {
-                global,
-                action: ConfigAction::Init { provider, profile },
+                action:
+                    ConfigAction::Global {
+                        action: GlobalConfigAction::Init { provider, profile },
+                    },
             } => {
-                assert!(global);
                 assert_eq!(provider.as_deref(), Some("env"));
                 assert_eq!(profile.as_deref(), Some("default"));
             }
@@ -1481,7 +1567,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "secretspec",
             "config",
-            "--global",
+            "global",
             "provider",
             "add",
             "bws",
@@ -1494,15 +1580,16 @@ mod tests {
         .unwrap();
         match cli.command {
             Commands::Config {
-                global,
                 action:
-                    ConfigAction::Provider(ProviderAction::Add {
-                        name,
-                        uri,
-                        credential,
-                    }),
+                    ConfigAction::Global {
+                        action:
+                            GlobalConfigAction::Provider(GlobalProviderAction::Add {
+                                name,
+                                uri,
+                                credential,
+                            }),
+                    },
             } => {
-                assert!(global);
                 assert_eq!(name, "bws");
                 assert_eq!(uri, "bws://proj");
                 assert_eq!(
@@ -1516,10 +1603,17 @@ mod tests {
 
     #[test]
     fn provider_add_help_describes_semantic_credentials() {
-        let help = Cli::try_parse_from(["secretspec", "config", "provider", "add", "--help"])
-            .err()
-            .expect("--help should stop parsing")
-            .to_string();
+        let help = Cli::try_parse_from([
+            "secretspec",
+            "config",
+            "global",
+            "provider",
+            "add",
+            "--help",
+        ])
+        .err()
+        .expect("--help should stop parsing")
+        .to_string();
 
         assert!(help.contains("semantic and provider-specific"));
         assert!(help.contains("access_token"));
@@ -1530,6 +1624,7 @@ mod tests {
         let error = Cli::try_parse_from([
             "secretspec",
             "config",
+            "global",
             "provider",
             "add",
             "bws",
@@ -1549,10 +1644,8 @@ mod tests {
             Cli::try_parse_from(["secretspec", "config", "provider", "login", "bws"]).unwrap();
         match cli.command {
             Commands::Config {
-                global,
                 action: ConfigAction::Provider(ProviderAction::Login { name }),
             } => {
-                assert!(!global);
                 assert_eq!(name, "bws");
             }
             _ => panic!("expected config provider login"),
@@ -1560,34 +1653,48 @@ mod tests {
     }
 
     #[test]
-    fn legacy_global_config_spelling_remains_supported() {
-        let cli = Cli::try_parse_from(["secretspec", "config", "show"]).unwrap();
-        match cli.command {
-            Commands::Config {
-                global,
-                action: ConfigAction::Show,
-            } => assert!(!global),
-            _ => panic!("expected config show"),
+    fn legacy_global_config_spellings_remain_supported() {
+        let commands: &[&[&str]] = &[
+            &[
+                "secretspec",
+                "config",
+                "init",
+                "--provider",
+                "env",
+                "--profile",
+                "default",
+            ],
+            &["secretspec", "config", "show"],
+            &[
+                "secretspec",
+                "config",
+                "provider",
+                "add",
+                "shared",
+                "keyring://",
+            ],
+            &["secretspec", "config", "provider", "list"],
+            &["secretspec", "config", "provider", "remove", "shared"],
+        ];
+
+        for command in commands {
+            assert!(
+                Cli::try_parse_from(*command).is_ok(),
+                "legacy command should remain accepted: {command:?}"
+            );
         }
     }
 
     #[test]
-    fn provider_login_rejects_global_scope() {
-        let cli = Cli::try_parse_from([
-            "secretspec",
-            "config",
-            "--global",
-            "provider",
-            "login",
-            "bws",
-        ])
-        .unwrap();
-        match cli.command {
-            Commands::Config {
-                global,
-                action: ConfigAction::Provider(ProviderAction::Login { .. }),
-            } => assert!(global),
-            _ => panic!("expected config provider login"),
-        }
+    fn global_provider_namespace_rejects_project_scoped_login() {
+        let error =
+            Cli::try_parse_from(["secretspec", "config", "global", "provider", "login", "bws"])
+                .err()
+                .expect("global provider namespace must not expose project-scoped login");
+        assert!(
+            error
+                .to_string()
+                .contains("unrecognized subcommand 'login'")
+        );
     }
 }

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -132,8 +132,11 @@ enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
-    /// Init or show ~/.config/secretspec/config.toml
+    /// Manage SecretSpec configuration
     Config {
+        /// Use the user-global configuration at ~/.config/secretspec/config.toml (0.17+)
+        #[arg(long)]
+        global: bool,
         #[command(subcommand)]
         action: ConfigAction,
     },
@@ -161,8 +164,8 @@ enum Commands {
 
 /// Configuration-related subcommands.
 ///
-/// These actions handle the user's global configuration settings,
-/// including initialization, viewing current settings, and managing provider aliases.
+/// Configuration actions. All actions except `provider login` operate on the
+/// user-global configuration. `--global` makes that scope explicit.
 #[derive(Subcommand)]
 enum ConfigAction {
     /// Initialize user configuration
@@ -183,7 +186,7 @@ enum ConfigAction {
 
 /// Provider alias management subcommands.
 ///
-/// These actions allow managing named provider aliases in the global configuration.
+/// These actions manage named provider aliases or store their credentials.
 #[derive(Subcommand)]
 enum ProviderAction {
     /// Add or update a provider alias
@@ -520,14 +523,14 @@ pub fn main() -> Result<()> {
             }
 
             println!("\nNext steps:");
-            println!("  1. secretspec config init    # Set up user configuration");
+            println!("  1. secretspec config --global init    # Set up user defaults (0.17+)");
             println!("  2. secretspec check          # Verify all secrets and set them");
             println!("  3. secretspec run -- your-command  # Run with secrets");
 
             Ok(())
         }
         // Handle configuration management commands
-        Commands::Config { action } => match action {
+        Commands::Config { global, action } => match action {
             // Initialize user configuration, prompting only for omitted values.
             ConfigAction::Init { provider, profile } => {
                 let provider = select_config_init_provider(provider)?;
@@ -577,7 +580,7 @@ pub fn main() -> Result<()> {
                     }
                     None => {
                         println!(
-                            "No configuration found. Run 'secretspec config init' to create one."
+                            "No configuration found. Run 'secretspec config --global init' to create one."
                         );
                     }
                 }
@@ -665,7 +668,7 @@ pub fn main() -> Result<()> {
                             }
                             None => {
                                 println!(
-                                    "✗ No configuration found. Run 'secretspec config init' first."
+                                    "✗ No configuration found. Run 'secretspec config --global init' first."
                                 );
                             }
                         }
@@ -691,13 +694,18 @@ pub fn main() -> Result<()> {
                             }
                             None => {
                                 println!(
-                                    "No configuration found. Run 'secretspec config init' first."
+                                    "No configuration found. Run 'secretspec config --global init' first."
                                 );
                             }
                         }
                         Ok(())
                     }
                     ProviderAction::Login { name } => {
+                        if global {
+                            return Err(miette!(
+                                "'secretspec config provider login' is project-scoped and does not accept '--global'"
+                            ));
+                        }
                         let app = load_secrets(&cli.file, &cli.reason)?;
                         let credentials =
                             app.declared_provider_credentials(&name).into_diagnostic()?;
@@ -1422,6 +1430,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "secretspec",
             "config",
+            "--global",
             "init",
             "--provider",
             "env",
@@ -1432,8 +1441,10 @@ mod tests {
 
         match cli.command {
             Commands::Config {
+                global,
                 action: ConfigAction::Init { provider, profile },
             } => {
+                assert!(global);
                 assert_eq!(provider.as_deref(), Some("env"));
                 assert_eq!(profile.as_deref(), Some("default"));
             }
@@ -1470,6 +1481,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "secretspec",
             "config",
+            "--global",
             "provider",
             "add",
             "bws",
@@ -1482,6 +1494,7 @@ mod tests {
         .unwrap();
         match cli.command {
             Commands::Config {
+                global,
                 action:
                     ConfigAction::Provider(ProviderAction::Add {
                         name,
@@ -1489,6 +1502,7 @@ mod tests {
                         credential,
                     }),
             } => {
+                assert!(global);
                 assert_eq!(name, "bws");
                 assert_eq!(uri, "bws://proj");
                 assert_eq!(
@@ -1535,10 +1549,44 @@ mod tests {
             Cli::try_parse_from(["secretspec", "config", "provider", "login", "bws"]).unwrap();
         match cli.command {
             Commands::Config {
+                global,
                 action: ConfigAction::Provider(ProviderAction::Login { name }),
             } => {
+                assert!(!global);
                 assert_eq!(name, "bws");
             }
+            _ => panic!("expected config provider login"),
+        }
+    }
+
+    #[test]
+    fn legacy_global_config_spelling_remains_supported() {
+        let cli = Cli::try_parse_from(["secretspec", "config", "show"]).unwrap();
+        match cli.command {
+            Commands::Config {
+                global,
+                action: ConfigAction::Show,
+            } => assert!(!global),
+            _ => panic!("expected config show"),
+        }
+    }
+
+    #[test]
+    fn provider_login_rejects_global_scope() {
+        let cli = Cli::try_parse_from([
+            "secretspec",
+            "config",
+            "--global",
+            "provider",
+            "login",
+            "bws",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Config {
+                global,
+                action: ConfigAction::Provider(ProviderAction::Login { .. }),
+            } => assert!(global),
             _ => panic!("expected config provider login"),
         }
     }

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -30,7 +30,7 @@ pub enum SecretSpecError {
     #[error("Dotenv error: {0}")]
     Dotenv(#[from] dotenvy::Error),
     #[error(
-        "No provider backend configured.\n\nTo fix this, either:\n  1. Run 'secretspec config --global init' to set up your default provider\n  2. Use --provider flag (e.g., 'secretspec check --provider keyring')"
+        "No provider backend configured.\n\nTo fix this, either:\n  1. Run 'secretspec config global init' to set up your default provider\n  2. Use --provider flag (e.g., 'secretspec check --provider keyring')"
     )]
     NoProviderConfigured,
     #[error("Provider backend '{0}' not found")]

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -30,7 +30,7 @@ pub enum SecretSpecError {
     #[error("Dotenv error: {0}")]
     Dotenv(#[from] dotenvy::Error),
     #[error(
-        "No provider backend configured.\n\nTo fix this, either:\n  1. Run 'secretspec config init' to set up your default provider\n  2. Use --provider flag (e.g., 'secretspec check --provider keyring')"
+        "No provider backend configured.\n\nTo fix this, either:\n  1. Run 'secretspec config --global init' to set up your default provider\n  2. Use --provider flag (e.g., 'secretspec check --provider keyring')"
     )]
     NoProviderConfigured,
     #[error("Provider backend '{0}' not found")]

--- a/tests/cli-integration.sh
+++ b/tests/cli-integration.sh
@@ -146,7 +146,7 @@ check_success "Set secret in production profile"
 # Test 9: List secrets - removed as this command doesn't exist
 
 # Test 10: Config command
-secretspec config --global show > /dev/null
+secretspec config global show > /dev/null
 check_success "Config show command works"
 
 # Test 11: Init from provider

--- a/tests/cli-integration.sh
+++ b/tests/cli-integration.sh
@@ -146,7 +146,7 @@ check_success "Set secret in production profile"
 # Test 9: List secrets - removed as this command doesn't exist
 
 # Test 10: Config command
-secretspec config show > /dev/null
+secretspec config --global show > /dev/null
 check_success "Config show command works"
 
 # Test 11: Init from provider


### PR DESCRIPTION
## Summary

- add `secretspec config global …` as an explicit namespace for commands that read or mutate `~/.config/secretspec/config.toml`
- retain existing invocations without the namespace as hidden aliases for backward compatibility
- keep `config provider login` visibly project-scoped and exclude it from `config global provider`
- update CLI guidance, README, docs, integration coverage, and the unreleased changelog entry

## Why

Project requirements live in `secretspec.toml`, while the config management commands operate on per-user defaults. The old spelling did not make that distinction visible and could imply project-local behavior.

A `global` namespace names the destination accurately without the misleading Git-style implication that omitting a `--global` flag selects a local configuration.

## User impact

SecretSpec 0.17+ can use the clearer spelling, for example:

```console
secretspec config global init
secretspec config global show
secretspec config global provider list
```

Legacy spellings such as `secretspec config init` continue to behave exactly as before, but are hidden from help so new usage converges on the explicit namespace.

## Validation

- `devenv shell cargo fmt --all -- --check`
- `devenv shell cargo test -p secretspec cli::tests` (25 passed)
- full pre-commit hooks (`clippy`, `rustfmt`) in `devenv`
- `devenv shell npm --prefix docs run build`
- inspected `config --help` and `config global provider --help` output
