### PR TITLE
Clarify audit reason defaults

### DIFF
--- a/docs/src/content/docs/concepts/audit.md
+++ b/docs/src/content/docs/concepts/audit.md
@@ -5,7 +5,8 @@ description: A local, append-only record of every secret access for after-the-fa
 
 secretspec records every secret access to a local audit log so you can review,
 after the fact, **what** secret was accessed, **when**, by **whom**, with what
-**reason**, and what the **outcome** was. Auditing is **on by default**.
+**reason, if supplied**, and what the **outcome** was. Auditing is **on by
+default**.
 
 Secret values are never written to the log. Only metadata is recorded, and any
 credentials embedded in a provider URI are redacted.
@@ -71,8 +72,8 @@ and how to turn it off.
 | `actor` | The OS user, the detected coding agent (if any), and whether this is an agent session |
 
 This pairs naturally with the [`require_reason`](/reference/configuration/#requiring-a-reason-for-secret-access)
-policy: the policy makes callers state *why* they need a secret, and the audit
-log records that reason alongside the access.
+policy: when that policy applies, SecretSpec requires the caller to state *why*
+before proceeding and records the supplied reason alongside the access.
 
 ## Reading the log
 

--- a/docs/src/content/docs/providers/protonpass.md
+++ b/docs/src/content/docs/providers/protonpass.md
@@ -145,7 +145,8 @@ The reason recorded in the Proton Pass audit log is resolved in this order:
 
 To force a meaningful reason instead of falling back to the default, use the
 [`require_reason`](/reference/configuration/#requiring-a-reason-for-secret-access)
-policy in `secretspec.toml`. It defaults to `"agents"`, so AI agents must always
-explain why they read a secret (humans are unaffected); set it to `true` to require
-a reason from every caller. secretspec then refuses any access that does not supply
-an explicit reason.
+policy in `secretspec.toml`. It defaults to `"agents"`, so sessions SecretSpec
+detects as AI agents must explain why they read a secret. Detection is
+heuristic; set it to `true` to require a reason from every SecretSpec caller.
+secretspec then refuses operations through SecretSpec that do not supply an
+explicit reason.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -37,22 +37,29 @@ It accepts three values:
 
 | Value | Behavior |
 |-------|----------|
-| `"agents"` (default) | Require a reason **only when an AI agent is detected**. Humans running interactively are unaffected. |
-| `true` | Require a reason from **every** caller (humans, CI, agents). |
+| `"agents"` (default) | Require a reason only when SecretSpec heuristically classifies the current process as an AI agent. Sessions not classified as agents are unaffected. |
+| `true` | Require a reason from every caller using SecretSpec (humans, CI, and agents). |
 | `false` | Never require a reason. |
 
-Because the rule is enforced inside secretspec and checked into `secretspec.toml`,
-every clone, CI runner, and AI agent is held to it — there is no per-tool opt-out:
+The policy is enforced at SecretSpec's secret-access entry points and travels
+with the checked-in `secretspec.toml`. With `true`, every caller using the
+manifest must supply a reason before SecretSpec proceeds:
 
 ```bash
-# Under an AI agent, with the default "agents" policy:
+# In a session SecretSpec detects as an agent, with the default "agents" policy:
 $ secretspec run -- ./deploy.sh
 Error: Accessing secrets requires a reason. Provide one with --reason "<why...>" ...
 
 $ secretspec run --reason "Deploy web frontend" -- ./deploy.sh   # ok
 ```
 
-**Agent detection.** secretspec delegates detection of known agents to the
+:::caution[Agent detection is heuristic]
+The default `"agents"` policy depends on detection. It can miss an unknown or
+changed agent and can classify a session incorrectly. Use
+`require_reason = true` when every SecretSpec caller must supply a reason.
+:::
+
+**Agent detection.** secretspec delegates heuristic detection of known agents to the
 [`detect-coding-agent`](https://crates.io/crates/detect-coding-agent) crate, which
 maintains the per-tool signal list (Claude Code, Cursor, Codex, Gemini CLI,
 Copilot, and more). It treats **autonomous and hybrid** environments as agents but
@@ -64,11 +71,12 @@ not human-driven interactive editors. In addition, secretspec checks its own
 $ export SECRETSPEC_AGENT=1
 ```
 
-If your agent isn't auto-detected, set `SECRETSPEC_AGENT=1` (or use
-`require_reason = true` to require a reason from everyone).
+Cooperative harnesses that are not auto-detected can set `SECRETSPEC_AGENT=1`.
+Do not rely on a caller to identify itself when a reason is mandatory; use
+`require_reason = true` instead.
 
-The reason is recorded in secretspec's own [audit log](/concepts/audit/) and is also
-forwarded to providers that support auditing (e.g. the
+The reason is recorded in secretspec's own [audit log](/concepts/audit/) and is
+also forwarded to providers that support auditing (e.g. the
 [Proton Pass](/providers/protonpass/) provider records it in the agent audit log).
 
 ### [profiles.*] Section

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -571,7 +571,7 @@ $ secretspec run --provider bws -- ./deploy
       <span class="landing-showcase-eyebrow">Audit &amp; AI agents</span>
       <h2 class="landing-section-title">See which secrets were accessed, by whom, and why.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        SecretSpec records access metadata in a local append-only log without recording secret values. You can also require AI agents to provide a reason before they access secrets. <a href="/concepts/audit/" class="landing-link">How auditing works →</a>
+        SecretSpec records access metadata in a local append-only log without recording secret values. You can require sessions SecretSpec detects as AI agents—or every caller—to provide a reason before SecretSpec proceeds. <a href="/concepts/audit/" class="landing-link">How auditing works →</a>
       </p>
     </div>
 
@@ -579,14 +579,14 @@ $ secretspec run --provider bws -- ./deploy
       <div class="landing-terminal">
         <div class="landing-terminal-header">
           <div class="landing-terminal-dots"><span></span><span></span><span></span></div>
-          <span class="landing-terminal-title">agent session</span>
+          <span class="landing-terminal-title">detected agent session</span>
         </div>
-        <pre is:raw class="landing-terminal-body"><code><span class="tok-com"># An AI agent runs your app without a reason</span>
+        <pre is:raw class="landing-terminal-body"><code><span class="tok-com"># A detected AI agent runs your app without a reason</span>
 $ secretspec run -- ./deploy.sh
 Error: accessing secrets requires a reason.
        Provide one with --reason <span class="tok-str">"&lt;why...&gt;"</span>
 
-<span class="tok-com"># State why; required for agents by default</span>
+<span class="tok-com"># State why; required for detected agents by default</span>
 $ secretspec run --reason <span class="tok-str">"Deploy web frontend"</span> \
     -- ./deploy.sh
 <span class="tok-str">✓</span> Loaded DATABASE_URL from keyring
@@ -607,7 +607,7 @@ $ secretspec audit -n 1
     </div>
 
     <p class="landing-chain-result" style="margin-top: 1.5rem;">
-      Commit <code class="inline-code">require_reason = "agents"</code> with the manifest to apply the same policy in every clone while leaving interactive human use unchanged. <a href="/reference/configuration/#requiring-a-reason-for-secret-access" class="landing-link">Configure the policy →</a>
+      Commit <code class="inline-code">require_reason = "agents"</code> to require reasons in sessions SecretSpec detects as agents. Detection is heuristic; use <code class="inline-code">require_reason = true</code> to require every SecretSpec caller to supply one. <a href="/reference/configuration/#requiring-a-reason-for-secret-access" class="landing-link">Configure the policy →</a>
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- clarify that the default `require_reason = "agents"` policy depends on heuristic agent detection
- document `require_reason = true` as the setting that requires a reason from every SecretSpec caller
- align the audit concept page, configuration reference, homepage, and Proton Pass provider wording

## Why

The documentation implied that every AI agent was always subject to the default reason policy. In practice, the default applies when SecretSpec detects an agent session, so unknown or changed agents can be missed. The audit log still records a reason when one is supplied; this change only clarifies how strictly the policy requires it.

## Impact

Users can distinguish the convenient detected-agent default from the all-callers policy without any runtime behavior change. The README and previously published release blog remain unchanged.

## Validation

- `devenv shell -- npm run build`
