### PR TITLE
Fix Rust and Go release packaging

### DIFF
--- a/.github/workflows/go-embed.yml
+++ b/.github/workflows/go-embed.yml
@@ -9,7 +9,19 @@ name: "Go embedded lib"
 
 on:
   workflow_call:
+    inputs:
+      release_tag:
+        description: Existing GitHub Release tag to upload artifacts to
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing GitHub Release tag to upload artifacts to
+        required: false
+        type: string
+        default: ""
   push:
     tags:
       - v**
@@ -91,3 +103,60 @@ jobs:
         with:
           name: go-embed-${{ matrix.target }}
           path: secretspec-go/lib/*
+
+  release:
+    name: Publish Go release
+    needs: embed
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      inputs.release_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v5
+        with:
+          pattern: go-embed-*
+          path: staged
+          merge-multiple: true
+
+      - name: Attach embedded libraries to the GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t assets < <(find staged -type f -name 'secretspec_ffi_*' -print | sort)
+          if [[ "${#assets[@]}" -ne 4 ]]; then
+            printf 'expected 4 embedded libraries, found %s\n' "${#assets[@]}" >&2
+            printf '%s\n' "${assets[@]}" >&2
+            exit 1
+          fi
+          bash scripts/upload-release-asset.sh \
+            "${{ inputs.release_tag || github.ref_name }}" "${assets[@]}"
+
+      - name: Publish the Go module tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          module_tag="secretspec-go/${GITHUB_REF_NAME}"
+          if git fetch origin "refs/tags/${module_tag}:refs/tags/${module_tag}"; then
+            existing_commit="$(git rev-list -n 1 "$module_tag")"
+            if [[ "$existing_commit" != "$GITHUB_SHA" ]]; then
+              echo "${module_tag} already points to ${existing_commit}, expected ${GITHUB_SHA}" >&2
+              exit 1
+            fi
+            echo "${module_tag} already points to ${GITHUB_SHA}"
+            exit 0
+          fi
+
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag -a "$module_tag" "$GITHUB_SHA" \
+            -m "Release Go SDK ${GITHUB_REF_NAME#v}"
+          git push origin "refs/tags/${module_tag}"

--- a/.github/workflows/go-static.yml
+++ b/.github/workflows/go-static.yml
@@ -15,7 +15,19 @@ name: "Go static lib"
 
 on:
   workflow_call:
+    inputs:
+      release_tag:
+        description: Existing GitHub Release tag to upload artifacts to
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing GitHub Release tag to upload artifacts to
+        required: false
+        type: string
+        default: ""
   push:
     tags:
       - v**
@@ -49,6 +61,9 @@ jobs:
 
       - name: Build and smoke test the fully-static binary
         run: |
+          # Variables in this single-quoted script intentionally expand inside
+          # the devenv shell, not in the outer workflow shell.
+          # shellcheck disable=SC2016
           devenv shell -- bash -c '
             set -euo pipefail
             # Stage the release musl archive + header + generated cgo LDFLAGS
@@ -99,3 +114,31 @@ jobs:
             secretspec-go/lib/*.a
             secretspec-go/include/secretspec.h
             secretspec-go/cgo_ldflags_*.go
+
+  release:
+    name: Publish Go static release
+    needs: static
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      inputs.release_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: go-static-x86_64-linux-musl
+          path: staged
+
+      - name: Attach the static SDK bundle to the GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          asset="secretspec-go-static-x86_64-linux-musl.tar.gz"
+          tar -czf "$asset" -C staged .
+          bash scripts/upload-release-asset.sh \
+            "${{ inputs.release_tag || github.ref_name }}" "$asset"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,21 @@ jobs:
           echo "::endgroup::"
         done
 
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install Rust
+      run: rustup toolchain install stable --profile minimal
+    - name: Verify the published crate contains its schema fixture
+      shell: bash
+      run: |
+        set -euo pipefail
+        fixture="secretspec/src/fixtures/resolution-report.schema.json"
+        cmp schema/resolution-report.schema.json "$fixture"
+        cargo package --package secretspec --list |
+          grep -Fx 'src/fixtures/resolution-report.schema.json'
+
   # Windows runners can't run Nix/devenv, so the suite runs here natively via
   # rustup + cargo. This exists specifically to catch Windows-only path handling
   # regressions (e.g. config discovery and relative `-f` paths, issue #59), which

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,9 @@ build + install) has been verified running end to end in CI, but the actual
 publish steps below have not (they need the one-time external Trusted
 Publisher / secret setup described per language first).
 
-Version tags are `vX.Y.Z`; the publish jobs trigger on them.
+Version tags are `vX.Y.Z`; the publish jobs trigger on them. After the Go
+release build succeeds, CI also creates the submodule tag
+`secretspec-go/vX.Y.Z`, which is the version the Go module proxy resolves.
 
 ## After every release
 
@@ -87,9 +89,10 @@ do — the first `vX.Y.Z` tag's `haskell-build.yml` publish job uploads with it.
 
 ### Go — nothing to set up
 
-No registry involved. `go get` reads the tag directly from git; `go-embed.yml`
-just attaches per-platform cdylibs to the GitHub Release for the optional
-self-contained build.
+No registry involved. `go get` reads the `secretspec-go/vX.Y.Z` submodule tag
+directly from git. `go-embed.yml` creates that tag after its full platform
+matrix succeeds and attaches the per-platform cdylibs to the GitHub Release for
+the optional self-contained build.
 
 ### Packagist (PHP) — not yet set up
 
@@ -170,9 +173,11 @@ self-contained, vendored build — not a module-proxy install).
 
 - **Build:** `go-embed.yml` builds the per-platform libs, uploads them as
   artifacts, and smoke-tests an `-tags embed_lib` build with a staged lib.
-- **Release:** nothing to publish to a registry. Attach the per-platform cdylibs
-  to the GitHub release so users who want a self-contained build can download and
-  stage them. Do **not** commit binaries to the repo (plain git or LFS).
+- **Release:** nothing is pushed to a registry. On a `vX.Y.Z` release,
+  `go-embed.yml` attaches the per-platform cdylibs to the GitHub Release and
+  creates `secretspec-go/vX.Y.Z` at the same commit for `go get`.
+  `go-static.yml` attaches its musl static SDK bundle separately. Do **not**
+  commit binaries to the repo (plain git or LFS).
 
 > The loader rejects an embedded git-LFS pointer with a clear error, so a botched
 > LFS-based build fails loudly instead of feeding pointer text to `dlopen`.

--- a/secretspec/src/fixtures/resolution-report.schema.json
+++ b/secretspec/src/fixtures/resolution-report.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://secretspec.dev/schema/resolution-report.schema.json",
+  "title": "SecretSpec resolution report",
+  "description": "Value-free, versioned description of how every declared secret resolved for one profile. Emitted by `secretspec check --json`. Never contains secret values.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "provider", "profile", "secrets"],
+  "properties": {
+    "schema_version": {
+      "description": "Wire-format version. Consumers should refuse versions they do not understand.",
+      "type": "integer",
+      "const": 1
+    },
+    "provider": {
+      "description": "Credential-free URI of the provider the resolution is reported against. The empty string when the resolution contacted no provider, which happens when a scope's intersection with the selected profile is empty and there is nothing to resolve.",
+      "type": "string"
+    },
+    "profile": {
+      "description": "The profile that was resolved.",
+      "type": "string"
+    },
+    "scope": {
+      "description": "The active secret scope, when resolution was scoped. Absent when the whole profile resolved.",
+      "type": "string"
+    },
+    "secrets": {
+      "description": "One entry per declared secret, sorted by name.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/secretResolution" }
+    },
+    "constraint_violations": {
+      "description": "Cross-secret presence constraints that failed. Added in SecretSpec 0.17 and omitted when empty.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/constraintViolation" }
+    }
+  },
+  "$defs": {
+    "constraintViolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "group", "secrets", "present"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["at_least_one", "exactly_one"]
+        },
+        "group": {
+          "description": "Group name declared by its member secrets.",
+          "type": "string"
+        },
+        "secrets": {
+          "description": "The constraint group's members that participated in this resolution. Normally all declared members (a group has at least two); under an active scope it is narrowed to the members the scope exposes, which may be a single secret.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "present": {
+          "description": "Group members that resolved; values are never included.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "secretResolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status", "required", "default_applied", "generated", "as_path"],
+      "properties": {
+        "name": {
+          "description": "Declared secret name (the UPPER_SNAKE manifest key).",
+          "type": "string"
+        },
+        "status": {
+          "description": "Whether the secret resolved, and if not whether that is an error.",
+          "type": "string",
+          "enum": ["resolved", "missing_required", "missing_optional"]
+        },
+        "required": {
+          "description": "Whether the active profile marks this secret as required.",
+          "type": "boolean"
+        },
+        "source_provider": {
+          "description": "Credential-free URI of the provider that answered. Present only when the value came from a provider (absent when generated, defaulted, or missing).",
+          "type": "string"
+        },
+        "default_applied": {
+          "description": "Whether the value came from the manifest's committed default.",
+          "type": "boolean"
+        },
+        "generated": {
+          "description": "Whether the value was freshly minted by the secret's generate config.",
+          "type": "boolean"
+        },
+        "as_path": {
+          "description": "Whether the value is materialized to a temp file and exposed as a path.",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -7920,8 +7920,7 @@ secrets = ["UNRELATED"]
 
         let instance = serde_json::to_value(&report).unwrap();
         let schema: serde_json::Value =
-            serde_json::from_str(include_str!("../../schema/resolution-report.schema.json"))
-                .unwrap();
+            serde_json::from_str(include_str!("fixtures/resolution-report.schema.json")).unwrap();
         let validator = jsonschema::validator_for(&schema).expect("the committed schema compiles");
         let errors: Vec<String> = validator
             .iter_errors(&instance)


### PR DESCRIPTION
## What changed

- Keep the resolution-report schema fixture inside the published `secretspec`
  crate and verify it stays identical to the canonical schema.
- Add a CI package-list check so the fixture cannot silently disappear from a
  future crate tarball.
- Attach Go embedded libraries and the static SDK bundle to GitHub Releases.
- Create the required `secretspec-go/vX.Y.Z` submodule tag after the Go release
  matrix succeeds.

## Why

The 0.17.0 crate contained a test that used `include_str!` on a workspace-level
file. Cargo does not package files outside the crate directory, so downstream
builds that compile tests failed with a missing
`schema/resolution-report.schema.json`.

The Go release workflows built and smoke-tested successfully, but only uploaded
ephemeral Actions artifacts. They neither created the submodule tag required by
the Go module proxy nor attached the documented binaries to the GitHub Release.

## Validation

- `cargo fmt --all -- --check`
- Clippy and rustfmt pre-commit hooks
- `actionlint` on all modified workflows
- Targeted schema test in the workspace
- The same schema test from an extracted generated `.crate`
- Confirmed the generated crate includes
  `src/fixtures/resolution-report.schema.json`
- Reconstructed the static release archive from the successful v0.17.0 workflow
  artifact and verified its contents
