### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.17.0] - 2026-07-26
 
 ### Fixed
 - Vault and OpenBao providers reuse one `reqwest::Client` per provider

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "age",
  "aws-config",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-derive"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "http 1.4.0",
  "insta",
@@ -4878,7 +4878,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-ffi"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "secretspec",
  "serde_json",
@@ -4887,7 +4887,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-node-native"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-php-native"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ext-php-rs",
  "secretspec",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-py-native"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "pyo3",
  "secretspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 
 [workspace.dependencies]
@@ -53,8 +53,8 @@ azure_identity = "1.0.0"
 azure_security_keyvault_secrets = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
-secretspec-derive = { version = "0.16.0", path = "./secretspec-derive" }
-secretspec = { version = "0.16.0", path = "./secretspec" }
+secretspec-derive = { version = "0.17.0", path = "./secretspec-derive" }
+secretspec = { version = "0.17.0", path = "./secretspec" }
 rand = "0.9"
 rsa = { version = "0.9", features = ["pem"] }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,19 @@ Publisher / secret setup described per language first).
 
 Version tags are `vX.Y.Z`; the publish jobs trigger on them.
 
+## After every release
+
+Once the release artifacts are available, update the `secretspec` package in
+Nixpkgs. From a Nixpkgs checkout, let `nix-update` update the crate source and
+Cargo dependency hashes and verify that the package builds:
+
+```bash
+nix-update --version=X.Y.Z --build secretspec
+```
+
+Commit the generated package change as `secretspec: OLD -> X.Y.Z`, include the
+GitHub release URL in the commit body, and submit it to Nixpkgs.
+
 ## Before your first release
 
 Trusted Publishing works differently per registry. PyPI and RubyGems let you

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -165,6 +165,11 @@ Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files,
             },
             { label: "Profiles", slug: "concepts/profiles" },
             {
+              label: "Scopes",
+              slug: "concepts/scopes",
+              badge: { text: "0.17+", variant: "note" },
+            },
+            {
               label: "Providers",
               items: [
                 { label: "Providers", slug: "concepts/providers" },

--- a/docs/src/content/docs/blog/secretspec-0-17-scopes-secrets-caching-age-and-systemd-credentials.md
+++ b/docs/src/content/docs/blog/secretspec-0-17-scopes-secrets-caching-age-and-systemd-credentials.md
@@ -1,0 +1,254 @@
+---
+title: "SecretSpec 0.17: Scopes, secrets caching, age, and systemd credentials"
+description: Resolve only the secrets a service needs, cache remote secrets safely, and use age-encrypted files or native systemd credentials alongside new providers.
+date: 2026-07-27
+authors:
+  - domen
+---
+
+[SecretSpec 0.17](https://github.com/cachix/secretspec/releases/tag/v0.17.0 "SecretSpec 0.17 release")
+ships:
+
+- **[Scopes](/concepts/scopes/)**: let each service or task resolve
+  only its declared subset of a profile.
+- **[Secrets caching](/concepts/providers/caching/)**: cache a slow fallback
+  route in a local secret store with bounded freshness and explicit
+  invalidation.
+- **[Cross-secret validation](#cross-secret-validation)**:
+  declare alternative or mutually exclusive credentials instead of marking
+  every value independently required or optional.
+- **[GitHub and Forgejo Actions](#github-and-forgejo-actions)**: resolve a
+  profile in one workflow step and expose its secrets to the steps that follow.
+- **[New providers](#new-providers)**: now with 20 providers, use
+  [SOPS](/providers/sops/), [age](/providers/age/), [KeePass
+  KDBX](/providers/kdbx/),
+  [OpenBao](/providers/openbao/), [Scaleway Secret
+  Manager](/providers/scaleway/), and [systemd
+  credentials](/providers/systemd-credential/) through the same SecretSpec
+  interface, with JWT/OIDC authentication for [Vault](/providers/vault/) and
+  [OpenBao](/providers/openbao/).
+
+## Scopes
+
+A profile describes how secrets resolve for an environment. A
+[scope](/concepts/scopes/) now describes which of those secrets one consumer
+may receive:
+
+```toml title="secretspec.toml"
+[profiles.default]
+DATABASE_URL = { description = "Database" }
+API_KEY = { description = "API key" }
+QUEUE_TOKEN = { description = "Queue token" }
+
+[scopes.api]
+secrets = ["DATABASE_URL", "API_KEY"]
+
+[scopes.worker]
+secrets = ["DATABASE_URL", "QUEUE_TOKEN"]
+```
+
+```bash
+secretspec run --scope api -- ./api
+secretspec run --scope worker -- ./worker
+```
+
+Composed secrets may still read hidden dependencies to build a visible value,
+but those inputs are not exposed to the child. The same scope selection is
+available to `check`, `export`, and the [SDK
+builders](/sdk/overview/). Scopes minimize secret delivery; they are not an
+authorization boundary when the child itself holds provider credentials.
+
+Carrying the selected scope through resolver requests and results required a
+breaking change to
+[`secretspec-ffi`](https://github.com/cachix/secretspec/tree/main/secretspec-ffi).
+All [SecretSpec SDKs](/sdk/overview/) have been updated for 0.17 to support
+scopes, so applications should upgrade their SDK package and bundled native
+resolver together.
+
+## Secrets caching
+
+Many cloud providers take long enough to resolve a secret that their latency
+becomes part of every development command.
+
+A single **1Password** lookup can take **roughly one second**.
+
+SecretSpec providers implement `get_many` so a backend can resolve several
+values together. Relatively few secret stores and CLIs expose a true bulk-read
+operation, however, so many providers still have to perform separate lookups.
+
+Waiting on a remote service or its CLI every time makes `check`, `run`, and
+application startup feel slow, especially as a project grows.
+
+A provider alias can now combine its authoritative fallback route with a local
+cache:
+
+```toml title="secretspec.toml"
+[providers]
+vault = "vault://vault.example.com:8200/secret"
+local = "keyring://secretspec/cache/{project}/{profile}/{key}"
+
+fast_vault = {
+  fallback = ["vault"],
+  cache = { provider = "local", max_age = "8h" }
+}
+
+[profiles.default.defaults]
+providers = ["fast_vault"]
+```
+
+Fresh entries avoid contacting the remote provider. A miss or expired entry
+falls through to [Vault](/providers/vault/) and refreshes the cache; writes
+update the authoritative provider first and then refresh or invalidate its
+cached copy. Route changes, reference changes, and writes that bypass the
+cached alias also invalidate the entry.
+
+The cache is a real copy of the secret, so SecretSpec requires a distinct store
+that it can delete from and records ownership before changing an entry.
+`secretspec cache clear [NAME]` forces the next read back through the
+authoritative route.
+
+[Vault](/providers/vault/) and [OpenBao](/providers/openbao/) KV v2 caches are
+the only providers that handle `max_age` as server-side expiry properly.
+
+None of SecretSpec's current local providers has strong native support for
+expiry. They can remove an expired entry the next time SecretSpec sees it, but
+cannot ensure the local copy disappears at its deadline if SecretSpec never
+runs again.
+
+Our planned [FactorSeal](https://github.com/domenkozar/factorseal)
+provider in [Future work](#future-work) is intended to close that gap with an
+explicit API for credential eviction among the other goals.
+
+## Cross-secret validation
+
+Profiles can now express credential alternatives directly:
+
+```toml title="secretspec.toml"
+[profiles.default]
+PASSWORD = { description = "Password", required = { at_least_one = "auth" } }
+ACCESS_TOKEN = { description = "Token", required = { at_least_one = "auth" } }
+
+GITHUB_TOKEN = { description = "GitHub token", required = { exactly_one = "github_auth" } }
+GITHUB_APP_KEY = { description = "GitHub App private key", required = { exactly_one = "github_auth" } }
+```
+
+The `auth` group accepts a password, an access token, or both. The
+`github_auth` group requires exactly one credential and rejects configurations
+that provide both the token and the app key.
+
+## New providers
+
+**[SOPS](/providers/sops/)** brings the encrypted-file workflow from our recent
+[SOPS comparison](/blog/but-i-use-sops/) behind SecretSpec's
+provider-independent CLI and SDKs. SecretSpec delegates encryption and
+decryption to the installed SOPS CLI, so existing SOPS key services and
+`.sops.yaml` creation rules remain in control.
+
+The provider reads and writes YAML, JSON, dotenv, and INI files, supports a
+single shared file or `{project}` / `{profile}` path templates, and can source
+sensitive SOPS inputs such as age keys or cloud credentials through provider
+credentials.
+
+```toml title="secretspec.toml"
+[providers]
+sops = "sops://secrets/{project}/{profile}.enc.yaml"
+
+[profiles.production.defaults]
+providers = ["sops"]
+```
+
+**[age](/providers/age/)** offers a smaller encrypted-file setup. It stores a
+dotenv-style secret set for one or more age recipients, including hybrid
+post-quantum recipients.
+
+**[KeePass KDBX](/providers/kdbx/)** reads KDBX 3 and 4 databases and writes
+KDBX 4, with master passwords sourced from another provider rather than
+embedded in the URI.
+
+**[OpenBao](/providers/openbao/)** gets its own `openbao://` identity and
+`BAO_*` configuration while sharing compatible KV, token, AppRole, and JWT
+mechanics with [Vault](/providers/vault/). Both Vault and OpenBao can now
+exchange a JWT for a short-lived token, including an OIDC token minted
+automatically in GitHub Actions and Forgejo Actions with `id-token: write`.
+
+**[Scaleway Secret Manager](/providers/scaleway/)** adds regional,
+project-aware cloud storage and read-only references to existing secrets and
+revisions.
+
+**[systemd credentials](/providers/systemd-credential/)** is a read-only
+provider that resolves values from the current service's
+`$CREDENTIALS_DIRECTORY`, including credentials used to bootstrap another
+provider.
+
+## GitHub and Forgejo Actions
+
+Alongside 0.17, the new
+[`cachix/secretspec-action`](https://github.com/cachix/secretspec-action)
+installs SecretSpec, resolves the selected profile, masks every value in the
+runner log, and adds the secrets to the environment of later job steps:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/secretspec-action@main
+        with:
+          profile: production
+          scope: api
+      - run: ./deploy.sh
+```
+
+A missing required secret fails the action, so the same step also checks that
+the deployment environment is complete. See the [GitHub Actions
+guide](/ci/github-actions/) for provider selection and tokenless
+[Vault](/providers/vault/) or [OpenBao](/providers/openbao/) authentication
+through the runner's OIDC identity.
+
+## Upgrading
+
+[SecretSpec 0.17](https://github.com/cachix/secretspec/releases/tag/v0.17.0)
+also brings:
+
+- **[Bitwarden Secrets Manager](/providers/bws/)** — now uses the separately
+  installed official `bws` CLI instead of linking its SDK.
+- **Non-interactive setup** — `secretspec config global init --provider ...
+  --profile ...` configures defaults without prompts.
+- **Windows packages** — for the Python, Ruby, and PHP SDKs.
+- **Clearer status output** — plus more controlled concurrency and retry
+  behavior for Vault and OpenBao.
+
+```bash
+cargo install secretspec
+```
+
+See the [full changelog](https://github.com/cachix/secretspec/blob/main/CHANGELOG.md)
+for every change in this release.
+
+## Future work
+
+The next work brings more control to local secret access:
+
+- **[GUI confirmation
+  dialogs](https://github.com/cachix/secretspec/pull/122)** — approve or deny a
+  secret request in a native prompt instead of requiring a terminal
+  interaction.
+- **A [Passbolt provider](https://github.com/cachix/secretspec/pull/127)** —
+  bring Passbolt's open-source, collaboration-focused credential manager
+  behind the same SecretSpec interface for cloud and self-hosted teams.
+- **A [Bitwarden Password Manager
+  provider](https://github.com/cachix/secretspec/pull/166)** — resolve regular
+  Bitwarden vault items, separately from the Bitwarden Secrets Manager provider
+  already available in SecretSpec.
+- **A JVM SDK** — work is underway to bring the shared SecretSpec resolver to
+  Java, Kotlin, and other JVM languages.
+- **A [FactorSeal](https://github.com/domenkozar/factorseal) provider** — we
+  have started work on a new Linux provider built around mandatory TPM-backed
+  storage and secure defaults. FactorSeal also provides an explicit API for
+  credential expiry, which is crucial for the caching work in this release:
+  local copies can carry a defined eviction deadline instead of living without
+  a retention policy. Still in development.
+
+Questions or feedback? Join us on
+[Discord](https://discord.gg/naMgvexb6q).

--- a/docs/src/content/docs/concepts/overview.md
+++ b/docs/src/content/docs/concepts/overview.md
@@ -33,6 +33,8 @@ Each concern is independent: you can change your storage backend without touchin
 ## Additional concepts
 
 - [Configuration Inheritance](/concepts/inheritance/) lets projects share common secret definitions via `extends`
+- [Scopes (0.17+)](/concepts/scopes/) let each service or task resolve
+  only its declared subset of a profile
 - [Secret Generation](/concepts/generation/) auto-creates passwords, tokens, and keys when secrets are missing
 - [Composed Secrets (0.16+)](/concepts/composed-secrets/) derive read-only
   values from other declared secrets

--- a/docs/src/content/docs/concepts/scopes.md
+++ b/docs/src/content/docs/concepts/scopes.md
@@ -1,0 +1,160 @@
+---
+title: Scopes
+description: Resolve and expose only the secrets a service or task needs
+---
+
+:::caution[Version compatibility]
+Scopes are available starting with SecretSpec 0.17.
+:::
+
+A profile defines how secrets behave in an environment. A scope selects which
+of those secrets one service, command, or task receives.
+
+This lets several consumers share one profile without giving every consumer the
+complete secret set. An API and a background worker can use the same
+`production` profile, for example, while receiving different credentials.
+
+## Define scopes
+
+Add a top-level `[scopes]` table to `secretspec.toml`. Each named scope contains
+an allowlist of secret names:
+
+```toml title="secretspec.toml"
+[profiles.default]
+DATABASE_URL = { description = "Database" }
+API_KEY = { description = "API key" }
+QUEUE_TOKEN = { description = "Queue token" }
+
+[scopes.api]
+secrets = ["DATABASE_URL", "API_KEY"]
+
+[scopes.worker]
+secrets = ["DATABASE_URL", "QUEUE_TOKEN"]
+```
+
+The active profile still controls requirements, defaults, providers,
+references, generation, composition, and storage addresses. Selecting `api`
+only narrows the resolved set to `DATABASE_URL` and `API_KEY`; it does not
+create another profile or another copy of either secret.
+
+A scope must contain at least one unique, non-blank name. Every name must be
+declared by at least one profile, although the active profile does not need to
+declare every member.
+
+## Select a scope
+
+`check`, `run`, and `export` accept `--scope`:
+
+```bash
+secretspec check --profile production --scope api
+secretspec run --profile production --scope api -- ./api-server
+secretspec export --profile production --scope worker --format dotenv
+```
+
+Set `SECRETSPEC_SCOPE` to select one without repeating the flag:
+
+```bash
+export SECRETSPEC_SCOPE=worker
+secretspec run --profile production -- ./worker
+```
+
+The command-line flag takes precedence over the environment variable. With no
+scope selected, SecretSpec resolves the complete profile as before.
+
+The untyped language SDK builders also accept an explicit scope and return its
+name in resolved and report results. See the [SDK
+overview](/sdk/overview/#the-runtime-api) for the shared behavior and each SDK
+guide for its language-specific method.
+
+## What gets resolved
+
+The visible set is the intersection of the selected scope and the merged active
+profile:
+
+- a required secret outside the scope does not block scoped resolution;
+- a secret outside the scope is not fetched unless a visible composed secret
+  needs it;
+- a valid scope whose intersection with the profile is empty resolves nothing
+  and contacts no provider;
+- a scope member absent from the active profile is simply absent from the
+  resolved result, allowing one scope to be reused across profiles with
+  different shapes.
+
+Scopes never change a secret's `{project}/{profile}/{key}` storage address. A
+scoped and unscoped read of the same secret addresses the same provider value.
+
+### Composed secrets
+
+A visible [composed secret](/concepts/composed-secrets/) may depend on values
+the scope excludes:
+
+```toml title="secretspec.toml"
+[profiles.default]
+DB_USER = { description = "Database user" }
+DB_PASSWORD = { description = "Database password" }
+DB_HOST = { description = "Database host" }
+DATABASE_URL = {
+  description = "Application database URL",
+  composed = "postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/app"
+}
+
+[scopes.api]
+secrets = ["DATABASE_URL"]
+```
+
+SecretSpec resolves the three inputs to build `DATABASE_URL`, then exposes only
+`DATABASE_URL`. A secret that is neither visible nor a dependency of a visible
+composition is never fetched.
+
+## Narrow a process environment
+
+`run --scope` removes every manifest-declared secret the scope does not admit
+from the child environment, even when the parent shell had already exported
+it. The removal covers names declared in every profile, preventing a value
+inherited from another profile from leaking into the launched process.
+
+`export --scope` only emits the selected values. It cannot remove variables
+that already exist in the current shell because its output formats cannot
+express an unset. Use `run --scope` when narrowing an existing environment is
+the goal.
+
+Scopes minimize secret delivery; they are not an authorization boundary. A
+child that has access to `secretspec.toml` and valid provider credentials may
+resolve another scope itself. Use provider permissions, service isolation, and
+operating-system controls when the process must be prevented from reading
+other values.
+
+## Validate scoped requirements
+
+[Cross-secret presence constraints](/reference/configuration/#cross-secret-presence-constraints-017)
+are evaluated over the group members visible to the scope. A group with no
+visible members is not enforced for that consumer. When some members are
+visible, `at_least_one` or `exactly_one` is enforced over those members so a
+scoped consumer cannot rely on a credential it never receives.
+
+Run an unscoped `secretspec check` when validating the complete profile rather
+than one consumer's view.
+
+## Profiles and inheritance
+
+Scopes are orthogonal to profiles and reusable across them. They do not inherit
+from the `default` profile; instead, the selected scope is applied after normal
+profile inheritance produces the effective profile.
+
+When a project uses [`extends`](/concepts/inheritance/), a child scope replaces
+a parent scope with the same name. The lists are not unioned, so extending a
+configuration cannot silently widen an allowlist. Scopes defined only by a
+parent remain available to the child.
+
+## Commands that ignore scopes
+
+`set` and `import` ignore `SECRETSPEC_SCOPE`: a resolution allowlist must not
+silently restrict which secrets a write or migration command manages.
+
+Rust's generated typed loaders also ignore the ambient scope because their
+structs contain a field for every secret in the profile. Use the untyped
+resolver API when a Rust consumer needs scoped resolution.
+
+See the [`[scopes]` configuration reference](/reference/configuration/#scopes-section)
+for validation details, empty-selection behavior, audit semantics, and clearing
+an inherited scope selection.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -198,6 +198,10 @@ release. With 0.16, give each service its own profile, or its own
 `secretspec.toml`.
 :::
 
+See [Scopes](/concepts/scopes/) for the conceptual model and a focused
+guide to narrowing services and tasks. This section specifies the complete
+configuration and resolution behavior.
+
 Scopes name membership-only subsets of a profile's secrets, so a single service
 or task resolves only what it declares instead of the entire profile. They are
 **orthogonal to profiles**: a profile decides how each secret resolves

--- a/docs/src/content/docs/sdk/overview.md
+++ b/docs/src/content/docs/sdk/overview.md
@@ -60,7 +60,7 @@ See each language's page for the idiomatic spelling: [Rust](/sdk/rust),
 [Node.js](/sdk/nodejs), [Haskell](/sdk/haskell), [PHP](/sdk/php), and
 [C# (0.16+)](/sdk/csharp).
 
-Every builder also takes a [scope (0.17+)](/reference/configuration/#scopes-section),
+Every builder also takes a [scope (0.17+)](/concepts/scopes/),
 resolving only a named subset of the profile and returning the selected name on
 the result. The one exception is Rust's typed loader, which always resolves the
 full profile because a generated struct has a field per declared secret; see

--- a/docs/src/content/docs/sdk/rust.md
+++ b/docs/src/content/docs/sdk/rust.md
@@ -90,7 +90,7 @@ returned when that profile resolves.
 
 ## Scopes (0.17+)
 
-A [scope](/reference/configuration/#scopes-section) resolves only a named subset
+A [scope](/concepts/scopes/) resolves only a named subset
 of a profile. In Rust it is available on the untyped `Secrets` API, through
 `set_scope`:
 

--- a/secretspec-derive/Cargo.toml
+++ b/secretspec-derive/Cargo.toml
@@ -15,7 +15,7 @@ quote.workspace = true
 proc-macro2.workspace = true
 toml.workspace = true
 serde.workspace = true
-secretspec = { version = "0.16.0", path = "../secretspec", default-features = false }
+secretspec = { version = "0.17.0", path = "../secretspec", default-features = false }
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>Cachix.SecretSpec</PackageId>
-    <Version>0.16.0</Version>
+    <Version>0.17.0</Version>
     <Authors>Cachix</Authors>
     <Description>C# SDK for SecretSpec, the declarative secrets manager.</Description>
     <PackageTags>secrets;configuration;security;dotnet</PackageTags>

--- a/secretspec-hs/secretspec.cabal
+++ b/secretspec-hs/secretspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               secretspec
-version:            0.16.0
+version:            0.17.0
 synopsis:           Haskell SDK for SecretSpec, a declarative secrets manager
 description:
   A thin client over the @secretspec-ffi@ C ABI (linked at build time).

--- a/secretspec-node/package.json
+++ b/secretspec-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretspec",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Declarative secrets, every environment, any provider (Node.js SDK)",
   "license": "Apache-2.0",
   "homepage": "https://secretspec.dev/",

--- a/secretspec-py/pyproject.toml
+++ b/secretspec-py/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "secretspec"
-version = "0.16.0"
+version = "0.17.0"
 description = "Declarative secrets, every environment, any provider (Python SDK)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/secretspec-rb/secretspec.gemspec
+++ b/secretspec-rb/secretspec.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "secretspec"
-  spec.version     = "0.16.0"
+  spec.version     = "0.17.0"
   spec.summary     = "Declarative secrets, every environment, any provider (Ruby SDK)"
   spec.description = "Ruby bindings for SecretSpec: a native extension that " \
                      "statically links the secretspec-ffi C ABI."


### PR DESCRIPTION
Bumps the workspace and every SDK packaging file to 0.17.0 and closes the changelog's unreleased section as `[0.17.0] - 2026-07-26`.

- `Cargo.toml` workspace version plus the `secretspec` / `secretspec-derive` workspace dependency pins, and the `secretspec` pin in `secretspec-derive/Cargo.toml`
- SDK packaging: `secretspec-node/package.json`, `secretspec-py/pyproject.toml`, `secretspec-hs/secretspec.cabal`, `secretspec-rb/secretspec.gemspec`, `secretspec-dotnet/src/SecretSpec/SecretSpec.csproj` (composer.json has no version field; Packagist reads git tags)
- `Cargo.lock` refreshed by `cargo build`

Also included is the 0.17 announcement post, which had not been pushed yet.

The changelog section was cross-checked against `git log --oneline v0.16.0..HEAD`; the only commit without an entry is a test-only fix for a `Text file busy` flake in the bws tests.

Created by Claude Code (see https://github.com/cli/cli/issues/13904).