### PR TITLE
test: property tests for the naming and encoding invariants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4080,6 +4080,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4146,6 +4165,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -4309,6 +4334,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4691,6 +4725,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4832,6 +4878,7 @@ dependencies = [
  "linkme",
  "miette",
  "percent-encoding",
+ "proptest",
  "rand 0.9.2",
  "reqwest 0.12.28",
  "rsa",
@@ -5857,6 +5904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6044,6 +6097,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ dotenvy = "0.15"
 inquire = { version = "0.9.4", features = ["experimental-multiline-input"] }
 miette = { version = "7.6", features = ["fancy"] }
 serde_json = "1.0"
+proptest = "1"
 tempfile = "3.0"
 http = "1.0"
 url = "2.5.4"

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -79,3 +79,4 @@ sops = []
 [dev-dependencies]
 # Validates serialized resolution reports against the committed JSON Schema.
 jsonschema = { version = "0.48.5", default-features = false }
+proptest.workspace = true

--- a/secretspec/src/provider/akv.rs
+++ b/secretspec/src/provider/akv.rs
@@ -861,3 +861,124 @@ mod tests {
         assert!(err.to_string().contains("ref"), "{err}");
     }
 }
+
+/// Property tests for the invariants `format_secret_name` is built on.
+///
+/// The example-based tests above pin the counterexamples already found --
+/// `b__c`/`c__d`, `b-`/`_C`, `API_KEY`/`api_key`. These quantify over the whole
+/// component domain, so the *next* collision fails a test rather than a user's
+/// `get`.
+#[cfg(test)]
+mod name_properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// A component Azure will accept: non-empty, alphanumeric/`_`/`-` only --
+    /// exactly the domain `validate_name_component` admits. Kept short so a
+    /// failure shrinks to a minimal, readable counterexample.
+    ///
+    /// The second arm is deliberate. Every collision this scheme has ever had
+    /// lived in `_`/`-` against the `--` delimiter, and a uniform alphanumeric
+    /// generator reaches that region far too rarely to find one: sampled against
+    /// the old `_`->`-` mapping, an unbiased generator reports no collision at
+    /// all. Weighting short delimiter-only components finds one immediately.
+    fn component() -> impl Strategy<Value = String> {
+        prop_oneof!["[A-Za-z0-9_-]{1,8}", "[_-]{1,3}"]
+    }
+
+    fn triple() -> impl Strategy<Value = (String, String, String)> {
+        (component(), component(), component())
+    }
+
+    /// Recovers the triple a name was built from.
+    ///
+    /// Injectivity is stated over pairs, but sampling pairs is a poor way to
+    /// look for a collision: two independently generated triples almost never
+    /// collide by chance, so such a test passes happily against a scheme that is
+    /// provably not injective. A left inverse is the stronger and cheaper claim
+    /// -- if every name decodes back to exactly one triple, no two triples can
+    /// share a name -- and every generated case exercises it.
+    fn decode_secret_name(name: &str) -> Option<(String, String, String)> {
+        let body = name.strip_prefix("secretspec--")?;
+        let parts: Vec<&str> = body.split("--").collect();
+        let [project, profile, key] = parts.as_slice() else {
+            return None;
+        };
+        let decode = |part: &str| {
+            let bytes = BASE32_NOPAD
+                .decode(part.to_ascii_uppercase().as_bytes())
+                .ok()?;
+            String::from_utf8(bytes).ok()
+        };
+        Some((decode(project)?, decode(profile)?, decode(key)?))
+    }
+
+    proptest! {
+        /// A name decodes back to the exact triple that built it.
+        ///
+        /// This is injectivity with teeth: it fails on the first generated case
+        /// under a lossy scheme. The `_`->`-` mapping this replaced fails here
+        /// immediately -- `-` and `_` both encode to `-`, so the original is
+        /// unrecoverable and two triples can reach one name.
+        #[test]
+        fn a_name_decodes_to_the_triple_that_built_it((project, profile, key) in triple()) {
+            let name = AkvProvider::format_secret_name(&project, &profile, &key)
+                .expect("a valid component must format");
+            prop_assert_eq!(
+                decode_secret_name(&name),
+                Some((project, profile, key)),
+                "name {:?} did not decode back to its triple",
+                name,
+            );
+        }
+
+        /// No two triples in a batch share a name.
+        ///
+        /// Weaker than the left inverse above and kept deliberately: it states
+        /// the guarantee in the form the module claims it ("injective"), and it
+        /// would catch a collision introduced somewhere other than the encoding
+        /// -- a changed delimiter, say, which decoding alone would not notice.
+        #[test]
+        fn distinct_triples_never_collide(triples in prop::collection::vec(triple(), 2..24)) {
+            let mut seen: std::collections::HashMap<String, (String, String, String)> =
+                std::collections::HashMap::new();
+            for triple in triples {
+                let name = AkvProvider::format_secret_name(&triple.0, &triple.1, &triple.2)
+                    .expect("a valid component must format");
+                if let Some(previous) = seen.insert(name.clone(), triple.clone()) {
+                    prop_assert_eq!(
+                        &previous,
+                        &triple,
+                        "distinct triples {:?} and {:?} both produced {:?}",
+                        previous,
+                        triple,
+                        name,
+                    );
+                }
+            }
+        }
+
+        /// Every formatted name is one Azure will accept: Key Vault permits
+        /// alphanumerics and hyphens only.
+        #[test]
+        fn formatted_names_are_azure_legal((project, profile, key) in triple()) {
+            let name = AkvProvider::format_secret_name(&project, &profile, &key)
+                .expect("a valid component must format");
+            prop_assert!(
+                name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+                "name {name:?} contains a character Azure rejects",
+            );
+        }
+
+        /// Names are already lowercase, so Azure's case-insensitive comparison
+        /// changes nothing. Case distinctions survive in the encoded bytes
+        /// rather than in the name's case, which is what lets `API_KEY` and
+        /// `api_key` coexist.
+        #[test]
+        fn formatted_names_are_lowercase((project, profile, key) in triple()) {
+            let name = AkvProvider::format_secret_name(&project, &profile, &key)
+                .expect("a valid component must format");
+            prop_assert_eq!(name.clone(), name.to_ascii_lowercase());
+        }
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -1585,3 +1585,67 @@ mod provider_credentials_tests {
         }
     }
 }
+
+/// Property tests for the URI encoding every provider's `uri()` runs through.
+///
+/// `QUERY_ENCODE_SET` states its own contract: it "makes `ProviderUrl::encode_query`
+/// a true inverse of that parsing, so query values round-trip". That is a claim
+/// about every string, checked today against one hand-written value in one
+/// provider's tests. These quantify it.
+#[cfg(test)]
+mod encoding_properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Reads a query value back the way a provider's `TryFrom` does.
+    fn query_value_of(uri: &str, key: &str) -> Option<String> {
+        let url = ProviderUrl::new(Url::parse(uri).ok()?);
+        url.query_pairs()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.into_owned())
+    }
+
+    proptest! {
+        /// A query value survives `encode_query` -> parse unchanged.
+        ///
+        /// The characters that break this are the ones form-urlencoded parsing
+        /// claims: `&` splits a pair, `+` becomes a space, `%` starts an escape,
+        /// `#` ends the query. Each silently truncates or mangles a value rather
+        /// than failing, so the store a provider ends up talking to is not the
+        /// one the URI named.
+        #[test]
+        fn encode_query_round_trips(value in ".*") {
+            let uri = format!("keyring://?v={}", ProviderUrl::encode_query(&value));
+            let decoded = query_value_of(&uri, "v");
+            prop_assert_eq!(
+                decoded.as_deref(),
+                Some(value.as_str()),
+                "value {:?} did not survive the round-trip through {:?}",
+                value,
+                uri,
+            );
+        }
+
+        /// Encoding is deterministic: the same value always encodes the same
+        /// way, so a `uri()` rendering is stable across runs (it lands in audit
+        /// records, which are compared).
+        #[test]
+        fn encode_query_is_deterministic(value in ".*") {
+            prop_assert_eq!(
+                ProviderUrl::encode_query(&value),
+                ProviderUrl::encode_query(&value),
+            );
+        }
+
+        /// An encoded value never carries a character that would end the query
+        /// or start a new pair, whatever went in.
+        #[test]
+        fn encoded_values_are_query_safe(value in ".*") {
+            let encoded = ProviderUrl::encode_query(&value);
+            prop_assert!(
+                !encoded.contains('&') && !encoded.contains('#') && !encoded.contains('+'),
+                "encoded {encoded:?} still carries a query-structural character",
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #156, taking the first two items of that issue's proposal. Reopens #157, which I closed by accident in a branch sweep — rebased onto `main`.

## What this is

`proptest` as a dev-dependency, plus the two properties #156 proposed first. No production code changes.

**1. `akv::format_secret_name` is injective.** Stated in prose today and guarded by `assert_ne!` over one pair each — the counterexamples already found (`b__c`/`c__d`, `b-`/`_C`, `API_KEY`/`api_key`). Checked through a left inverse rather than sampled pairs: two independently generated triples essentially never collide, so that phrasing passes against a scheme that is provably not injective, while decoding every name back to its triple fails on the first case under a lossy scheme. The old `_`→`-` mapping fails it immediately.

**2. `encode_query` and `query_pairs` are inverse.** `QUERY_ENCODE_SET`'s own doc says it "makes `ProviderUrl::encode_query` a true inverse of that parsing, so query values round-trip" — a claim about every string, exercised today by one provider's list of eight hand-chosen values.

Item 3 from the issue (`parse(uri(cfg)) == parse(spec)`) is not here; it needs generators per config type and I would rather see whether these two earn their keep first.

## Why it is smaller than my last push

You said property tests across the providers would be great, and I had built that: two defaulted `Provider` methods let one property enumerate the registry and check determinism, legality and injectivity for every provider at once. Writing it turned up findings that make it premature, so I have parked it rather than ask you to review it.

The registry-wide injectivity property only passes today because three separate things are papered over: a `KNOWN_COLLIDING` exemption for a real `gcsm` collision, a trait method exempting stores that address by key alone, and a generated key domain that does not match the one config validation actually enforces. Each of those is a decision about what a valid convention component is, and none of them is mine to make. The cross-provider version is worth having once that is settled — it is ready and I will send it then.

The findings are in #219, separately, since they hold on `main` today and need nothing from this PR.

## Cost

The dependency, as flagged in #156 — dev-only, so nothing reaches a shipped binary. Runtime is 0.2s for these properties; the suite is 791 tests green on Linux and macOS.
