### PR TITLE
Allow writing AWS Parameter Store refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   libdbus.
 
 ### Fixed
+- AWS Parameter Store writes now reject unsupported reference coordinates and
+  ARN-pinned references before requesting a value. Versioned ARNs now point
+  users to writable parameter-name references instead of suggesting that only
+  the version selector be removed.
 - Cached provider routes now recognize Vault and OpenBao configurations that
   address the same endpoint, namespace, and mount as one store, even when they
   use different provider names or authentication methods, so a cache cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   feature; planned for 0.18) for reading and writing KMS-encrypted
   `SecureString` parameters. It supports AWS profiles and regions, an optional
   hierarchy prefix, customer-managed KMS keys, parameter tiers, batched reads,
-  and read-only references pinned to a parameter version or label.
+  and references by parameter name, version, label, or ARN. Unversioned
+  parameter-name references can be written in place; version-, label-, and
+  ARN-pinned references are read-only.
   ([#209](https://github.com/cachix/secretspec/issues/209))
 
 ### Fixed

--- a/docs/src/content/docs/development/adding-providers.md
+++ b/docs/src/content/docs/development/adding-providers.md
@@ -27,9 +27,10 @@ pub trait Provider: Send + Sync {
     /// honor beyond `item`; every other coordinate is rejected for you.
     fn supported_coords(&self) -> &'static [&'static str] { &[] }
 
-    /// Optional, defaults to writable. Read-only providers reject every
-    /// address; providers whose refs name externally managed secrets reject
-    /// native addresses only. State the reason: it is what the user sees.
+    /// Optional, defaults to writable. Reject only the addresses the provider
+    /// cannot safely write: for example every address on a read-only provider,
+    /// or version-pinned and ARN refs on an otherwise writable provider. State
+    /// the reason: it is what the user sees.
     fn check_writable(&self, addr: Address<'_>) -> Result<()> { Ok(()) }
 
     /// Optional batch read. The default resolves each request's address and

--- a/docs/src/content/docs/providers/awsps.md
+++ b/docs/src/content/docs/providers/awsps.md
@@ -18,7 +18,7 @@ parameters.
 | --- | --- |
 | Provider | `awsps` (0.18+) |
 | URI | `awsps://[AWS_PROFILE@]REGION[?options]` |
-| Access | Read and write; parameter references are read-only |
+| Access | Read and write; version-, label-, and ARN-pinned references are read-only |
 | Best for | AWS workloads using Parameter Store for application configuration |
 | Authentication | Standard AWS SDK credential chain |
 | Build feature | `awsps` (0.18+) |
@@ -145,7 +145,8 @@ In SecretSpec 0.18+, a secret's
 [`ref`](/reference/configuration/#secret-references) field can name an existing
 Parameter Store parameter. `item` is its full name or ARN. The optional
 `version` is appended as a Parameter Store selector and may be a numeric
-version or label. References are **read-only**.
+version or label. An unversioned reference by parameter name is writable;
+references using a version, label, or ARN are read-only.
 
 ```toml
 [profiles.production]
@@ -157,17 +158,26 @@ SIGNING_KEY = { description = "Signing key", ref = { item = "/prod/signing-key",
 
 # Version carrying the "current" label
 API_TOKEN = { description = "API token", ref = { item = "/prod/api-token", version = "current" }, providers = ["awsps://us-east-1"] }
+
+# Generate at an existing hierarchy on first use, then reuse it
+DB_PASSWORD = { description = "DB password", ref = { item = "/prod/db-password" }, type = "password", generate = true, providers = ["awsps://us-east-1"] }
 ```
 
-Cross-account shared parameters must be read by ARN. SecretSpec still writes
-only to its convention hierarchy in the provider's configured account and
-region.
+`secretspec set`, interactive `check`, generation, and `import` write an
+unversioned name reference at that exact parameter name. As with convention
+writes, an existing value receives a new Parameter Store version and is never
+changed from `String` or `StringList` to `SecureString`.
+
+Cross-account shared parameters must be read by ARN. ARN references are
+read-only; SecretSpec writes only by parameter name in the provider's
+configured account and region.
 
 ## IAM permissions
 
-Reads require `ssm:GetParameter` and `ssm:GetParameters`; convention writes
-require `ssm:PutParameter`. A customer-managed KMS key also needs the
-corresponding KMS permissions for encryption and decryption.
+Reads require `ssm:GetParameter` and `ssm:GetParameters`; convention and
+unversioned name-reference writes require `ssm:PutParameter`. A
+customer-managed KMS key also needs the corresponding KMS permissions for
+encryption and decryption.
 
 Scope IAM resources to the configured hierarchy where possible. For the
 `/myteam/secretspec/` prefix in `us-east-1`, that resource pattern is:

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -628,7 +628,7 @@ chain, and each provider is asked for the same coordinates.
 | [Vault](/providers/vault/#use-existing-secrets) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
 | [OpenBao](/providers/openbao/#use-existing-secrets) (0.17+) | KV path relative to the mount | Required (KV entries are maps) | Error | — (read-only) |
 | [AWS Secrets Manager](/providers/awssm/#use-existing-secrets) | Secret name or ARN | JSON key | Whole secret string | — (read-only) |
-| [AWS Parameter Store (0.18+)](/providers/awsps/#use-existing-parameters) | Parameter name or ARN; `version` selects a version or label | Rejected | Reads the decrypted value | — (read-only) |
+| [AWS Parameter Store (0.18+)](/providers/awsps/#use-existing-parameters) | Parameter name or ARN; `version` selects a version or label | Rejected | Reads the decrypted value | ✅ by unversioned parameter name; version, label, and ARN refs are read-only |
 | [GCSM](/providers/gcsm/#use-existing-secrets) | Secret id; `version` also applies | Rejected | Reads latest or the pinned version | — (read-only) |
 | [Bitwarden (bws)](/providers/bws/#use-existing-secrets) | BWS key name | Rejected | Reads the key | ✅ |
 | [Azure Key Vault (0.15+)](/providers/akv/#use-existing-secrets) | Secret name | Rejected | Reads the secret | — (read-only) |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -264,7 +264,8 @@ awsps://                                           # SDK defaults
 
 **Features (0.18+)**: Read/write, `SecureString` encryption, cloud sync,
 profiles, IAM/SSO authentication, batched reads, version- or label-pinned
-read-only refs
+read-only refs, writable unversioned parameter-name refs; ARN refs are
+read-only
 **Prerequisites (0.18+)**: AWS credentials configured, build with
 `--features awsps`
 **Storage (0.18+)**: Parameter

--- a/secretspec/src/provider/awsps.rs
+++ b/secretspec/src/provider/awsps.rs
@@ -432,9 +432,21 @@ impl Provider for AwspsProvider {
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         match addr {
             Address::Convention { .. } => Ok(()),
-            Address::Native(_) => Err(SecretSpecError::ProviderOperationFailed(
-                "awsps parameter references are read-only and cannot be written".to_string(),
-            )),
+            Address::Native(native) if native.version.is_some() => {
+                Err(SecretSpecError::ProviderOperationFailed(
+                    "awsps refs pinning a `version` are read-only: a Parameter Store version or \
+                     label cannot be overwritten. Drop `version` to write a new latest version."
+                        .to_string(),
+                ))
+            }
+            Address::Native(native) if native.item.starts_with("arn:") => {
+                Err(SecretSpecError::ProviderOperationFailed(
+                    "awsps refs using a parameter ARN are read-only: use the parameter's name to \
+                     write it in the provider's configured account and region."
+                        .to_string(),
+                ))
+            }
+            Address::Native(native) => Self::validate_parameter_name(&native.item),
         }
     }
 
@@ -632,7 +644,19 @@ mod tests {
     }
 
     #[test]
-    fn native_ref_is_read_only() {
+    fn unversioned_native_name_ref_is_writable() {
+        let provider = AwspsProvider::new(config("awsps://us-east-1"));
+        let reference = crate::config::NativeAddress {
+            item: "/prod/token".to_string(),
+            ..Default::default()
+        };
+        provider
+            .check_writable(Address::Native(&reference))
+            .unwrap();
+    }
+
+    #[test]
+    fn versioned_native_ref_is_read_only() {
         let provider = AwspsProvider::new(config("awsps://us-east-1"));
         let reference = crate::config::NativeAddress {
             item: "/prod/token".to_string(),
@@ -642,6 +666,20 @@ mod tests {
         let error = provider
             .check_writable(Address::Native(&reference))
             .unwrap_err();
+        assert!(error.to_string().contains("read-only"), "{error}");
+    }
+
+    #[test]
+    fn native_arn_ref_is_read_only() {
+        let provider = AwspsProvider::new(config("awsps://us-east-1"));
+        let reference = crate::config::NativeAddress {
+            item: "arn:aws:ssm:us-east-1:123456789012:parameter/prod/token".to_string(),
+            ..Default::default()
+        };
+        let error = provider
+            .check_writable(Address::Native(&reference))
+            .unwrap_err();
+        assert!(error.to_string().contains("ARN"), "{error}");
         assert!(error.to_string().contains("read-only"), "{error}");
     }
 

--- a/secretspec/src/provider/awsps.rs
+++ b/secretspec/src/provider/awsps.rs
@@ -431,14 +431,6 @@ impl Provider for AwspsProvider {
 
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         match addr {
-            Address::Convention { .. } => Ok(()),
-            Address::Native(native) if native.version.is_some() => {
-                Err(SecretSpecError::ProviderOperationFailed(
-                    "awsps refs pinning a `version` are read-only: a Parameter Store version or \
-                     label cannot be overwritten. Drop `version` to write a new latest version."
-                        .to_string(),
-                ))
-            }
             Address::Native(native) if native.item.starts_with("arn:") => {
                 Err(SecretSpecError::ProviderOperationFailed(
                     "awsps refs using a parameter ARN are read-only: use the parameter's name to \
@@ -446,7 +438,16 @@ impl Provider for AwspsProvider {
                         .to_string(),
                 ))
             }
-            Address::Native(native) => Self::validate_parameter_name(&native.item),
+            Address::Native(native) if native.version.is_some() => {
+                Err(SecretSpecError::ProviderOperationFailed(
+                    "awsps refs pinning a `version` are read-only: a Parameter Store version or \
+                     label cannot be overwritten. Drop `version` to write a new latest version."
+                        .to_string(),
+                ))
+            }
+            _ => self
+                .resolve_coords(addr)
+                .and_then(|coordinates| Self::validate_parameter_name(&coordinates.item)),
         }
     }
 
@@ -684,17 +685,57 @@ mod tests {
     }
 
     #[test]
-    fn native_ref_rejects_field_before_network_access() {
+    fn versioned_native_arn_ref_reports_arn_remediation() {
         let provider = AwspsProvider::new(config("awsps://us-east-1"));
         let reference = crate::config::NativeAddress {
-            item: "/prod/token".to_string(),
-            field: Some("password".to_string()),
+            item: "arn:aws:ssm:us-east-1:123456789012:parameter/prod/token".to_string(),
+            version: Some("3".to_string()),
             ..Default::default()
         };
         let error = provider
-            .resolve_coords(Address::Native(&reference))
+            .check_writable(Address::Native(&reference))
             .unwrap_err();
-        assert!(error.to_string().contains("`field`"), "{error}");
+        let message = error.to_string();
+        assert!(message.contains("ARN"), "{message}");
+        assert!(!message.contains("Drop `version`"), "{message}");
+    }
+
+    #[test]
+    fn native_ref_rejects_unsupported_coordinates_during_writability_check() {
+        let provider = AwspsProvider::new(config("awsps://us-east-1"));
+        let references = [
+            (
+                "field",
+                crate::config::NativeAddress {
+                    item: "/prod/token".to_string(),
+                    field: Some("password".to_string()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "vault",
+                crate::config::NativeAddress {
+                    item: "/prod/token".to_string(),
+                    vault: Some("production".to_string()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "section",
+                crate::config::NativeAddress {
+                    item: "/prod/token".to_string(),
+                    section: Some("credentials".to_string()),
+                    ..Default::default()
+                },
+            ),
+        ];
+
+        for (coordinate, reference) in references {
+            let error = provider
+                .check_writable(Address::Native(&reference))
+                .unwrap_err();
+            assert!(error.to_string().contains(coordinate), "{error}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- allow AWS Parameter Store refs using an unversioned parameter name to be written at that exact name
- keep version-, label-, and ARN-based refs read-only with actionable errors
- document generated and imported values at existing Parameter Store names

## Why

The AWSPS provider could write convention addresses but rejected every native
`ref`, even when the ref named an ordinary parameter in the configured account
and region. Parameter Store can safely create or update that exact name with
`PutParameter`, so the blanket restriction prevented `set`, interactive
`check`, generation, and import from working with established parameter names.

Historical version or label selectors cannot be overwritten, and ARN refs can
identify shared or cross-account parameters, so those remain read-only.

## Example

```toml
[profiles.production]
DB_PASSWORD = {
  description = "DB password",
  ref = { item = "/prod/db-password" },
  type = "password",
  generate = true,
  providers = ["awsps://us-east-1"]
}
```

## Validation

- `devenv shell cargo test --package secretspec awsps` — 22 passed
- repository pre-commit Clippy and rustfmt hooks — passed
- `devenv shell cargo fmt --all -- --check` — passed
- `git diff --check` — passed
