### PR TITLE
Add provider-backed declaration discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The keyring provider now uses keyring 4's Rust-native Secret Service
   transport on Linux, so source builds and binaries no longer require system
   libdbus.
+- `secretspec init --from` now accepts every provider with declaration
+  reflection, including age, AWS Parameter Store, and Bitwarden Password
+  Manager, and accepts `--project` and `--profile` as explicit discovery
+  context for hierarchical stores.
+- Custom Rust providers now pass discovery context to the
+  `Provider::reflect` hook so hierarchical stores can select the project and
+  profile namespace.
 
 ### Fixed
 - The Bitwarden provider now treats a locked vault or a missing session as a
@@ -36,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `secretspec add NAME --description "..."` (available in 0.18) adds a secret
   declaration to the active profile while preserving the manifest's
   existing comments, formatting, and unrelated configuration.
+- AWS Parameter Store convention templates and bounded `GetParametersByPath`
+  discovery can create declarations from the direct children of an existing
+  hierarchy without decrypting their values.
 - Swift SDK (available in 0.18) for resolving SecretSpec manifests from macOS
   12+ on Intel and Apple silicon. The SwiftPM package provides fluent and
   one-shot resolution, typed failures, scopes, value-free reports, provenance,

--- a/docs/src/content/docs/development/adding-providers.md
+++ b/docs/src/content/docs/development/adding-providers.md
@@ -38,6 +38,13 @@ pub trait Provider: Send + Sync {
     /// store has a real bulk surface (one listing, a batch API).
     fn get_many(&self, requests: &[(&str, Address<'_>)])
         -> Result<HashMap<String, SecretString>> { /* default */ }
+
+    /// SecretSpec 0.18+: optional discovery hook used to build secret
+    /// declarations from a provider. Return definitions only; never put values
+    /// in descriptions or other manifest fields. Flat stores can ignore the
+    /// context; hierarchical stores use it to bound discovery.
+    fn reflect(&self, context: DiscoveryContext<'_>)
+        -> Result<HashMap<String, Secret>> { /* unsupported */ }
 }
 ```
 
@@ -48,6 +55,54 @@ written for another store fails loudly instead of resolving something else —
 you declare the set, you never write the check. Have `set` call
 `self.check_writable(addr)?` first, so the pre-check and the write agree on
 one refusal message.
+
+### Convention templates
+
+When a provider lets users replace its complete convention layout, call that
+option `template` and support the `{project}`, `{profile}`, and `{key}`
+placeholders. Reserve `prefix` for an option that only prepends literal text to
+an otherwise fixed convention. For example, a hierarchical provider might use:
+
+```text
+mybackend://account?template=/{profile}/{project}/{key}
+```
+
+Render the template only in `convention_address`, then validate the resulting
+native name before any provider I/O. This keeps `get`, `set`, batch reads,
+generation, and imports in the same address space. Document when a template
+omits a placeholder intentionally; in particular, omitting `{key}` can make
+several declarations target the same stored value.
+
+### Discovery and `init --from`
+
+SecretSpec 0.18+ passes a `DiscoveryContext` to the `reflect(context)`
+discovery hook. During `secretspec init --from PROVIDER`, the CLI constructs
+the provider, calls that hook, and turns the returned map into declarations in
+a new manifest. Flat stores such as dotenv and age ignore the context;
+hierarchical stores use it to bound discovery. A reflected `Secret` describes
+the discovered key; do not copy its value into the description, default, or
+any other committed field.
+
+`secretspec import PROVIDER` is different: it does **not** call
+`reflect(context)` or enumerate the source. It iterates the secrets
+already declared in the active and default profiles and copies their values
+into the configured destination. Implement the reflection hook for manifest
+discovery, not to change import semantics. SecretSpec 0.18+ accepts any
+provider that implements the hook as an `init --from` source. Use `--project`
+and `--profile` when the provider's convention needs context other than the
+current directory name and the `default` profile.
+
+For a hierarchical store, reflection must have a bounded namespace and a
+reversible mapping from native names to SecretSpec keys. A configured template
+such as `/{profile}/{project}/{key}` provides both: render it with
+`DiscoveryContext`, list the prefix before `{key}`, reject nested or otherwise
+ambiguous results, and return the remaining key names. Do not list an entire
+account or vault as a fallback.
+
+The reflection hook returns declarations, not values, so it is also not a
+runtime namespace-injection API. A Chamber-style “export everything under this
+path” feature would need a separate value-bearing contract or an intentional
+extension of the provider trait.
 
 ## Implementation Steps
 

--- a/docs/src/content/docs/providers/age.md
+++ b/docs/src/content/docs/providers/age.md
@@ -88,6 +88,19 @@ post-quantum protection.
 
 ## Configuration
 
+### Discover declarations (0.18+)
+
+SecretSpec 0.18+ can initialize a manifest from the key names already in an
+age file. Reflection decrypts the file in memory to enumerate its keys but
+never writes their values to `secretspec.toml`:
+
+```bash
+$ secretspec init --from "age://secrets.age?identity=$HOME/.config/age/plugin-identity.txt"
+```
+
+The provider must have enough identity configuration to open the file. Use
+`--project` and `--profile` to choose the metadata written to the new manifest.
+
 ### URI format
 
 ```text

--- a/docs/src/content/docs/providers/awsps.md
+++ b/docs/src/content/docs/providers/awsps.md
@@ -22,7 +22,7 @@ parameters.
 | Best for | AWS workloads using Parameter Store for application configuration |
 | Authentication | Standard AWS SDK credential chain |
 | Build feature | `awsps` (0.18+) |
-| Default storage | `/secretspec/{project}/{profile}/{key}` |
+| Default storage | `/secretspec/{project}/{profile}/{key}`; replaceable with `template` |
 
 ## Quick start
 
@@ -76,13 +76,17 @@ awsps
 ### URI format
 
 ```text
-awsps://[AWS_PROFILE@]REGION[?prefix=PREFIX][&kms_key_id=KEY][&tier=TIER]
+awsps://[AWS_PROFILE@]REGION[?prefix=PREFIX][&template=TEMPLATE][&kms_key_id=KEY][&tier=TIER]
 ```
 
 - `AWS_PROFILE`: Optional profile from the shared AWS config.
 - `REGION`: Optional AWS region. If omitted, the SDK region chain is used.
 - `prefix`: Optional hierarchy before `/secretspec`. A leading slash is
   optional and normalized.
+- `template`: Optional complete hierarchy using `{project}`, `{profile}`, and
+  `{key}`. It must start with `/`, contain `{key}` exactly once as the final
+  path segment, and include a parent path before it. `template` and `prefix`
+  are mutually exclusive.
 - `kms_key_id`: Optional customer-managed KMS key ID, ARN, or alias used for
   `SecureString` writes. If omitted, Parameter Store uses the account's default
   key.
@@ -95,6 +99,7 @@ awsps://[AWS_PROFILE@]REGION[?prefix=PREFIX][&kms_key_id=KEY][&tier=TIER]
 awsps://us-east-1
 awsps://production@us-east-1
 awsps://us-east-1?prefix=/myteam
+awsps://us-east-1?template=/{profile}/{project}/{key}
 awsps://us-east-1?kms_key_id=alias/my-key&tier=advanced
 awsps://
 ```
@@ -124,6 +129,50 @@ With `?prefix=/myteam`, it maps to:
 ```text
 /myteam/secretspec/myapp/production/DATABASE_URL
 ```
+
+Use `template` to replace the whole convention. This is useful when Terraform
+already provisions a Chamber-style hierarchy. For example,
+`?template=/{profile}/{project}/{key}` maps the same declaration to:
+
+```text
+/production/myapp/DATABASE_URL
+```
+
+The `{project}` and `{profile}` placeholders are optional, but `{key}` must be
+the final path segment. That restriction gives discovery a bounded parent path
+and a reversible mapping from parameter names to SecretSpec declarations.
+
+## Discover existing parameters
+
+SecretSpec 0.18+ can create declarations for the direct children of the
+rendered Parameter Store hierarchy. It calls `GetParametersByPath` without
+decryption, does not write parameter values to the manifest, and does not scan
+outside that one path:
+
+```bash
+$ secretspec init \
+    --from 'awsps://production@us-east-1?template=/{profile}/{project}/{key}' \
+    --project payments \
+    --profile production
+✓ Created secretspec.toml with 12 secrets
+```
+
+`--project` defaults to the current directory name and `--profile` defaults to
+`default`. Initialization discovers declarations only. To continue reading the
+values from Parameter Store, add the URI as a checked-in provider alias and use
+it as the profile default:
+
+```toml title="secretspec.toml"
+[providers]
+parameters = "awsps://production@us-east-1?template=/{profile}/{project}/{key}"
+
+[profiles.production.defaults]
+providers = ["parameters"]
+```
+
+Alternatively, `secretspec import` copies the now-declared values from the
+source into your configured destination provider; it does not perform
+discovery itself.
 
 Every value SecretSpec creates is a `SecureString`. Writes set
 `Overwrite=true`, so updating a value creates a new Parameter Store version.
@@ -178,6 +227,9 @@ Reads require `ssm:GetParameter` and `ssm:GetParameters`; convention and
 unversioned name-reference writes require `ssm:PutParameter`. A
 customer-managed KMS key also needs the corresponding KMS permissions for
 encryption and decryption.
+
+Discovery requires `ssm:GetParametersByPath`. It requests encrypted values
+without decrypting them, while normal secret reads do decrypt.
 
 Scope IAM resources to the configured hierarchy where possible. For the
 `/myteam/secretspec/` prefix in `us-east-1`, that resource pattern is:

--- a/docs/src/content/docs/providers/bw.md
+++ b/docs/src/content/docs/providers/bw.md
@@ -123,6 +123,31 @@ $ secretspec get 'MyApp Database' --provider 'bw://?type=login'
 $ secretspec run -- npm start
 ```
 
+### Discover declarations (0.18+)
+
+SecretSpec 0.18+ can initialize a manifest from the items visible through a
+Bitwarden provider URI. Scope discovery to a collection, and optionally an
+item type, so unrelated personal or organization-vault entries are not treated
+as application secrets:
+
+```bash
+$ secretspec init --from 'bw://myorg@dev-secrets?type=login' # 0.18+
+✓ Created secretspec.toml with 8 secrets
+```
+
+Each item name becomes a SecretSpec key. Names must therefore contain only
+letters, numbers, and underscores, cannot start with a number, and cannot be
+the reserved name `defaults`. Bitwarden allows duplicate names and matches them
+case-insensitively; discovery stops when two selected items collide under those
+rules instead of generating an ambiguous manifest. Rename the items or use
+`?type=` to select one type.
+
+Discovery writes only names and generated descriptions to `secretspec.toml`;
+it never writes secret values. The `--project` and `--profile` discovery
+context does not change Bitwarden item names. To migrate the discovered values
+after reviewing the declarations, run the `secretspec import` command printed
+by `init`.
+
 ### Item Type Configuration
 
 The Bitwarden provider supports all Bitwarden item types with smart field detection:

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -21,19 +21,45 @@ $ secretspec run --reason "Deploying web frontend" -- ./deploy.sh
 ## Commands
 
 ### init
-Initialize a new `secretspec.toml` configuration file from an existing .env file.
+Initialize a new `secretspec.toml` from declarations discovered in a provider.
+Dotenv files are supported in every current release. SecretSpec 0.18+ accepts
+any provider that implements reflection, including age files, AWS Parameter
+Store, and Bitwarden Password Manager vaults.
 
 ```bash
-secretspec init [OPTIONS]
+secretspec init [--from <PROVIDER>] [--project <PROJECT>] [--profile <PROFILE>]
 ```
 
 **Options:**
-- `--from <PATH>` - Path to .env file to import from (default: `.env`)
 
-**Example:**
+- `--from <PROVIDER>` - Provider URI to discover (default: `dotenv://.env`);
+  use a `dotenv://` URI for dotenv files
+- `--project <PROJECT>` - Project used to render the provider namespace
+  (SecretSpec 0.18+; default: current directory name)
+- `-P, --profile <PROFILE>` - Profile used to render the provider namespace
+  and written to the manifest (SecretSpec 0.18+; default: `default`)
+
+Reflection creates declarations only: values are never written to the
+manifest. Configure the discovered provider as the profile's source to keep
+using it, or run `secretspec import` afterward to copy the declared values to a
+different destination.
+
+**Examples:**
+
 ```bash
-$ secretspec init --from .env.example
+$ secretspec init --from dotenv://.env.example
 ✓ Created secretspec.toml with 5 secrets
+
+# SecretSpec 0.18+: discover one rendered Parameter Store hierarchy
+$ secretspec init \
+    --from 'awsps://us-east-1?template=/{profile}/{project}/{key}' \
+    --project payments \
+    --profile production
+✓ Created secretspec.toml with 12 secrets
+
+# SecretSpec 0.18+: discover items in one Bitwarden collection
+$ secretspec init --from 'bw://dev-secrets?type=login'
+✓ Created secretspec.toml with 8 secrets
 ```
 
 ### config global init

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -251,13 +251,16 @@ awssm://                      # SDK default region and credentials
 The `awsps` provider is added in SecretSpec 0.18.
 :::
 
-**URI**: `awsps://[profile@]REGION[?prefix=PATH&kms_key_id=KEY&tier=TIER]` -
-Stores secrets as encrypted AWS Systems Manager Parameter Store values
+**URI (0.18+)**:
+`awsps://[profile@]REGION[?prefix=PATH&template=TEMPLATE&kms_key_id=KEY&tier=TIER]`
+- Stores secrets as encrypted AWS Systems Manager Parameter Store values;
+  `prefix` and `template` are mutually exclusive.
 
 ```bash
 awsps://us-east-1                                  # Specific AWS region
 awsps://production@us-east-1                       # AWS profile and region
 awsps://us-east-1?prefix=/team                     # Additional hierarchy
+awsps://us-east-1?template=/{profile}/{project}/{key} # Replace the hierarchy
 awsps://us-east-1?kms_key_id=alias/key&tier=advanced
 awsps://                                           # SDK defaults
 ```
@@ -269,9 +272,10 @@ read-only
 **Prerequisites (0.18+)**: AWS credentials configured, build with
 `--features awsps`
 **Storage (0.18+)**: Parameter
-`[/prefix]/secretspec/{project}/{profile}/{key}`; `kms_key_id` selects a
-customer-managed key, while `tier` accepts `standard`, `advanced`, or
-`intelligent-tiering`
+`[/prefix]/secretspec/{project}/{profile}/{key}`. `template` replaces the
+complete layout and must end in `/{key}`; `kms_key_id` selects a customer-managed
+key, while `tier` accepts `standard`, `advanced`, or `intelligent-tiering`
+**Discovery (0.18+)**: Bounded declaration discovery through `init --from`
 
 ## Scaleway Secret Manager Provider (0.17+)
 
@@ -368,7 +372,7 @@ parameter, is rejected when the address is parsed rather than ignored.
 configure the CLI themselves and SecretSpec verifies the setting matches before
 each operation. See the [provider guide](/providers/bw/#self-hosted-servers).
 
-**Features**: Read/write, all vault item types (logins, cards, identities, SSH keys, secure notes), organization/collection addressing by name or ID, field selection, `ref = { item, field }` mapping in `secretspec.toml`
+**Features**: Read/write, all vault item types (logins, cards, identities, SSH keys, secure notes), organization/collection addressing by name or ID, field selection, `ref = { item, field }` mapping in `secretspec.toml`, declaration discovery through `init --from` (0.18+)
 **Prerequisites**: Bitwarden CLI (`bw`), signed in and unlocked (`BW_SESSION` env var), self-hosted servers set with `bw config server` before login, build with `--features bw`
 **Storage**: One vault item per secret; reads use per-type default fields unless `?field=` or a `ref` mapping selects one
 

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -41,12 +41,17 @@ struct Cli {
 enum Commands {
     /// Initialize a new secretspec.toml (optionally, from a provider)
     Init {
-        /// Provider URL to import from (e.g., dotenv://.env, dotenv://.env.production)
-        /// Currently only dotenv provider is supported.
+        /// Discover declarations from a provider (additional providers in 0.18+)
         ///
         /// Note: no short flag here — `-f` is the global `--file` option.
         #[arg(long, default_value = "dotenv://.env")]
         from: String,
+        /// Project used to select the provider namespace (0.18+; defaults to directory name)
+        #[arg(long)]
+        project: Option<String>,
+        /// Profile used to select the provider namespace (0.18+)
+        #[arg(short = 'P', long, default_value = "default")]
+        profile: String,
     },
     /// Add a secret declaration to secretspec.toml (0.18+)
     Add {
@@ -356,7 +361,7 @@ fn normalize_config_action(action: ConfigAction) -> ConfigAction {
 fn get_example_toml() -> &'static str {
     r#"# DATABASE_URL = { description = "Database connection string", required = true }
 
-[profiles.development]
+# [profiles.development]
 # Development profile inherits all secrets from default profile
 # Only define secrets here that need different values or settings than default
 # DATABASE_URL = { default = "sqlite:///dev.db" }
@@ -364,6 +369,17 @@ fn get_example_toml() -> &'static str {
 # New secrets
 # REDIS_URL = { description = "Redis connection URL for caching", required = false, default = "redis://localhost:6379" }
 "#
+}
+
+/// Builds a copyable POSIX-shell command for importing discovered values.
+fn migration_command(from: &str, profile: &str) -> String {
+    let from = crate::secrets::shell_single_quote(from);
+    if profile == "default" {
+        format!("secretspec import {from}")
+    } else {
+        let profile = crate::secrets::shell_single_quote(profile);
+        format!("SECRETSPEC_PROFILE={profile} secretspec import {from}")
+    }
 }
 
 /// Generates a `secretspec.toml` document from a [`Config`] with helpful comments.
@@ -754,7 +770,11 @@ pub fn main() -> Result<()> {
 
     match cli.command {
         // Initialize a new secretspec.toml configuration file
-        Commands::Init { from } => {
+        Commands::Init {
+            from,
+            project,
+            profile,
+        } => {
             // Check if secretspec.toml already exists
             if PathBuf::from("secretspec.toml").exists() {
                 use inquire::Confirm;
@@ -769,25 +789,34 @@ pub fn main() -> Result<()> {
                 }
             }
 
-            // Create provider from the specification string
-            // This handles various formats like "dotenv", "dotenv:.env", "dotenv://.env.production"
-            let provider: Box<dyn Provider> = from.as_str().try_into().into_diagnostic()?;
-
-            // Check if it's a dotenv provider
-            if provider.name() != "dotenv" {
-                return Err(miette!(
-                    "Only 'dotenv' provider is currently supported for init --from. Got provider: {}",
-                    provider.name()
-                ));
+            let project_name = match project {
+                Some(project) => project,
+                None => std::env::current_dir()
+                    .into_diagnostic()?
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string(),
+            };
+            if project_name.is_empty() {
+                return Err(miette!("init project cannot be empty"));
+            }
+            if profile.is_empty() {
+                return Err(miette!("init profile cannot be empty"));
             }
 
-            // Reflect secrets from the provider
-            let secrets = provider.reflect().into_diagnostic()?;
+            // Create provider from the specification string.
+            let provider: Box<dyn Provider> = from.as_str().try_into().into_diagnostic()?;
+
+            // Discover declarations in the namespace the new manifest will use.
+            let secrets = provider
+                .reflect(crate::DiscoveryContext::new(&project_name, &profile))
+                .into_diagnostic()?;
 
             // Create a new project config
             let mut profiles = HashMap::new();
             profiles.insert(
-                "default".to_string(),
+                profile.clone(),
                 Profile {
                     defaults: None,
                     secrets,
@@ -796,12 +825,7 @@ pub fn main() -> Result<()> {
 
             let project_config = Config {
                 project: Project {
-                    name: std::env::current_dir()
-                        .into_diagnostic()?
-                        .file_name()
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                        .to_string(),
+                    name: project_name,
                     ..Default::default()
                 },
                 profiles,
@@ -831,11 +855,15 @@ pub fn main() -> Result<()> {
                 .sum::<usize>();
             println!("✓ Created secretspec.toml with {} secrets", secret_count);
 
-            // If we imported from a provider, suggest migration
-            if provider.name() == "dotenv" && secret_count > 0 {
+            // If we discovered a populated provider, explain how to copy its
+            // values after reviewing the declarations.
+            if secret_count > 0 {
                 println!("\nTo migrate your secrets from {}:", from);
                 println!("  1. Review secretspec.toml and adjust as needed");
-                println!("  2. secretspec import {}    # Import secret values", from);
+                println!(
+                    "  2. {}    # Import secret values",
+                    migration_command(&from, &profile)
+                );
             }
 
             println!("\nNext steps:");
@@ -1793,16 +1821,43 @@ mod tests {
     }
 
     #[test]
-    fn generated_config_with_example_template_is_valid_toml() {
-        let mut out = generate_toml_with_comments(&config_with_secret(Secret {
-            description: Some("desc".to_string()),
-            ..Default::default()
-        }))
-        .unwrap();
-        out.push_str(get_example_toml());
-        // The appended example only adds commented secrets, so it must remain
-        // syntactically valid TOML.
-        toml::from_str::<Config>(&out).expect("init output template must be valid TOML");
+    fn generated_config_with_example_template_is_valid_for_every_profile() {
+        for profile in ["default", "development", "production"] {
+            let mut config = config_with_secret(Secret {
+                description: Some("desc".to_string()),
+                ..Default::default()
+            });
+            if profile != "default" {
+                let declarations = config.profiles.remove("default").unwrap();
+                config.profiles.insert(profile.to_string(), declarations);
+            }
+
+            let mut out = generate_toml_with_comments(&config).unwrap();
+            out.push_str(get_example_toml());
+
+            let parsed: Config = toml::from_str(&out)
+                .unwrap_or_else(|error| panic!("init output for {profile} must parse: {error}"));
+            parsed
+                .validate()
+                .unwrap_or_else(|error| panic!("init output for {profile} must validate: {error}"));
+            assert_eq!(parsed.profiles.len(), 1);
+            assert!(parsed.profiles.contains_key(profile));
+        }
+    }
+
+    #[test]
+    fn migration_command_shell_quotes_provider_and_profile() {
+        assert_eq!(
+            migration_command(
+                "awsps://us-east-1?template=/{profile}/{project}/{key}&tier=advanced",
+                "default"
+            ),
+            "secretspec import 'awsps://us-east-1?template=/{profile}/{project}/{key}&tier=advanced'"
+        );
+        assert_eq!(
+            migration_command("dotenv://.env production", "team's production"),
+            "SECRETSPEC_PROFILE='team'\\''s production' secretspec import 'dotenv://.env production'"
+        );
     }
 
     #[test]
@@ -1815,7 +1870,45 @@ mod tests {
     fn init_defaults_from_to_dotenv() {
         let cli = Cli::try_parse_from(["secretspec", "init"]).unwrap();
         match cli.command {
-            Commands::Init { from } => assert_eq!(from, "dotenv://.env"),
+            Commands::Init {
+                from,
+                project,
+                profile,
+            } => {
+                assert_eq!(from, "dotenv://.env");
+                assert_eq!(project, None);
+                assert_eq!(profile, "default");
+            }
+            _ => panic!("expected Init command"),
+        }
+    }
+
+    #[test]
+    fn init_accepts_discovery_context() {
+        let cli = Cli::try_parse_from([
+            "secretspec",
+            "init",
+            "--from",
+            "awsps://us-east-1?template=/{profile}/{project}/{key}",
+            "--project",
+            "payments",
+            "--profile",
+            "production",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Init {
+                from,
+                project,
+                profile,
+            } => {
+                assert_eq!(
+                    from,
+                    "awsps://us-east-1?template=/{profile}/{project}/{key}"
+                );
+                assert_eq!(project.as_deref(), Some("payments"));
+                assert_eq!(profile, "production");
+            }
             _ => panic!("expected Init command"),
         }
     }

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -76,7 +76,7 @@ pub use config::{GenerateConfig, GenerateOptions, Secret};
 
 // Public API exports
 pub use error::{Result, SecretSpecError};
-pub use provider::Provider;
+pub use provider::{DiscoveryContext, Provider};
 pub use report::{
     RESOLUTION_REPORT_SCHEMA_VERSION, ResolutionReport, ResolutionStatus, SecretResolution,
 };

--- a/secretspec/src/provider/age.rs
+++ b/secretspec/src/provider/age.rs
@@ -22,7 +22,10 @@
 //! keys also work when their `age-plugin-*` binary is on `PATH`, including the
 //! ML-KEM-768 + X25519 `age1pq1...` recipient via `age-plugin-pq`.
 
-use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env, flat_item};
+use super::{
+    Address, DiscoveryContext, Provider, ProviderCredentials, ProviderUrl, credential_or_env,
+    flat_item,
+};
 use crate::config::{NativeAddress, Secret};
 use crate::{Result, SecretSpecError};
 use age::armor::{ArmoredReader, ArmoredWriter, Format};
@@ -447,7 +450,7 @@ impl Provider for AgeProvider {
         Ok(out)
     }
 
-    fn reflect(&self) -> Result<HashMap<String, Secret>> {
+    fn reflect(&self, _context: DiscoveryContext<'_>) -> Result<HashMap<String, Secret>> {
         Ok(self
             .load()?
             .into_keys()

--- a/secretspec/src/provider/awsps.rs
+++ b/secretspec/src/provider/awsps.rs
@@ -7,20 +7,21 @@
 //!
 //! # URI Format
 //!
-//! `awsps://[aws-profile@]region[?prefix=PREFIX][&kms_key_id=KEY][&tier=TIER]`
+//! `awsps://[aws-profile@]region[?prefix=PREFIX][&template=TEMPLATE][&kms_key_id=KEY][&tier=TIER]`
 //!
 //! - `awsps://us-east-1` — use SDK default credentials in us-east-1
 //! - `awsps://production@us-east-1` — use the "production" AWS profile
 //! - `awsps://us-east-1?prefix=/myteam` — store parameters below `/myteam`
+//! - `awsps://us-east-1?template=/{profile}/{project}/{key}` — use a custom hierarchy
 //! - `awsps://us-east-1?kms_key_id=alias/my-key&tier=advanced`
 //! - `awsps://` — use SDK defaults for both profile and region
 //!
 //! # Parameter Naming
 //!
-//! Parameters use the path
-//! `[/prefix]/secretspec/{project}/{profile}/{key}`.
+//! Parameters use the path `[/prefix]/secretspec/{project}/{profile}/{key}` by
+//! default. `template` replaces that complete layout.
 
-use super::{Address, Provider, ProviderUrl};
+use super::{Address, DiscoveryContext, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use aws_sdk_ssm::Client;
 use aws_sdk_ssm::error::{ProvideErrorMetadata, SdkError};
@@ -33,6 +34,7 @@ use std::fmt::Debug;
 
 /// Maximum number of names accepted by one `GetParameters` request.
 const AWS_GET_PARAMETERS_MAX_NAMES: usize = 10;
+const DEFAULT_PARAMETER_TEMPLATE: &str = "/secretspec/{project}/{profile}/{key}";
 
 /// Formats an AWS SDK error without collapsing non-service failures into a
 /// generated operation error's opaque `unhandled error` variant.
@@ -101,6 +103,9 @@ pub struct AwspsConfig {
     pub aws_profile: Option<String>,
     /// Optional hierarchy placed before `/secretspec`.
     pub prefix: Option<String>,
+    /// Optional complete convention layout. Must end in `/{key}` so discovery
+    /// can map one bounded hierarchy back to declaration names.
+    pub template: Option<String>,
     /// Optional customer-managed KMS key for `SecureString` writes.
     pub kms_key_id: Option<String>,
     /// Optional Parameter Store tier for writes.
@@ -127,6 +132,17 @@ impl TryFrom<&ProviderUrl> for AwspsConfig {
             .query_value("prefix")
             .map(|value| value.trim_matches('/').to_string())
             .filter(|value| !value.is_empty());
+        let template = url.query_value("template");
+        if prefix.is_some() && template.is_some() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "awsps `prefix` and `template` are mutually exclusive: `prefix` prepends the \
+                 default layout, while `template` replaces it"
+                    .to_string(),
+            ));
+        }
+        if let Some(template) = &template {
+            AwspsProvider::validate_template(template)?;
+        }
         let kms_key_id = url.query_value("kms_key_id");
         let tier = url
             .query_value("tier")
@@ -147,6 +163,7 @@ impl TryFrom<&ProviderUrl> for AwspsConfig {
             region,
             aws_profile,
             prefix,
+            template,
             kms_key_id,
             tier,
         })
@@ -168,6 +185,7 @@ crate::register_provider! {
         "awsps://us-east-1",
         "awsps://production@us-east-1",
         "awsps://us-east-1?prefix=/myteam",
+        "awsps://us-east-1?template=/{profile}/{project}/{key}",
         "awsps://us-east-1?kms_key_id=alias/my-key&tier=advanced",
     ],
 }
@@ -177,9 +195,88 @@ impl AwspsProvider {
         Self { config }
     }
 
+    fn effective_template(prefix: Option<&str>, template: Option<&str>) -> Result<String> {
+        if prefix.is_some() && template.is_some() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "awsps `prefix` and `template` are mutually exclusive: `prefix` prepends the \
+                 default layout, while `template` replaces it"
+                    .to_string(),
+            ));
+        }
+        if let Some(template) = template {
+            return Ok(template.to_string());
+        }
+
+        let prefix = prefix.unwrap_or_default().trim_matches('/');
+        if prefix.is_empty() {
+            Ok(DEFAULT_PARAMETER_TEMPLATE.to_string())
+        } else {
+            Ok(format!("/{prefix}{DEFAULT_PARAMETER_TEMPLATE}"))
+        }
+    }
+
+    fn validate_template(template: &str) -> Result<()> {
+        if !template.starts_with('/') {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "awsps template must start with `/`".to_string(),
+            ));
+        }
+
+        let mut rest = template;
+        let mut key_count = 0;
+        while let Some(open) = rest.find('{') {
+            if rest[..open].contains('}') {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "awsps template '{template}' contains an unmatched `}}`"
+                )));
+            }
+            let after_open = &rest[open + 1..];
+            let Some(close) = after_open.find('}') else {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "awsps template '{template}' contains an unmatched `{{`"
+                )));
+            };
+            let placeholder = &after_open[..close];
+            match placeholder {
+                "project" | "profile" => {}
+                "key" => key_count += 1,
+                _ => {
+                    return Err(SecretSpecError::ProviderOperationFailed(format!(
+                        "unknown awsps template placeholder '{{{placeholder}}}': expected \
+                         {{project}}, {{profile}}, or {{key}}"
+                    )));
+                }
+            }
+            rest = &after_open[close + 1..];
+        }
+        if rest.contains('}') {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "awsps template '{template}' contains an unmatched `}}`"
+            )));
+        }
+        if key_count != 1 || !template.ends_with("/{key}") {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "awsps template must contain `{key}` exactly once as its final path segment"
+                    .to_string(),
+            ));
+        }
+        if template == "/{key}" {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "awsps template must include a bounded parent path before `/{key}`".to_string(),
+            ));
+        }
+
+        let sample = template
+            .replace("{project}", "project")
+            .replace("{profile}", "profile")
+            .replace("{key}", "KEY");
+        Self::validate_parameter_name(&sample)
+    }
+
     /// Builds and validates the convention hierarchy.
     fn format_parameter_name(
         prefix: Option<&str>,
+        template: Option<&str>,
         project: &str,
         profile: &str,
         key: &str,
@@ -192,14 +289,68 @@ impl AwspsProvider {
             }
         }
 
-        let prefix = prefix.unwrap_or_default().trim_matches('/');
-        let parameter_name = if prefix.is_empty() {
-            format!("/secretspec/{project}/{profile}/{key}")
-        } else {
-            format!("/{prefix}/secretspec/{project}/{profile}/{key}")
-        };
+        let template = Self::effective_template(prefix, template)?;
+        Self::validate_template(&template)?;
+        let parameter_name = template
+            .replace("{project}", project)
+            .replace("{profile}", profile)
+            .replace("{key}", key);
         Self::validate_parameter_name(&parameter_name)?;
         Ok(parameter_name)
+    }
+
+    /// Renders the exact parent hierarchy that reflection may enumerate.
+    fn discovery_path(
+        prefix: Option<&str>,
+        template: Option<&str>,
+        context: DiscoveryContext<'_>,
+    ) -> Result<String> {
+        for (name, value) in [("project", context.project), ("profile", context.profile)] {
+            if value.is_empty() {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "discovery {name} cannot be empty"
+                )));
+            }
+        }
+
+        let template = Self::effective_template(prefix, template)?;
+        Self::validate_template(&template)?;
+        let rendered = template
+            .replace("{project}", context.project)
+            .replace("{profile}", context.profile);
+        let path = rendered
+            .strip_suffix("/{key}")
+            .expect("validated template ends in /{key}")
+            .to_string();
+        Self::validate_parameter_name(&path)?;
+        Ok(path)
+    }
+
+    fn declaration_from_parameter(
+        path: &str,
+        name: &str,
+    ) -> Result<Option<(String, crate::Secret)>> {
+        let Some(key) = name.strip_prefix(&format!("{path}/")) else {
+            return Ok(None);
+        };
+        if key.is_empty() || key.contains('/') {
+            return Ok(None);
+        }
+        if !crate::config::is_valid_identifier(key) {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Parameter Store parameter '{name}' maps to invalid SecretSpec name '{key}': \
+                 names must be alphanumeric and underscores and cannot start with a number"
+            )));
+        }
+
+        Ok(Some((
+            key.to_string(),
+            crate::Secret {
+                description: Some(format!("{key} secret")),
+                required: Some(true),
+                ..Default::default()
+            },
+        )))
     }
 
     /// Applies the Parameter Store naming constraints that can be checked
@@ -393,6 +544,52 @@ impl AwspsProvider {
         })?;
         Ok(())
     }
+
+    async fn reflect_async(
+        &self,
+        context: DiscoveryContext<'_>,
+    ) -> Result<HashMap<String, crate::Secret>> {
+        let path = Self::discovery_path(
+            self.config.prefix.as_deref(),
+            self.config.template.as_deref(),
+            context,
+        )?;
+        let client = self.create_client().await;
+        let mut declarations = HashMap::new();
+        let mut next_token = None;
+
+        loop {
+            let mut request = client
+                .get_parameters_by_path()
+                .path(&path)
+                .recursive(false)
+                .with_decryption(false);
+            if let Some(token) = next_token {
+                request = request.next_token(token);
+            }
+            let output = request.send().await.map_err(|error| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to discover Parameter Store parameters under '{path}': {}",
+                    format_aws_error(&error)
+                ))
+            })?;
+
+            for parameter in output.parameters() {
+                if let Some(name) = parameter.name()
+                    && let Some((key, declaration)) = Self::declaration_from_parameter(&path, name)?
+                {
+                    declarations.insert(key, declaration);
+                }
+            }
+
+            next_token = output.next_token().map(str::to_string);
+            if next_token.is_none() {
+                break;
+            }
+        }
+
+        Ok(declarations)
+    }
 }
 
 impl Provider for AwspsProvider {
@@ -405,6 +602,7 @@ impl Provider for AwspsProvider {
         Ok(crate::config::NativeAddress {
             item: Self::format_parameter_name(
                 self.config.prefix.as_deref(),
+                self.config.template.as_deref(),
                 project,
                 profile,
                 key,
@@ -473,6 +671,9 @@ impl Provider for AwspsProvider {
                 ProviderUrl::encode_query(&format!("/{prefix}"))
             ));
         }
+        if let Some(template) = &self.config.template {
+            parameters.push(format!("template={}", ProviderUrl::encode_query(template)));
+        }
         if let Some(kms_key_id) = &self.config.kms_key_id {
             parameters.push(format!(
                 "kms_key_id={}",
@@ -505,6 +706,10 @@ impl Provider for AwspsProvider {
         }
         super::block_on(self.get_many_async(&resolved))
     }
+
+    fn reflect(&self, context: DiscoveryContext<'_>) -> Result<HashMap<String, crate::Secret>> {
+        super::block_on(self.reflect_async(context))
+    }
 }
 
 #[cfg(test)]
@@ -530,23 +735,25 @@ mod tests {
     fn convention_accepts_normalized_prefix() {
         for prefix in ["myteam", "/myteam", "/myteam/"] {
             let name =
-                AwspsProvider::format_parameter_name(Some(prefix), "app", "prod", "TOKEN").unwrap();
+                AwspsProvider::format_parameter_name(Some(prefix), None, "app", "prod", "TOKEN")
+                    .unwrap();
             assert_eq!(name, "/myteam/secretspec/app/prod/TOKEN");
         }
     }
 
     #[test]
     fn convention_rejects_invalid_names() {
-        assert!(AwspsProvider::format_parameter_name(None, "", "prod", "KEY").is_err());
-        assert!(AwspsProvider::format_parameter_name(None, "app", "", "KEY").is_err());
-        assert!(AwspsProvider::format_parameter_name(None, "app", "prod", "").is_err());
+        assert!(AwspsProvider::format_parameter_name(None, None, "", "prod", "KEY").is_err());
+        assert!(AwspsProvider::format_parameter_name(None, None, "app", "", "KEY").is_err());
+        assert!(AwspsProvider::format_parameter_name(None, None, "app", "prod", "").is_err());
 
         let error =
-            AwspsProvider::format_parameter_name(None, "my app", "prod", "KEY").unwrap_err();
+            AwspsProvider::format_parameter_name(None, None, "my app", "prod", "KEY").unwrap_err();
         assert!(error.to_string().contains("invalid character"), "{error}");
 
-        let error = AwspsProvider::format_parameter_name(Some("/aws/team"), "app", "prod", "KEY")
-            .unwrap_err();
+        let error =
+            AwspsProvider::format_parameter_name(Some("/aws/team"), None, "app", "prod", "KEY")
+                .unwrap_err();
         assert!(error.to_string().contains("reserved prefix"), "{error}");
     }
 
@@ -556,9 +763,85 @@ mod tests {
             .map(|number| format!("p{number}"))
             .collect::<Vec<_>>()
             .join("/");
-        let error =
-            AwspsProvider::format_parameter_name(Some(&prefix), "app", "prod", "KEY").unwrap_err();
+        let error = AwspsProvider::format_parameter_name(Some(&prefix), None, "app", "prod", "KEY")
+            .unwrap_err();
         assert!(error.to_string().contains("maximum 15"), "{error}");
+    }
+
+    #[test]
+    fn custom_template_replaces_default_hierarchy() {
+        let provider = AwspsProvider::new(config(
+            "awsps://us-east-1?template=/{profile}/{project}/{key}",
+        ));
+        let address = provider
+            .convention_address("payments", "production", "DATABASE_URL")
+            .unwrap();
+        assert_eq!(address.item, "/production/payments/DATABASE_URL");
+    }
+
+    #[test]
+    fn template_requires_a_bounded_reversible_key_path() {
+        for template in [
+            "relative/{key}",
+            "/{key}",
+            "/prod/static",
+            "/prod/{key}/nested",
+            "/prod/{unknown}/{key}",
+            "/prod/{key}/{key}",
+        ] {
+            let uri = format!("awsps://us-east-1?template={template}");
+            let url = url::Url::parse(&uri).unwrap();
+            assert!(
+                AwspsConfig::try_from(&ProviderUrl::new(url)).is_err(),
+                "expected invalid template: {template}"
+            );
+        }
+    }
+
+    #[test]
+    fn prefix_and_template_are_mutually_exclusive() {
+        let url =
+            url::Url::parse("awsps://us-east-1?prefix=/team&template=/{profile}/{project}/{key}")
+                .unwrap();
+        let error = AwspsConfig::try_from(&ProviderUrl::new(url)).unwrap_err();
+        assert!(error.to_string().contains("mutually exclusive"), "{error}");
+    }
+
+    #[test]
+    fn discovery_renders_the_same_bounded_parent_as_the_convention() {
+        let context = DiscoveryContext::new("payments", "production");
+        assert_eq!(
+            AwspsProvider::discovery_path(None, None, context).unwrap(),
+            "/secretspec/payments/production"
+        );
+        assert_eq!(
+            AwspsProvider::discovery_path(None, Some("/{profile}/{project}/{key}"), context,)
+                .unwrap(),
+            "/production/payments"
+        );
+    }
+
+    #[test]
+    fn discovery_maps_only_direct_valid_children_to_declarations() {
+        let path = "/production/payments";
+        let (key, declaration) =
+            AwspsProvider::declaration_from_parameter(path, "/production/payments/DATABASE_URL")
+                .unwrap()
+                .unwrap();
+        assert_eq!(key, "DATABASE_URL");
+        assert_eq!(declaration.required, Some(true));
+        assert!(
+            AwspsProvider::declaration_from_parameter(path, "/production/payments/nested/TOKEN")
+                .unwrap()
+                .is_none()
+        );
+
+        let error = AwspsProvider::declaration_from_parameter(path, "/production/payments/api-key")
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("invalid SecretSpec name"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -593,6 +876,23 @@ mod tests {
         let reparsed = config(&uri);
         assert_eq!(reparsed.prefix.as_deref(), Some("team/platform"));
         assert_eq!(reparsed.tier, Some(AwspsTier::IntelligentTiering));
+    }
+
+    #[test]
+    fn uri_round_trips_template() {
+        let provider = AwspsProvider::new(config(
+            "awsps://production@us-east-1?template=/{profile}/{project}/{key}",
+        ));
+        let uri = provider.uri();
+        assert_eq!(
+            uri,
+            "awsps://production@us-east-1?template=/{profile}/{project}/{key}"
+        );
+        let reparsed = config(&uri);
+        assert_eq!(
+            reparsed.template.as_deref(),
+            Some("/{profile}/{project}/{key}")
+        );
     }
 
     #[test]

--- a/secretspec/src/provider/bw.rs
+++ b/secretspec/src/provider/bw.rs
@@ -1,7 +1,8 @@
-use crate::provider::{Address, Provider, ProviderCredentials, ProviderUrl};
-use crate::{Result, SecretSpecError};
+use crate::provider::{Address, DiscoveryContext, Provider, ProviderCredentials, ProviderUrl};
+use crate::{Result, Secret, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::process::Command;
 use std::sync::OnceLock;
 
@@ -1071,6 +1072,64 @@ fn find_addressed_item<'a>(
                 .join("\n"),
         ))),
     }
+}
+
+/// Builds declarations for the Bitwarden items the provider can address.
+///
+/// Reflection uses the same optional type filter as reads and writes. Item
+/// names are otherwise direct convention addresses, so every reflected name
+/// must already be a valid SecretSpec identifier. Bitwarden compares names
+/// case-insensitively and permits duplicates; reject either kind of collision
+/// instead of generating declarations that would be ambiguous at read time.
+fn declarations_from_items(
+    items: &[BitwardenItem],
+    required_type: Option<BitwardenItemType>,
+) -> Result<HashMap<String, Secret>> {
+    let mut declarations = HashMap::new();
+    let mut seen_names = HashMap::<String, &BitwardenItem>::new();
+
+    for item in items
+        .iter()
+        .filter(|item| required_type.is_none_or(|item_type| item.item_type == item_type))
+    {
+        if !crate::config::is_valid_identifier(&item.name) {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Bitwarden item '{}' cannot become a SecretSpec declaration: names must be \
+                 alphanumeric and underscores and cannot start with a number. Rename the item \
+                 or narrow discovery with a collection and/or `?type=`.",
+                item.name
+            )));
+        }
+        if item.name == "defaults" {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "Bitwarden item 'defaults' cannot become a SecretSpec declaration because \
+                 that name is reserved for profile defaults. Rename the item or narrow \
+                 discovery with a collection and/or `?type=`."
+                    .to_string(),
+            ));
+        }
+
+        let folded_name = item.name.to_lowercase();
+        if let Some(previous) = seen_names.insert(folded_name, item) {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Bitwarden items '{}' ({}) and '{}' ({}) have names that collide \
+                 case-insensitively. Rename one or narrow discovery with `?type=` so every \
+                 reflected declaration has one address.",
+                previous.name, previous.id, item.name, item.id
+            )));
+        }
+
+        declarations.insert(
+            item.name.clone(),
+            Secret {
+                description: Some(format!("{} Bitwarden secret", item.name)),
+                required: Some(true),
+                ..Default::default()
+            },
+        );
+    }
+
+    Ok(declarations)
 }
 
 crate::register_provider! {
@@ -2608,6 +2667,17 @@ impl Provider for BitwardenProvider {
         let target_field = coords.field.as_deref();
         self.set_to_password_manager(item_name, target_field, value)
     }
+
+    fn reflect(&self, _context: DiscoveryContext<'_>) -> Result<HashMap<String, Secret>> {
+        if !self.is_authenticated()? {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "Bitwarden authentication required. Please run 'bw login' and 'bw unlock', then set the BW_SESSION environment variable.".to_string(),
+            ));
+        }
+
+        let items = self.list_items(None)?;
+        declarations_from_items(&items, self.resolved_item_type()?)
+    }
 }
 
 impl Default for BitwardenProvider {
@@ -3975,6 +4045,76 @@ mod tests {
         );
     }
 
+    #[test]
+    fn reflection_builds_declarations_for_the_addressed_item_type() {
+        let items = [
+            named_item("login", "API_KEY", BitwardenItemType::Login),
+            named_item("card", "API_KEY", BitwardenItemType::Card),
+            named_item("token", "CARD_TOKEN", BitwardenItemType::Card),
+        ];
+
+        let declarations = declarations_from_items(&items, Some(BitwardenItemType::Card))
+            .expect("the type filter makes every item addressable");
+
+        assert_eq!(declarations.len(), 2);
+        assert_eq!(
+            declarations["API_KEY"].description.as_deref(),
+            Some("API_KEY Bitwarden secret")
+        );
+        assert_eq!(declarations["API_KEY"].required, Some(true));
+        assert!(declarations.contains_key("CARD_TOKEN"));
+    }
+
+    #[test]
+    fn reflection_rejects_names_that_cannot_be_declared() {
+        let items = [named_item(
+            "invalid",
+            "Database Login",
+            BitwardenItemType::Login,
+        )];
+
+        let err = declarations_from_items(&items, None)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("cannot become a SecretSpec declaration"),
+            "{err}"
+        );
+        assert!(err.contains("Database Login"), "{err}");
+        assert!(err.contains("collection and/or `?type=`"), "{err}");
+    }
+
+    #[test]
+    fn reflection_rejects_the_reserved_defaults_name() {
+        let items = [named_item(
+            "reserved",
+            "defaults",
+            BitwardenItemType::SecureNote,
+        )];
+
+        let err = declarations_from_items(&items, None)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("reserved for profile defaults"), "{err}");
+    }
+
+    #[test]
+    fn reflection_rejects_case_insensitive_name_collisions() {
+        let items = [
+            named_item("first", "API_KEY", BitwardenItemType::Login),
+            named_item("second", "api_key", BitwardenItemType::Login),
+        ];
+
+        let err = declarations_from_items(&items, None)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("collide case-insensitively"), "{err}");
+        assert!(err.contains("first") && err.contains("second"), "{err}");
+    }
+
     // ---------------------------------------------------------------------
     // Behavioral coverage for the pure extraction / mutation / resolution
     // helpers (see ashebanow/secretspec#5). These read and write the same
@@ -4772,6 +4912,50 @@ mod tests {
             assert!(
                 format!("{err}").contains("Bitwarden authentication required"),
                 "{err}"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reflect_lists_the_addressed_collection_without_copying_values() {
+        let fake = FakeBw::new()
+            .with_organizations(json!([{"id": "org-id", "name": "Acme"}]))
+            .with_collections(json!([{
+                "id": "collection-id",
+                "name": "dev-secrets",
+                "organizationId": "org-id"
+            }]))
+            .with_items(json!([{
+                "id": "item-id",
+                "name": "API_KEY",
+                "type": 1,
+                "login": {"password": "must-not-appear"}
+            }]));
+
+        fake.run(|| {
+            let provider = BitwardenProvider::new(BitwardenConfig {
+                collection_id: Some("dev-secrets".to_string()),
+                ..Default::default()
+            });
+            let declarations = provider
+                .reflect(DiscoveryContext::new("ignored", "ignored"))
+                .unwrap();
+
+            assert_eq!(declarations.len(), 1);
+            assert_eq!(
+                declarations["API_KEY"].description.as_deref(),
+                Some("API_KEY Bitwarden secret")
+            );
+            assert!(!format!("{:?}", declarations["API_KEY"]).contains("must-not-appear"));
+
+            let log = fake.invocations();
+            assert!(log.contains("<status>"), "{log}");
+            assert!(log.contains("<list> <organizations>"), "{log}");
+            assert!(log.contains("<list> <collections>"), "{log}");
+            assert!(
+                log.contains("<list> <items> <--collectionid> <collection-id>"),
+                "{log}"
             );
         });
     }

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -1,4 +1,4 @@
-use super::{Address, Provider, ProviderUrl};
+use super::{Address, DiscoveryContext, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -372,7 +372,10 @@ impl Provider for DotEnvProvider {
         Ok(true)
     }
 
-    fn reflect(&self) -> Result<HashMap<String, crate::config::Secret>> {
+    fn reflect(
+        &self,
+        _context: DiscoveryContext<'_>,
+    ) -> Result<HashMap<String, crate::config::Secret>> {
         use crate::config::Secret;
 
         if !self.config.path.exists() {
@@ -518,7 +521,9 @@ mod tests {
             path: env_file.clone(),
         });
 
-        let secrets = provider.reflect().unwrap();
+        let secrets = provider
+            .reflect(DiscoveryContext::new("project", "default"))
+            .unwrap();
         assert_eq!(secrets.len(), 2);
         assert!(secrets.contains_key("API_KEY"));
         assert!(secrets.contains_key("DATABASE_URL"));
@@ -538,7 +543,9 @@ mod tests {
             path: PathBuf::from("/tmp/nonexistent/.env"),
         });
 
-        let secrets = provider.reflect().unwrap();
+        let secrets = provider
+            .reflect(DiscoveryContext::new("project", "default"))
+            .unwrap();
         assert!(secrets.is_empty());
     }
 

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -565,6 +565,23 @@ pub(crate) fn provider_display_name_for_spec(spec: &str) -> String {
         .unwrap_or_else(|| scheme.to_string())
 }
 
+/// Context supplied when a provider discovers secret declarations.
+///
+/// Available starting with SecretSpec 0.18. Hierarchical providers use the
+/// project and profile to render a bounded namespace before listing it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DiscoveryContext<'a> {
+    pub project: &'a str,
+    pub profile: &'a str,
+}
+
+impl<'a> DiscoveryContext<'a> {
+    pub const fn new(project: &'a str, profile: &'a str) -> Self {
+        Self { project, profile }
+    }
+}
+
 /// Trait defining the interface for secret storage providers.
 ///
 /// All secret storage backends must implement this trait to integrate with SecretSpec.
@@ -832,26 +849,27 @@ pub trait Provider: Send + Sync {
     /// [`with_base_dir`]: Provider::with_base_dir
     fn with_credentials(&mut self, _credentials: ProviderCredentials) {}
 
-    /// Discovers and returns all secrets available in this provider.
+    /// Discovers declarations using the project and profile that the new
+    /// manifest will contain. Available starting with SecretSpec 0.18.
     ///
-    /// This method is used to introspect the provider and find all available secrets.
-    /// It's particularly useful for importing secrets from external sources.
-    ///
-    /// # Returns
-    ///
-    /// A HashMap where keys are secret names and values are `Secret` configurations.
-    /// The default implementation returns an empty map, indicating the provider
-    /// doesn't support reflection.
+    /// Providers whose namespace does not depend on that context can ignore
+    /// it. Hierarchical providers should use it so discovery stays inside the
+    /// same namespace as [`convention_address`](Provider::convention_address).
+    /// The default implementation returns an unsupported-operation error.
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// let secrets = provider.reflect()?;
+    /// let context = DiscoveryContext::new("payments", "production");
+    /// let secrets = provider.reflect(context)?;
     /// for (name, secret) in secrets {
     ///     println!("Found secret: {} = {:?}", name, secret);
     /// }
     /// ```
-    fn reflect(&self) -> Result<HashMap<String, crate::config::Secret>> {
+    fn reflect(
+        &self,
+        _context: DiscoveryContext<'_>,
+    ) -> Result<HashMap<String, crate::config::Secret>> {
         Err(SecretSpecError::ProviderOperationFailed(format!(
             "Provider '{}' does not support reflection",
             self.name()
@@ -1025,8 +1043,11 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn set_reason(&self, reason: Option<String>) {
         (**self).set_reason(reason);
     }
-    fn reflect(&self) -> Result<HashMap<String, crate::config::Secret>> {
-        (**self).reflect()
+    fn reflect(
+        &self,
+        context: DiscoveryContext<'_>,
+    ) -> Result<HashMap<String, crate::config::Secret>> {
+        (**self).reflect(context)
     }
     fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
         (**self).get_many(requests)
@@ -1217,9 +1238,12 @@ impl Provider for PreflightGuard {
         self.inner.with_credentials(credentials);
     }
 
-    fn reflect(&self) -> Result<HashMap<String, crate::config::Secret>> {
+    fn reflect(
+        &self,
+        context: DiscoveryContext<'_>,
+    ) -> Result<HashMap<String, crate::config::Secret>> {
         self.check()?;
-        self.inner.reflect()
+        self.inner.reflect(context)
     }
 
     fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use crate::provider::{Address, Provider};
+use crate::provider::{Address, DiscoveryContext, Provider};
 use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -1358,9 +1358,9 @@ mod integration_tests {
 
     #[test]
     fn test_default_reflect_returns_error() {
-        // Test that the default reflect implementation returns an error
+        // Test that the default reflection implementation returns an error
         let provider = MockProvider::new();
-        let result = provider.reflect();
+        let result = provider.reflect(DiscoveryContext::new("project", "default"));
         assert!(
             result.is_err(),
             "Default reflect implementation should return an error"

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -4742,7 +4742,7 @@ fn write_export(
 }
 
 /// POSIX single-quote escaping so the value survives `eval` verbatim
-fn shell_single_quote(value: &str) -> String {
+pub(crate) fn shell_single_quote(value: &str) -> String {
     let mut out = String::with_capacity(value.len() + 2);
     out.push('\'');
     for ch in value.chars() {


### PR DESCRIPTION
## Summary

- replace the context-free provider reflection API with the 0.18+ `reflect_with_context` hook using project and profile
- let `secretspec init --from` use every provider with reflection support, with explicit `--project` and `--profile` context
- add AWSPS `template=/{profile}/{project}/{key}` so its convention can match existing Terraform or Chamber hierarchies
- discover direct children of the rendered AWSPS path through `GetParametersByPath` without decrypting values
- migrate the existing dotenv and age reflection implementations to the contextual hook

AWSPS native refs remain read-only in this PR; writable refs are handled
independently by #234.

## Why

Terraform often owns resource-derived Parameter Store values while application
workflows use a hierarchy such as `/{environment}/{service}/{key}`. The fixed
AWSPS convention forced those teams either to duplicate every declaration or
generate `secretspec.toml`. A provider template preserves the cloud-resource
linkage, while bounded reflection can create the SecretSpec declarations from
the keys already present under that exact hierarchy.

`Provider::reflect_with_context()` is now the sole discovery hook. Flat
providers such as dotenv and age ignore the supplied context, while
hierarchical providers use it to discover only the namespace represented by
the new manifest.

## Example

```bash
secretspec init \
  --from 'awsps://production@us-east-1?template=/{profile}/{project}/{key}' \
  --project payments \
  --profile production
```

```toml
[providers]
parameters = "awsps://production@us-east-1?template=/{profile}/{project}/{key}"

[profiles.production.defaults]
providers = ["parameters"]
```

Discovery is non-recursive, requests no decryption, and returns declarations
only. `secretspec import` remains declaration-driven and does not enumerate a
provider.

## Validation

- `devenv shell cargo test --all` — passed
- `devenv shell cargo fmt --all -- --check` — passed
- pre-commit Clippy and rustfmt hooks — passed
- `devenv shell npm run build` in `docs/` — passed
- `git diff --check` — passed
