### PR TITLE
Add Swift SDK support

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,6 +19,7 @@ on:
       - "secretspec-py/pyproject.toml"
       - "secretspec-rb/secretspec.gemspec"
       - "secretspec-dotnet/src/SecretSpec/SecretSpec.csproj"
+      - "Package.swift"
 
 permissions:
   contents: read
@@ -115,6 +116,11 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/dotnet-package.yml
+
+  swift:
+    name: Swift package
+    needs: authorize
+    uses: ./.github/workflows/swift-package.yml
 
   release-artifacts:
     name: CLI release artifacts

--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -2,7 +2,7 @@ name: "SDKs"
 
 # Runs every language SDK's full test suite (unit + cross-language conformance +
 # the schema/quicktype codegen pipeline) against a freshly built cdylib, so the
-# Python/Go/Ruby/Node/Haskell/C#/PHP bindings cannot silently rot.
+# Python/Go/Ruby/Node/Haskell/C#/PHP/Swift bindings cannot silently rot.
 
 on:
   workflow_call:
@@ -34,3 +34,22 @@ jobs:
         run: nix profile install nixpkgs#devenv
       - name: Build cdylib and run all SDK suites
         run: devenv shell -- bash scripts/ci-sdks.sh
+
+  swift:
+    name: Swift SDK
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust (pinned by rust-toolchain.toml)
+        run: rustup toolchain install
+      - name: Build the native resolver
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
+        run: cargo build -p secretspec-ffi
+      - name: Build the local XCFramework
+        run: >-
+          bash scripts/build-swift-xcframework.sh
+          secretspec-swift/Artifacts/CSecretSpec.xcframework
+          target/debug/libsecretspec_ffi.dylib
+      - name: Run the Swift SDK and conformance tests
+        run: swift test --parallel

--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -52,4 +52,6 @@ jobs:
           secretspec-swift/Artifacts/CSecretSpec.xcframework
           target/debug/libsecretspec_ffi.dylib
       - name: Run the Swift SDK and conformance tests
-        run: swift test --parallel
+        run: |
+          swift test --parallel
+          swift test --filter SecretSpecTests.testCrossLanguageConformance

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -105,7 +105,9 @@ jobs:
             secretspec-swift/Artifacts/CSecretSpec.xcframework \
             "${libraries[@]}"
       - name: Run Swift SDK tests and cross-language conformance
-        run: swift test --parallel
+        run: |
+          swift test --parallel
+          swift test --filter SecretSpecTests.testCrossLanguageConformance
       - name: Create the release archive
         shell: bash
         run: |

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -1,0 +1,178 @@
+name: "Swift SDK"
+
+# Builds the macOS Intel and Apple-silicon Rust cdylibs, packages them as one
+# XCFramework, and runs the Swift SDK (including cross-language conformance)
+# against that exact local artifact. A release tag publishes the checksummed
+# XCFramework ZIP that the root Package.swift references.
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: Attach the XCFramework to the GitHub Release
+        required: false
+        type: boolean
+        default: false
+      release_tag:
+        description: Existing GitHub Release tag to upload the XCFramework to
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Attach the XCFramework to an existing GitHub Release
+        required: false
+        type: boolean
+        default: false
+      release_tag:
+        description: Existing GitHub Release tag to upload the XCFramework to
+        required: false
+        type: string
+        default: ""
+  push:
+    tags:
+      - v**
+  pull_request:
+    paths:
+      - "Package.swift"
+      - "secretspec-swift/**"
+      - "secretspec-ffi/**"
+      - "scripts/build-swift-xcframework.sh"
+      - "scripts/sync-sdk-versions.sh"
+      - ".github/workflows/swift-package.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  native:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust
+        run: rustup toolchain install
+      - name: Build native resolver
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
+          RUSTFLAGS: "-C strip=symbols"
+        run: >-
+          cargo build -p secretspec-ffi --release
+          --target ${{ matrix.target }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: swift-native-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/libsecretspec_ffi.dylib
+
+  package:
+    name: XCFramework and Swift tests
+    needs: native
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Verify the committed Swift binary version
+        shell: bash
+        run: |
+          bash scripts/sync-sdk-versions.sh
+          git diff --exit-code -- Package.swift
+      - uses: actions/download-artifact@v5
+        with:
+          pattern: swift-native-*
+          path: staged
+      - name: Build the universal XCFramework
+        shell: bash
+        run: |
+          libraries=()
+          while IFS= read -r library; do
+            libraries+=("$library")
+          done < <(find staged -type f -name libsecretspec_ffi.dylib -print | sort)
+          if [[ "${#libraries[@]}" -ne 2 ]]; then
+            printf 'expected 2 native libraries, found %s\n' "${#libraries[@]}" >&2
+            printf '%s\n' "${libraries[@]}" >&2
+            exit 1
+          fi
+          bash scripts/build-swift-xcframework.sh \
+            secretspec-swift/Artifacts/CSecretSpec.xcframework \
+            "${libraries[@]}"
+      - name: Run Swift SDK tests and cross-language conformance
+        run: swift test --parallel
+      - name: Create the release archive
+        shell: bash
+        run: |
+          # SwiftPM checks the ZIP byte-for-byte. Normalize metadata and archive
+          # in lexical order so release preparation and the tag build produce
+          # the same checksum from identical Mach-O inputs.
+          xattr -cr secretspec-swift/Artifacts/CSecretSpec.xcframework
+          find secretspec-swift/Artifacts/CSecretSpec.xcframework \
+            -exec touch -t 200001010000 {} +
+          (
+            cd secretspec-swift/Artifacts
+            find CSecretSpec.xcframework -print |
+              LC_ALL=C sort |
+              zip -X -q "$GITHUB_WORKSPACE/CSecretSpec.xcframework.zip" -@
+          )
+      - name: Record the SwiftPM checksum
+        id: checksum
+        shell: bash
+        run: |
+          actual="$(swift package compute-checksum CSecretSpec.xcframework.zip)"
+          echo "checksum=$actual" >> "$GITHUB_OUTPUT"
+          echo "CSecretSpec.xcframework.zip checksum: $actual"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: swift-xcframework
+          path: CSecretSpec.xcframework.zip
+      - name: Validate the committed SwiftPM checksum
+        shell: bash
+        env:
+          ACTUAL_CHECKSUM: ${{ steps.checksum.outputs.checksum }}
+        run: |
+          pending="0000000000000000000000000000000000000000000000000000000000000000"
+          expected="$(sed -n \
+            's/^let secretSpecBinaryChecksum = "\\([0-9a-f]*\\)"/\\1/p' \
+            Package.swift)"
+          if [[ "$ACTUAL_CHECKSUM" == "$expected" ]]; then
+            exit 0
+          fi
+
+          echo "Package.swift checksum does not match the XCFramework" >&2
+          echo "expected: $expected" >&2
+          echo "actual:   $ACTUAL_CHECKSUM" >&2
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* || "$expected" != "$pending" ]]; then
+            echo "download the uploaded artifact and update Package.swift before tagging" >&2
+            exit 1
+          fi
+          echo "the all-zero checksum is allowed only while the first Swift release is in development"
+
+  publish:
+    name: Publish Swift XCFramework
+    needs: package
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (inputs.publish && inputs.release_tag != '')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v5
+        with:
+          name: swift-xcframework
+          path: artifacts
+      - name: Attach the XCFramework to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          bash scripts/upload-release-asset.sh
+          "${{ inputs.release_tag || github.ref_name }}"
+          artifacts/CSecretSpec.xcframework.zip

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           pending="0000000000000000000000000000000000000000000000000000000000000000"
           expected="$(sed -n \
-            's/^let secretSpecBinaryChecksum = "\\([0-9a-f]*\\)"/\\1/p' \
+            's/^let secretSpecBinaryChecksum = "\([0-9a-f]*\)"/\1/p' \
             Package.swift)"
           if [[ "$ACTUAL_CHECKSUM" == "$expected" ]]; then
             exit 0

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -47,32 +47,30 @@ permissions:
 
 jobs:
   native:
-    name: ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-apple-darwin
-            runner: macos-15-intel
-          - target: aarch64-apple-darwin
-            runner: macos-latest
+    name: macOS native libraries
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
-        run: rustup toolchain install
+        run: |
+          rustup toolchain install
+          rustup target add x86_64-apple-darwin
       - name: Build native resolver
         env:
           MACOSX_DEPLOYMENT_TARGET: "12.0"
           RUSTFLAGS: "-C strip=symbols"
-        run: >-
-          cargo build -p secretspec-ffi --release
-          --target ${{ matrix.target }}
+        run: |
+          cargo build -p secretspec-ffi --release \
+            --target aarch64-apple-darwin
+          cargo build -p secretspec-ffi --release \
+            --target x86_64-apple-darwin
       - uses: actions/upload-artifact@v4
         with:
-          name: swift-native-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/libsecretspec_ffi.dylib
+          name: swift-native-macos
+          path: |
+            target/aarch64-apple-darwin/release/libsecretspec_ffi.dylib
+            target/x86_64-apple-darwin/release/libsecretspec_ffi.dylib
 
   package:
     name: XCFramework and Swift tests
@@ -87,7 +85,7 @@ jobs:
           git diff --exit-code -- Package.swift
       - uses: actions/download-artifact@v5
         with:
-          pattern: swift-native-*
+          name: swift-native-macos
           path: staged
       - name: Build the universal XCFramework
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,8 @@ target
 /secretspec-dotnet/**/bin/
 /secretspec-dotnet/**/obj/
 
+# Swift SDK local native artifact and build output
+/.build/
+/secretspec-swift/Artifacts/
+
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of always pointing at a `ref` item the config may not contain.
 
 ### Added
+- Swift SDK (available in 0.18) for resolving SecretSpec manifests from macOS
+  12+ on Intel and Apple silicon. The SwiftPM package provides fluent and
+  one-shot resolution, typed failures, scopes, value-free reports, provenance,
+  environment export, codegen input, and deterministic `as_path` cleanup. Its
+  checksummed XCFramework includes the shared Rust resolver, so applications do
+  not need a Rust toolchain or separately installed native library.
 - Dashlane provider (`dashlane://`) for reading secrets from a Dashlane vault
   through the `dcli` CLI. Convention secrets read the item titled
   `secretspec/{project}/{profile}/{key}`, and a `ref` names an existing item by

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version: 5.9
+
+import Foundation
+import PackageDescription
+
+// Keep this in sync with the Cargo workspace version via
+// scripts/sync-sdk-versions.sh. Release preparation replaces the checksum
+// after building the versioned XCFramework; see RELEASE.md.
+let secretSpecBinaryVersion = "0.17.0"
+let secretSpecBinaryChecksum = "0000000000000000000000000000000000000000000000000000000000000000"
+
+let localBinaryPath = "secretspec-swift/Artifacts/CSecretSpec.xcframework"
+let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+let hasLocalBinary = FileManager.default.fileExists(
+    atPath: packageRoot.appendingPathComponent(localBinaryPath).path
+)
+
+let ffiTarget: Target = hasLocalBinary
+    ? .binaryTarget(name: "CSecretSpec", path: localBinaryPath)
+    : .binaryTarget(
+        name: "CSecretSpec",
+        url: "https://github.com/cachix/secretspec/releases/download/v\(secretSpecBinaryVersion)/CSecretSpec.xcframework.zip",
+        checksum: secretSpecBinaryChecksum
+    )
+
+let package = Package(
+    name: "SecretSpec",
+    platforms: [
+        .macOS(.v12),
+    ],
+    products: [
+        .library(name: "SecretSpec", targets: ["SecretSpec"]),
+    ],
+    targets: [
+        ffiTarget,
+        .target(
+            name: "SecretSpec",
+            dependencies: ["CSecretSpec"],
+            path: "secretspec-swift/Sources/SecretSpec"
+        ),
+        .testTarget(
+            name: "SecretSpecTests",
+            dependencies: ["SecretSpec"],
+            path: "secretspec-swift/Tests/SecretSpecTests"
+        ),
+    ]
+)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,10 @@
 # Releasing the language SDKs
 
-Each SDK is a thin client over the Rust core (the `secretspec-ffi` cdylib, a
-pyo3 extension for Python, or the napi-rs addon for Node). A release builds
-the native artifact per platform and publishes it through that ecosystem's
-registry, so users install with no native build. The per-platform build
-workflows are drafted under `.github/workflows/`; the Python build (wheel
-build + install) has been verified running end to end in CI, but the actual
-publish steps below have not (they need the one-time external Trusted
-Publisher / secret setup described per language first).
+Each SDK is a thin client over the Rust core (the `secretspec-ffi` C ABI, a
+pyo3 extension for Python, or the napi-rs addon for Node). A release builds the
+native artifact per platform and publishes it through that ecosystem's
+registry or as a checksummed SwiftPM binary, so users install with no native
+build.
 
 Version tags are `vX.Y.Z`; the publish jobs trigger on them. After the Go
 release build succeeds, CI also creates the submodule tag
@@ -125,6 +122,32 @@ one `.nupkg`, run clean-package and NativeAOT consumers on every RID, and
 publish with a short-lived OIDC-issued API key (`--skip-duplicate` makes
 re-runs of an already-published version harmless).
 
+### SwiftPM (0.18+) — no registry setup
+
+The root `Package.swift` makes this repository a Swift package and downloads
+`CSecretSpec.xcframework.zip` from the matching GitHub Release. SwiftPM requires
+that remote binary's SHA-256 checksum to already be present in `Package.swift`,
+so Swift has one required release-preparation step after the workspace version
+is bumped and before the version tag is created:
+
+1. Run `swift-package.yml` on the release branch with `publish: false`.
+2. Download its `swift-xcframework` artifact and run:
+
+   ```bash
+   swift package compute-checksum CSecretSpec.xcframework.zip
+   ```
+
+3. Replace `secretSpecBinaryChecksum` in `/Package.swift` with that value,
+   commit it, and rerun the workflow.
+4. Create the version tag only after the rerun passes. The tag workflow rebuilds
+   the deterministic archive, refuses to publish if its checksum differs, and
+   attaches the ZIP to the existing GitHub Release.
+
+`scripts/sync-sdk-versions.sh` updates the version in the XCFramework URL but
+intentionally leaves the checksum alone, making a missing checksum refresh
+visible during release review. There is no Swift registry credential or
+separate repository.
+
 ## Python (PyPI) — `python-wheels.yml`
 
 - **Build:** the Rust resolver is statically linked into a pyo3 extension
@@ -194,6 +217,24 @@ self-contained, vendored build — not a module-proxy install).
   links a Rust archive Hackage doesn't build); the upload still succeeds, it
   just won't show as "buildable" in Hackage's UI. The README documents the
   link requirement for anyone installing from source.
+
+## Swift (0.18+, SwiftPM + XCFramework) — `swift-package.yml`
+
+- **Build:** native Intel and Apple-silicon macOS runners build the
+  `secretspec-ffi` cdylib with a macOS 12 deployment target.
+  `scripts/build-swift-xcframework.sh` gives each dylib an `@rpath` install
+  name, adds the public header and Clang module map, and combines both slices
+  with `xcodebuild -create-xcframework`.
+- **Test:** the Swift package selects the local XCFramework when staged under
+  `secretspec-swift/Artifacts/`; its unit and cross-language conformance tests
+  run against the final two-architecture artifact.
+- **Publish:** the workflow normalizes archive metadata, verifies the
+  precommitted SwiftPM checksum, and attaches
+  `CSecretSpec.xcframework.zip` to the version's GitHub Release. Follow the
+  pre-tag checksum procedure above.
+- **Platforms:** macOS 12+ on Intel and Apple silicon. Mobile Apple platforms
+  are intentionally unsupported because SecretSpec's development-workflow
+  providers rely on desktop files, processes, CLIs, and credential stores.
 
 ## Node.js (npm) — `node-addon.yml`
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -223,8 +223,8 @@ self-contained, vendored build — not a module-proxy install).
 - **Build:** native Intel and Apple-silicon macOS runners build the
   `secretspec-ffi` cdylib with a macOS 12 deployment target.
   `scripts/build-swift-xcframework.sh` gives each dylib an `@rpath` install
-  name, adds the public header and Clang module map, and combines both slices
-  with `xcodebuild -create-xcframework`.
+  name, combines the slices into a universal dylib, adds the public header and
+  Clang module map, and wraps it with `xcodebuild -create-xcframework`.
 - **Test:** the Swift package selects the local XCFramework when staged under
   `secretspec-swift/Artifacts/`; its unit and cross-language conformance tests
   run against the final two-architecture artifact.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,8 +1,9 @@
 # Cross-language conformance suite
 
-Every SecretSpec SDK (Python, Go, Ruby, Node.js, Haskell, C#, and PHP) is a thin
-client over the same resolver contract. This suite proves they agree: each SDK
-resolves the same fixtures and must produce the identical **canonical** result.
+Every SecretSpec SDK (Python, Go, Ruby, Node.js, Haskell, C#, PHP, and Swift
+(0.18+)) is a thin client over the same resolver contract. This suite proves
+they agree: each SDK resolves the same fixtures and must produce the identical
+**canonical** result.
 
 ## Fixtures
 
@@ -60,3 +61,6 @@ relative to the repo root:
   staticlib staged on `--extra-lib-dirs`; see the Haskell SDK build steps)
 - C#: `cd secretspec-dotnet && dotnet run --project tests/SecretSpec.Tests`
 - PHP: `cd secretspec-php && ./vendor/bin/phpunit tests/ConformanceTest.php`
+- Swift (0.18+, macOS):
+  `swift test --filter SecretSpecTests.testCrossLanguageConformance` after
+  staging the local XCFramework as described in `secretspec-swift/README.md`

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -84,6 +84,19 @@ run_dotnet() { (
   cd secretspec-dotnet
   dotnet run --project tests/SecretSpec.Tests --configuration Release
 ); }
+run_swift() { (
+  local artifact="$repo_root/secretspec-swift/Artifacts/CSecretSpec.xcframework"
+  if [[ "$(uname -s)" != Darwin ]]; then
+    echo "Swift binary dependencies are supported only on Apple platforms"
+    return 125
+  fi
+  if [[ -e "$artifact" ]]; then
+    rm -rf "$artifact"
+  fi
+  bash scripts/build-swift-xcframework.sh \
+    "$artifact" "$SECRETSPEC_FFI_LIB"
+  swift test --filter SecretSpecTests.testCrossLanguageConformance
+); }
 
 run "Python"  python run_python
 run "Go"      go     run_go
@@ -92,6 +105,12 @@ run "Node"    node   run_node
 run "Haskell" cabal  run_haskell
 run "C#"      dotnet run_dotnet
 run "PHP"     php    run_php
+if [[ "$(uname -s)" == Darwin ]]; then
+  run "Swift" swift run_swift
+else
+  echo "==> SKIP Swift (the XCFramework SDK is macOS-only)"
+  names+=("Swift"); statuses+=("SKIP")
+fi
 
 echo
 echo "==> Conformance summary"

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -331,6 +331,11 @@ Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files,
               slug: "sdk/csharp",
               badge: { text: "0.16+", variant: "note" },
             },
+            {
+              label: "Swift",
+              slug: "sdk/swift",
+              badge: { text: "0.18+", variant: "note" },
+            },
           ],
         },
         {

--- a/docs/src/content/docs/blog/but-i-use-sops.md
+++ b/docs/src/content/docs/blog/but-i-use-sops.md
@@ -48,11 +48,11 @@ The same secret can come from a developer's
 [system keyring](/providers/keyring/) or CI
 [environment variables](/providers/env/), while a more sensitive production
 environment resolves it from [Vault](/providers/vault/). Applications use the
-same declaration through eight SDKs for [Rust](/sdk/rust/),
+same declaration through nine SDKs for [Rust](/sdk/rust/),
 [Python](/sdk/python/), [Go](/sdk/go/),
 [Ruby](/sdk/ruby/), [Node.js/TypeScript](/sdk/nodejs/),
-[Haskell](/sdk/haskell/), [PHP](/sdk/php/), and [C#](/sdk/csharp/) without
-knowing the provider.
+[Haskell](/sdk/haskell/), [PHP](/sdk/php/), [C#](/sdk/csharp/), and
+[Swift (0.18+)](/sdk/swift/) without knowing the provider.
 
 Encrypted files also make the key workflow a project-wide requirement. Adding a
 teammate means adding their key to `.sops.yaml` and re-encrypting every file;

--- a/docs/src/content/docs/blog/secrets-dont-belong-in-config.md
+++ b/docs/src/content/docs/blog/secrets-dont-belong-in-config.md
@@ -137,8 +137,8 @@ secretspec run -- ./myapp
 
 Applications can also resolve them directly through the
 [SecretSpec SDKs](/sdk/overview/) for Rust, Python, Go, Ruby,
-Node.js/TypeScript, Haskell, PHP, and C#, all sharing the same resolver
-so behavior stays consistent across languages.
+Node.js/TypeScript, Haskell, PHP, C#, and Swift (0.18+), all sharing the same
+resolver so behavior stays consistent across languages.
 
 Providers own where secret values come from. SDKs give applications an
 idiomatic way to consume them. Configuration remains a shareable declaration of

--- a/docs/src/content/docs/development/sdks.md
+++ b/docs/src/content/docs/development/sdks.md
@@ -4,10 +4,10 @@ description: How the language SDKs are built, packaged, and released, and which 
 ---
 
 SecretSpec ships SDKs for Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell,
-PHP, and C#. This page is for contributors: how the SDKs are put together, how
-each one is packaged and released, which platforms each artifact covers, and
-what to update when adding a platform or a new SDK. For the user-facing
-architecture and API, see the [SDK overview](/sdk/overview).
+PHP, C#, and Swift (0.18+). This page is for contributors: how the SDKs are put
+together, how each one is packaged and released, which platforms each artifact
+covers, and what to update when adding a platform or a new SDK. For the
+user-facing architecture and API, see the [SDK overview](/sdk/overview).
 
 ## One resolver, many packages
 
@@ -18,8 +18,9 @@ two ways:
   loading and a `staticlib` for embedding): Ruby (mkmf extension statically
   links the archive), Go (purego `dlopen` of the cdylib, or cgo against the
   archive with `-tags static`), Haskell (GHC FFI against the archive), C#
-  (P/Invoke against per-runtime cdylibs in the NuGet package), and PHP's
-  `ext-ffi` fallback (runtime `dlopen` of the cdylib).
+  (P/Invoke against per-runtime cdylibs in the NuGet package), Swift (0.18+;
+  Clang C import from an XCFramework), and PHP's `ext-ffi` fallback (runtime
+  `dlopen` of the cdylib).
 - **As an embedded extension**: Python ([pyo3](https://pyo3.rs/)), Node.js
   ([napi-rs](https://napi.rs/)), and PHP's preferred backend
   ([ext-php-rs](https://github.com/davidcole1340/ext-php-rs)) compile the
@@ -47,6 +48,7 @@ platform and publishes on a version tag:
 | Go | Go module (source) + `secretspec-ffi` release assets | `go-embed.yml`, `go-static.yml`, `ffi-build.yml` |
 | Ruby | `secretspec` platform gems on RubyGems | `ruby-gems.yml` |
 | C# | `Cachix.SecretSpec` on NuGet | `dotnet-package.yml` |
+| Swift (0.18+) | SwiftPM source package + XCFramework release asset | `swift-package.yml` |
 | PHP | Composer package (source) + prebuilt extension binaries and `secretspec-ffi` release assets | `php-ext.yml`, `ffi-build.yml` |
 | Haskell | `secretspec` on Hackage (source) | `haskell-build.yml` |
 
@@ -63,6 +65,7 @@ the Ruby gem, and the PHP extension binaries is added in SecretSpec 0.17.
 | Go | ✓ | ✓ | — | ✓ | ✓ | — |
 | Ruby | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
 | C# | ✓ (glibc and musl) | ✓ (glibc and musl) | ✓ | ✓ | ✓ | ✓ |
+| Swift (0.18+) | — | — | ✓ | ✓ | — | — |
 | PHP | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
 | Haskell (source) | ✓ (CI-covered) | — | — | — | ✓ (CI-covered, 0.17+) | — |
 
@@ -75,7 +78,33 @@ Notes:
   require system libdbus.
 - Hackage distributes source only; the Haskell column records which platforms
   CI builds and tests, since users link `secretspec-ffi` themselves.
+- The Swift package targets macOS 12+ only. Its XCFramework contains native
+  Intel and Apple-silicon slices; mobile Apple platforms are intentionally out
+  of scope for a development-workflow resolver that launches provider CLIs and
+  reads desktop files and credential stores.
 - The fully-static Go binary (`-tags static`, musl) is Linux x64 only.
+
+## Why Swift uses the C ABI
+
+Swift interoperates with C directly through Clang modules, and SwiftPM
+distributes native Apple binaries as XCFramework binary targets. That fits the
+existing `secretspec-ffi` boundary exactly: three ownership-audited C functions
+carry one already-versioned JSON contract.
+
+[UniFFI](https://mozilla.github.io/uniffi-rs/latest/) is a good default for a
+new object-rich Rust API that needs generated Swift and Kotlin bindings. It
+would be the wrong layer here: SecretSpec already has a deliberately narrow ABI
+shared by several SDKs, and introducing UniFFI would create a second exported
+ABI, generated Rust scaffolding, and another schema to version. The hand-written
+Swift layer is limited to `Codable` request/response models and idiomatic errors;
+resolution remains entirely in Rust.
+
+`scripts/build-swift-xcframework.sh` changes Cargo's target-local dylib install
+name to `@rpath`, adds the C header and module map, and invokes
+`xcodebuild -create-xcframework`. `swift-package.yml` builds each architecture
+natively, tests the final two-slice artifact, computes SwiftPM's SHA-256
+checksum, and attaches the ZIP to the GitHub release. See `RELEASE.md` for the
+required pre-tag checksum step.
 
 ## Windows toolchains
 

--- a/docs/src/content/docs/development/sdks.md
+++ b/docs/src/content/docs/development/sdks.md
@@ -100,9 +100,10 @@ Swift layer is limited to `Codable` request/response models and idiomatic errors
 resolution remains entirely in Rust.
 
 `scripts/build-swift-xcframework.sh` changes Cargo's target-local dylib install
-name to `@rpath`, adds the C header and module map, and invokes
+name to `@rpath`, merges the native slices into a universal dylib, adds the C
+header and module map, and invokes
 `xcodebuild -create-xcframework`. `swift-package.yml` builds each architecture
-natively, tests the final two-slice artifact, computes SwiftPM's SHA-256
+natively, tests the final universal artifact, computes SwiftPM's SHA-256
 checksum, and attaches the ZIP to the GitHub release. See `RELEASE.md` for the
 required pre-tag checksum step.
 

--- a/docs/src/content/docs/sdk/overview.md
+++ b/docs/src/content/docs/sdk/overview.md
@@ -4,9 +4,9 @@ description: How the SecretSpec language SDKs work
 ---
 
 SecretSpec ships SDKs for Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell,
-PHP, and C# (0.16+). They all resolve secrets from the same declarative
-`secretspec.toml`, and they all behave identically, because they share one
-resolver.
+PHP, C# (0.16+), and Swift (0.18+). They all resolve secrets from the same
+declarative `secretspec.toml`, and they all behave identically, because they
+share one resolver.
 
 > **C# compatibility:** Available since SecretSpec 0.16. The 0.15.0 NuGet
 > package is an unsupported package-ID bootstrap; use version 0.16 or later
@@ -26,6 +26,8 @@ that core rather than a reimplementation:
 - **Haskell** links the same C ABI at build time via the GHC FFI.
 - **C# (0.16+)** loads the same C ABI with P/Invoke from a runtime-specific
   native asset in the NuGet package.
+- **Swift (0.18+)** imports the same C ABI as a Clang module from a macOS
+  XCFramework and maps the shared JSON envelope to `Codable` value types.
 - **Python** uses a [pyo3](https://pyo3.rs/) native extension, and
   **Node.js/TypeScript** uses a [napi-rs](https://napi.rs/) native addon; both
   embed the same resolver directly and exchange the same JSON request/response
@@ -57,8 +59,8 @@ print(resolved.secrets["DATABASE_URL"].get)
 
 See each language's page for the idiomatic spelling: [Rust](/sdk/rust),
 [Python](/sdk/python), [Go](/sdk/go), [Ruby](/sdk/ruby),
-[Node.js](/sdk/nodejs), [Haskell](/sdk/haskell), [PHP](/sdk/php), and
-[C# (0.16+)](/sdk/csharp).
+[Node.js](/sdk/nodejs), [Haskell](/sdk/haskell), [PHP](/sdk/php),
+[C# (0.16+)](/sdk/csharp), and [Swift (0.18+)](/sdk/swift).
 
 Every builder also takes a [scope (0.17+)](/concepts/scopes/),
 resolving only a named subset of the profile and returning the selected name on
@@ -98,6 +100,9 @@ no runtime library path to set:
   NuGet package and loads the matching asset through P/Invoke. The managed
   client supports trimming and NativeAOT; glibc/musl Linux, Intel/Arm macOS,
   and x64/Arm64 Windows assets are included.
+- **Swift (0.18+)** ships Intel and Apple-silicon macOS cdylibs in one
+  checksummed XCFramework binary target. SwiftPM selects and embeds the matching
+  architecture.
 - **Go** embeds the `cdylib` in the module and loads it at runtime via purego
   (no cgo); an opt-in `-tags static` build links it statically instead.
 - **Node.js** builds the resolver into a napi-rs addon.
@@ -123,6 +128,7 @@ SecretSpec 0.17.
 | Go | ✓ | ✓ | — | ✓ | ✓ | — |
 | Ruby | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
 | C# | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Swift (0.18+) | — | — | ✓ | ✓ | — | — |
 | PHP | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
 | Haskell (source) | ✓ | — | — | — | ✓ (0.17+) | — |
 

--- a/docs/src/content/docs/sdk/swift.md
+++ b/docs/src/content/docs/sdk/swift.md
@@ -1,0 +1,146 @@
+---
+title: Swift SDK
+description: Resolve SecretSpec secrets from Swift on macOS
+---
+
+> **Version compatibility:** The Swift SDK is available in SecretSpec 0.18+.
+
+The Swift SDK is a thin `Codable` wrapper over the same Rust resolver and
+versioned C ABI as the other language SDKs. Every provider, fallback chain,
+profile, scope, generator, reference, and `as_path` secret therefore works
+without Swift-side resolution logic.
+
+## Install (0.18+)
+
+In Xcode, choose **File → Add Package Dependencies** and enter:
+
+```text
+https://github.com/cachix/secretspec
+```
+
+Or add the package to `Package.swift`:
+
+```swift
+dependencies: [
+    .package(
+        url: "https://github.com/cachix/secretspec",
+        from: "0.18.0"
+    ),
+],
+targets: [
+    .target(
+        name: "MyApp",
+        dependencies: [
+            .product(name: "SecretSpec", package: "secretspec"),
+        ]
+    ),
+]
+```
+
+The package supports macOS 12 or later on Intel and Apple silicon. Its
+checksummed XCFramework contains the native Rust resolver, so consumers need
+neither Rust nor a separately installed SecretSpec library. SecretSpec is a
+development-workflow secrets manager with filesystem, process, and desktop
+credential-store integrations; the SDK does not target iOS, watchOS, tvOS, or
+visionOS.
+
+## Quick start
+
+```swift
+import SecretSpec
+
+let resolved = try SecretSpec.builder()
+    .withProvider("keyring://")
+    .withProfile("production")
+    .withReason("boot web app")
+    .load()
+defer { try? resolved.close() }
+
+print(resolved.provider, resolved.profile)
+print(resolved.secrets["DATABASE_URL"]?.get() ?? "")
+try resolved.setAsEnvironment()
+```
+
+`get()` returns the inline value, or the readable file path for an `as_path`
+secret. A missing required secret throws `MissingRequiredError`; its `missing`
+property contains the unresolved names. Other failures throw
+`SecretSpecError`, whose `kind` property is a stable error category:
+
+```swift
+do {
+    let resolved = try SecretSpec.builder().load()
+    defer { try? resolved.close() }
+    // Use resolved.
+} catch let error as MissingRequiredError {
+    print("Missing:", error.missing.joined(separator: ", "))
+} catch let error as SecretSpecError {
+    print("\(error.kind): \(error.message)")
+}
+```
+
+A one-shot form is also available:
+
+```swift
+let resolved = try SecretSpec.resolve(
+    provider: "keyring://",
+    profile: "production",
+    reason: "boot web app"
+)
+```
+
+## Scopes
+
+Use `withScope("api")` to resolve only a named `[scopes.api]` subset. The
+selected name is available through `resolved.scope` and `report.scope`:
+
+```swift
+let resolved = try SecretSpec.builder().withScope("api").load()
+```
+
+## Value-free preflight
+
+`report()` returns the inventory view exposed by `secretspec check --json`. It
+never carries values. A missing required secret appears with
+`status == "missing_required"` rather than throwing, so an incomplete
+deployment can still be inspected.
+
+```swift
+let report = try SecretSpec.builder()
+    .withProfile("production")
+    .withReason("deployment preflight")
+    .report()
+
+for secret in report.secrets {
+    print("\(secret.name): \(secret.status)")
+}
+```
+
+## Typed access
+
+Generate an idiomatic Swift model from the manifest schema:
+
+```bash
+secretspec schema |
+  quicktype -s schema --top-level AppSecrets --lang swift -o AppSecrets.swift
+```
+
+Then decode the SDK's flat field map:
+
+```swift
+let typed = try JSONDecoder().decode(
+    AppSecrets.self,
+    from: resolved.fieldsJSON()
+)
+print(typed.databaseURL)
+```
+
+The schema models successful resolution: required, defaulted, and generated
+secrets are non-nullable, and profile schemas include inherited
+default-profile fields.
+
+## Files (`as_path`)
+
+File-shaped secrets are materialized as mode-0400 temporary files. Call
+`resolved.close()` after the last consumer finishes with those paths.
+`Resolved` also performs best-effort cleanup when it is deinitialized, but
+explicit cleanup gives deterministic lifetime and reports filesystem errors.

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -770,7 +770,7 @@ $ secretspec export --format json
       <span class="landing-showcase-eyebrow">Language SDKs</span>
       <h2 class="landing-section-title">Resolve secrets directly from your language.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        All {sdkCount} SDKs—Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell, PHP, and C#—use the same resolver as the CLI, so provider and profile behavior stays consistent. <a href="/sdk/overview/" class="landing-link">Explore the SDKs →</a>
+        All {sdkCount} SDKs—Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell, PHP, C#, and Swift (0.18+)—use the same resolver as the CLI, so provider and profile behavior stays consistent. <a href="/sdk/overview/" class="landing-link">Explore the SDKs →</a>
       </p>
     </div>
 
@@ -885,6 +885,21 @@ print (S.get <span class="tok-pun">=&lt;&lt;</span> Map.lookup <span class="tok-
     .WithProvider(<span class="tok-str">"keyring://"</span>)
     .WithReason(<span class="tok-str">"boot"</span>).Load();
 Console.WriteLine(s.Secrets[<span class="tok-str">"DATABASE_URL"</span>].Get());</code></pre>
+      </div>
+    </div>
+
+    <div class="landing-fallback" style="margin-top: 1.5rem;">
+      <!-- Swift -->
+      <div class="landing-terminal">
+        <div class="landing-terminal-header">
+          <div class="landing-terminal-dots"><span></span><span></span><span></span></div>
+          <span class="landing-terminal-title">Swift · macOS (0.18+)</span>
+        </div>
+        <pre is:raw class="landing-terminal-body"><code><span class="tok-key">let</span> s <span class="tok-pun">=</span> <span class="tok-key">try</span> SecretSpec<span class="tok-pun">.</span>builder<span class="tok-pun">()</span>
+    <span class="tok-pun">.</span>withProvider<span class="tok-pun">(</span><span class="tok-str">"keyring://"</span><span class="tok-pun">)</span>
+    <span class="tok-pun">.</span>withReason<span class="tok-pun">(</span><span class="tok-str">"boot"</span><span class="tok-pun">).</span>load<span class="tok-pun">()</span>
+<span class="tok-key">defer</span> <span class="tok-pun">{</span> <span class="tok-key">try</span><span class="tok-pun">?</span> s<span class="tok-pun">.</span>close<span class="tok-pun">()</span> <span class="tok-pun">}</span>
+print<span class="tok-pun">(</span>s<span class="tok-pun">.</span>secrets<span class="tok-pun">[</span><span class="tok-str">"DATABASE_URL"</span><span class="tok-pun">]?.</span>get<span class="tok-pun">()</span> <span class="tok-pun">??</span> <span class="tok-str">""</span><span class="tok-pun">)</span></code></pre>
       </div>
     </div>
 

--- a/scripts/build-swift-xcframework.sh
+++ b/scripts/build-swift-xcframework.sh
@@ -2,7 +2,8 @@
 #
 # Package one or more macOS secretspec-ffi cdylibs as the CSecretSpec
 # XCFramework imported by the Swift SDK. Pass one native library per
-# architecture; xcodebuild reads each Mach-O architecture from the file.
+# architecture; multiple inputs are merged into one universal Mach-O because
+# xcodebuild rejects separate library definitions for the same platform.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -31,9 +32,7 @@ fi
 staging="$(mktemp -d "${TMPDIR:-/tmp}/secretspec-swift.XXXXXX")"
 trap 'rm -rf "$staging"' EXIT
 
-xcframework_args=()
 seen_arches=""
-index=0
 
 for library in "$@"; do
   if [[ ! -f "$library" ]]; then
@@ -54,30 +53,30 @@ for library in "$@"; do
     seen_arches="$seen_arches $arch"
   done
 
-  slice="$staging/slice-$index"
-  headers="$slice/Headers"
-  mkdir -p "$headers"
-  staged_library="$slice/libCSecretSpec.dylib"
-  cp "$library" "$staged_library"
-  cp "$repo_root/secretspec-ffi/include/secretspec.h" "$headers/"
-  cp "$repo_root/secretspec-swift/ffi/module.modulemap" "$headers/"
-
-  # A SwiftPM binary target embeds this dylib beside the consumer and supplies
-  # an @rpath. Do not retain Cargo's absolute/target-local install name. The
-  # edit invalidates Cargo/linker's existing signature on Apple silicon, so
-  # replace it with a deterministic ad-hoc signature for local SwiftPM loads;
-  # application distribution can sign the embedded dylib with its own identity.
-  install_name_tool -id "@rpath/libCSecretSpec.dylib" "$staged_library"
-  codesign --force --sign - --timestamp=none "$staged_library"
-
-  xcframework_args+=(
-    -library "$staged_library"
-    -headers "$headers"
-  )
-  index=$((index + 1))
 done
+
+slice="$staging/macos"
+headers="$slice/Headers"
+mkdir -p "$headers"
+staged_library="$slice/libCSecretSpec.dylib"
+if [[ "$#" -eq 1 ]]; then
+  cp "$1" "$staged_library"
+else
+  xcrun lipo -create "$@" -output "$staged_library"
+fi
+cp "$repo_root/secretspec-ffi/include/secretspec.h" "$headers/"
+cp "$repo_root/secretspec-swift/ffi/module.modulemap" "$headers/"
+
+# A SwiftPM binary target embeds this dylib beside the consumer and supplies
+# an @rpath. Do not retain Cargo's absolute/target-local install name. The
+# edit invalidates Cargo/linker's existing signature on Apple silicon, so
+# replace it with a deterministic ad-hoc signature for local SwiftPM loads;
+# application distribution can sign the embedded dylib with its own identity.
+install_name_tool -id "@rpath/libCSecretSpec.dylib" "$staged_library"
+codesign --force --sign - --timestamp=none "$staged_library"
 
 mkdir -p "$(dirname "$output")"
 xcodebuild -create-xcframework \
-  "${xcframework_args[@]}" \
+  -library "$staged_library" \
+  -headers "$headers" \
   -output "$output"

--- a/scripts/build-swift-xcframework.sh
+++ b/scripts/build-swift-xcframework.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Package one or more macOS secretspec-ffi cdylibs as the CSecretSpec
+# XCFramework imported by the Swift SDK. Pass one native library per
+# architecture; xcodebuild reads each Mach-O architecture from the file.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "$#" -lt 2 ]]; then
+  echo "usage: $0 OUTPUT.xcframework LIBSECRETSPEC_FFI.dylib [...]" >&2
+  exit 2
+fi
+
+output="$1"
+shift
+
+if [[ "$output" != *.xcframework || "$output" == "/" ]]; then
+  echo "output must be a specific .xcframework path: $output" >&2
+  exit 2
+fi
+if [[ -e "$output" ]]; then
+  echo "output already exists: $output" >&2
+  exit 2
+fi
+if ! command -v xcodebuild >/dev/null 2>&1; then
+  echo "xcodebuild is required (run this script on macOS with Xcode)" >&2
+  exit 1
+fi
+
+staging="$(mktemp -d "${TMPDIR:-/tmp}/secretspec-swift.XXXXXX")"
+trap 'rm -rf "$staging"' EXIT
+
+xcframework_args=()
+seen_arches=""
+index=0
+
+for library in "$@"; do
+  if [[ ! -f "$library" ]]; then
+    echo "native library does not exist: $library" >&2
+    exit 2
+  fi
+
+  arches="$(xcrun lipo -archs "$library")"
+  if [[ -z "$arches" ]]; then
+    echo "could not determine Mach-O architecture: $library" >&2
+    exit 1
+  fi
+  for arch in $arches; do
+    if [[ " $seen_arches " == *" $arch "* ]]; then
+      echo "duplicate architecture $arch in $library" >&2
+      exit 2
+    fi
+    seen_arches="$seen_arches $arch"
+  done
+
+  slice="$staging/slice-$index"
+  headers="$slice/Headers"
+  mkdir -p "$headers"
+  staged_library="$slice/libCSecretSpec.dylib"
+  cp "$library" "$staged_library"
+  cp "$repo_root/secretspec-ffi/include/secretspec.h" "$headers/"
+  cp "$repo_root/secretspec-swift/ffi/module.modulemap" "$headers/"
+
+  # A SwiftPM binary target embeds this dylib beside the consumer and supplies
+  # an @rpath. Do not retain Cargo's absolute/target-local install name. The
+  # edit invalidates Cargo/linker's existing signature on Apple silicon, so
+  # replace it with a deterministic ad-hoc signature for local SwiftPM loads;
+  # application distribution can sign the embedded dylib with its own identity.
+  install_name_tool -id "@rpath/libCSecretSpec.dylib" "$staged_library"
+  codesign --force --sign - --timestamp=none "$staged_library"
+
+  xcframework_args+=(
+    -library "$staged_library"
+    -headers "$headers"
+  )
+  index=$((index + 1))
+done
+
+mkdir -p "$(dirname "$output")"
+xcodebuild -create-xcframework \
+  "${xcframework_args[@]}" \
+  -output "$output"

--- a/scripts/sync-sdk-versions.sh
+++ b/scripts/sync-sdk-versions.sh
@@ -114,6 +114,17 @@ update_file() {
         END { if (!changed) exit 1 }
       ' "$file" > "$tmp"
       ;;
+    swift-package)
+      awk -v version="$workspace_version" '
+        !changed && /^let secretSpecBinaryVersion = / {
+          print "let secretSpecBinaryVersion = \"" version "\""
+          changed = 1
+          next
+        }
+        { print }
+        END { if (!changed) exit 1 }
+      ' "$file" > "$tmp"
+      ;;
     *)
       echo "unknown manifest kind: $kind" >&2
       rm -f "$tmp"
@@ -130,5 +141,6 @@ update_file secretspec-hs/secretspec.cabal cabal
 update_file secretspec-node/package.json package-json
 update_file secretspec-dotnet/src/SecretSpec/SecretSpec.csproj csproj
 update_file secretspec-dotnet/tests/SecretSpec.PackageSmoke/SecretSpec.PackageSmoke.csproj csproj
+update_file Package.swift swift-package
 
 echo "synced SDK package versions to $workspace_version"

--- a/secretspec-swift/README.md
+++ b/secretspec-swift/README.md
@@ -1,0 +1,48 @@
+# SecretSpec for Swift
+
+> Available in SecretSpec 0.18+.
+
+The `SecretSpec` Swift package resolves the same `secretspec.toml` manifests as
+the CLI and every other SDK. It supports macOS 12 or later on Intel and Apple
+silicon; the SwiftPM package includes the Rust resolver in an XCFramework.
+
+```swift
+import SecretSpec
+
+let resolved = try SecretSpec.builder()
+    .withProvider("keyring://")
+    .withProfile("production")
+    .withReason("boot web app")
+    .load()
+defer { try? resolved.close() }
+
+print(resolved.secrets["DATABASE_URL"]?.get() ?? "")
+try resolved.setAsEnvironment()
+```
+
+A missing required secret throws `MissingRequiredError`. Other failures throw
+`SecretSpecError`, whose `kind` is a stable machine-readable category.
+
+## Local development
+
+Build the Rust cdylib on macOS, turn it into the local XCFramework, and run the
+Swift tests:
+
+```bash
+cargo build -p secretspec-ffi
+mkdir -p secretspec-swift/Artifacts
+bash scripts/build-swift-xcframework.sh \
+  secretspec-swift/Artifacts/CSecretSpec.xcframework \
+  target/debug/libsecretspec_ffi.dylib
+swift test
+```
+
+The checked-in `Package.swift` selects that ignored local artifact when it
+exists. Otherwise it downloads the checksummed release XCFramework.
+
+The SDK deliberately wraps SecretSpec's existing, versioned JSON-over-C ABI
+instead of adding UniFFI. The core already presents only three C functions and
+all other language SDKs conform to its JSON schema; a generated object ABI would
+duplicate that contract without removing meaningful Swift code. Swift imports
+the C header as a Clang module, while the public package exposes only idiomatic
+Swift `Codable` models and errors.

--- a/secretspec-swift/Sources/SecretSpec/Errors.swift
+++ b/secretspec-swift/Sources/SecretSpec/Errors.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// A manifest, provider, policy, native-boundary, or wire-format failure.
+public struct SecretSpecError: Error, LocalizedError, CustomStringConvertible, Sendable {
+    /// A stable machine-readable error category.
+    public let kind: String
+
+    /// The human-readable failure detail.
+    public let message: String
+
+    public init(kind: String, message: String) {
+        self.kind = kind
+        self.message = message
+    }
+
+    public var description: String {
+        "\(message) (kind: \(kind))"
+    }
+
+    public var errorDescription: String? {
+        description
+    }
+}
+
+/// Required secrets that could not be resolved.
+public struct MissingRequiredError: Error, LocalizedError, CustomStringConvertible, Sendable {
+    public let missing: [String]
+
+    public init(missing: [String]) {
+        self.missing = missing
+    }
+
+    public var kind: String {
+        "missing_required"
+    }
+
+    public var description: String {
+        "missing required secret(s): \(missing.joined(separator: ", "))"
+    }
+
+    public var errorDescription: String? {
+        description
+    }
+}

--- a/secretspec-swift/Sources/SecretSpec/Models.swift
+++ b/secretspec-swift/Sources/SecretSpec/Models.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+/// One resolved secret and its provenance.
+public struct ResolvedSecret: Decodable, Sendable {
+    /// The inline value, or `nil` for an `as_path` secret.
+    public let value: String?
+
+    /// The materialized file path, or `nil` for an inline secret.
+    public let path: String?
+
+    public let asPath: Bool
+    public let source: String
+    public let sourceProvider: String?
+
+    enum CodingKeys: String, CodingKey {
+        case value
+        case path
+        case asPath = "as_path"
+        case source
+        case sourceProvider = "source_provider"
+    }
+
+    /// The usable string: the file path for `as_path`, otherwise the value.
+    ///
+    /// A value-free resolution returns `nil`.
+    public func get() -> String? {
+        asPath ? path : value
+    }
+}
+
+/// A successful, value-carrying resolution.
+///
+/// Call ``close()`` when finished to remove files backing `as_path` secrets.
+/// Deinitialization also attempts a best-effort cleanup.
+public final class Resolved {
+    public let provider: String
+    public let profile: String
+    public let scope: String?
+    public let secrets: [String: ResolvedSecret]
+    public let missingOptional: [String]
+
+    private var closed = false
+
+    init(
+        provider: String,
+        profile: String,
+        scope: String?,
+        secrets: [String: ResolvedSecret],
+        missingOptional: [String]
+    ) {
+        self.provider = provider
+        self.profile = profile
+        self.scope = scope
+        self.secrets = secrets
+        self.missingOptional = missingOptional
+    }
+
+    deinit {
+        try? close()
+    }
+
+    /// Exports every present secret into the current process environment.
+    public func setAsEnvironment() throws {
+        for (name, secret) in secrets {
+            guard let value = secret.get() else {
+                continue
+            }
+            guard !value.utf8.contains(0) else {
+                throw SecretSpecError(
+                    kind: "environment",
+                    message: "secret \(name) contains a NUL byte and cannot be exported"
+                )
+            }
+
+            let result = name.withCString { namePointer in
+                value.withCString { valuePointer in
+                    setenv(namePointer, valuePointer, 1)
+                }
+            }
+            guard result == 0 else {
+                throw SecretSpecError(
+                    kind: "environment",
+                    message: "could not export \(name): \(String(cString: strerror(errno)))"
+                )
+            }
+        }
+    }
+
+    /// A flat secret-name-to-value map suitable for a generated decoder.
+    ///
+    /// File-shaped secrets map to their paths; stripped values map to `nil`.
+    public func fields() -> [String: String?] {
+        Dictionary(uniqueKeysWithValues: secrets.map { name, secret in
+            (name, secret.get())
+        })
+    }
+
+    /// Encodes ``fields()`` as the JSON input for a generated typed decoder.
+    public func fieldsJSON() throws -> Data {
+        try JSONEncoder().encode(fields())
+    }
+
+    /// Removes temporary files backing `as_path` secrets.
+    public func close() throws {
+        guard !closed else {
+            return
+        }
+        closed = true
+
+        var firstError: Error?
+        for secret in secrets.values where secret.asPath {
+            guard let path = secret.path else {
+                continue
+            }
+            do {
+                if FileManager.default.fileExists(atPath: path) {
+                    try FileManager.default.removeItem(atPath: path)
+                }
+            } catch {
+                firstError = firstError ?? error
+            }
+        }
+
+        if let firstError {
+            throw firstError
+        }
+    }
+}
+
+/// The value-free resolution outcome for one declared secret.
+public struct SecretReport: Decodable, Sendable {
+    public let name: String
+    public let status: String
+    public let required: Bool
+    public let sourceProvider: String?
+    public let defaultApplied: Bool
+    public let generated: Bool
+    public let asPath: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case status
+        case required
+        case sourceProvider = "source_provider"
+        case defaultApplied = "default_applied"
+        case generated
+        case asPath = "as_path"
+    }
+}
+
+/// A value-free inventory/preflight snapshot.
+public struct ResolutionReport: Sendable {
+    public let provider: String
+    public let profile: String
+    public let scope: String?
+    public let secrets: [SecretReport]
+}

--- a/secretspec-swift/Sources/SecretSpec/Native.swift
+++ b/secretspec-swift/Sources/SecretSpec/Native.swift
@@ -1,0 +1,37 @@
+import CSecretSpec
+import Foundation
+
+enum Native {
+    static func resolve(_ requestJSON: String) throws -> String {
+        guard let response = requestJSON.withCString({ secretspec_resolve($0) }) else {
+            throw SecretSpecError(
+                kind: "ffi",
+                message: "secretspec_resolve returned null"
+            )
+        }
+        defer {
+            secretspec_free(response)
+        }
+
+        guard let result = String(validatingUTF8: response) else {
+            throw SecretSpecError(
+                kind: "ffi",
+                message: "secretspec_resolve returned invalid UTF-8"
+            )
+        }
+        return result
+    }
+
+    static func abiVersion() throws -> String {
+        guard
+            let pointer = secretspec_abi_version(),
+            let version = String(validatingUTF8: pointer)
+        else {
+            throw SecretSpecError(
+                kind: "ffi",
+                message: "secretspec_abi_version returned null or invalid UTF-8"
+            )
+        }
+        return version
+    }
+}

--- a/secretspec-swift/Sources/SecretSpec/SecretSpec.swift
+++ b/secretspec-swift/Sources/SecretSpec/SecretSpec.swift
@@ -1,0 +1,274 @@
+import Foundation
+
+private let resolveSchemaVersion = 2
+private let reportSchemaVersion = 1
+
+private struct ResolveRequest: Encodable, Sendable {
+    var path: String? = nil
+    var provider: String? = nil
+    var profile: String? = nil
+    var scope: String? = nil
+    var reason: String? = nil
+    var noValues: Bool? = nil
+    var mode: String? = nil
+
+    enum CodingKeys: String, CodingKey {
+        case path
+        case provider
+        case profile
+        case scope
+        case reason
+        case noValues = "no_values"
+        case mode
+    }
+}
+
+private struct ErrorPayload: Decodable {
+    let kind: String?
+    let message: String?
+}
+
+private struct Envelope<Response: Decodable>: Decodable {
+    let ok: Bool
+    let response: Response?
+    let error: ErrorPayload?
+}
+
+private struct ResolveResponse: Decodable {
+    let schemaVersion: Int
+    let provider: String
+    let profile: String
+    let scope: String?
+    let secrets: [String: ResolvedSecret]
+    let missingRequired: [String]
+    let missingOptional: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case provider
+        case profile
+        case scope
+        case secrets
+        case missingRequired = "missing_required"
+        case missingOptional = "missing_optional"
+    }
+}
+
+private struct ReportResponse: Decodable {
+    let schemaVersion: Int
+    let provider: String
+    let profile: String
+    let scope: String?
+    let secrets: [SecretReport]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case provider
+        case profile
+        case scope
+        case secrets
+    }
+}
+
+/// Configures a SecretSpec resolution.
+public struct SecretSpecBuilder: Sendable {
+    private var request = ResolveRequest()
+
+    public init() {}
+
+    public func withPath(_ path: String?) -> Self {
+        setting(\.path, to: path)
+    }
+
+    public func withProvider(_ provider: String?) -> Self {
+        setting(\.provider, to: provider)
+    }
+
+    public func withProfile(_ profile: String?) -> Self {
+        setting(\.profile, to: profile)
+    }
+
+    /// Limits resolution to a named manifest scope.
+    public func withScope(_ scope: String?) -> Self {
+        setting(\.scope, to: scope)
+    }
+
+    public func withReason(_ reason: String?) -> Self {
+        setting(\.reason, to: reason)
+    }
+
+    public func withNoValues(_ noValues: Bool = true) -> Self {
+        setting(\.noValues, to: noValues)
+    }
+
+    /// Resolves the configured secrets.
+    ///
+    /// - Throws: ``MissingRequiredError`` when required secrets are absent, or
+    ///   ``SecretSpecError`` for any other failure.
+    public func load() throws -> Resolved {
+        let response: ResolveResponse = try call(mode: nil)
+        try ensureSchemaVersion(
+            actual: response.schemaVersion,
+            expected: resolveSchemaVersion,
+            kind: "resolve"
+        )
+        if !response.missingRequired.isEmpty {
+            throw MissingRequiredError(missing: response.missingRequired)
+        }
+
+        return Resolved(
+            provider: response.provider,
+            profile: response.profile,
+            scope: response.scope,
+            secrets: response.secrets,
+            missingOptional: response.missingOptional
+        )
+    }
+
+    /// Builds a value-free inventory report.
+    ///
+    /// Missing required secrets appear in the report rather than throwing.
+    public func report() throws -> ResolutionReport {
+        let response: ReportResponse = try call(mode: "report")
+        try ensureSchemaVersion(
+            actual: response.schemaVersion,
+            expected: reportSchemaVersion,
+            kind: "report"
+        )
+        return ResolutionReport(
+            provider: response.provider,
+            profile: response.profile,
+            scope: response.scope,
+            secrets: response.secrets
+        )
+    }
+
+    private func setting<Value>(
+        _ keyPath: WritableKeyPath<ResolveRequest, Value>,
+        to value: Value
+    ) -> Self {
+        var copy = self
+        copy.request[keyPath: keyPath] = value
+        return copy
+    }
+
+    private func call<Response: Decodable>(mode: String?) throws -> Response {
+        var configured = request
+        configured.mode = mode
+
+        let requestData: Data
+        do {
+            requestData = try JSONEncoder().encode(configured)
+        } catch {
+            throw SecretSpecError(kind: "encode", message: error.localizedDescription)
+        }
+        guard let requestJSON = String(data: requestData, encoding: .utf8) else {
+            throw SecretSpecError(
+                kind: "encode",
+                message: "could not encode the request as UTF-8"
+            )
+        }
+
+        let responseJSON = try Native.resolve(requestJSON)
+        let envelope: Envelope<Response>
+        do {
+            envelope = try JSONDecoder().decode(
+                Envelope<Response>.self,
+                from: Data(responseJSON.utf8)
+            )
+        } catch {
+            throw SecretSpecError(kind: "parse", message: error.localizedDescription)
+        }
+
+        guard envelope.ok else {
+            throw SecretSpecError(
+                kind: envelope.error?.kind ?? "unknown",
+                message: envelope.error?.message
+                    ?? "native resolver returned an unspecified error"
+            )
+        }
+        guard let response = envelope.response else {
+            throw SecretSpecError(
+                kind: "ffi",
+                message: "secretspec_resolve reported ok with no response"
+            )
+        }
+        return response
+    }
+
+    private func ensureSchemaVersion(
+        actual: Int,
+        expected: Int,
+        kind: String
+    ) throws {
+        guard actual == expected else {
+            throw SecretSpecError(
+                kind: "version",
+                message: "unsupported \(kind) schema version \(actual) "
+                    + "(expected \(expected)); the secretspec-ffi library "
+                    + "and this SDK are out of sync"
+            )
+        }
+    }
+}
+
+/// Entry point for the SecretSpec Swift SDK.
+public enum SecretSpec {
+    public static func builder() -> SecretSpecBuilder {
+        SecretSpecBuilder()
+    }
+
+    /// Resolves secrets in one call.
+    public static func resolve(
+        path: String? = nil,
+        provider: String? = nil,
+        profile: String? = nil,
+        scope: String? = nil,
+        reason: String? = nil
+    ) throws -> Resolved {
+        try configured(
+            path: path,
+            provider: provider,
+            profile: profile,
+            scope: scope,
+            reason: reason
+        ).load()
+    }
+
+    /// Builds a value-free inventory report in one call.
+    public static func report(
+        path: String? = nil,
+        provider: String? = nil,
+        profile: String? = nil,
+        scope: String? = nil,
+        reason: String? = nil
+    ) throws -> ResolutionReport {
+        try configured(
+            path: path,
+            provider: provider,
+            profile: profile,
+            scope: scope,
+            reason: reason
+        ).report()
+    }
+
+    /// The ABI version reported by the bundled native resolver.
+    public static func abiVersion() throws -> String {
+        try Native.abiVersion()
+    }
+
+    private static func configured(
+        path: String?,
+        provider: String?,
+        profile: String?,
+        scope: String?,
+        reason: String?
+    ) -> SecretSpecBuilder {
+        builder()
+            .withPath(path)
+            .withProvider(provider)
+            .withProfile(profile)
+            .withScope(scope)
+            .withReason(reason)
+    }
+}

--- a/secretspec-swift/Tests/SecretSpecTests/SecretSpecTests.swift
+++ b/secretspec-swift/Tests/SecretSpecTests/SecretSpecTests.swift
@@ -1,0 +1,342 @@
+import Foundation
+import XCTest
+
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+@testable import SecretSpec
+
+final class SecretSpecTests: XCTestCase {
+    private static let manifest = """
+    [project]
+    name = "swift-test"
+    revision = "1.0"
+
+    [profiles.default]
+    DATABASE_URL = { description = "DB", required = true }
+    DEV_SESSION_SECRET = { description = "Development-only session secret", required = false, default = "development-only-secret" }
+    SENTRY_DSN = { description = "sentry", required = false }
+
+    [scopes.database]
+    secrets = ["DATABASE_URL"]
+    """
+
+    func testABIVersion() throws {
+        XCTAssertFalse(try SecretSpec.abiVersion().isEmpty)
+    }
+
+    func testLoadValuesAndProvenance() throws {
+        let project = try Project(
+            manifest: Self.manifest,
+            dotenv: "DATABASE_URL=postgres://db\n"
+        )
+        let resolved = try project.builder().load()
+        defer { try? resolved.close() }
+
+        XCTAssertEqual(resolved.profile, "default")
+        XCTAssertEqual(resolved.secrets["DATABASE_URL"]?.get(), "postgres://db")
+        XCTAssertEqual(resolved.secrets["DATABASE_URL"]?.source, "provider")
+        XCTAssertNotNil(resolved.secrets["DATABASE_URL"]?.sourceProvider)
+        XCTAssertEqual(
+            resolved.secrets["DEV_SESSION_SECRET"]?.get(),
+            "development-only-secret"
+        )
+        XCTAssertEqual(resolved.secrets["DEV_SESSION_SECRET"]?.source, "default")
+        XCTAssertEqual(resolved.missingOptional, ["SENTRY_DSN"])
+        XCTAssertNil(resolved.secrets["SENTRY_DSN"])
+
+        let fields = try JSONSerialization.jsonObject(with: resolved.fieldsJSON())
+        let object = try XCTUnwrap(fields as? [String: Any])
+        XCTAssertEqual(object["DATABASE_URL"] as? String, "postgres://db")
+    }
+
+    func testScopedResolveAndReport() throws {
+        let project = try Project(
+            manifest: Self.manifest,
+            dotenv: "DATABASE_URL=postgres://db\nSENTRY_DSN=https://sentry\n"
+        )
+        let builder = project.builder().withScope("database")
+
+        let resolved = try builder.load()
+        defer { try? resolved.close() }
+        XCTAssertEqual(resolved.scope, "database")
+        XCTAssertEqual(Set(resolved.secrets.keys), ["DATABASE_URL"])
+
+        let report = try builder.report()
+        XCTAssertEqual(report.scope, "database")
+        XCTAssertEqual(report.secrets.map(\.name), ["DATABASE_URL"])
+    }
+
+    func testMissingRequiredError() throws {
+        let project = try Project(manifest: Self.manifest, dotenv: "")
+        XCTAssertThrowsError(try project.builder().load()) { error in
+            guard let missing = error as? MissingRequiredError else {
+                return XCTFail("expected MissingRequiredError, got \(error)")
+            }
+            XCTAssertEqual(missing.missing, ["DATABASE_URL"])
+            XCTAssertEqual(missing.kind, "missing_required")
+        }
+    }
+
+    func testInvalidManifestError() {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("secretspec.toml")
+            .path
+
+        XCTAssertThrowsError(
+            try SecretSpec.builder().withPath(path).withReason("Swift test").load()
+        ) { error in
+            guard let failure = error as? SecretSpecError else {
+                return XCTFail("expected SecretSpecError, got \(error)")
+            }
+            XCTAssertFalse(failure.kind.isEmpty)
+        }
+    }
+
+    func testAsPathCleanup() throws {
+        let manifest = """
+        [project]
+        name = "swift-test"
+        revision = "1.0"
+
+        [profiles.default]
+        TLS_CERT = { description = "cert", required = true, as_path = true }
+        """
+        let project = try Project(manifest: manifest, dotenv: "TLS_CERT=----cert----\n")
+        let resolved = try project.builder().load()
+        let certificate = try XCTUnwrap(resolved.secrets["TLS_CERT"])
+        XCTAssertTrue(certificate.asPath)
+        XCTAssertNil(certificate.value)
+        let path = try XCTUnwrap(certificate.get())
+        XCTAssertEqual(try String(contentsOfFile: path), "----cert----")
+
+        try resolved.close()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path))
+    }
+
+    func testValueFreeReport() throws {
+        let project = try Project(manifest: Self.manifest, dotenv: "")
+        let report = try project.builder().report()
+
+        XCTAssertEqual(report.profile, "default")
+        let database = try XCTUnwrap(
+            report.secrets.first { $0.name == "DATABASE_URL" }
+        )
+        XCTAssertEqual(database.status, "missing_required")
+        XCTAssertTrue(database.required)
+        let session = try XCTUnwrap(
+            report.secrets.first { $0.name == "DEV_SESSION_SECRET" }
+        )
+        XCTAssertTrue(session.defaultApplied)
+    }
+
+    func testEnvironmentExport() throws {
+        let project = try Project(
+            manifest: Self.manifest,
+            dotenv: "DATABASE_URL=postgres://environment\n"
+        )
+        let previous = getenv("DATABASE_URL").map { String(cString: $0) }
+        defer {
+            if let previous {
+                setenv("DATABASE_URL", previous, 1)
+            } else {
+                unsetenv("DATABASE_URL")
+            }
+        }
+
+        let resolved = try project.builder().load()
+        defer { try? resolved.close() }
+        try resolved.setAsEnvironment()
+        XCTAssertEqual(
+            getenv("DATABASE_URL").map { String(cString: $0) },
+            "postgres://environment"
+        )
+    }
+
+    func testOneShotAPI() throws {
+        let project = try Project(
+            manifest: Self.manifest,
+            dotenv: "DATABASE_URL=postgres://one-shot\n"
+        )
+        let resolved = try SecretSpec.resolve(
+            path: project.manifestPath,
+            provider: project.provider,
+            reason: "Swift test"
+        )
+        defer { try? resolved.close() }
+        XCTAssertEqual(resolved.secrets["DATABASE_URL"]?.get(), "postgres://one-shot")
+
+        let report = try SecretSpec.report(
+            path: project.manifestPath,
+            provider: project.provider,
+            reason: "Swift test"
+        )
+        XCTAssertEqual(
+            report.secrets.first { $0.name == "DATABASE_URL" }?.status,
+            "resolved"
+        )
+    }
+
+    func testCrossLanguageConformance() throws {
+        let root = try repositoryRoot()
+        let fixtures = root.appendingPathComponent("conformance/fixtures")
+        let fixtureDirectories = try FileManager.default
+            .contentsOfDirectory(
+                at: fixtures,
+                includingPropertiesForKeys: [.isDirectoryKey]
+            )
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        for fixture in fixtureDirectories {
+            let manifest = fixture.appendingPathComponent("secretspec.toml").path
+            let provider = "dotenv://\(fixture.appendingPathComponent(".env").path)"
+            let builder = SecretSpec.builder()
+                .withPath(manifest)
+                .withProvider(provider)
+                .withReason("conformance")
+
+            let resolved = try builder.load()
+            try assertJSONEqual(
+                expectedAt: fixture.appendingPathComponent("expected.json"),
+                actual: try canonicalResolved(resolved)
+            )
+            try resolved.close()
+
+            let noValues = try builder.withNoValues().load()
+            try assertJSONEqual(
+                expectedAt: fixture.appendingPathComponent("expected_no_values.json"),
+                actualData: try noValues.fieldsJSON()
+            )
+            try noValues.close()
+
+            let report = try builder.report()
+            try assertJSONEqual(
+                expectedAt: fixture.appendingPathComponent("expected_report.json"),
+                actual: canonicalReport(report)
+            )
+        }
+    }
+
+    private func canonicalResolved(_ resolved: Resolved) throws -> [String: Any] {
+        var secrets: [String: Any] = [:]
+        for (name, secret) in resolved.secrets {
+            let value: String?
+            if secret.asPath {
+                value = try secret.get().map { try String(contentsOfFile: $0) }
+            } else {
+                value = secret.value
+            }
+            let canonicalValue: Any = value.map { $0 as Any } ?? NSNull()
+            let canonicalSecret: [String: Any] = [
+                "value": canonicalValue,
+                "source": secret.source,
+                "as_path": secret.asPath,
+            ]
+            secrets[name] = canonicalSecret
+        }
+        return [
+            "profile": resolved.profile,
+            "secrets": secrets,
+            "missing_required": [String](),
+            "missing_optional": resolved.missingOptional,
+        ]
+    }
+
+    private func canonicalReport(_ report: ResolutionReport) -> [String: Any] {
+        var secrets: [String: Any] = [:]
+        for secret in report.secrets {
+            let canonicalSecret: [String: Any] = [
+                "status": secret.status,
+                "required": secret.required,
+                "as_path": secret.asPath,
+                "generated": secret.generated,
+                "default_applied": secret.defaultApplied,
+                "source_provider": secret.sourceProvider != nil,
+            ]
+            secrets[secret.name] = canonicalSecret
+        }
+        return [
+            "profile": report.profile,
+            "secrets": secrets,
+        ]
+    }
+
+    private func repositoryRoot() throws -> URL {
+        var candidate = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        while candidate.path != "/" {
+            if FileManager.default.fileExists(
+                atPath: candidate.appendingPathComponent("Cargo.toml").path
+            ), FileManager.default.fileExists(
+                atPath: candidate.appendingPathComponent("conformance").path
+            ) {
+                return candidate
+            }
+            candidate.deleteLastPathComponent()
+        }
+        throw SecretSpecError(
+            kind: "test",
+            message: "could not find the SecretSpec repository root"
+        )
+    }
+
+    private func assertJSONEqual(
+        expectedAt url: URL,
+        actual: [String: Any]
+    ) throws {
+        let actualData = try JSONSerialization.data(
+            withJSONObject: actual,
+            options: [.sortedKeys]
+        )
+        try assertJSONEqual(expectedAt: url, actualData: actualData)
+    }
+
+    private func assertJSONEqual(
+        expectedAt url: URL,
+        actualData: Data
+    ) throws {
+        let expected = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        let actual = try JSONSerialization.jsonObject(with: actualData)
+        let expectedObject = try XCTUnwrap(expected as? NSObject)
+        XCTAssertTrue(
+            expectedObject.isEqual(actual),
+            "JSON mismatch for \(url.deletingLastPathComponent().lastPathComponent)"
+        )
+    }
+}
+
+private final class Project {
+    let root: URL
+    let manifestPath: String
+    let provider: String
+
+    init(manifest: String, dotenv: String) throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("secretspec-swift-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        let manifestURL = root.appendingPathComponent("secretspec.toml")
+        let dotenvURL = root.appendingPathComponent(".env")
+        try Data(manifest.utf8).write(to: manifestURL)
+        try Data(dotenv.utf8).write(to: dotenvURL)
+        manifestPath = manifestURL.path
+        provider = "dotenv://\(dotenvURL.path)"
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func builder() -> SecretSpecBuilder {
+        SecretSpec.builder()
+            .withPath(manifestPath)
+            .withProvider(provider)
+            .withReason("Swift test")
+    }
+}

--- a/secretspec-swift/Tests/SecretSpecTests/SecretSpecTests.swift
+++ b/secretspec-swift/Tests/SecretSpecTests/SecretSpecTests.swift
@@ -191,6 +191,10 @@ final class SecretSpecTests: XCTestCase {
             )
             .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        XCTAssertFalse(
+            fixtureDirectories.isEmpty,
+            "no cross-language conformance fixtures were discovered"
+        )
 
         for fixture in fixtureDirectories {
             let manifest = fixture.appendingPathComponent("secretspec.toml").path

--- a/secretspec-swift/ffi/module.modulemap
+++ b/secretspec-swift/ffi/module.modulemap
@@ -1,0 +1,4 @@
+module CSecretSpec {
+  header "secretspec.h"
+  export *
+}

--- a/secretspec-swift/ffi/secretspec.h
+++ b/secretspec-swift/ffi/secretspec.h
@@ -1,0 +1,8 @@
+/*
+ * Development-only forwarding header for the checked-in module map.
+ *
+ * The release XCFramework places the canonical secretspec-ffi header beside
+ * that module map; keep a relative include here so local Clang/Swift tooling
+ * can validate the same module without duplicating the ABI declaration.
+ */
+#include "../../secretspec-ffi/include/secretspec.h"

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -225,6 +225,7 @@ works identically with no per-language resolution logic:
 - [Haskell](https://secretspec.dev/sdk/haskell) (build-time FFI link)
 - [PHP](https://secretspec.dev/sdk/php) (ext-php-rs extension, with an `ext-ffi` fallback)
 - [C# (0.16+)](https://secretspec.dev/sdk/csharp) (P/Invoke with native assets in the NuGet package)
+- [Swift (0.18+)](https://secretspec.dev/sdk/swift) (SwiftPM XCFramework for macOS Intel and Apple silicon)
 
 ```python
 from secretspec import SecretSpec


### PR DESCRIPTION
## Summary

- add a SwiftPM `SecretSpec` package with an idiomatic `Codable` wrapper over the existing versioned JSON/C ABI
- package the Rust resolver as a checksummed macOS XCFramework for Intel and Apple silicon
- add Swift unit and cross-language conformance tests, SDK CI, and a release workflow
- document installation, API usage, platform support, architecture, and the 0.18+ release process

## Why

SecretSpec already exposes a narrow, ownership-audited three-function C ABI shared by several SDKs. Importing that ABI through a Clang module keeps all resolution logic in Rust and avoids introducing a second generated ABI or schema. SwiftPM can then distribute the native resolver using its standard XCFramework binary-target mechanism.

## Impact

Starting with SecretSpec 0.18, macOS 12+ applications can resolve SecretSpec manifests directly from Swift without installing Rust or a separate native library. The API supports fluent and one-shot resolution, scopes, typed errors, reports, provenance, environment export, codegen input, and deterministic cleanup for `as_path` secrets.

## Validation

- `cargo test -p secretspec-ffi` — 11 C ABI tests pass
- Swift SDK sources and tests typecheck with warnings treated as errors
- `Package.swift` typechecks against the SwiftPM manifest API
- documentation build completes with zero errors
- `cargo fmt --all -- --check`
- `actionlint` on the changed workflows
- `bash -n` on the changed shell scripts
- `git diff --check`

The final XCFramework link/runtime test is macOS-specific and is exercised by the new macOS CI jobs.
