### PR TITLE
Add AWS Parameter Store provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cache-compatible deletion. SDK calls are safe from async Rust applications,
   and updates preserve the JSON types of Keeper fields such as dates,
   checkboxes, hosts, and names.
+- AWS Systems Manager Parameter Store provider (`awsps://`, `awsps` build
+  feature; planned for 0.18) for reading and writing KMS-encrypted
+  `SecureString` parameters. It supports AWS profiles and regions, an optional
+  hierarchy prefix, customer-managed KMS keys, parameter tiers, batched reads,
+  and read-only references pinned to a parameter version or label.
+  ([#209](https://github.com/cachix/secretspec/issues/209))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Provider and SDK errors now retain underlying causes such as authentication,
   timeout, DNS, TLS, connection, and response-parsing failures. AWS Secrets
-  Manager errors also report AWS error codes and messages instead of only
-  `unhandled error`.
+  Manager and Parameter Store errors also report AWS error codes and messages
+  instead of only `unhandled error`.
 - The dotenv provider's "cannot store" error now tells you to rename the secret
   in `secretspec.toml` when the name came from a manifest declaration, instead
   of always pointing at a `ref` item the config may not contain.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-ssm"
+version = "1.108.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1fe76483d66e14a1b2c70f2f8af5902794d8a4787eeb705957d4f0b57cee1e"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sso"
 version = "1.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5185,6 +5209,7 @@ dependencies = [
  "age",
  "aws-config",
  "aws-sdk-secretsmanager",
+ "aws-sdk-ssm",
  "azure_core",
  "azure_identity",
  "azure_security_keyvault_secrets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 google-cloud-secretmanager-v1 = "1.2"
 aws-config = "1"
 aws-sdk-secretsmanager = "1"
+aws-sdk-ssm = "1"
 azure_core = "1.0.0"
 azure_identity = "1.0.0"
 azure_security_keyvault_secrets = "1.0.0"

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -120,7 +120,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+).`,
+Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+).`,
         }),
       ],
       title: "SecretSpec",
@@ -252,6 +252,11 @@ Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files,
             {
               label: "AWS Secrets Manager",
               slug: "providers/awssm",
+            },
+            {
+              label: "AWS Parameter Store",
+              slug: "providers/awsps",
+              badge: { text: "0.18+", variant: "note" },
             },
             {
               label: "Scaleway Secret Manager",

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -53,6 +53,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [keeper](/providers/keeper/) (0.18+) | Keeper Secrets Manager (requires the `keeper` build feature) | ✓ | ✓ | ✓ | — |
 | [gcsm](/providers/gcsm/) | Google Cloud Secret Manager (requires the `gcsm` build feature) | ✓ | ✓ | ✓ | — |
 | [awssm](/providers/awssm/) | AWS Secrets Manager (requires the `awssm` build feature) | ✓ | ✓ | ✓ | — |
+| [awsps](/providers/awsps/) (0.18+) | AWS Systems Manager Parameter Store (requires the `awsps` build feature in 0.18+) | ✓ | ✓ | ✓ (`SecureString`) | — |
 | [scaleway](/providers/scaleway/) (0.17+) | Scaleway Secret Manager (requires the `scaleway` build feature) | ✓ | ✓ | ✓ | — |
 | [vault](/providers/vault/) | HashiCorp Vault (requires the `vault` build feature) | ✓ | ✓ | ✓ | — |
 | [openbao](/providers/openbao/) (0.17+) | OpenBao (requires the `openbao` build feature; 0.16 uses `openbao://` through `vault`) | ✓ | ✓ | ✓ | — |

--- a/docs/src/content/docs/providers/awsps.md
+++ b/docs/src/content/docs/providers/awsps.md
@@ -1,0 +1,186 @@
+---
+title: AWS Systems Manager Parameter Store Provider
+description: AWS Systems Manager Parameter Store integration
+---
+
+:::note
+The AWS Systems Manager Parameter Store provider is available in SecretSpec
+0.18+.
+:::
+
+The AWS Parameter Store provider stores secrets as encrypted
+[`SecureString`](https://docs.aws.amazon.com/systems-manager/latest/userguide/secure-string-parameter-kms-encryption.html)
+parameters.
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `awsps` (0.18+) |
+| URI | `awsps://[AWS_PROFILE@]REGION[?options]` |
+| Access | Read and write; parameter references are read-only |
+| Best for | AWS workloads using Parameter Store for application configuration |
+| Authentication | Standard AWS SDK credential chain |
+| Build feature | `awsps` (0.18+) |
+| Default storage | `/secretspec/{project}/{profile}/{key}` |
+
+## Quick start
+
+```bash
+# Set an encrypted parameter
+$ secretspec set DATABASE_URL --provider awsps://us-east-1
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret 'DATABASE_URL' saved to awsps (profile: default)
+
+# Get it back
+$ secretspec get DATABASE_URL --provider awsps://us-east-1
+postgresql://localhost/mydb
+
+# Run with parameters
+$ secretspec run --provider awsps://us-east-1 -- npm start
+```
+
+## Setup
+
+### Prerequisites
+
+- An AWS account with Systems Manager Parameter Store enabled
+- IAM permission to read and write the target parameter hierarchy
+- Build with `--features awsps` using SecretSpec 0.18+
+
+### Authentication
+
+The provider uses the standard AWS SDK credential chain, including:
+
+1. `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional
+   `AWS_SESSION_TOKEN`
+2. Shared AWS config and credentials files
+3. IAM Identity Center (SSO) sessions
+4. ECS task roles, EC2 instance profiles, and other workload identities
+
+Set a shared-config profile before the region in the URI:
+
+```text
+awsps://production@us-east-1
+```
+
+When the profile and region are omitted, the SDK resolves both from its
+ordinary environment and shared-config chains:
+
+```text
+awsps
+```
+
+## Configuration
+
+### URI format
+
+```text
+awsps://[AWS_PROFILE@]REGION[?prefix=PREFIX][&kms_key_id=KEY][&tier=TIER]
+```
+
+- `AWS_PROFILE`: Optional profile from the shared AWS config.
+- `REGION`: Optional AWS region. If omitted, the SDK region chain is used.
+- `prefix`: Optional hierarchy before `/secretspec`. A leading slash is
+  optional and normalized.
+- `kms_key_id`: Optional customer-managed KMS key ID, ARN, or alias used for
+  `SecureString` writes. If omitted, Parameter Store uses the account's default
+  key.
+- `tier`: Optional `standard`, `advanced`, or `intelligent-tiering` value.
+  Omitting it uses the account's Parameter Store default tier.
+
+### URI examples
+
+```text
+awsps://us-east-1
+awsps://production@us-east-1
+awsps://us-east-1?prefix=/myteam
+awsps://us-east-1?kms_key_id=alias/my-key&tier=advanced
+awsps://
+```
+
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+parameters = "awsps://production@us-east-1?prefix=/myteam&kms_key_id=alias/parameter-store"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["parameters"] }
+```
+
+## Storage model
+
+Convention secrets are stored at
+`[/prefix]/secretspec/{project}/{profile}/{key}`. For example,
+`DATABASE_URL` in project `myapp` and profile `production` maps to:
+
+```text
+/secretspec/myapp/production/DATABASE_URL
+```
+
+With `?prefix=/myteam`, it maps to:
+
+```text
+/myteam/secretspec/myapp/production/DATABASE_URL
+```
+
+Every value SecretSpec creates is a `SecureString`. Writes set
+`Overwrite=true`, so updating a value creates a new Parameter Store version.
+Parameter Store retains its normal version history.
+
+Standard parameters accept values up to 4 KB; advanced parameters accept up to
+8 KB and incur AWS charges. A standard parameter can be promoted to advanced,
+but Parameter Store does not downgrade an advanced parameter in place.
+
+:::caution
+SecretSpec does not change an existing parameter from `String` or `StringList`
+to `SecureString`. Parameter Store rejects that type change; create a new
+encrypted parameter or migrate the existing parameter first.
+:::
+
+## Use existing parameters
+
+In SecretSpec 0.18+, a secret's
+[`ref`](/reference/configuration/#secret-references) field can name an existing
+Parameter Store parameter. `item` is its full name or ARN. The optional
+`version` is appended as a Parameter Store selector and may be a numeric
+version or label. References are **read-only**.
+
+```toml
+[profiles.production]
+# Latest value
+DATABASE_URL = { description = "DB", ref = { item = "/prod/database-url" }, providers = ["awsps://us-east-1"] }
+
+# Version 7
+SIGNING_KEY = { description = "Signing key", ref = { item = "/prod/signing-key", version = "7" }, providers = ["awsps://us-east-1"] }
+
+# Version carrying the "current" label
+API_TOKEN = { description = "API token", ref = { item = "/prod/api-token", version = "current" }, providers = ["awsps://us-east-1"] }
+```
+
+Cross-account shared parameters must be read by ARN. SecretSpec still writes
+only to its convention hierarchy in the provider's configured account and
+region.
+
+## IAM permissions
+
+Reads require `ssm:GetParameter` and `ssm:GetParameters`; convention writes
+require `ssm:PutParameter`. A customer-managed KMS key also needs the
+corresponding KMS permissions for encryption and decryption.
+
+Scope IAM resources to the configured hierarchy where possible. For the
+`/myteam/secretspec/` prefix in `us-east-1`, that resource pattern is:
+
+```text
+arn:aws:ssm:us-east-1:ACCOUNT_ID:parameter/myteam/secretspec/*
+```
+
+## CI/CD
+
+Prefer an AWS workload identity or short-lived OIDC credentials:
+
+```bash
+$ export AWS_REGION=us-east-1
+$ secretspec run --provider awsps -- deploy
+```

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -113,6 +113,7 @@ $ secretspec config global init  # 0.17+
   dashlane: Dashlane password manager, read-only (0.18+)
   gcsm: Google Cloud Secret Manager
   awssm: AWS Secrets Manager
+  awsps: AWS Systems Manager Parameter Store (0.18+)
   scaleway: Scaleway Secret Manager (0.17+)
   vault: HashiCorp Vault secret management
   openbao: OpenBao secret management (0.17+)

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -586,13 +586,13 @@ never silently ignored.
 | `field` | No | A named component inside the item. Rejected by stores whose secrets hold a single value |
 | `vault` | No | The container holding the item. 1Password only; other stores take their container from the provider URI |
 | `section` | No | A named group of fields inside the item. 1Password only; requires `field` |
-| `version` | No | Which revision of the secret to read. Google Secret Manager only; defaults to the latest |
+| `version` | No | Which revision of the secret to read. Supported by versioned stores such as Google Secret Manager and AWS Parameter Store (0.18+); defaults to the latest |
 
 Stores fall into two groups for `field`:
 
 | Store | Shape of one secret | `field` |
 |-------|---------------------|---------|
-| dotenv, env, pass, LastPass, Proton Pass, Bitwarden | a single value | Rejected: there is nothing to select |
+| dotenv, env, pass, LastPass, Proton Pass, Bitwarden, AWS Parameter Store (0.18+) | a single value | Rejected: there is nothing to select |
 | 1Password, Keeper (0.18+), Vault KV, AWS Secrets Manager, keyring | a record of named parts | Selects the part: field label, map key, JSON key, account |
 
 `vault` is the only container coordinate. For every store except 1Password the
@@ -628,6 +628,7 @@ chain, and each provider is asked for the same coordinates.
 | [Vault](/providers/vault/#use-existing-secrets) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
 | [OpenBao](/providers/openbao/#use-existing-secrets) (0.17+) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
 | [AWS Secrets Manager](/providers/awssm/#use-existing-secrets) | Secret name or ARN | JSON key | Whole secret string | — (read-only) |
+| [AWS Parameter Store (0.18+)](/providers/awsps/#use-existing-parameters) | Parameter name or ARN; `version` selects a version or label | Rejected | Reads the decrypted value | — (read-only) |
 | [GCSM](/providers/gcsm/#use-existing-secrets) | Secret id; `version` also applies | Rejected | Reads latest or the pinned version | — (read-only) |
 | [Bitwarden (bws)](/providers/bws/#use-existing-secrets) | BWS key name | Rejected | Reads the key | ✅ |
 | [Azure Key Vault (0.15+)](/providers/akv/#use-existing-secrets) | Secret name | Rejected | Reads the secret | — (read-only) |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -245,6 +245,33 @@ awssm://                      # SDK default region and credentials
 **Prerequisites**: AWS credentials configured, build with `--features awssm`
 **Storage**: Secret name `secretspec/{project}/{profile}/{key}`
 
+## AWS Systems Manager Parameter Store Provider (0.18+)
+
+:::caution[Version compatibility]
+The `awsps` provider is added in SecretSpec 0.18.
+:::
+
+**URI**: `awsps://[profile@]REGION[?prefix=PATH&kms_key_id=KEY&tier=TIER]` -
+Stores secrets as encrypted AWS Systems Manager Parameter Store values
+
+```bash
+awsps://us-east-1                                  # Specific AWS region
+awsps://production@us-east-1                       # AWS profile and region
+awsps://us-east-1?prefix=/team                     # Additional hierarchy
+awsps://us-east-1?kms_key_id=alias/key&tier=advanced
+awsps://                                           # SDK defaults
+```
+
+**Features (0.18+)**: Read/write, `SecureString` encryption, cloud sync,
+profiles, IAM/SSO authentication, batched reads, version- or label-pinned
+read-only refs
+**Prerequisites (0.18+)**: AWS credentials configured, build with
+`--features awsps`
+**Storage (0.18+)**: Parameter
+`[/prefix]/secretspec/{project}/{profile}/{key}`; `kms_key_id` selects a
+customer-managed key, while `tier` accepts `standard`, `advanced`, or
+`intelligent-tiering`
+
 ## Scaleway Secret Manager Provider (0.17+)
 
 **URI**: `scaleway://[REGION][?project_id=UUID&path=/folder]` - Stores secrets in Scaleway Secret Manager
@@ -451,6 +478,7 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Keeper (0.18+) | ✅ End-to-end | Cloud (Keeper) | ✅ Yes |
 | GCSM | ✅ Google-managed | Cloud (GCP) | ✅ Yes |
 | AWSSM | ✅ AWS KMS | Cloud (AWS) | ✅ Yes |
+| AWS Parameter Store (0.18+) | ✅ AWS KMS (`SecureString`) | Cloud (AWS) | ✅ Yes |
 | Scaleway (0.17+) | ✅ Scaleway-managed | Cloud (Scaleway) | ✅ Yes |
 | Vault | ✅ Vault encryption | Vault server | ✅ Yes |
 | OpenBao (0.17+) | ✅ OpenBao encryption | OpenBao server | ✅ Yes |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -51,6 +51,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'vault', slug: 'vault', label: 'Vault' },
   { slug: 'openbao', label: 'OpenBao (0.17+)' },
   { slug: 'awssm', label: 'AWS Secrets Manager' },
+  { slug: 'awsps', label: 'AWS Parameter Store (0.18+)' },
   { slug: 'scaleway', label: 'Scaleway Secret Manager (0.17+)' },
   { icon: 'googlecloud', slug: 'gcsm', label: 'Google Cloud Secret Manager' },
   { icon: 'microsoftazure', slug: 'akv', label: 'Azure Key Vault' },
@@ -161,6 +162,7 @@ $ secretspec config global init
   age: age-encrypted file (0.17+)
   sops: SOPS encrypted files (0.17+)
   systemd-credential: Read-only systemd service credentials (0.17+)
+  awsps: AWS Systems Manager Parameter Store (0.18+)
   scaleway: Scaleway Secret Manager (0.17+)
   dashlane: Dashlane password manager, read-only (0.18+)
 <span class="tok-str">✓</span> Saved to ~/.config/secretspec/config.toml
@@ -246,6 +248,7 @@ $ secretspec run --profile production -- npm start
   age: age-encrypted file (0.17+)
   sops: SOPS encrypted files (0.17+)
   systemd-credential: Read-only systemd service credentials (0.17+)
+  awsps: AWS Systems Manager Parameter Store (0.18+)
   scaleway: Scaleway Secret Manager (0.17+)</code></pre>
       </div>
 
@@ -386,6 +389,7 @@ println<span class="tok-pun">!(</span><span class="tok-str">"{}"</span><span cla
           <button type="button" class="landing-provider-tab" data-provider="vault">Vault</button>
           <button type="button" class="landing-provider-tab" data-provider="openbao">OpenBao (0.17+)</button>
           <button type="button" class="landing-provider-tab" data-provider="awssm">AWS</button>
+          <button type="button" class="landing-provider-tab" data-provider="awsps">AWS PS (0.18+)</button>
           <button type="button" class="landing-provider-tab" data-provider="gcsm">GCP</button>
           <button type="button" class="landing-provider-tab" data-provider="akv">Azure</button>
           <button type="button" class="landing-provider-tab" data-provider="dotenv">.env</button>
@@ -1042,6 +1046,7 @@ REDIS_URL=redis://…</code></pre>
       vault:       'HashiCorp Vault',
       openbao:     'OpenBao (0.17+)',
       awssm:       'AWS Secrets Manager',
+      awsps:        'AWS Parameter Store (0.18+)',
       gcsm:        'Google Cloud Secret Manager',
       akv:         'Azure Key Vault',
       dotenv:      '.env file',

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -40,6 +40,7 @@ secrecy.workspace = true
 google-cloud-secretmanager-v1 = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-secretsmanager = { workspace = true, optional = true }
+aws-sdk-ssm = { workspace = true, optional = true }
 azure_core = { workspace = true, optional = true }
 azure_identity = { workspace = true, optional = true }
 azure_security_keyvault_secrets = { workspace = true, optional = true }
@@ -53,13 +54,14 @@ detect-coding-agent.workspace = true
 age = { workspace = true, optional = true }
 
 [features]
-default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "vault", "openbao", "bws", "akv", "infisical", "age", "scaleway", "sops"]
+default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "infisical", "age", "scaleway", "sops"]
 cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
 keeper = ["dep:keeper-secrets-manager-core"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager", "aws-config/credentials-login"]
+awsps = ["dep:aws-config", "dep:aws-sdk-ssm"]
 vault = ["dep:reqwest"]
 # Scaleway Secret Manager talks to the v1beta1 REST API directly; base64
 # payloads use data-encoding, which is already a non-optional dependency.

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -31,6 +31,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [systemd credentials](https://secretspec.dev/providers/systemd-credential) (0.17+)
   - [Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
+  - [AWS Systems Manager Parameter Store](https://secretspec.dev/providers/awsps) (0.18+)
   - [Scaleway Secret Manager](https://secretspec.dev/providers/scaleway) (0.17+)
   - [Vault](https://secretspec.dev/providers/vault)
   - [OpenBao](https://secretspec.dev/providers/openbao) (0.17+)
@@ -75,6 +76,7 @@ $ secretspec config global init  # 0.17+
   dashlane: Dashlane password manager, read-only (0.18+)
   gcsm: Google Cloud Secret Manager
   awssm: AWS Secrets Manager
+  awsps: AWS Systems Manager Parameter Store (0.18+)
   scaleway: Scaleway Secret Manager (0.17+)
   vault: HashiCorp Vault secret management
   openbao: OpenBao secret management (0.17+)
@@ -171,6 +173,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Dashlane](https://secretspec.dev/providers/dashlane)** (0.18+) - Read-only access to a Dashlane vault via the `dcli` CLI
 - **[Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)** - GCP secret management
 - **[AWS Secrets Manager](https://secretspec.dev/providers/awssm)** - AWS secret management
+- **[AWS Systems Manager Parameter Store](https://secretspec.dev/providers/awsps)** (0.18+) - Encrypted hierarchical parameters in AWS
 - **[Scaleway Secret Manager](https://secretspec.dev/providers/scaleway)** (0.17+) - Scaleway secret management
 - **[Vault](https://secretspec.dev/providers/vault)** - HashiCorp Vault KV engine
 - **[OpenBao](https://secretspec.dev/providers/openbao)** (0.17+) - OpenBao KV integration; SecretSpec 0.16 accepts `openbao://` through the Vault provider

--- a/secretspec/src/provider/awsps.rs
+++ b/secretspec/src/provider/awsps.rs
@@ -1,0 +1,645 @@
+//! AWS Systems Manager Parameter Store provider
+//!
+//! Available starting with SecretSpec 0.18.
+//!
+//! This provider stores SecretSpec values as encrypted `SecureString`
+//! parameters in AWS Systems Manager Parameter Store.
+//!
+//! # URI Format
+//!
+//! `awsps://[aws-profile@]region[?prefix=PREFIX][&kms_key_id=KEY][&tier=TIER]`
+//!
+//! - `awsps://us-east-1` — use SDK default credentials in us-east-1
+//! - `awsps://production@us-east-1` — use the "production" AWS profile
+//! - `awsps://us-east-1?prefix=/myteam` — store parameters below `/myteam`
+//! - `awsps://us-east-1?kms_key_id=alias/my-key&tier=advanced`
+//! - `awsps://` — use SDK defaults for both profile and region
+//!
+//! # Parameter Naming
+//!
+//! Parameters use the path
+//! `[/prefix]/secretspec/{project}/{profile}/{key}`.
+
+use super::{Address, Provider, ProviderUrl};
+use crate::{Result, SecretSpecError};
+use aws_sdk_ssm::Client;
+use aws_sdk_ssm::types::{ParameterTier, ParameterType};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+/// Maximum number of names accepted by one `GetParameters` request.
+const AWS_GET_PARAMETERS_MAX_NAMES: usize = 10;
+
+/// Parameter Store tier requested for writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AwspsTier {
+    Standard,
+    Advanced,
+    IntelligentTiering,
+}
+
+impl AwspsTier {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "standard" => Ok(Self::Standard),
+            "advanced" => Ok(Self::Advanced),
+            "intelligent-tiering" => Ok(Self::IntelligentTiering),
+            other => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "invalid awsps tier '{other}': expected standard, advanced, or \
+                 intelligent-tiering"
+            ))),
+        }
+    }
+
+    fn as_uri_value(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Advanced => "advanced",
+            Self::IntelligentTiering => "intelligent-tiering",
+        }
+    }
+
+    fn as_sdk_value(self) -> ParameterTier {
+        match self {
+            Self::Standard => ParameterTier::Standard,
+            Self::Advanced => ParameterTier::Advanced,
+            Self::IntelligentTiering => ParameterTier::IntelligentTiering,
+        }
+    }
+}
+
+/// Configuration for the AWS Systems Manager Parameter Store provider.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AwspsConfig {
+    /// AWS region. `None` uses the SDK default region chain.
+    pub region: Option<String>,
+    /// AWS shared-config profile. `None` uses the SDK default credential chain.
+    pub aws_profile: Option<String>,
+    /// Optional hierarchy placed before `/secretspec`.
+    pub prefix: Option<String>,
+    /// Optional customer-managed KMS key for `SecureString` writes.
+    pub kms_key_id: Option<String>,
+    /// Optional Parameter Store tier for writes.
+    pub tier: Option<AwspsTier>,
+}
+
+impl TryFrom<&ProviderUrl> for AwspsConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> Result<Self> {
+        if url.scheme() != "awsps" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for awsps provider. Expected 'awsps'.",
+                url.scheme()
+            )));
+        }
+
+        let aws_profile = {
+            let username = url.username();
+            (!username.is_empty()).then_some(username)
+        };
+        let region = url.host().filter(|value| !value.is_empty());
+        let prefix = url
+            .query_value("prefix")
+            .map(|value| value.trim_matches('/').to_string())
+            .filter(|value| !value.is_empty());
+        let kms_key_id = url.query_value("kms_key_id");
+        let tier = url
+            .query_value("tier")
+            .map(|value| AwspsTier::parse(&value))
+            .transpose()?;
+
+        let path = url.path();
+        let item = path.trim_start_matches('/');
+        if !item.is_empty() {
+            let hint = crate::config::ref_table_hint(None, item, None, None);
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "awsps URIs take no path: address the parameter with {hint} on \
+                 the secret instead"
+            )));
+        }
+
+        Ok(Self {
+            region,
+            aws_profile,
+            prefix,
+            kms_key_id,
+            tier,
+        })
+    }
+}
+
+/// AWS Systems Manager Parameter Store provider, available in SecretSpec 0.18+.
+pub struct AwspsProvider {
+    config: AwspsConfig,
+}
+
+crate::register_provider! {
+    struct: AwspsProvider,
+    config: AwspsConfig,
+    name: "awsps",
+    description: "AWS Systems Manager Parameter Store (0.18+)",
+    schemes: ["awsps"],
+    examples: [
+        "awsps://us-east-1",
+        "awsps://production@us-east-1",
+        "awsps://us-east-1?prefix=/myteam",
+        "awsps://us-east-1?kms_key_id=alias/my-key&tier=advanced",
+    ],
+}
+
+impl AwspsProvider {
+    pub fn new(config: AwspsConfig) -> Self {
+        Self { config }
+    }
+
+    /// Builds and validates the convention hierarchy.
+    fn format_parameter_name(
+        prefix: Option<&str>,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<String> {
+        for (name, value) in [("project", project), ("profile", profile), ("key", key)] {
+            if value.is_empty() {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "{name} cannot be empty"
+                )));
+            }
+        }
+
+        let prefix = prefix.unwrap_or_default().trim_matches('/');
+        let parameter_name = if prefix.is_empty() {
+            format!("/secretspec/{project}/{profile}/{key}")
+        } else {
+            format!("/{prefix}/secretspec/{project}/{profile}/{key}")
+        };
+        Self::validate_parameter_name(&parameter_name)?;
+        Ok(parameter_name)
+    }
+
+    /// Applies the Parameter Store naming constraints that can be checked
+    /// without knowing the caller's AWS partition, account, and region.
+    fn validate_parameter_name(name: &str) -> Result<()> {
+        if name.len() > 1011 {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Parameter name too long: {} characters (maximum 1011 before \
+                 AWS applies its ARN-specific limit)",
+                name.len()
+            )));
+        }
+
+        let path = name.trim_start_matches('/');
+        let mut parts = path.split('/');
+        let Some(first) = parts.next().filter(|part| !part.is_empty()) else {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "Parameter name cannot be empty".to_string(),
+            ));
+        };
+        let first_lower = first.to_ascii_lowercase();
+        if first_lower.starts_with("aws") || first_lower.starts_with("ssm") {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Parameter name '{name}' cannot start with the reserved prefix \
+                 'aws' or 'ssm'"
+            )));
+        }
+
+        let parts: Vec<&str> = std::iter::once(first).chain(parts).collect();
+        if parts.len() > 15 {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Parameter hierarchy has {} levels (maximum 15)",
+                parts.len()
+            )));
+        }
+        if parts.iter().any(|part| part.is_empty()) {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Parameter name '{name}' contains an empty hierarchy level"
+            )));
+        }
+        if let Some(character) = path
+            .chars()
+            .find(|character| !character.is_ascii_alphanumeric() && !"_.-/".contains(*character))
+        {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Parameter name '{name}' contains invalid character '{character}'"
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn create_client(&self) -> Client {
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+        if let Some(region) = &self.config.region {
+            loader = loader.region(aws_config::Region::new(region.clone()));
+        }
+        if let Some(profile) = &self.config.aws_profile {
+            loader = loader.profile_name(profile);
+        }
+        Client::new(&loader.load().await)
+    }
+
+    /// Parameter Store selects a version or label by appending it to the name.
+    fn selected_name(item: &str, version: Option<&str>) -> String {
+        match version {
+            Some(version) => format!("{item}:{version}"),
+            None => item.to_string(),
+        }
+    }
+
+    async fn get_parameter_async(&self, name: &str) -> Result<Option<SecretString>> {
+        let client = self.create_client().await;
+        let output = match client
+            .get_parameter()
+            .name(name)
+            .with_decryption(true)
+            .send()
+            .await
+        {
+            Ok(output) => output,
+            Err(error) => {
+                let service_error = error.into_service_error();
+                return if service_error.is_parameter_not_found() {
+                    Ok(None)
+                } else {
+                    Err(SecretSpecError::ProviderOperationFailed(format!(
+                        "Failed to get Parameter Store parameter '{name}': {service_error}"
+                    )))
+                };
+            }
+        };
+
+        Ok(output
+            .parameter()
+            .and_then(|parameter| parameter.value())
+            .map(|value| SecretString::new(value.to_string().into())))
+    }
+
+    /// Indexes a returned parameter by the name and ARN forms accepted in the
+    /// request, preserving a version or label selector when one was used.
+    fn index_parameter(
+        values: &mut HashMap<String, String>,
+        parameter: &aws_sdk_ssm::types::Parameter,
+    ) {
+        let Some(value) = parameter.value() else {
+            return;
+        };
+        let selector = parameter.selector().map_or_else(String::new, |selector| {
+            if selector.starts_with(':') {
+                selector.to_string()
+            } else {
+                format!(":{selector}")
+            }
+        });
+        for identity in [parameter.name(), parameter.arn()].into_iter().flatten() {
+            values.insert(format!("{identity}{selector}"), value.to_string());
+        }
+    }
+
+    async fn get_many_async(
+        &self,
+        resolved: &[(&str, crate::config::NativeAddress)],
+    ) -> Result<HashMap<String, SecretString>> {
+        let client = self.create_client().await;
+        let mut unique_names = Vec::new();
+        let mut seen = HashSet::new();
+        for (_, coordinates) in resolved {
+            let name = Self::selected_name(&coordinates.item, coordinates.version.as_deref());
+            if seen.insert(name.clone()) {
+                unique_names.push(name);
+            }
+        }
+
+        let mut values = HashMap::new();
+        for names in unique_names.chunks(AWS_GET_PARAMETERS_MAX_NAMES) {
+            let output = client
+                .get_parameters()
+                .set_names(Some(names.to_vec()))
+                .with_decryption(true)
+                .send()
+                .await
+                .map_err(|error| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "GetParameters failed: {}",
+                        error.into_service_error()
+                    ))
+                })?;
+            for parameter in output.parameters() {
+                Self::index_parameter(&mut values, parameter);
+            }
+            // Parameter Store reports absent names in `invalid_parameters`;
+            // like every other provider, absent secrets are omitted.
+        }
+
+        let mut results = HashMap::new();
+        for (secret_name, coordinates) in resolved {
+            let name = Self::selected_name(&coordinates.item, coordinates.version.as_deref());
+            if let Some(value) = values.get(&name) {
+                results.insert(
+                    (*secret_name).to_string(),
+                    SecretString::new(value.clone().into()),
+                );
+            }
+        }
+        Ok(results)
+    }
+
+    async fn set_parameter_async(&self, name: &str, value: &SecretString) -> Result<()> {
+        let client = self.create_client().await;
+        let mut request = client
+            .put_parameter()
+            .name(name)
+            .value(value.expose_secret())
+            .r#type(ParameterType::SecureString)
+            .overwrite(true);
+        if let Some(kms_key_id) = &self.config.kms_key_id {
+            request = request.key_id(kms_key_id);
+        }
+        if let Some(tier) = self.config.tier {
+            request = request.tier(tier.as_sdk_value());
+        }
+        request.send().await.map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to write Parameter Store parameter '{name}': {}",
+                error.into_service_error()
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+impl Provider for AwspsProvider {
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: Self::format_parameter_name(
+                self.config.prefix.as_deref(),
+                project,
+                profile,
+                key,
+            )?,
+            ..Default::default()
+        })
+    }
+
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["version"]
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coordinates = self.resolve_coords(addr)?;
+        let name = Self::selected_name(&coordinates.item, coordinates.version.as_deref());
+        super::block_on(self.get_parameter_async(&name))
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let coordinates = self.resolve_coords(addr)?;
+        super::block_on(self.set_parameter_async(&coordinates.item, value))
+    }
+
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Convention { .. } => Ok(()),
+            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(
+                "awsps parameter references are read-only and cannot be written".to_string(),
+            )),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let base = match (&self.config.aws_profile, &self.config.region) {
+            (Some(profile), Some(region)) => format!(
+                "awsps://{}@{}",
+                ProviderUrl::encode(profile),
+                ProviderUrl::encode(region)
+            ),
+            (None, Some(region)) => format!("awsps://{}", ProviderUrl::encode(region)),
+            (_, None) => "awsps".to_string(),
+        };
+
+        let mut parameters = Vec::new();
+        if let Some(prefix) = &self.config.prefix {
+            parameters.push(format!(
+                "prefix={}",
+                ProviderUrl::encode_query(&format!("/{prefix}"))
+            ));
+        }
+        if let Some(kms_key_id) = &self.config.kms_key_id {
+            parameters.push(format!(
+                "kms_key_id={}",
+                ProviderUrl::encode_query(kms_key_id)
+            ));
+        }
+        if let Some(tier) = self.config.tier {
+            parameters.push(format!("tier={}", tier.as_uri_value()));
+        }
+
+        if parameters.is_empty() {
+            base
+        } else {
+            let separator = if self.config.region.is_some() {
+                "?"
+            } else {
+                "://?"
+            };
+            format!("{base}{separator}{}", parameters.join("&"))
+        }
+    }
+
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        if requests.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut resolved = Vec::with_capacity(requests.len());
+        for (name, address) in requests {
+            resolved.push((*name, self.resolve_coords(*address)?.into_owned()));
+        }
+        super::block_on(self.get_many_async(&resolved))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(uri: &str) -> AwspsConfig {
+        let url = url::Url::parse(uri).unwrap();
+        AwspsConfig::try_from(&ProviderUrl::new(url)).unwrap()
+    }
+
+    #[test]
+    fn convention_uses_parameter_hierarchy() {
+        let provider = AwspsProvider::new(config("awsps://us-east-1"));
+        let address = provider
+            .convention_address("myapp", "production", "DATABASE_URL")
+            .unwrap();
+        assert_eq!(address.item, "/secretspec/myapp/production/DATABASE_URL");
+    }
+
+    #[test]
+    fn convention_accepts_normalized_prefix() {
+        for prefix in ["myteam", "/myteam", "/myteam/"] {
+            let name =
+                AwspsProvider::format_parameter_name(Some(prefix), "app", "prod", "TOKEN").unwrap();
+            assert_eq!(name, "/myteam/secretspec/app/prod/TOKEN");
+        }
+    }
+
+    #[test]
+    fn convention_rejects_invalid_names() {
+        assert!(AwspsProvider::format_parameter_name(None, "", "prod", "KEY").is_err());
+        assert!(AwspsProvider::format_parameter_name(None, "app", "", "KEY").is_err());
+        assert!(AwspsProvider::format_parameter_name(None, "app", "prod", "").is_err());
+
+        let error =
+            AwspsProvider::format_parameter_name(None, "my app", "prod", "KEY").unwrap_err();
+        assert!(error.to_string().contains("invalid character"), "{error}");
+
+        let error = AwspsProvider::format_parameter_name(Some("/aws/team"), "app", "prod", "KEY")
+            .unwrap_err();
+        assert!(error.to_string().contains("reserved prefix"), "{error}");
+    }
+
+    #[test]
+    fn convention_rejects_hierarchies_deeper_than_fifteen_levels() {
+        let prefix = (0..12)
+            .map(|number| format!("p{number}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        let error =
+            AwspsProvider::format_parameter_name(Some(&prefix), "app", "prod", "KEY").unwrap_err();
+        assert!(error.to_string().contains("maximum 15"), "{error}");
+    }
+
+    #[test]
+    fn parses_profile_region_and_options() {
+        let parsed = config(
+            "awsps://production@us-east-1?prefix=/team/platform&kms_key_id=alias/team&tier=advanced",
+        );
+        assert_eq!(parsed.aws_profile.as_deref(), Some("production"));
+        assert_eq!(parsed.region.as_deref(), Some("us-east-1"));
+        assert_eq!(parsed.prefix.as_deref(), Some("team/platform"));
+        assert_eq!(parsed.kms_key_id.as_deref(), Some("alias/team"));
+        assert_eq!(parsed.tier, Some(AwspsTier::Advanced));
+    }
+
+    #[test]
+    fn rejects_invalid_tier() {
+        let url = url::Url::parse("awsps://us-east-1?tier=free").unwrap();
+        let error = AwspsConfig::try_from(&ProviderUrl::new(url)).unwrap_err();
+        assert!(error.to_string().contains("invalid awsps tier"), "{error}");
+    }
+
+    #[test]
+    fn uri_round_trips_all_options() {
+        let provider = AwspsProvider::new(config(
+            "awsps://production@us-east-1?prefix=/team/platform&kms_key_id=alias/team&tier=intelligent-tiering",
+        ));
+        let uri = provider.uri();
+        assert_eq!(
+            uri,
+            "awsps://production@us-east-1?prefix=/team/platform&kms_key_id=alias/team&tier=intelligent-tiering"
+        );
+        let reparsed = config(&uri);
+        assert_eq!(reparsed.prefix.as_deref(), Some("team/platform"));
+        assert_eq!(reparsed.tier, Some(AwspsTier::IntelligentTiering));
+    }
+
+    #[test]
+    fn uri_without_region_uses_bare_provider_name() {
+        assert_eq!(AwspsProvider::new(config("awsps://")).uri(), "awsps");
+        assert_eq!(
+            AwspsProvider::new(config("awsps://?prefix=/team")).uri(),
+            "awsps://?prefix=/team"
+        );
+    }
+
+    #[test]
+    fn path_is_rejected_in_favor_of_ref() {
+        let url = url::Url::parse("awsps://us-east-1/existing/parameter").unwrap();
+        let error = AwspsConfig::try_from(&ProviderUrl::new(url)).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("URIs take no path"), "{message}");
+        assert!(message.contains("ref = { item ="), "{message}");
+    }
+
+    #[test]
+    fn native_ref_supports_version_or_label_selector() {
+        assert_eq!(
+            AwspsProvider::selected_name("/prod/token", Some("7")),
+            "/prod/token:7"
+        );
+        assert_eq!(
+            AwspsProvider::selected_name("/prod/token", Some("current")),
+            "/prod/token:current"
+        );
+    }
+
+    #[test]
+    fn batch_response_preserves_selector_and_arn_forms() {
+        let parameter = aws_sdk_ssm::types::Parameter::builder()
+            .name("/prod/token")
+            .arn("arn:aws:ssm:us-east-1:123456789012:parameter/prod/token")
+            .selector(":7")
+            .value("secret")
+            .build();
+        let mut values = HashMap::new();
+        AwspsProvider::index_parameter(&mut values, &parameter);
+
+        assert_eq!(values["/prod/token:7"], "secret");
+        assert_eq!(
+            values["arn:aws:ssm:us-east-1:123456789012:parameter/prod/token:7"],
+            "secret"
+        );
+        assert!(!values.contains_key("/prod/token"));
+    }
+
+    #[test]
+    fn native_ref_is_read_only() {
+        let provider = AwspsProvider::new(config("awsps://us-east-1"));
+        let reference = crate::config::NativeAddress {
+            item: "/prod/token".to_string(),
+            version: Some("3".to_string()),
+            ..Default::default()
+        };
+        let error = provider
+            .check_writable(Address::Native(&reference))
+            .unwrap_err();
+        assert!(error.to_string().contains("read-only"), "{error}");
+    }
+
+    #[test]
+    fn native_ref_rejects_field_before_network_access() {
+        let provider = AwspsProvider::new(config("awsps://us-east-1"));
+        let reference = crate::config::NativeAddress {
+            item: "/prod/token".to_string(),
+            field: Some("password".to_string()),
+            ..Default::default()
+        };
+        let error = provider
+            .resolve_coords(Address::Native(&reference))
+            .unwrap_err();
+        assert!(error.to_string().contains("`field`"), "{error}");
+    }
+
+    #[test]
+    fn batch_limit_is_ten_names() {
+        let names: Vec<_> = (0..23).collect();
+        let chunks: Vec<_> = names.chunks(AWS_GET_PARAMETERS_MAX_NAMES).collect();
+        assert_eq!(
+            chunks.iter().map(|chunk| chunk.len()).collect::<Vec<_>>(),
+            [10, 10, 3]
+        );
+    }
+}

--- a/secretspec/src/provider/awsps.rs
+++ b/secretspec/src/provider/awsps.rs
@@ -23,13 +23,35 @@
 use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use aws_sdk_ssm::Client;
+use aws_sdk_ssm::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_ssm::types::{ParameterTier, ParameterType};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::fmt::Debug;
 
 /// Maximum number of names accepted by one `GetParameters` request.
 const AWS_GET_PARAMETERS_MAX_NAMES: usize = 10;
+
+/// Formats an AWS SDK error without collapsing non-service failures into a
+/// generated operation error's opaque `unhandled error` variant.
+fn format_aws_error<E, R>(error: &SdkError<E, R>) -> String
+where
+    E: Error + ProvideErrorMetadata + 'static,
+    R: Debug + 'static,
+{
+    if let Some(service_error) = error.as_service_error() {
+        return match (service_error.code(), service_error.message()) {
+            (Some(code), Some(message)) => format!("{code}: {message}"),
+            (Some(code), None) => code.to_string(),
+            (None, Some(message)) => message.to_string(),
+            (None, None) => crate::error::display_error_chain(service_error),
+        };
+    }
+
+    crate::error::display_error_chain(error)
+}
 
 /// Parameter Store tier requested for writes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -260,12 +282,15 @@ impl AwspsProvider {
         {
             Ok(output) => output,
             Err(error) => {
-                let service_error = error.into_service_error();
-                return if service_error.is_parameter_not_found() {
+                return if error
+                    .as_service_error()
+                    .is_some_and(|service_error| service_error.is_parameter_not_found())
+                {
                     Ok(None)
                 } else {
                     Err(SecretSpecError::ProviderOperationFailed(format!(
-                        "Failed to get Parameter Store parameter '{name}': {service_error}"
+                        "Failed to get Parameter Store parameter '{name}': {}",
+                        format_aws_error(&error)
                     )))
                 };
             }
@@ -323,7 +348,7 @@ impl AwspsProvider {
                 .map_err(|error| {
                     SecretSpecError::ProviderOperationFailed(format!(
                         "GetParameters failed: {}",
-                        error.into_service_error()
+                        format_aws_error(&error)
                     ))
                 })?;
             for parameter in output.parameters() {
@@ -363,7 +388,7 @@ impl AwspsProvider {
         request.send().await.map_err(|error| {
             SecretSpecError::ProviderOperationFailed(format!(
                 "Failed to write Parameter Store parameter '{name}': {}",
-                error.into_service_error()
+                format_aws_error(&error)
             ))
         })?;
         Ok(())
@@ -472,6 +497,7 @@ impl Provider for AwspsProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_sdk_ssm::operation::get_parameters::GetParametersError;
 
     fn config(uri: &str) -> AwspsConfig {
         let url = url::Url::parse(uri).unwrap();
@@ -640,6 +666,33 @@ mod tests {
         assert_eq!(
             chunks.iter().map(|chunk| chunk.len()).collect::<Vec<_>>(),
             [10, 10, 3]
+        );
+    }
+
+    #[test]
+    fn aws_error_includes_unmodeled_service_code_and_message() {
+        let service_error = GetParametersError::generic(
+            aws_sdk_ssm::error::ErrorMetadata::builder()
+                .code("AccessDeniedException")
+                .message("not authorized to read these parameters")
+                .build(),
+        );
+        let sdk_error = SdkError::service_error(service_error, ());
+
+        assert_eq!(
+            format_aws_error(&sdk_error),
+            "AccessDeniedException: not authorized to read these parameters"
+        );
+    }
+
+    #[test]
+    fn aws_error_includes_non_service_cause() {
+        let sdk_error: SdkError<GetParametersError, ()> =
+            SdkError::construction_failure(std::io::Error::other("invalid AWS endpoint"));
+
+        assert_eq!(
+            format_aws_error(&sdk_error),
+            "failed to construct request: invalid AWS endpoint"
         );
     }
 }

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -29,6 +29,7 @@
 //! - [`dashlane::DashlaneProvider`]: Dashlane integration, read-only (0.18+)
 //! - [`gcsm::GcsmProvider`]: Google Cloud Secret Manager integration
 //! - [`awssm::AwssmProvider`]: AWS Secrets Manager integration
+//! - [`awsps::AwspsProvider`]: AWS Systems Manager Parameter Store integration (0.18+)
 //! - [`vault::VaultProvider`]: HashiCorp Vault integration
 //! - [`openbao::OpenBaoProvider`]: OpenBao integration (0.17+)
 //! - [`bws::BwsProvider`]: Bitwarden Secrets Manager integration
@@ -280,6 +281,8 @@ pub(crate) fn block_on<F: std::future::Future>(future: F) -> F::Output {
 pub mod age;
 #[cfg(feature = "akv")]
 pub mod akv;
+#[cfg(feature = "awsps")]
+pub mod awsps;
 #[cfg(feature = "awssm")]
 pub mod awssm;
 #[cfg(feature = "bws")]

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1507,6 +1507,51 @@ mod integration_tests {
         assert!(!result.contains_key("NONEXISTENT"));
     }
 
+    #[cfg(feature = "awsps")]
+    #[test]
+    fn test_awsps_batch_get() {
+        let providers = get_test_providers();
+        if !providers.contains(&"awsps".to_string()) {
+            return;
+        }
+
+        let (provider, _temp_dir) = create_provider_with_temp_path("awsps");
+        let project_name = generate_test_project_name();
+        let profile = "default";
+
+        let test_parameters = [
+            ("BATCH_TEST_1", "value1"),
+            ("BATCH_TEST_2", "value2"),
+            ("BATCH_TEST_3", "value3"),
+        ];
+        for (key, value) in test_parameters {
+            provider
+                .set(
+                    Address::convention(&project_name, profile, key),
+                    &SecretString::new(value.to_string().into()),
+                )
+                .unwrap();
+        }
+
+        let keys = [
+            "BATCH_TEST_1",
+            "BATCH_TEST_2",
+            "BATCH_TEST_3",
+            "NONEXISTENT",
+        ];
+        let requests: Vec<(&str, Address<'_>)> = keys
+            .iter()
+            .map(|key| (*key, Address::convention(&project_name, profile, key)))
+            .collect();
+        let result = provider.get_many(&requests).unwrap();
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result["BATCH_TEST_1"].expose_secret(), "value1");
+        assert_eq!(result["BATCH_TEST_2"].expose_secret(), "value2");
+        assert_eq!(result["BATCH_TEST_3"].expose_secret(), "value3");
+        assert!(!result.contains_key("NONEXISTENT"));
+    }
+
     #[cfg(feature = "awssm")]
     #[test]
     fn test_awssm_provider_creation() {
@@ -1566,6 +1611,40 @@ mod integration_tests {
         let provider = Box::<dyn Provider>::try_from("awssm://?prefix=myteam").unwrap();
         assert_eq!(provider.name(), "awssm");
         assert_eq!(provider.uri(), "awssm://?prefix=myteam");
+    }
+
+    #[cfg(feature = "awsps")]
+    #[test]
+    fn test_awsps_provider_creation() {
+        let provider = Box::<dyn Provider>::try_from("awsps://us-east-1").unwrap();
+        assert_eq!(provider.name(), "awsps");
+        assert_eq!(provider.uri(), "awsps://us-east-1");
+    }
+
+    #[cfg(feature = "awsps")]
+    #[test]
+    fn test_awsps_provider_creation_without_region() {
+        let provider = Box::<dyn Provider>::try_from("awsps://").unwrap();
+        assert_eq!(provider.name(), "awsps");
+        assert_eq!(provider.uri(), "awsps");
+
+        let provider = Box::<dyn Provider>::try_from("awsps").unwrap();
+        assert_eq!(provider.name(), "awsps");
+        assert_eq!(provider.uri(), "awsps");
+    }
+
+    #[cfg(feature = "awsps")]
+    #[test]
+    fn test_awsps_provider_with_profile_and_options() {
+        let provider = Box::<dyn Provider>::try_from(
+            "awsps://production@us-east-1?prefix=/team&kms_key_id=alias/parameters&tier=advanced",
+        )
+        .unwrap();
+        assert_eq!(provider.name(), "awsps");
+        assert_eq!(
+            provider.uri(),
+            "awsps://production@us-east-1?prefix=/team&kms_key_id=alias/parameters&tier=advanced"
+        );
     }
 
     #[cfg(feature = "vault")]


### PR DESCRIPTION
Closes #209

## What changed

- add an `awsps://` provider backed by AWS Systems Manager Parameter Store
- write values as KMS-encrypted `SecureString` parameters under `[/prefix]/secretspec/{project}/{profile}/{key}`
- support AWS shared-config profiles and regions, hierarchy prefixes, customer-managed KMS keys, and parameter tiers
- batch reads through `GetParameters` in groups of 10
- support read-only native references pinned to a parameter version or label
- enable the `awsps` Cargo feature by default and document the provider for SecretSpec 0.18+

## User impact

AWS users can keep SecretSpec-managed values in Parameter Store while using the standard AWS SDK credential chain. Existing parameters can be read by name or ARN without moving them into SecretSpec's convention hierarchy.

## Documentation checklist

Followed `docs/src/content/docs/development/adding-providers.md`: the provider page includes the version notice and standard section order; all provider lists, tables, selectors, sidebar entries, README examples, generated documentation summary, reference/security tables, and the unreleased changelog entry are updated with the 0.18+ minimum version.

## Validation

- `cargo test --all`
- `cargo test --package secretspec --lib awsps` (18 tests)
- standalone `awsps` feature build
- strict Clippy for the standalone `awsps` feature
- repository pre-commit Clippy and rustfmt hooks
- Astro documentation check and production build
- `cargo doc --package secretspec --all-features --no-deps`

## AWS testing requested

The live integration path is opt-in because it writes temporary parameters to the configured AWS account. To exercise it:

```bash
AWS_REGION=us-east-1 \
SECRETSPEC_TEST_PROVIDERS=awsps \
cargo test --package secretspec provider::tests::integration_tests -- --nocapture
```

An identity used for this test needs `ssm:GetParameter`, `ssm:GetParameters`, and `ssm:PutParameter` for the `/secretspec/` hierarchy, plus the appropriate KMS permissions.
