### PR TITLE
Add Keeper Secrets Manager provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Check each provider feature standalone
       run: |
         set -euo pipefail
-        for feature in cli keyring gcsm awssm vault openbao infisical bws akv sops; do
+        for feature in cli keyring keeper gcsm awssm vault openbao infisical bws akv sops; do
           echo "::group::$feature"
           cargo check --package secretspec --no-default-features --features "$feature"
           echo "::endgroup::"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Injected credentials read through a private, owner-only `dcli` state
   directory of their own, because `dcli` otherwise prefers a device already
   registered on the machine and reads that identity's vault instead.
+- Keeper Secrets Manager provider (`keeper://FOLDER_UID`, `keeper` build feature) using
+  Keeper's official Rust SDK, with convention-based records, references to
+  existing records and fields, provider credentials, batch reads, writes, and
+  cache-compatible deletion. SDK calls are safe from async Rust applications,
+  and updates preserve the JSON types of Keeper fields such as dates,
+  checkboxes, hosts, and names.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,8 +1252,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1460,6 +1462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 dependencies = [
  "futures",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1853,6 +1865,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -2375,7 +2396,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 1.4.0",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rustc_version",
  "rustls 0.23.37",
  "rustls-pki-types",
@@ -2427,7 +2448,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "percent-encoding",
  "pin-project",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rustc_version",
  "serde",
  "serde_json",
@@ -2882,9 +2903,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3366,7 +3389,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.28.0",
  "unicode-general-category",
  "uuid-simd",
 ]
@@ -3435,6 +3458,40 @@ dependencies = [
  "twofish",
  "uuid",
  "zeroize",
+]
+
+[[package]]
+name = "keeper-secrets-manager-core"
+version = "17.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf807a8d4a1ea057446b4ac9535df3ec0ffb6b1c58c7884f231e0fe0eaea092"
+dependencies = [
+ "aes 0.8.4",
+ "aes-gcm",
+ "base64",
+ "block-padding 0.3.3",
+ "chrono",
+ "cipher 0.4.4",
+ "data-encoding",
+ "ecdsa",
+ "hex",
+ "hmac 0.12.1",
+ "log",
+ "num-bigint",
+ "p256",
+ "rand 0.8.5",
+ "regex",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "winapi",
 ]
 
 [[package]]
@@ -4698,14 +4755,17 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4714,6 +4774,8 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4918,7 +4980,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -5137,6 +5199,7 @@ dependencies = [
  "jiff",
  "jsonschema",
  "keepass",
+ "keeper-secrets-manager-core",
  "keyring",
  "linkme",
  "miette",
@@ -5228,7 +5291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5296,6 +5359,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -5556,11 +5620,30 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5642,6 +5725,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6163,7 +6267,7 @@ dependencies = [
  "futures",
  "pin-project",
  "rand 0.10.2",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "time",
@@ -6703,6 +6807,17 @@ dependencies = [
  "regex",
  "windows-sys 0.61.2",
  "zeroize",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2024"
 clap = { version = "4.0", features = ["derive", "env"] }
 keyring = "4"
 keepass = { version = "0.13.17", features = ["save_kdbx4"] }
+keeper-secrets-manager-core = { version = "17.3.0", default-features = false, features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9"
 toml_edit = "0.23"

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -120,7 +120,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Google Cloud Secret Manager, AWS Secrets Manager, Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+).`,
+Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+).`,
         }),
       ],
       title: "SecretSpec",
@@ -235,6 +235,11 @@ Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files,
               badge: { text: "0.18+", variant: "note" },
             },
             { label: "1Password", slug: "providers/onepassword" },
+            {
+              label: "Keeper Secrets Manager",
+              slug: "providers/keeper",
+              badge: { text: "0.18+", variant: "note" },
+            },
             {
               label: "Gopass",
               slug: "providers/gopass",

--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -50,6 +50,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [onepassword](/providers/onepassword/) | 1Password | ✓ | ✓ | ✓ | — |
 | [lastpass](/providers/lastpass/) | LastPass | ✓ | ✓ | ✓ | — |
 | [dashlane](/providers/dashlane/) (0.18+) | Dashlane, through the `dcli` CLI | ✓ | ✗ | ✓ | — |
+| [keeper](/providers/keeper/) (0.18+) | Keeper Secrets Manager (requires the `keeper` build feature) | ✓ | ✓ | ✓ | — |
 | [gcsm](/providers/gcsm/) | Google Cloud Secret Manager (requires the `gcsm` build feature) | ✓ | ✓ | ✓ | — |
 | [awssm](/providers/awssm/) | AWS Secrets Manager (requires the `awssm` build feature) | ✓ | ✓ | ✓ | — |
 | [scaleway](/providers/scaleway/) (0.17+) | Scaleway Secret Manager (requires the `scaleway` build feature) | ✓ | ✓ | ✓ | — |

--- a/docs/src/content/docs/providers/keeper.md
+++ b/docs/src/content/docs/providers/keeper.md
@@ -1,0 +1,208 @@
+---
+title: Keeper Secrets Manager Provider
+description: Keeper Secrets Manager integration through Keeper's official Rust SDK
+---
+
+:::caution[Version compatibility]
+The `keeper` provider is added in SecretSpec 0.18.
+:::
+
+The Keeper provider reads and writes records available to a
+[Keeper Secrets Manager](https://docs.keeper.io/keeperpam/secrets-manager)
+application. SecretSpec links
+[Keeper's official Rust SDK](https://github.com/Keeper-Security/secrets-manager/tree/master/sdk/rust),
+so no separate `ksm` executable is required.
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `keeper` (0.18+) |
+| URI | `keeper://FOLDER_UID[?config_file=PATH]` |
+| Access | Read, write, and delete |
+| Best for | Machine and CI/CD secrets managed in Keeper |
+| Authentication | KSM configuration, or a one-time token while creating a file configuration |
+| Availability | SecretSpec 0.18+; requires the `keeper` build feature |
+| Default storage | Login record `secretspec/{project}/{profile}/{key}`, field `password` |
+
+## Quick start
+
+```bash
+# Store a secret as a Keeper record
+$ secretspec set DATABASE_URL \
+    --provider "keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json"
+
+# Read it back
+$ secretspec get DATABASE_URL \
+    --provider "keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json"
+
+# Resolve the profile and run a command
+$ secretspec run \
+    --provider "keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json" \
+    -- npm start
+```
+
+The folder must be shared with the KSM application and grant edit permission
+for writes.
+
+## Setup
+
+### Prerequisites
+
+- SecretSpec 0.18+ built with the `keeper` feature
+- A Keeper Secrets Manager application
+- A shared folder available to that application
+- A bound KSM client configuration, or a one-time access token for initial
+  binding
+
+Keeper's Rust SDK is embedded in SecretSpec. Keeper Commander and the `ksm` CLI
+are useful for application setup, but neither is needed when SecretSpec runs.
+
+### Authentication with KSM_CONFIG
+
+Set `KSM_CONFIG` to the JSON or Base64 KSM client configuration:
+
+```bash
+export KSM_CONFIG="$KEEPER_CLIENT_CONFIG"
+secretspec check --provider "keeper://SHARED_FOLDER_UID"
+```
+
+The configuration contains private client keys. Treat the whole value as a
+secret.
+
+SecretSpec 0.18+ also declares `config` as a
+[provider credential](/concepts/providers/#provider-credentials), so the
+configuration can be loaded from another provider instead of the environment:
+
+```toml title="secretspec.toml"
+[providers]
+bootstrap = "keyring://"
+
+[providers.keeper]
+uri = "keeper://SHARED_FOLDER_UID"
+credentials = { config = "bootstrap" }
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["keeper"] }
+```
+
+When no explicit `config` credential is supplied, the provider falls back to
+`KSM_CONFIG`.
+
+### Authentication with a configuration file
+
+Use `config_file` to read and update a Keeper SDK configuration file:
+
+```toml title="secretspec.toml"
+[providers]
+keeper = "keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json"
+```
+
+Relative paths are resolved from the directory containing `secretspec.toml`.
+Without `config_file`, the SDK honors `KSM_CONFIG_FILE`, then uses its
+`client-config.json` default.
+
+### Bind with a one-time token
+
+The `token` provider credential, or `KSM_TOKEN` fallback, can bind a new client.
+Pair it with file storage so the SDK can persist the generated client keys for
+later SecretSpec processes:
+
+```bash
+export KSM_TOKEN="US:ONE_TIME_TOKEN"
+secretspec check \
+  --provider "keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json"
+unset KSM_TOKEN
+```
+
+A Keeper one-time token cannot be reused. Remove it after the first successful
+request and retain the generated configuration file securely.
+
+## Configuration
+
+### URI format
+
+```text
+keeper://FOLDER_UID[?config_file=PATH]
+```
+
+- `FOLDER_UID` is required. It is the case-sensitive UID of a shared folder or
+  one of its subfolders. New convention records are created there.
+- `config_file` is optional. It selects a Keeper SDK client configuration file.
+
+### URI examples
+
+```text
+keeper://SHARED_FOLDER_UID
+keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json
+```
+
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+keeper_prod = "keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json"
+
+[profiles.production]
+DATABASE_URL = { description = "Database URL", providers = ["keeper_prod"] }
+API_KEY = { description = "API key", providers = ["keeper_prod"] }
+```
+
+## Storage model
+
+Convention secrets use Keeper login records:
+
+```text
+record title: secretspec/{project}/{profile}/{key}
+field:        password
+```
+
+For example, project `storefront`, profile `production`, and key `DATABASE_URL`
+map to record title `secretspec/storefront/production/DATABASE_URL`.
+
+SecretSpec fetches the application's available records once for a batch of
+secret requests, then resolves all requested titles and fields locally. A
+duplicate convention title is rejected as ambiguous.
+
+## Use existing records
+
+A secret's [`ref`](/reference/configuration/#secret-references) can select an
+existing Keeper record by exact title or record UID. `field` selects a standard
+field type/label or custom field label and defaults to `password`:
+
+```toml title="secretspec.toml"
+[providers]
+keeper = "keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json"
+
+[profiles.production]
+DATABASE_URL = {
+  description = "Database URL",
+  providers = ["keeper"],
+  ref = { item = "KEEPER_RECORD_UID", field = "Database URL" }
+}
+```
+
+Reads and writes target the existing field in place. A write through `ref`
+never creates a missing record or field; create it in Keeper first. Use a
+record UID when duplicate titles exist.
+
+## CI/CD
+
+Store the bound KSM configuration as one protected CI secret:
+
+```bash
+export KSM_CONFIG="$CI_KEEPER_CONFIG"
+secretspec run --provider "keeper://SHARED_FOLDER_UID" -- ./deploy
+```
+
+The KSM application should receive access only to the folders the job needs.
+Grant edit permission only when the job must run `set`, refresh a Keeper-backed
+cache, or otherwise write records.
+
+## Security considerations
+
+The official SDK encrypts and decrypts Keeper records inside the SecretSpec
+process. Secret values and KSM credentials are not placed in child-process
+arguments. A `config_file` contains long-lived private client keys and must be
+protected like any other secret; prefer `KSM_CONFIG` or a provider credential
+when persistent local files are undesirable.

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -102,6 +102,7 @@ $ secretspec config global init  # 0.17+
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)
   onepassword: OnePassword password manager
+  keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   dotenv: Traditional .env files
   env: Read-only environment variables
   systemd-credential: Read-only systemd service credentials (0.17+)

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -593,7 +593,7 @@ Stores fall into two groups for `field`:
 | Store | Shape of one secret | `field` |
 |-------|---------------------|---------|
 | dotenv, env, pass, LastPass, Proton Pass, Bitwarden | a single value | Rejected: there is nothing to select |
-| 1Password, Vault KV, AWS Secrets Manager, keyring | a record of named parts | Selects the part: field label, map key, JSON key, account |
+| 1Password, Keeper (0.18+), Vault KV, AWS Secrets Manager, keyring | a record of named parts | Selects the part: field label, map key, JSON key, account |
 
 `vault` is the only container coordinate. For every store except 1Password the
 container is part of the provider URI, not the ref:
@@ -615,6 +615,7 @@ chain, and each provider is asked for the same coordinates.
 | Provider | `item` | `field` | Without `field` | Writes via ref |
 |----------|--------|---------|-----------------|----------------|
 | [OnePassword](/providers/onepassword/#use-existing-secrets) | Item title or UUID | Field label; `vault` and `section` also apply | Reads the item like a convention secret (its value or password field); writes edit the `value` field | ✅ via `op item edit` (adds a missing field, never creates items) |
+| [Keeper (0.18+)](/providers/keeper/#use-existing-records) | Record UID or exact title | Standard field type/label or custom field label | Reads `password` | ✅ for existing records and fields |
 | [keyring](/providers/keyring/#use-existing-secrets) | Service | Account (defaults to the current system username) | Current user's entry | ✅ |
 | [dotenv](/providers/dotenv/#use-existing-secrets) | `.env` key | Rejected | Reads the key | ✅ |
 | [env](/providers/env/#use-existing-secrets) | Variable name | Rejected | Reads the variable | — (read-only) |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -169,6 +169,30 @@ write an existing item's field in place, name it with the `ref` field
 (`SECRET = { description = "…", ref = { item = "…", field = "…" } }`); see
 [Secret References](/reference/configuration/#secret-references).
 
+## Keeper Secrets Manager Provider (0.18+)
+
+:::caution[Version compatibility]
+The `keeper` provider is added in SecretSpec 0.18.
+:::
+
+**URI**: `keeper://FOLDER_UID[?config_file=PATH]` - Stores records in
+Keeper Secrets Manager through Keeper's official Rust SDK
+
+```bash
+keeper://SHARED_FOLDER_UID
+keeper://SHARED_FOLDER_UID?config_file=.keeper/client-config.json
+```
+
+**Features**: Read/write/delete, end-to-end encryption, profile-aware record
+titles, standard and custom field references, batched retrieval
+**Prerequisites**: A Keeper Secrets Manager application with access to the
+selected folder; build with `--features keeper` (0.18+)
+**Authentication**: `config` provider credential or `KSM_CONFIG`; alternatively
+a bound `config_file`. `token`/`KSM_TOKEN` can initialize a file configuration.
+**Storage**: Login record titled `secretspec/{project}/{profile}/{key}`, field
+`password`. A `ref` selects an existing record by UID or exact title and an
+optional standard/custom `field`.
+
 ## Pass Provider
 
 **URI**: `pass://` - Uses Unix password manager with GPG encryption
@@ -424,6 +448,7 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | LastPass | ✅ End-to-end | Cloud (LastPass) | ✅ Yes |
 | Dashlane (0.18+) | ✅ End-to-end | Cloud (Dashlane), synced locally | Yes — `dcli` auto-syncs hourly |
 | OnePassword | ✅ End-to-end | Cloud (OnePassword) | ✅ Yes |
+| Keeper (0.18+) | ✅ End-to-end | Cloud (Keeper) | ✅ Yes |
 | GCSM | ✅ Google-managed | Cloud (GCP) | ✅ Yes |
 | AWSSM | ✅ AWS KMS | Cloud (AWS) | ✅ Yes |
 | Scaleway (0.17+) | ✅ Scaleway-managed | Cloud (Scaleway) | ✅ Yes |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -44,6 +44,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'apple', slug: 'keyring', label: 'macOS Keychain' },
   { slug: 'kdbx', label: 'KeePass KDBX (0.17+)' },
   { icon: '1password', slug: 'onepassword', label: '1Password' },
+  { slug: 'keeper', label: 'Keeper Secrets Manager (0.18+)' },
   { icon: 'lastpass', slug: 'lastpass', label: 'LastPass' },
   { slug: 'dashlane', label: 'Dashlane (0.18+)' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden' },
@@ -154,6 +155,7 @@ $ secretspec config global init
 ? Select your preferred provider backend:
 <span class="tok-pun">›</span> keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)
+  keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   infisical: Infisical secret management
   openbao: OpenBao secret management (0.17+)
   age: age-encrypted file (0.17+)
@@ -238,6 +240,7 @@ $ secretspec run --profile production -- npm start
 ? Select your preferred provider backend:
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)
+  keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   infisical: Infisical secret management
   openbao: OpenBao secret management (0.17+)
   age: age-encrypted file (0.17+)

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -19,6 +19,7 @@ required-features = ["cli"]
 clap.workspace = true
 keyring = { workspace = true, optional = true }
 keepass = { workspace = true, optional = true }
+keeper-secrets-manager-core = { workspace = true, optional = true }
 serde.workspace = true
 toml.workspace = true
 toml_edit = { workspace = true, optional = true }
@@ -52,10 +53,11 @@ detect-coding-agent.workspace = true
 age = { workspace = true, optional = true }
 
 [features]
-default = ["cli", "keyring", "kdbx", "gcsm", "awssm", "vault", "openbao", "bws", "akv", "infisical", "age", "scaleway", "sops"]
+default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "vault", "openbao", "bws", "akv", "infisical", "age", "scaleway", "sops"]
 cli = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
+keeper = ["dep:keeper-secrets-manager-core"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager", "aws-config/credentials-login"]
 vault = ["dep:reqwest"]

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -21,6 +21,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [KeePass KDBX](https://secretspec.dev/providers/kdbx) (0.17+)
   - [.env](https://secretspec.dev/providers/dotenv)
   - [OnePassword](https://secretspec.dev/providers/onepassword)
+  - [Keeper Secrets Manager](https://secretspec.dev/providers/keeper) (0.18+)
   - [LastPass](https://secretspec.dev/providers/lastpass)
   - [Dashlane](https://secretspec.dev/providers/dashlane) (0.18+)
   - [Pass](https://secretspec.dev/providers/pass)
@@ -63,6 +64,7 @@ $ secretspec config global init  # 0.17+
 > keyring: Uses system keychain (Recommended)
   kdbx: KeePass KDBX databases (0.17+)
   onepassword: OnePassword password manager
+  keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   dotenv: Traditional .env files
   env: Read-only environment variables
   systemd-credential: Read-only systemd service credentials (0.17+)
@@ -164,6 +166,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Gopass](https://secretspec.dev/providers/gopass)** (0.15+) - GPG-based password manager with git-synced password store
 - **[Proton Pass](https://secretspec.dev/providers/protonpass)** - End-to-end encrypted via Proton's official pass-cli
 - **[OnePassword](https://secretspec.dev/providers/onepassword)** - Team secret management
+- **[Keeper Secrets Manager](https://secretspec.dev/providers/keeper)** (0.18+) - Machine secrets through Keeper's official Rust SDK
 - **[LastPass](https://secretspec.dev/providers/lastpass)** - Cloud password manager
 - **[Dashlane](https://secretspec.dev/providers/dashlane)** (0.18+) - Read-only access to a Dashlane vault via the `dcli` CLI
 - **[Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)** - GCP secret management

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Features
 //!
 //! - **Declarative Configuration**: Define secrets in `secretspec.toml`
-//! - **Multiple Providers**: Keyring, dotenv, environment variables, OnePassword, LastPass
+//! - **Multiple Providers**: Keyring, dotenv, environment variables, Keeper Secrets Manager (0.18+)
 //! - **Profile Support**: Different configurations for development, staging, production
 //! - **Type Safety**: Optional compile-time code generation for strongly-typed access
 //! - **Validation**: Ensure all required secrets are present before running applications

--- a/secretspec/src/provider/keeper.rs
+++ b/secretspec/src/provider/keeper.rs
@@ -1,0 +1,1052 @@
+//! Keeper Secrets Manager provider.
+//!
+//! This provider uses Keeper's official Rust SDK. A Keeper Secrets Manager
+//! application must have access to the shared folder named by the provider URI.
+//! Convention secrets are stored as login records titled
+//! `secretspec/{project}/{profile}/{key}`, with the value in the `password`
+//! field.
+
+use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
+use crate::config::NativeAddress;
+use crate::{Result, SecretSpecError};
+use keeper_secrets_manager_core::core::{ClientOptions, SecretsManager};
+use keeper_secrets_manager_core::dto::dtos::{Record, RecordCreate};
+use keeper_secrets_manager_core::dto::field_structs::KeeperField;
+use keeper_secrets_manager_core::enums::KvStoreType;
+use keeper_secrets_manager_core::storage::{FileKeyValueStorage, InMemoryKeyValueStorage};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+const CONFIG: &str = "config";
+const TOKEN: &str = "token";
+const KSM_CONFIG_ENV: &str = "KSM_CONFIG";
+const KSM_TOKEN_ENV: &str = "KSM_TOKEN";
+const DEFAULT_FIELD: &str = "password";
+
+/// Configuration for Keeper Secrets Manager.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KeeperConfig {
+    /// UID of a shared folder, or one of its subfolders, available to the KSM
+    /// application. New convention records are created here.
+    pub folder_uid: String,
+    /// Optional path to the SDK client configuration file.
+    pub config_file: Option<String>,
+}
+
+impl TryFrom<&ProviderUrl> for KeeperConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "keeper" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for Keeper provider. Expected 'keeper'.",
+                url.scheme()
+            )));
+        }
+
+        if !url.path().trim_matches('/').is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "Keeper provider URIs take no path. \
+                 Use keeper://SHARED_FOLDER_UID."
+                    .to_string(),
+            ));
+        }
+
+        let folder_uid = url
+            .host()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(
+                    "Keeper shared folder UID is required. \
+                 Use keeper://SHARED_FOLDER_UID."
+                        .to_string(),
+                )
+            })?;
+
+        if url.query_value("folder").is_some() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "Keeper's folder UID belongs in the URI authority, not the `folder` query \
+                 parameter. Use keeper://SHARED_FOLDER_UID."
+                    .to_string(),
+            ));
+        }
+
+        Ok(Self {
+            folder_uid,
+            config_file: url.query_value("config_file"),
+        })
+    }
+}
+
+trait KeeperApi: Send {
+    fn get_secrets(&mut self) -> std::result::Result<Vec<Record>, String>;
+    fn update_secret(&mut self, record: Record) -> std::result::Result<(), String>;
+    fn create_secret(
+        &mut self,
+        folder_uid: &str,
+        record: RecordCreate,
+    ) -> std::result::Result<String, String>;
+    fn delete_secret(&mut self, record_uid: &str) -> std::result::Result<(), String>;
+}
+
+impl KeeperApi for SecretsManager {
+    fn get_secrets(&mut self) -> std::result::Result<Vec<Record>, String> {
+        SecretsManager::get_secrets(self, Vec::new()).map_err(|error| error.to_string())
+    }
+
+    fn update_secret(&mut self, record: Record) -> std::result::Result<(), String> {
+        SecretsManager::update_secret(self, record).map_err(|error| error.to_string())
+    }
+
+    fn create_secret(
+        &mut self,
+        folder_uid: &str,
+        record: RecordCreate,
+    ) -> std::result::Result<String, String> {
+        SecretsManager::create_secret(self, folder_uid, record).map_err(|error| error.to_string())
+    }
+
+    fn delete_secret(&mut self, record_uid: &str) -> std::result::Result<(), String> {
+        SecretsManager::delete_secret(self, vec![record_uid.to_string()])
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+}
+
+type KeeperClient = Mutex<Box<dyn KeeperApi>>;
+
+/// Keeper Secrets Manager provider backed by Keeper's official Rust SDK.
+pub struct KeeperProvider {
+    config: KeeperConfig,
+    credentials: ProviderCredentials,
+    client: OnceLock<std::result::Result<KeeperClient, String>>,
+}
+
+crate::register_provider! {
+    struct: KeeperProvider,
+    config: KeeperConfig,
+    name: "keeper",
+    description: "Keeper Secrets Manager (0.18+) via official Rust SDK",
+    schemes: ["keeper"],
+    examples: ["keeper://SHARED_FOLDER_UID"],
+    credential_names: [CONFIG, TOKEN],
+    deletes: true,
+}
+
+#[derive(Clone)]
+struct KeeperTarget {
+    item: String,
+    field: String,
+    native: bool,
+}
+
+#[derive(Clone, Copy)]
+enum FieldSection {
+    Standard,
+    Custom,
+}
+
+struct LocatedField {
+    section: FieldSection,
+    value: Value,
+}
+
+impl KeeperProvider {
+    /// Creates a Keeper provider with lazy SDK initialization.
+    pub fn new(config: KeeperConfig) -> Self {
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+            client: OnceLock::new(),
+        }
+    }
+
+    fn config_value(&self) -> Option<String> {
+        credential_or_env(&self.credentials, CONFIG, KSM_CONFIG_ENV)
+    }
+
+    fn token(&self) -> Option<String> {
+        credential_or_env(&self.credentials, TOKEN, KSM_TOKEN_ENV)
+    }
+
+    fn sanitize(&self, message: &str) -> String {
+        let mut sanitized = message.to_string();
+        for secret in [self.config_value(), self.token()].into_iter().flatten() {
+            if !secret.is_empty() {
+                sanitized = sanitized.replace(&secret, "[REDACTED]");
+            }
+        }
+        sanitized
+    }
+
+    fn operation_error(&self, action: &str, detail: impl AsRef<str>) -> SecretSpecError {
+        SecretSpecError::ProviderOperationFailed(
+            self.sanitize(&format!("Keeper failed to {action}: {}", detail.as_ref())),
+        )
+    }
+
+    fn build_client(&self) -> std::result::Result<KeeperClient, String> {
+        let storage = match self.config_value() {
+            Some(config) => InMemoryKeyValueStorage::new_config_storage(Some(config)),
+            None => {
+                FileKeyValueStorage::new(self.config.config_file.clone()).map(KvStoreType::File)
+            }
+        }
+        .map_err(|error| error.to_string())?;
+
+        let options = match self.token() {
+            Some(token) => ClientOptions::new_client_options_with_token(token, storage),
+            None => ClientOptions::new_client_options(storage),
+        };
+        let client = SecretsManager::new(options).map_err(|error| error.to_string())?;
+        Ok(Mutex::new(Box::new(client)))
+    }
+
+    fn client(&self) -> Result<&KeeperClient> {
+        match self.client.get_or_init(|| self.build_client()) {
+            Ok(client) => Ok(client),
+            Err(error) => Err(self.operation_error("initialize the SDK client", error)),
+        }
+    }
+
+    fn with_client<T>(
+        &self,
+        action: &str,
+        operation: impl FnOnce(&mut dyn KeeperApi) -> std::result::Result<T, String> + Send,
+    ) -> Result<T>
+    where
+        T: Send,
+    {
+        let result = std::thread::scope(|scope| {
+            scope
+                .spawn(move || {
+                    let mut client = self.client()?.lock().map_err(|_| {
+                        SecretSpecError::ProviderOperationFailed(
+                            "Keeper SDK client lock was poisoned by an earlier failure".to_string(),
+                        )
+                    })?;
+                    operation(client.as_mut()).map_err(|error| self.operation_error(action, error))
+                })
+                .join()
+        });
+        result
+            .unwrap_or_else(|_| Err(self.operation_error(action, "the SDK worker thread panicked")))
+    }
+
+    fn target(&self, addr: Address<'_>) -> Result<KeeperTarget> {
+        let native = matches!(addr, Address::Native(_));
+        let coords = self.resolve_coords(addr)?;
+        Ok(KeeperTarget {
+            item: coords.item.clone(),
+            field: coords
+                .field
+                .clone()
+                .unwrap_or_else(|| DEFAULT_FIELD.to_string()),
+            native,
+        })
+    }
+
+    fn records(&self) -> Result<Vec<Record>> {
+        self.with_client("retrieve records", |client| client.get_secrets())
+    }
+
+    fn record_index(&self, records: &[Record], target: &KeeperTarget) -> Result<Option<usize>> {
+        if target.native
+            && let Some(index) = records.iter().position(|record| record.uid == target.item)
+        {
+            return Ok(Some(index));
+        }
+
+        let matches: Vec<usize> = records
+            .iter()
+            .enumerate()
+            .filter_map(|(index, record)| (record.title == target.item).then_some(index))
+            .collect();
+
+        match matches.as_slice() {
+            [] => Ok(None),
+            [index] => Ok(Some(*index)),
+            _ => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper record name '{}' is ambiguous; use its unique record UID in `ref.item`",
+                target.item
+            ))),
+        }
+    }
+
+    fn fields<'a>(record: &'a Record, key: &str, section: &str) -> Option<&'a Value> {
+        let fields = record.record_dict.get(section)?.as_array()?;
+        fields
+            .iter()
+            .find(|field| field.get("label").and_then(Value::as_str) == Some(key))
+            .or_else(|| {
+                fields.iter().find(|field| {
+                    field
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .is_some_and(|field_type| field_type.eq_ignore_ascii_case(key))
+                })
+            })
+    }
+
+    fn locate_field(record: &Record, key: &str) -> Option<LocatedField> {
+        let (section, field) = Self::fields(record, key, "fields")
+            .map(|field| (FieldSection::Standard, field))
+            .or_else(|| {
+                Self::fields(record, key, "custom").map(|field| (FieldSection::Custom, field))
+            })?;
+        let value = match field.get("value") {
+            Some(Value::Array(values)) => values
+                .first()
+                .cloned()
+                .unwrap_or_else(|| Value::String(String::new())),
+            Some(value) => value.clone(),
+            None => Value::String(String::new()),
+        };
+        Some(LocatedField { section, value })
+    }
+
+    fn secret_value(record: &Record, field: &str) -> Result<SecretString> {
+        let located = Self::locate_field(record, field).ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper record '{}' has no standard or custom field named '{}'",
+                record.title, field
+            ))
+        })?;
+        let value = match located.value {
+            Value::String(value) => value,
+            value => serde_json::to_string(&value).map_err(|error| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Keeper field '{}' in record '{}' could not be represented as text: {error}",
+                    field, record.title
+                ))
+            })?,
+        };
+        Ok(SecretString::new(value.into()))
+    }
+
+    fn updated_field_value(
+        record: &Record,
+        field: &str,
+        current: &Value,
+        value: &SecretString,
+    ) -> Result<Value> {
+        if current.is_string() {
+            return Ok(Value::String(value.expose_secret().to_string()));
+        }
+
+        let updated: Value = serde_json::from_str(value.expose_secret()).map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper field '{}' in record '{}' stores a {}; \
+                 the new value must be valid JSON with the same type: {error}",
+                field,
+                record.title,
+                Self::value_type(current),
+            ))
+        })?;
+        if std::mem::discriminant(current) != std::mem::discriminant(&updated) {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper field '{}' in record '{}' stores a {}; \
+                 the new value must be valid JSON with the same type",
+                field,
+                record.title,
+                Self::value_type(current),
+            )));
+        }
+        Ok(updated)
+    }
+
+    fn value_type(value: &Value) -> &'static str {
+        match value {
+            Value::Null => "null",
+            Value::Bool(_) => "boolean",
+            Value::Number(_) => "number",
+            Value::String(_) => "string",
+            Value::Array(_) => "array",
+            Value::Object(_) => "object",
+        }
+    }
+
+    fn update_record(&self, mut record: Record, field: &str, value: &SecretString) -> Result<()> {
+        if !record.is_editable {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper record '{}' is not editable by this application",
+                record.title
+            )));
+        }
+
+        let located = Self::locate_field(&record, field).ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper record '{}' has no standard or custom field named '{}'",
+                record.title, field
+            ))
+        })?;
+        let value = Self::updated_field_value(&record, field, &located.value, value)?;
+        let update = match located.section {
+            FieldSection::Standard => record.set_standard_field_value_mut(field, value),
+            FieldSection::Custom => record.set_custom_field_value_mut(field, value),
+        };
+        update.map_err(|error| self.operation_error("update a record field", error.to_string()))?;
+
+        self.with_client("save a record", |client| client.update_secret(record))
+    }
+
+    fn create_record(&self, title: &str, value: &SecretString) -> Result<()> {
+        let mut record =
+            RecordCreate::new("login", title, Some("Managed by SecretSpec".to_string()));
+        let mut password = KeeperField::new(DEFAULT_FIELD, None);
+        password.value = Value::Array(vec![Value::String(value.expose_secret().to_string())]);
+        password.privacy_screen = true;
+        record.append_standard_fields(password);
+
+        self.with_client("create a record", |client| {
+            client
+                .create_secret(&self.config.folder_uid, record)
+                .map(|_| ())
+        })
+    }
+}
+
+impl Provider for KeeperProvider {
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        Ok(NativeAddress {
+            item: format!("secretspec/{project}/{profile}/{key}"),
+            field: Some(DEFAULT_FIELD.to_string()),
+            ..Default::default()
+        })
+    }
+
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field"]
+    }
+
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
+    fn with_base_dir(&mut self, base_dir: &Path) {
+        let Some(config_file) = self.config.config_file.as_ref() else {
+            return;
+        };
+        let path = Path::new(config_file);
+        if path.is_relative() {
+            self.config.config_file = Some(base_dir.join(path).to_string_lossy().into_owned());
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let mut uri = format!("keeper://{}", ProviderUrl::encode(&self.config.folder_uid));
+        if let Some(config_file) = &self.config.config_file {
+            uri.push_str("?config_file=");
+            uri.push_str(&ProviderUrl::encode_query(config_file));
+        }
+        uri
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let target = self.target(addr)?;
+        let records = self.records()?;
+        let Some(index) = self.record_index(&records, &target)? else {
+            return Ok(None);
+        };
+        Self::secret_value(&records[index], &target.field).map(Some)
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let target = self.target(addr)?;
+        let mut records = self.records()?;
+        match self.record_index(&records, &target)? {
+            Some(index) => self.update_record(records.swap_remove(index), &target.field, value),
+            None if target.native => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper record '{}' referenced by `ref.item` does not exist; \
+                 create it in Keeper before writing this secret",
+                target.item
+            ))),
+            None => self.create_record(&target.item, value),
+        }
+    }
+
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        self.resolve_coords(addr).map(|_| ())
+    }
+
+    fn delete(&self, addr: Address<'_>) -> Result<bool> {
+        let target = self.target(addr)?;
+        let mut records = self.records()?;
+        let Some(index) = self.record_index(&records, &target)? else {
+            return Ok(false);
+        };
+        let record = records.swap_remove(index);
+        if !record.is_editable {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper record '{}' is not editable by this application",
+                record.title
+            )));
+        }
+        self.with_client("delete a record", |client| {
+            client.delete_secret(&record.uid)
+        })?;
+        Ok(true)
+    }
+
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        if requests.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let targets: Vec<(&str, KeeperTarget)> = requests
+            .iter()
+            .map(|(name, addr)| Ok((*name, self.target(*addr)?)))
+            .collect::<Result<_>>()?;
+        let records = self.records()?;
+        let mut values = HashMap::new();
+        for (name, target) in targets {
+            if let Some(index) = self.record_index(&records, &target)? {
+                values.insert(
+                    name.to_string(),
+                    Self::secret_value(&records[index], &target.field)?,
+                );
+            }
+        }
+        Ok(values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+    use std::sync::Arc;
+    use url::Url;
+
+    fn provider_url(value: &str) -> ProviderUrl {
+        ProviderUrl::new(Url::parse(value).unwrap())
+    }
+
+    fn record(uid: &str, title: &str, editable: bool, fields: Value, custom: Value) -> Record {
+        Record {
+            uid: uid.to_string(),
+            title: title.to_string(),
+            is_editable: editable,
+            record_dict: HashMap::from([
+                ("type".to_string(), Value::String("login".to_string())),
+                ("title".to_string(), Value::String(title.to_string())),
+                ("fields".to_string(), fields),
+                ("custom".to_string(), custom),
+            ]),
+            ..Default::default()
+        }
+    }
+
+    #[derive(Default)]
+    struct MockState {
+        records: Vec<Record>,
+        gets: usize,
+        updated: Vec<Record>,
+        created: Vec<(String, HashMap<String, Value>)>,
+        deleted: Vec<String>,
+    }
+
+    struct MockApi {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    fn assert_outside_tokio_runtime() {
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "Keeper SDK calls must run outside Tokio runtimes"
+        );
+    }
+
+    impl KeeperApi for MockApi {
+        fn get_secrets(&mut self) -> std::result::Result<Vec<Record>, String> {
+            assert_outside_tokio_runtime();
+            let mut state = self.state.lock().unwrap();
+            state.gets += 1;
+            Ok(state.records.clone())
+        }
+
+        fn update_secret(&mut self, record: Record) -> std::result::Result<(), String> {
+            assert_outside_tokio_runtime();
+            self.state.lock().unwrap().updated.push(record);
+            Ok(())
+        }
+
+        fn create_secret(
+            &mut self,
+            folder_uid: &str,
+            record: RecordCreate,
+        ) -> std::result::Result<String, String> {
+            assert_outside_tokio_runtime();
+            self.state
+                .lock()
+                .unwrap()
+                .created
+                .push((folder_uid.to_string(), record.to_dict().unwrap()));
+            Ok("new-record-uid".to_string())
+        }
+
+        fn delete_secret(&mut self, record_uid: &str) -> std::result::Result<(), String> {
+            assert_outside_tokio_runtime();
+            self.state
+                .lock()
+                .unwrap()
+                .deleted
+                .push(record_uid.to_string());
+            Ok(())
+        }
+    }
+
+    fn provider_with_records(records: Vec<Record>) -> (KeeperProvider, Arc<Mutex<MockState>>) {
+        let state = Arc::new(Mutex::new(MockState {
+            records,
+            ..Default::default()
+        }));
+        let provider = KeeperProvider::new(KeeperConfig {
+            folder_uid: "FolderUID".to_string(),
+            config_file: None,
+        });
+        provider
+            .client
+            .set(Ok(Mutex::new(Box::new(MockApi {
+                state: Arc::clone(&state),
+            }))))
+            .ok()
+            .unwrap();
+        (provider, state)
+    }
+
+    #[test]
+    fn config_requires_folder_authority() {
+        let error = KeeperConfig::try_from(&provider_url("keeper://")).unwrap_err();
+        assert!(error.to_string().contains("folder UID"), "{error}");
+
+        let error =
+            KeeperConfig::try_from(&provider_url("keeper://?folder=LegacyFolderUID")).unwrap_err();
+        assert!(
+            error.to_string().contains("keeper://SHARED_FOLDER_UID"),
+            "{error}"
+        );
+
+        let error = KeeperConfig::try_from(&provider_url("keeper:///FolderUID")).unwrap_err();
+        assert!(error.to_string().contains("take no path"), "{error}");
+
+        let error =
+            KeeperConfig::try_from(&provider_url("keeper://FolderUID?folder=OtherFolderUID"))
+                .unwrap_err();
+        assert!(
+            error.to_string().contains("not the `folder` query"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn config_and_uri_round_trip_case_sensitive_values() {
+        let config = KeeperConfig::try_from(&provider_url(
+            "keeper://AbC_123-xYz?config_file=.keeper%2Fclient.json",
+        ))
+        .unwrap();
+        assert_eq!(config.folder_uid, "AbC_123-xYz");
+        assert_eq!(config.config_file.as_deref(), Some(".keeper/client.json"));
+        assert_eq!(
+            KeeperProvider::new(config).uri(),
+            "keeper://AbC_123-xYz?config_file=.keeper/client.json"
+        );
+    }
+
+    #[test]
+    fn convention_uses_profile_aware_title_and_password_field() {
+        let provider = KeeperProvider::new(KeeperConfig {
+            folder_uid: "folder".to_string(),
+            config_file: None,
+        });
+        let address = provider
+            .convention_address("demo", "production", "DATABASE_URL")
+            .unwrap();
+        assert_eq!(address.item, "secretspec/demo/production/DATABASE_URL");
+        assert_eq!(address.field.as_deref(), Some("password"));
+    }
+
+    #[test]
+    fn get_reads_convention_and_native_custom_fields() {
+        let (provider, _) = provider_with_records(vec![record(
+            "RecordUID",
+            "secretspec/demo/default/API_KEY",
+            true,
+            serde_json::json!([
+                {"type": "password", "label": "", "value": ["convention-value"]}
+            ]),
+            serde_json::json!([
+                {"type": "text", "label": "API token", "value": ["native-value"]}
+            ]),
+        )]);
+
+        let convention = provider
+            .get(Address::convention("demo", "default", "API_KEY"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(convention.expose_secret(), "convention-value");
+
+        let native = NativeAddress {
+            item: "RecordUID".to_string(),
+            field: Some("API token".to_string()),
+            ..Default::default()
+        };
+        let native = provider.get(Address::Native(&native)).unwrap().unwrap();
+        assert_eq!(native.expose_secret(), "native-value");
+    }
+
+    #[test]
+    fn native_uid_wins_over_a_colliding_record_title() {
+        let (provider, _) = provider_with_records(vec![
+            record(
+                "RecordUID",
+                "wanted",
+                true,
+                serde_json::json!([
+                    {"type": "password", "label": "", "value": ["by-uid"]}
+                ]),
+                serde_json::json!([]),
+            ),
+            record(
+                "other",
+                "RecordUID",
+                true,
+                serde_json::json!([
+                    {"type": "password", "label": "", "value": ["by-title"]}
+                ]),
+                serde_json::json!([]),
+            ),
+        ]);
+        let native = NativeAddress {
+            item: "RecordUID".to_string(),
+            field: Some("password".to_string()),
+            ..Default::default()
+        };
+
+        let value = provider.get(Address::Native(&native)).unwrap().unwrap();
+        assert_eq!(value.expose_secret(), "by-uid");
+    }
+
+    #[test]
+    fn get_many_fetches_the_keeper_vault_once() {
+        let (provider, state) = provider_with_records(vec![
+            record(
+                "one",
+                "secretspec/demo/default/ONE",
+                true,
+                serde_json::json!([
+                    {"type": "password", "label": "", "value": ["first"]}
+                ]),
+                serde_json::json!([]),
+            ),
+            record(
+                "two",
+                "secretspec/demo/default/TWO",
+                true,
+                serde_json::json!([
+                    {"type": "password", "label": "", "value": ["second"]}
+                ]),
+                serde_json::json!([]),
+            ),
+        ]);
+
+        let values = provider
+            .get_many(&[
+                ("ONE", Address::convention("demo", "default", "ONE")),
+                ("TWO", Address::convention("demo", "default", "TWO")),
+                ("MISSING", Address::convention("demo", "default", "MISSING")),
+            ])
+            .unwrap();
+
+        assert_eq!(values["ONE"].expose_secret(), "first");
+        assert_eq!(values["TWO"].expose_secret(), "second");
+        assert!(!values.contains_key("MISSING"));
+        assert_eq!(state.lock().unwrap().gets, 1);
+    }
+
+    #[test]
+    fn set_updates_existing_standard_and_custom_fields() {
+        let (provider, state) = provider_with_records(vec![record(
+            "RecordUID",
+            "existing",
+            true,
+            serde_json::json!([
+                {"type": "password", "label": "", "value": ["old"]}
+            ]),
+            serde_json::json!([
+                {"type": "text", "label": "API token", "value": ["old-token"]}
+            ]),
+        )]);
+
+        let native = NativeAddress {
+            item: "RecordUID".to_string(),
+            field: Some("API token".to_string()),
+            ..Default::default()
+        };
+        provider
+            .set(
+                Address::Native(&native),
+                &SecretString::new("new-token".to_string().into()),
+            )
+            .unwrap();
+
+        let state = state.lock().unwrap();
+        assert_eq!(state.updated.len(), 1);
+        assert_eq!(
+            KeeperProvider::secret_value(&state.updated[0], "API token")
+                .unwrap()
+                .expose_secret(),
+            "new-token"
+        );
+        assert!(matches!(
+            KeeperProvider::locate_field(&state.updated[0], "API token")
+                .unwrap()
+                .value,
+            Value::String(_)
+        ));
+    }
+
+    #[test]
+    fn set_preserves_typed_field_values() {
+        let (provider, state) = provider_with_records(vec![record(
+            "RecordUID",
+            "typed fields",
+            true,
+            serde_json::json!([
+                {"type": "date", "label": "Renewal", "value": [1700000000000_u64]}
+            ]),
+            serde_json::json!([
+                {"type": "checkbox", "label": "Enabled", "value": [true]},
+                {
+                    "type": "host",
+                    "label": "Server",
+                    "value": [{"hostName": "db.example.com", "port": "5432"}]
+                },
+                {
+                    "type": "name",
+                    "label": "Owner",
+                    "value": [{"first": "Ada", "last": "Lovelace"}]
+                }
+            ]),
+        )]);
+        let updates = [
+            ("Renewal", "1700000000001"),
+            ("Enabled", "false"),
+            (
+                "Server",
+                r#"{"hostName":"replica.example.com","port":"5433"}"#,
+            ),
+            ("Owner", r#"{"first":"Grace","last":"Hopper"}"#),
+        ];
+
+        for (field, value) in updates {
+            let native = NativeAddress {
+                item: "RecordUID".to_string(),
+                field: Some(field.to_string()),
+                ..Default::default()
+            };
+            provider
+                .set(
+                    Address::Native(&native),
+                    &SecretString::new(value.to_string().into()),
+                )
+                .unwrap();
+        }
+
+        let state = state.lock().unwrap();
+        let expected = [
+            serde_json::json!(1700000000001_u64),
+            serde_json::json!(false),
+            serde_json::json!({"hostName": "replica.example.com", "port": "5433"}),
+            serde_json::json!({"first": "Grace", "last": "Hopper"}),
+        ];
+        for ((field, _), (record, expected)) in updates
+            .iter()
+            .zip(state.updated.iter().zip(expected.iter()))
+        {
+            assert_eq!(
+                KeeperProvider::locate_field(record, field).unwrap().value,
+                *expected
+            );
+        }
+    }
+
+    #[test]
+    fn set_rejects_a_different_type_for_a_typed_field() {
+        let (provider, state) = provider_with_records(vec![record(
+            "RecordUID",
+            "typed fields",
+            true,
+            serde_json::json!([
+                {"type": "date", "label": "Renewal", "value": [1700000000000_u64]}
+            ]),
+            serde_json::json!([]),
+        )]);
+        let native = NativeAddress {
+            item: "RecordUID".to_string(),
+            field: Some("Renewal".to_string()),
+            ..Default::default()
+        };
+
+        let error = provider
+            .set(
+                Address::Native(&native),
+                &SecretString::new("\"1700000000001\"".to_string().into()),
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("stores a number"), "{error}");
+        assert!(state.lock().unwrap().updated.is_empty());
+    }
+
+    #[test]
+    fn sdk_client_initializes_when_called_from_a_tokio_runtime() {
+        const MOCK_TOKEN: &str = "US:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let mut provider = KeeperProvider::new(KeeperConfig {
+                folder_uid: "FolderUID".to_string(),
+                config_file: None,
+            });
+            provider.credentials.insert(
+                TOKEN.to_string(),
+                SecretString::new(MOCK_TOKEN.to_string().into()),
+            );
+            provider.credentials.insert(
+                CONFIG.to_string(),
+                SecretString::new("{}".to_string().into()),
+            );
+
+            provider
+                .with_client("initialize the SDK client", |_| Ok(()))
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn sdk_operations_run_outside_tokio_runtimes() {
+        let (provider, state) = provider_with_records(vec![record(
+            "RecordUID",
+            "existing",
+            true,
+            serde_json::json!([
+                {"type": "password", "label": "", "value": ["old"]}
+            ]),
+            serde_json::json!([]),
+        )]);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let native = NativeAddress {
+                item: "RecordUID".to_string(),
+                field: Some("password".to_string()),
+                ..Default::default()
+            };
+            provider.get(Address::Native(&native)).unwrap();
+            provider
+                .set(
+                    Address::Native(&native),
+                    &SecretString::new("new".to_string().into()),
+                )
+                .unwrap();
+            provider
+                .set(
+                    Address::convention("demo", "default", "new"),
+                    &SecretString::new("created".to_string().into()),
+                )
+                .unwrap();
+            provider.delete(Address::Native(&native)).unwrap();
+        });
+
+        let state = state.lock().unwrap();
+        assert_eq!(state.updated.len(), 1);
+        assert_eq!(state.created.len(), 1);
+        assert_eq!(state.deleted, ["RecordUID"]);
+    }
+
+    #[test]
+    fn set_creates_missing_convention_record_in_configured_folder() {
+        let (provider, state) = provider_with_records(Vec::new());
+        provider
+            .set(
+                Address::convention("demo", "production", "API_KEY"),
+                &SecretString::new("new-value".to_string().into()),
+            )
+            .unwrap();
+
+        let state = state.lock().unwrap();
+        let (folder, record) = &state.created[0];
+        assert_eq!(folder, "FolderUID");
+        assert_eq!(
+            record.get("title").and_then(Value::as_str),
+            Some("secretspec/demo/production/API_KEY")
+        );
+        assert_eq!(
+            record
+                .get("fields")
+                .and_then(Value::as_array)
+                .and_then(|fields| fields[0].get("value"))
+                .and_then(Value::as_array)
+                .and_then(|values| values[0].as_str()),
+            Some("new-value")
+        );
+    }
+
+    #[test]
+    fn set_does_not_create_a_missing_native_reference() {
+        let (provider, state) = provider_with_records(Vec::new());
+        let native = NativeAddress {
+            item: "missing-record".to_string(),
+            field: Some("password".to_string()),
+            ..Default::default()
+        };
+        let error = provider
+            .set(
+                Address::Native(&native),
+                &SecretString::new("value".to_string().into()),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("create it in Keeper"), "{error}");
+        assert!(state.lock().unwrap().created.is_empty());
+    }
+
+    #[test]
+    fn delete_is_idempotent_and_uses_the_record_uid() {
+        let (provider, state) = provider_with_records(vec![record(
+            "RecordUID",
+            "secretspec/demo/default/API_KEY",
+            true,
+            serde_json::json!([
+                {"type": "password", "label": "", "value": ["value"]}
+            ]),
+            serde_json::json!([]),
+        )]);
+        assert!(
+            provider
+                .delete(Address::convention("demo", "default", "API_KEY"))
+                .unwrap()
+        );
+        assert_eq!(state.lock().unwrap().deleted, ["RecordUID"]);
+
+        let (provider, _) = provider_with_records(Vec::new());
+        assert!(
+            !provider
+                .delete(Address::convention("demo", "default", "API_KEY"))
+                .unwrap()
+        );
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -17,6 +17,7 @@
 //!
 //! - [`keyring::KeyringProvider`]: System keyring integration (default)
 //! - [`kdbx::KdbxProvider`]: KeePass KDBX database integration (0.17+)
+//! - [`keeper::KeeperProvider`]: Keeper Secrets Manager integration (0.18+)
 //! - [`dotenv::DotEnvProvider`]: `.env` file support
 //! - [`env::EnvProvider`]: Environment variables (read-only)
 //! - [`pass::PassProvider`]: Pass integration
@@ -44,6 +45,7 @@
 //! dotenv://.env.production
 //! onepassword://vault
 //! lastpass://folder
+//! keeper://SHARED_FOLDER_UID  # Keeper, 0.18+
 //! ```
 //!
 //! ## Example
@@ -292,6 +294,8 @@ pub mod gopass;
 pub mod infisical;
 #[cfg(feature = "kdbx")]
 pub mod kdbx;
+#[cfg(feature = "keeper")]
+pub mod keeper;
 #[cfg(feature = "keyring")]
 pub mod keyring;
 pub mod lastpass;


### PR DESCRIPTION
## Summary

- add a `keeper://?folder=FOLDER_UID[&config_file=PATH]` provider backed by Keeper's official `keeper-secrets-manager-core` Rust SDK
- support convention records, existing-record `ref` lookups by UID or exact title, standard/custom fields, batch reads, writes, and cache-compatible deletion
- support `KSM_CONFIG`, `KSM_TOKEN`, `KSM_CONFIG_FILE`, and SecretSpec provider credentials without passing secrets through command-line arguments
- add the optional `keeper` build feature, standalone feature CI coverage, an Unreleased changelog entry, and the complete 0.18+ provider documentation/visibility checklist

## Why

This implements and closes #120 without requiring Keeper Commander or the `ksm` CLI at runtime.

## Testing

- `devenv shell cargo test --all`
- `devenv shell cargo clippy --package secretspec --no-default-features --features keeper -- -D warnings`
- `devenv shell cargo fmt --all -- --check`
- `devenv shell npm --prefix docs run build`
- staged pre-commit hooks (`clippy`, `rustfmt`)
- `git diff --check`

## Keeper testing help

@vintersnow, as the original requester, and @dominicegginton, @stuart-warren, @ysomatb, and @phynias, who reacted with 👍: help testing this against real Keeper Secrets Manager applications would be very welcome. In particular, feedback on `KSM_CONFIG`, one-time-token binding to `config_file`, record creation/update, and existing-record `ref` behavior would be useful.

Closes #120
