### PR TITLE
Fix Linux Go SDK libdbus packaging

### DIFF
--- a/.github/workflows/ffi-build.yml
+++ b/.github/workflows/ffi-build.yml
@@ -37,10 +37,8 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container || null }}
-    # Needed by the tag-only "Publish cdylib to the release" step below, which
-    # attaches the library to the GitHub Release cargo-dist creates for the tag.
     permissions:
-      contents: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -98,25 +96,59 @@ jobs:
           DYLD_LIBRARY_PATH=target/${{ matrix.target }}/release \
           ./smoke
 
+      - name: Stage release asset
+        id: stage
+        shell: bash
+        run: |
+          ext="${{ matrix.artifact }}"; ext="${ext##*.}"
+          asset="secretspec-ffi-${{ matrix.target }}.${ext}"
+          cp "target/${{ matrix.target }}/release/${{ matrix.artifact }}" "$asset"
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: secretspec-ffi-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/${{ matrix.artifact }}
+            ${{ steps.stage.outputs.asset }}
             secretspec-ffi/include/secretspec.h
 
-      # On a version tag, attach the cdylib (named for its target, with a sha256
-      # sidecar) to the GitHub Release so the PHP SDK's `secretspec-install-lib`
-      # command can fetch the right one for a plain `composer require` install.
-      - name: Publish cdylib to the release
-        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.release_tag != ''
+  release:
+    name: Publish FFI release
+    needs: build
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      inputs.release_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v5
+        with:
+          pattern: secretspec-ffi-*
+          path: staged
+          merge-multiple: true
+
+      # Attach each cdylib (named for its target, with a sha256 sidecar) to the
+      # GitHub Release so the PHP SDK's `secretspec-install-lib` command can
+      # fetch the right one for a plain `composer require` install. Publication
+      # runs outside the manylinux build containers, which do not include `gh`.
+      - name: Publish cdylibs to the release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          ext="${{ matrix.artifact }}"; ext="${ext##*.}"
-          asset="secretspec-ffi-${{ matrix.target }}.${ext}"
-          cp "target/${{ matrix.target }}/release/${{ matrix.artifact }}" "$asset"
-          bash scripts/upload-release-asset.sh "${{ inputs.release_tag || github.ref_name }}" "$asset"
+          mapfile -t assets < <(
+            find staged -maxdepth 1 -type f -name 'secretspec-ffi-*' -print |
+              sort
+          )
+          if [[ "${#assets[@]}" -ne 4 ]]; then
+            printf 'expected 4 FFI libraries, found %s\n' "${#assets[@]}" >&2
+            printf '%s\n' "${assets[@]}" >&2
+            exit 1
+          fi
+          bash scripts/upload-release-asset.sh \
+            "${{ inputs.release_tag || github.ref_name }}" "${assets[@]}"

--- a/.github/workflows/ffi-build.yml
+++ b/.github/workflows/ffi-build.yml
@@ -1,14 +1,9 @@
 name: "FFI cdylib"
 
 # Builds the secretspec-ffi C ABI library for each platform the language SDKs
-# bundle. Builds NATIVELY on a per-platform runner rather than cross-compiling,
-# because the crate links system libraries (e.g. dbus/keyring on Linux) that
-# make cross toolchains painful.
-#
-# NOTE: This produces development-grade artifacts. Production packaging
-# (manylinux compliance for Python wheels, macOS code signing/notarization,
-# Windows runtime considerations) is follow-up work tracked with the SDK
-# distribution effort.
+# bundle. Linux builds use a manylinux_2_28 baseline and compile libdbus into
+# the library so consumers do not need a matching system soname. Other targets
+# build natively on per-platform runners rather than cross-compiling.
 
 on:
   workflow_call:
@@ -35,11 +30,13 @@ on:
     paths:
       - "secretspec-ffi/**"
       - ".github/workflows/ffi-build.yml"
+      - "scripts/check-linux-portability.sh"
 
 jobs:
   build:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container || null }}
     # Needed by the tag-only "Publish cdylib to the release" step below, which
     # attaches the library to the GitHub Release cargo-dist creates for the tag.
     permissions:
@@ -50,10 +47,14 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
             artifact: libsecretspec_ffi.so
+            cargo_features: --features vendored-dbus
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
             artifact: libsecretspec_ffi.so
+            cargo_features: --features vendored-dbus
           - target: aarch64-apple-darwin
             runner: macos-latest
             artifact: libsecretspec_ffi.dylib
@@ -64,15 +65,27 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Install rustup (the manylinux container ships none)
+        if: matrix.container
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+            sh -s -- -y --default-toolchain none
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
 
       - name: Build cdylib
-        run: cargo build -p secretspec-ffi --release --target ${{ matrix.target }}
+        run: >-
+          cargo build -p secretspec-ffi --release
+          --target ${{ matrix.target }} ${{ matrix.cargo_features }}
+
+      - name: Verify Linux portability (glibc <= 2.28, no dynamic libdbus)
+        if: matrix.container
+        shell: bash
+        run: >-
+          bash scripts/check-linux-portability.sh
+          "target/${{ matrix.target }}/release/${{ matrix.artifact }}"
 
       - name: Smoke test the C ABI (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/go-embed.yml
+++ b/.github/workflows/go-embed.yml
@@ -2,10 +2,12 @@ name: "Go embedded lib"
 
 # Builds the per-platform cdylib the Go SDK embeds (go:embed, behind the
 # `embed_lib` build tag) and verifies the embedded build works with no
-# SECRETSPEC_FFI_LIB set. The libraries are uploaded as artifacts and attached to
-# GitHub releases for users who want a self-contained `-tags embed_lib` build;
-# they are never committed to the repo (the Go module proxy does not carry binary
-# assets — see RELEASE.md).
+# SECRETSPEC_FFI_LIB set. Linux builds use a manylinux_2_28 baseline and compile
+# libdbus into the cdylib, so the release assets work without distro-specific
+# runtime libraries (including on NixOS). The libraries are uploaded as
+# artifacts and attached to GitHub releases for users who want a self-contained
+# `-tags embed_lib` build; they are never committed to the repo (the Go module
+# proxy does not carry binary assets — see RELEASE.md).
 
 on:
   workflow_call:
@@ -32,27 +34,37 @@ on:
   pull_request:
     paths:
       - "secretspec-go/**"
+      - "secretspec-ffi/**"
       - ".github/workflows/go-embed.yml"
+      - "scripts/check-linux-portability.sh"
 
 jobs:
   embed:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container || null }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { target: linux_amd64, runner: ubuntu-latest }
-          - { target: linux_arm64, runner: ubuntu-24.04-arm }
+          - target: linux_amd64
+            runner: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
+          - target: linux_arm64
+            runner: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
           - { target: darwin_arm64, runner: macos-latest }
           - { target: windows_amd64, runner: windows-latest }
 
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Linux system dependencies (dbus for keyring)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Install rustup (the manylinux container ships none)
+        if: matrix.container
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+            sh -s -- -y --default-toolchain none
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
@@ -63,6 +75,13 @@ jobs:
       - name: Stage the embedded cdylib
         shell: bash
         run: bash secretspec-go/scripts/stage-cdylib.sh
+
+      - name: Verify Linux portability (glibc <= 2.28, no dynamic libdbus)
+        if: matrix.container
+        shell: bash
+        run: >-
+          bash scripts/check-linux-portability.sh
+          "secretspec-go/lib/secretspec_ffi_${{ matrix.target }}.so"
 
       - name: Build and smoke test the embedded SDK (no SECRETSPEC_FFI_LIB)
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.0] - 2026-07-26
 
 ### Fixed
+- Prebuilt Linux Go SDK and `secretspec-ffi` libraries now include libdbus
+  instead of requiring the build host's `libdbus-1.so.3`, so they load on
+  NixOS and other systems without a matching system library.
+  ([#214](https://github.com/cachix/secretspec/issues/214))
 - Cache reads, refreshes, and clears now share one ownership and freshness
   policy, consistently handling expiration boundaries, clock rollback,
   corrupted SecretSpec entries, and values owned by another project or profile.

--- a/secretspec-go/scripts/stage-cdylib.sh
+++ b/secretspec-go/scripts/stage-cdylib.sh
@@ -14,13 +14,25 @@ set -euo pipefail
 pkg_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_root="$(cd "$pkg_dir/.." && pwd)"
 
-cargo build -p secretspec-ffi --release --manifest-path "$repo_root/Cargo.toml"
+goos="$(go env GOOS)"
+goarch="$(go env GOARCH)"
+
+build_args=(
+  -p secretspec-ffi
+  --release
+  --manifest-path "$repo_root/Cargo.toml"
+)
+# The staged library is a distributable artifact, not a development build.
+# Linux consumers cannot be expected to provide the exact libdbus soname from
+# the build host (notably on NixOS), so compile libdbus into the cdylib.
+if [[ "$goos" == "linux" ]]; then
+  build_args+=(--features vendored-dbus)
+fi
+cargo build "${build_args[@]}"
 
 target_dir="$(cargo metadata --no-deps --format-version 1 --manifest-path "$repo_root/Cargo.toml" \
   | grep -o '"target_directory":"[^"]*"' | head -1 | sed 's/.*:"\(.*\)"/\1/')"
 
-goos="$(go env GOOS)"
-goarch="$(go env GOARCH)"
 case "$goos" in
   darwin)  src="libsecretspec_ffi.dylib"; ext="dylib" ;;
   windows) src="secretspec_ffi.dll";      ext="dll" ;;


### PR DESCRIPTION
## Summary

- build Linux Go embedded libraries and generic `secretspec-ffi` release assets on a manylinux 2.28 baseline
- enable the existing `vendored-dbus` feature so release libraries do not require `libdbus-1.so.3` from the host
- run the existing Linux portability check in both release workflows
- record the v0.17.0 packaging fix in the changelog

## Root cause

The Go and generic FFI workflows installed dbus development headers and built
against the runner's system library. Their smoke tests passed on Ubuntu because
that same library was present, but the published cdylibs retained a `NEEDED`
entry for `libdbus-1.so.3`. NixOS users could download the official artifact yet
fail during `dlopen` because the soname was not in a conventional global loader
path.

## User impact

Rebuilt v0.17.0 Linux assets carry libdbus in the cdylib and retain a glibc 2.28
compatibility floor, so they load on NixOS and other supported glibc
distributions without a separate libdbus runtime package.

Fixes #214.

## Validation

- `cargo build -p secretspec-ffi --release --features vendored-dbus`
- Go SDK test suite against the staged vendored library
- C ABI smoke test against the release library
- ELF `NEEDED` inspection confirmed no dynamic dbus dependency
- `actionlint` on both changed workflows
- `shellcheck` on the staging and portability scripts
- `git diff --check`
