### PR TITLE
fix(cache): detect Vault-compatible store aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   libdbus.
 
 ### Fixed
+- Cached provider routes now recognize Vault and OpenBao configurations that
+  address the same endpoint, namespace, and mount as one store, even when they
+  use different provider names or authentication methods, so a cache cannot
+  target its own authoritative source.
 - Provider and SDK errors now retain underlying causes such as authentication,
   timeout, DNS, TLS, connection, and response-parsing failures. AWS Secrets
   Manager and Parameter Store errors also report AWS error codes and messages

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -516,17 +516,24 @@ impl Secrets {
 
         let source_identities = source_uris
             .iter()
+            .map(|uri| self.canonical_storage_identity(uri))
+            .collect::<Result<Vec<_>>>()?;
+        let source_route_uris = source_uris
+            .iter()
             .map(|uri| self.canonical_provider_uri(uri))
             .collect::<Result<Vec<_>>>()?;
-        let cache_identity = self.canonical_provider_uri(&cache_uri)?;
+        let cache_identity = self.canonical_storage_identity(&cache_uri)?;
 
         // The cache entry lives at the same logical address the authoritative
         // read asks for, so a cache pointed at one of its own sources would
         // overwrite the secret with the cache envelope the first time it
         // refreshed, and then serve that envelope back as the value. Compare
-        // provider-reconstructed URIs after applying the project base directory:
+        // provider-reconstructed storage identities after applying the project
+        // base directory:
         // raw specs such as `dotenv:.env` and `dotenv://.env` are different
-        // strings but identify the same store.
+        // strings but identify the same store. Public provider attribution is
+        // deliberately not used: two auth methods, or Vault and OpenBao, can
+        // address the same physical store through different public URIs.
         if let Some(shared) = source_identities
             .iter()
             .position(|identity| *identity == cache_identity)
@@ -564,20 +571,31 @@ impl Secrets {
                 spec: cache.provider().to_string(),
                 uri: cache_uri,
                 max_age_secs: cache.max_age_secs(),
-                route_fingerprint: stable_fingerprint(source_identities.iter().map(String::as_str)),
+                route_fingerprint: stable_fingerprint(source_route_uris.iter().map(String::as_str)),
             }),
         })
     }
 
-    /// Reconstruct a provider's public URI without resolving its credentials or
-    /// touching the store. Provider implementations normalize shorthand,
-    /// defaults, percent encoding, and relative filesystem paths in this URI,
-    /// making it suitable for cache/source identity comparisons.
+    /// Reconstruct a provider's public canonical URI without resolving its
+    /// credentials or touching the store. Unlike its storage identity, this URI
+    /// retains configuration that can change what the authoritative route
+    /// answers and must therefore invalidate cached values.
     fn canonical_provider_uri(&self, uri: &str) -> Result<String> {
         let mut provider =
             crate::provider::provider_from_spec(uri, crate::provider::ProviderCredentials::new())?;
         provider.with_base_dir(&self.config_dir);
         Ok(provider.uri())
+    }
+
+    /// Reconstruct a provider's physical storage identity without resolving its
+    /// credentials or touching the store. Provider implementations normalize
+    /// shorthand, defaults, percent encoding, relative filesystem paths, and
+    /// compatible public provider spellings in this identity.
+    fn canonical_storage_identity(&self, uri: &str) -> Result<String> {
+        let mut provider =
+            crate::provider::provider_from_spec(uri, crate::provider::ProviderCredentials::new())?;
+        provider.with_base_dir(&self.config_dir);
+        Ok(provider.storage_identity())
     }
 
     /// The URI to report for an explicit provider override.
@@ -1025,6 +1043,107 @@ mod tests {
         let message = spec.build_plan(None).unwrap_err().to_string();
         assert!(message.contains("distinct store"), "{message}");
         assert!(message.contains("dotenv:.env"), "{message}");
+    }
+
+    #[test]
+    fn vault_compatible_spelling_and_auth_cannot_bypass_cache_separation() {
+        let _env = scrub_resolution_env();
+        for (source, cache) in [
+            (
+                "vault://127.0.0.1:8200/secret?tls=false",
+                "openbao://127.0.0.1:8200/secret?tls=false",
+            ),
+            (
+                "vault://127.0.0.1:8200/secret?tls=false&auth=token",
+                "vault://127.0.0.1:8200/secret?tls=false&auth=approle",
+            ),
+            (
+                "openbao://127.0.0.1:8200/secret?tls=false&auth=jwt&role=read&audience=one",
+                "openbao://127.0.0.1:8200/secret?tls=false&auth=jwt&role=deploy&audience=two",
+            ),
+            (
+                "vault://127.0.0.1:8200/secret?tls=false&kv=1",
+                "openbao://127.0.0.1:8200/secret?tls=false&kv=2",
+            ),
+        ] {
+            let spec = cached_spec_with(
+                vec!["route"],
+                &[("route", cached_alias(&[source], cache, "8h"))],
+            );
+
+            let message = spec.build_plan(None).unwrap_err().to_string();
+            assert!(
+                message.contains("distinct store"),
+                "{source} / {cache}: {message}"
+            );
+            assert!(message.contains(source), "{source} / {cache}: {message}");
+        }
+    }
+
+    #[test]
+    fn compatible_providers_may_cache_into_a_different_location() {
+        let _env = scrub_resolution_env();
+        for (source, cache) in [
+            (
+                "vault://team-a@bao.example.com:8200/secret",
+                "openbao://team-b@bao.example.com:8200/secret",
+            ),
+            (
+                "vault://team-a@bao.example.com:8200/secret",
+                "openbao://team-a@bao.example.com:8200/cache",
+            ),
+            (
+                "vault://team-a@bao.example.com:8200/secret",
+                "openbao://team-a@other.example.com:8200/secret",
+            ),
+        ] {
+            let spec = cached_spec_with(
+                vec!["route"],
+                &[("route", cached_alias(&[source], cache, "8h"))],
+            );
+
+            assert!(
+                spec.build_plan(None).is_ok(),
+                "{source} and {cache} are different stores"
+            );
+        }
+    }
+
+    #[test]
+    fn vault_compatible_route_configuration_changes_invalidate_the_cache() {
+        let _env = scrub_resolution_env();
+        let fingerprint = |source| {
+            let spec = cached_spec_with(
+                vec!["route"],
+                &[("route", cached_alias(&[source], "keyring://", "8h"))],
+            );
+            let plan = plan(&spec);
+            route(find(&plan, "API_KEY"))
+                .cache()
+                .expect("cached route")
+                .route_fingerprint
+                .clone()
+        };
+
+        let baseline = fingerprint("vault://bao.example.com:8200/secret");
+        for changed in [
+            "openbao://bao.example.com:8200/secret",
+            "vault://bao.example.com:8200/secret?auth=approle",
+            "vault://bao.example.com:8200/secret?auth=jwt&role=ci&audience=deploy",
+            "vault://bao.example.com:8200/secret?kv=1",
+        ] {
+            assert_ne!(
+                baseline,
+                fingerprint(changed),
+                "route configuration change must invalidate the cache: {changed}"
+            );
+        }
+
+        assert_ne!(
+            fingerprint("vault://bao.example.com:8200/secret?auth=jwt&role=read"),
+            fingerprint("vault://bao.example.com:8200/secret?auth=jwt&role=deploy"),
+            "changing the JWT role must invalidate the cache"
+        );
     }
 
     #[test]

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -768,6 +768,24 @@ pub trait Provider: Send + Sync {
     /// `provider::tests`.
     fn uri(&self) -> String;
 
+    /// Returns a credential-free identity for the physical store this provider
+    /// addresses.
+    ///
+    /// Unlike [`Self::uri`], this value is not user-facing attribution. It is
+    /// used when SecretSpec must decide whether two differently configured
+    /// providers can read and write the same storage location, such as when
+    /// ensuring a cache is distinct from its authoritative sources. Authentication
+    /// choices that do not change the store must therefore not change this
+    /// identity, and protocol-compatible provider names should return the same
+    /// identity when they target the same store.
+    ///
+    /// Most providers have one public spelling for a store, so the default uses
+    /// their canonical URI. Providers with equivalent spellings or compatible
+    /// identities should override this method.
+    fn storage_identity(&self) -> String {
+        self.uri()
+    }
+
     /// Records a human-readable reason for the secrets access happening in this
     /// session (e.g. "secretspec run: deploy"), set via [`Secrets::with_reason`].
     ///
@@ -982,6 +1000,9 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn uri(&self) -> String {
         (**self).uri()
     }
+    fn storage_identity(&self) -> String {
+        (**self).storage_identity()
+    }
     fn set_reason(&self, reason: Option<String>) {
         (**self).set_reason(reason);
     }
@@ -1159,6 +1180,10 @@ impl Provider for PreflightGuard {
 
     fn uri(&self) -> String {
         self.inner.uri()
+    }
+
+    fn storage_identity(&self) -> String {
+        self.inner.storage_identity()
     }
 
     fn set_reason(&self, reason: Option<String>) {

--- a/secretspec/src/provider/openbao.rs
+++ b/secretspec/src/provider/openbao.rs
@@ -133,6 +133,10 @@ impl Provider for OpenBaoProvider {
         self.core.uri()
     }
 
+    fn storage_identity(&self) -> String {
+        self.core.storage_identity()
+    }
+
     fn supported_coords(&self) -> &'static [&'static str] {
         &["field"]
     }

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -121,6 +121,10 @@ impl Provider for VaultProvider {
         self.core.uri()
     }
 
+    fn storage_identity(&self) -> String {
+        self.core.storage_identity()
+    }
+
     fn supported_coords(&self) -> &'static [&'static str] {
         &["field"]
     }

--- a/secretspec/src/provider/vault_common.rs
+++ b/secretspec/src/provider/vault_common.rs
@@ -408,20 +408,16 @@ impl KvProvider {
         })
     }
 
-    /// Returns the credential-free provider URI used in audit records and
-    /// fallback diagnostics.
-    ///
-    /// The URI is canonical rather than source-preserving: implicit defaults
-    /// stay implicit, while every setting that changes the effective store or
-    /// authentication context is retained.
-    pub(crate) fn uri(&self) -> String {
+    /// Builds the shared authority, namespace, and mount portion of a canonical
+    /// provider or storage-identity URL.
+    fn base_uri(&self, scheme: &str) -> Url {
         let authority = self
             .config
             .endpoint
             .strip_prefix("https://")
             .or_else(|| self.config.endpoint.strip_prefix("http://"))
             .expect("KvConfig endpoints are normalized HTTP origins");
-        let mut uri = Url::parse(&format!("{}://{authority}", self.product.scheme()))
+        let mut uri = Url::parse(&format!("{scheme}://{authority}"))
             .expect("a normalized endpoint forms a provider URI");
 
         if let Some(namespace) = &self.config.namespace {
@@ -429,6 +425,18 @@ impl KvProvider {
                 .expect("a provider URI supports namespace userinfo");
         }
         uri.set_path(&format!("/{}", self.config.mount));
+
+        uri
+    }
+
+    /// Returns the credential-free provider URI used in audit records and
+    /// fallback diagnostics.
+    ///
+    /// The URI is canonical rather than source-preserving: implicit defaults
+    /// stay implicit, while every setting that changes the effective store or
+    /// authentication context is retained.
+    pub(crate) fn uri(&self) -> String {
+        let mut uri = self.base_uri(self.product.scheme());
 
         if self.config.endpoint.starts_with("http://") {
             uri.query_pairs_mut().append_pair("tls", "false");
@@ -452,6 +460,20 @@ impl KvProvider {
             }
         }
 
+        uri.into()
+    }
+
+    /// Canonical identity of the Vault-compatible KV mount behind this provider.
+    ///
+    /// Vault and OpenBao are separate public providers, but their compatible KV
+    /// clients can address the same endpoint, namespace, and mount. Authentication
+    /// method, role, audience, and KV interpretation do not create a distinct
+    /// physical store, so none of them may let a cache disguise its own source.
+    pub(crate) fn storage_identity(&self) -> String {
+        let mut uri = self.base_uri("vault-compatible");
+        if self.config.endpoint.starts_with("http://") {
+            uri.query_pairs_mut().append_pair("tls", "false");
+        }
         uri.into()
     }
 
@@ -1357,6 +1379,62 @@ mod tests {
             KvProvider::new(approle, Product::OpenBao).uri(),
             "openbao://team-a@bao.example.com:8200/secret?auth=approle"
         );
+    }
+
+    #[test]
+    fn storage_identity_unifies_compatible_products_and_authentication() {
+        let vault = KvConfig::parse(
+            &provider_url("vault://team-a@bao.example.com:8200/secret?tls=false&kv=1&auth=approle"),
+            Product::Vault,
+        )
+        .unwrap();
+        let openbao = KvConfig::parse(
+            &provider_url(
+                "openbao://team-a@bao.example.com:8200/secret?tls=false&auth=jwt&role=ci&audience=deploy",
+            ),
+            Product::OpenBao,
+        )
+        .unwrap();
+
+        let expected = "vault-compatible://team-a@bao.example.com:8200/secret?tls=false";
+        assert_eq!(
+            KvProvider::new(vault, Product::Vault).storage_identity(),
+            expected
+        );
+        assert_eq!(
+            KvProvider::new(openbao, Product::OpenBao).storage_identity(),
+            expected
+        );
+    }
+
+    #[test]
+    fn storage_identity_retains_the_physical_location() {
+        let identity = |spec, product| {
+            let config = KvConfig::parse(&provider_url(spec), product).unwrap();
+            KvProvider::new(config, product).storage_identity()
+        };
+        let base = identity("vault://team-a@bao.example.com:8200/secret", Product::Vault);
+
+        for different in [
+            identity(
+                "openbao://team-b@bao.example.com:8200/secret",
+                Product::OpenBao,
+            ),
+            identity(
+                "openbao://team-a@bao.example.com:8200/cache",
+                Product::OpenBao,
+            ),
+            identity(
+                "openbao://team-a@other.example.com:8200/secret",
+                Product::OpenBao,
+            ),
+            identity(
+                "openbao://team-a@bao.example.com:8200/secret?tls=false",
+                Product::OpenBao,
+            ),
+        ] {
+            assert_ne!(base, different);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a credential-free storage identity for provider safety comparisons.
- Treat Vault and OpenBao configurations targeting the same endpoint, namespace, and mount as the same physical store.
- Prevent cached routes from overwriting their authoritative source through different schemes or authentication settings.
- Keep route fingerprints configuration-sensitive so provider and authentication changes invalidate cached values.

## Rationale

Using Vault and OpenBao together can be valid during migrations or when they target different stores. The unsafe case is specifically when a cache and its authoritative source resolve to the same physical store, even when represented by different provider schemes, aliases, or authentication methods. Comparing storage identity addresses that case without prohibiting valid mixed-provider routes.

## Testing

- cargo test --package secretspec
- cargo test --all
- Vault-only and OpenBao-only feature builds
- devenv shell -- pre-commit run -a
- git diff --check