### PR TITLE
docs: escape regex dot operator in .sops.yaml example

### DIFF
--- a/docs/src/content/docs/providers/sops.md
+++ b/docs/src/content/docs/providers/sops.md
@@ -196,7 +196,7 @@ exists next to the project's `secretspec.toml`, configure a creation rule:
 
 ```yaml title=".sops.yaml"
 creation_rules:
-  - path_regex: secrets.enc.json$
+  - path_regex: secrets\.enc\.json$
     age: "age1jpa8rf5qmrg6pw444fcgpkaxg8x4neueszrexzagdjpunjlgeyzq304w34"
 ```
 


### PR DESCRIPTION
Upstream documentation suggests sops always parses the `path_regex` attribute as a regular expression. This subtly causes the un-escaped `.` (wildcard operator) to match against any character other than line endings.

Updating this in the docs reminds the reader to be cognizant of regex syntax.

This is consistent with the regex escape pattern found in sops documentation here: https://getsops.io/docs/usage/identities/config-file/