### PR TITLE
Enable aws-config/credentials-login for awssm feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-signin",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
@@ -304,15 +305,20 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "base64-simd",
  "bytes",
  "fastrand",
  "hex",
  "http 1.4.0",
+ "p256",
+ "rand 0.8.5",
  "sha1 0.10.6",
+ "sha2 0.10.9",
  "time",
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "zeroize",
 ]
 
@@ -380,6 +386,30 @@ name = "aws-sdk-secretsmanager"
 version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae64963d3d16d8070aaa2fb79c11cd3b13f44d2f13bba3fe8f49dcd2c42f2987"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-signin"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83ed6776794d4f6e28f8055a1ab2b64c2bac84fd2b6ecf967b979196c526c44"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1668,6 +1698,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1730,8 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
+ "pem-rfc7468 0.7.0",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -3825,8 +3871,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4471,6 +4519,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4793,6 +4851,7 @@ dependencies = [
  "base16ct",
  "der 0.7.10",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -61,7 +61,7 @@ kdbx = ["dep:keepass"]
 # prebuilt release artifacts that must run on distros we don't build on.
 vendored-dbus = ["keyring?/vendored"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
-awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
+awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager", "aws-config/credentials-login"]
 vault = ["dep:reqwest"]
 # Scaleway Secret Manager talks to the v1beta1 REST API directly; base64
 # payloads use data-encoding, which is already a non-optional dependency.

--- a/secretspec/src/provider/awssm.rs
+++ b/secretspec/src/provider/awssm.rs
@@ -297,7 +297,7 @@ impl AwssmProvider {
 
             let response = request.send().await.map_err(|e| {
                 SecretSpecError::ProviderOperationFailed(format!(
-                    "BatchGetSecretValue failed: {}",
+                    "BatchGetSecretValue failed: {:?}",
                     e.into_service_error()
                 ))
             })?;

--- a/secretspec/src/provider/awssm.rs
+++ b/secretspec/src/provider/awssm.rs
@@ -297,7 +297,7 @@ impl AwssmProvider {
 
             let response = request.send().await.map_err(|e| {
                 SecretSpecError::ProviderOperationFailed(format!(
-                    "BatchGetSecretValue failed: {:?}",
+                    "BatchGetSecretValue failed: {}",
                     e.into_service_error()
                 ))
             })?;


### PR DESCRIPTION
[awssm provider documentation](https://secretspec.dev/providers/awssm/#authentication) states that it should be able to authenticate using credentials from the aws cli. That functionality is gated behind the `credentials-login` feature that wasn't enabled to date. 

Current builds of `secretspec` fail with a generic error message when trying to authenticate with a session from the cli:
```
Checking secrets in backend (profile: default)...

warning: primary provider awssm://us-east-2 failed: Provider operation failed: BatchGetSecretValue failed: unhandled error; will try fallback chain for affected secrets
Error:   × Failed to check secrets
  ╰─▶ Provider operation failed: BatchGetSecretValue failed: unhandled error
  ```
  
  When debug printing the error to see the root cause, it mentions this feature
  
  ```
  Checking secrets in backend (profile: default)...

warning: primary provider awssm://us-east-2 failed: Provider operation failed: BatchGetSecretValue failed: Unhandled(Unhandled { source: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InvalidConfiguration(InvalidConfiguration { source: "ProfileFile provider could not be built: This behavior requires following cargo feature(s) enabled: credentials-login. In order to use an active login session, the `credentials-login` feature must be enabled." }), connection: Unknown } }), meta: ErrorMetadata { code: None, message: None, extras: None } }); will try fallback chain for affected secrets
Error:   × Failed to check secrets
  ╰─▶ Provider operation failed: BatchGetSecretValue failed: Unhandled(Unhandled { source: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source:
      InvalidConfiguration(InvalidConfiguration { source: "ProfileFile provider could not be built: This behavior requires following cargo feature(s) enabled: credentials-login. In order to use an active login
      session, the `credentials-login` feature must be enabled." }), connection: Unknown } }), meta: ErrorMetadata { code: None, message: None, extras: None } })
 ```
 
 Enabling this feature doesn't affect authenticating with access keys passed through envvars.