### PR TITLE
fix(providers): reuse Vault-compatible logins per operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ARN-pinned references before requesting a value. Versioned ARNs now point
   users to writable parameter-name references instead of suggesting that only
   the version selector be removed.
+- Vault and OpenBao AppRole and JWT authentication methods now reuse login
+  tokens within each provider operation up to each token's reported use and
+  lease limits, including time spent completing authentication, avoiding
+  repeated logins without exhausting or outliving tokens during batches,
+  writes, or deletes. Invalid batch addresses are rejected before login, and
+  concurrent requests remain safe across Tokio runtime flavors while keeping
+  pooled HTTP connections alive for the full operation.
 - Cached provider routes now recognize Vault and OpenBao configurations that
   address the same endpoint, namespace, and mount as one store, even when they
   use different provider names or authentication methods, so a cache cannot

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -62,11 +62,11 @@ keeper = ["dep:keeper-secrets-manager-core"]
 gcsm = ["dep:google-cloud-secretmanager-v1"]
 awssm = ["dep:aws-config", "dep:aws-sdk-secretsmanager", "aws-config/credentials-login"]
 awsps = ["dep:aws-config", "dep:aws-sdk-ssm"]
-vault = ["dep:reqwest"]
+vault = ["dep:reqwest", "tokio/sync"]
 # Scaleway Secret Manager talks to the v1beta1 REST API directly; base64
 # payloads use data-encoding, which is already a non-optional dependency.
 scaleway = ["dep:reqwest"]
-openbao = ["dep:reqwest"]
+openbao = ["dep:reqwest", "tokio/sync"]
 # `tokio/sync` for the async `OnceCell` that serializes the Universal Auth
 # exchange. It is already on transitively via reqwest, but a provider should
 # name the features it uses rather than inherit them from a sibling.

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -907,6 +907,20 @@ pub(crate) fn get_each<P: Provider + ?Sized>(
     provider: &P,
     requests: &[(&str, Address<'_>)],
 ) -> Result<HashMap<String, SecretString>> {
+    get_each_with(requests, |addr| provider.get(addr))
+}
+
+/// [`get_each`] with an operation-scoped fetch function.
+///
+/// Providers can use this when the per-address reads need to share state that
+/// belongs to exactly one `get_many` call, such as a short-lived login token.
+pub(crate) fn get_each_with<'a, F>(
+    requests: &[(&str, Address<'a>)],
+    fetch: F,
+) -> Result<HashMap<String, SecretString>>
+where
+    F: Fn(Address<'a>) -> Result<Option<SecretString>> + Sync,
+{
     let mut groups: HashMap<Address<'_>, Vec<&str>> = HashMap::new();
     for (name, addr) in requests {
         groups.entry(*addr).or_default().push(name);
@@ -921,7 +935,7 @@ pub(crate) fn get_each<P: Provider + ?Sized>(
     let fetched: Vec<(Vec<&str>, Result<Option<SecretString>>)> = if groups.len() <= 1 {
         groups
             .into_iter()
-            .map(|(addr, names)| (names, provider.get(addr)))
+            .map(|(addr, names)| (names, fetch(addr)))
             .collect()
     } else {
         let concurrency = get_each_concurrency();
@@ -936,7 +950,8 @@ pub(crate) fn get_each<P: Provider + ?Sized>(
                     .iter()
                     .map(|(addr, names)| {
                         let addr = *addr;
-                        (names, scope.spawn(move || provider.get(addr)))
+                        let fetch = &fetch;
+                        (names, scope.spawn(move || fetch(addr)))
                     })
                     .collect();
                 for (names, handle) in handles {

--- a/secretspec/src/provider/openbao.rs
+++ b/secretspec/src/provider/openbao.rs
@@ -138,13 +138,22 @@ impl Provider for OpenBaoProvider {
     }
 
     fn supported_coords(&self) -> &'static [&'static str] {
-        &["field"]
+        self.core.supported_coords()
     }
 
     /// A native reference must identify the field inside the KV entry's map.
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         let coords = self.resolve_coords(addr)?;
         self.core.get(&coords)
+    }
+
+    /// Reuses one operation-scoped login across the batch while retaining the
+    /// default address deduplication and concurrency cap.
+    fn get_many(
+        &self,
+        requests: &[(&str, Address<'_>)],
+    ) -> Result<std::collections::HashMap<String, SecretString>> {
+        self.core.get_many(requests)
     }
 
     /// Only convention addresses are writable; see [`Self::check_writable`].

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -126,13 +126,22 @@ impl Provider for VaultProvider {
     }
 
     fn supported_coords(&self) -> &'static [&'static str] {
-        &["field"]
+        self.core.supported_coords()
     }
 
     /// A native reference must identify the field inside the KV entry's map.
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         let coords = self.resolve_coords(addr)?;
         self.core.get(&coords)
+    }
+
+    /// Reuses one operation-scoped login across the batch while retaining the
+    /// default address deduplication and concurrency cap.
+    fn get_many(
+        &self,
+        requests: &[(&str, Address<'_>)],
+    ) -> Result<std::collections::HashMap<String, SecretString>> {
+        self.core.get_many(requests)
     }
 
     /// Only convention addresses are writable; see [`Self::check_writable`].

--- a/secretspec/src/provider/vault_common.rs
+++ b/secretspec/src/provider/vault_common.rs
@@ -10,13 +10,53 @@ use crate::{Result, SecretSpecError};
 use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
 use url::Url;
 
 pub(crate) const ROLE_ID: &str = "role_id";
 pub(crate) const SECRET_ID: &str = "secret_id";
 pub(crate) const TOKEN: &str = "token";
+
+/// Stable runtime for the shared Vault-compatible HTTP connection pools.
+///
+/// `get_many` invokes its synchronous fetch closure from several OS threads.
+/// Giving each closure a temporary runtime can strand a pooled reqwest
+/// connection when the runtime that owns its dispatch task is dropped. One
+/// process-wide runtime keeps those tasks alive across requests and providers.
+fn runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create Vault-compatible HTTP runtime")
+    })
+}
+
+fn block_on<F>(future: F) -> F::Output
+where
+    F: std::future::Future + Send,
+    F::Output: Send,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(|| runtime().block_on(future))
+        }
+        Ok(_) => std::thread::scope(|scope| {
+            let worker = scope.spawn(move || runtime().block_on(future));
+            match worker.join() {
+                Ok(output) => output,
+                Err(panic) => std::panic::resume_unwind(panic),
+            }
+        }),
+        Err(_) => runtime().block_on(future),
+    }
+}
 
 /// KV secrets engine version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -352,6 +392,120 @@ pub(crate) struct KvProvider {
     http: OnceLock<reqwest::Client>,
 }
 
+/// Number of authenticated requests an issued login token can still serve.
+#[derive(Clone, Copy)]
+enum TokenUses {
+    Unlimited,
+    Limited(u64),
+}
+
+/// A client token together with the use limit reported by a login response.
+struct IssuedToken {
+    value: SecretString,
+    uses: TokenUses,
+    usable_until: Option<Instant>,
+}
+
+impl IssuedToken {
+    fn static_token(value: SecretString) -> Self {
+        Self {
+            value,
+            uses: TokenUses::Unlimited,
+            usable_until: None,
+        }
+    }
+
+    fn login_token(
+        value: SecretString,
+        num_uses: Option<u64>,
+        usable_until: Option<Instant>,
+        lease_known: bool,
+    ) -> Self {
+        let uses = match num_uses {
+            Some(0) => TokenUses::Unlimited,
+            Some(uses) => TokenUses::Limited(uses),
+            // Vault-compatible login responses normally include
+            // `num_uses`. A partial response must not make us assume a
+            // token is safe to reuse.
+            None => TokenUses::Limited(1),
+        };
+        Self {
+            value,
+            uses: if lease_known {
+                uses
+            } else {
+                // A partial response without `lease_duration` may describe a
+                // short-lived token. Use it once, then authenticate again.
+                TokenUses::Limited(1)
+            },
+            usable_until,
+        }
+    }
+
+    fn claim(&mut self) -> Option<SecretString> {
+        if self.available_uses() == 0 {
+            return None;
+        }
+        match &mut self.uses {
+            TokenUses::Unlimited => Some(self.value.clone()),
+            TokenUses::Limited(0) => None,
+            TokenUses::Limited(uses) => {
+                *uses -= 1;
+                Some(self.value.clone())
+            }
+        }
+    }
+
+    fn available_uses(&self) -> usize {
+        if self
+            .usable_until
+            .is_some_and(|usable_until| Instant::now() >= usable_until)
+        {
+            return 0;
+        }
+
+        match self.uses {
+            TokenUses::Unlimited => usize::MAX,
+            TokenUses::Limited(uses) => usize::try_from(uses).unwrap_or(usize::MAX),
+        }
+    }
+}
+
+/// Login tokens acquired for one operation, including capacity preflighted for
+/// a multi-request mutation.
+struct TokenPool {
+    tokens: VecDeque<IssuedToken>,
+}
+
+impl TokenPool {
+    fn new(token: IssuedToken) -> Self {
+        Self {
+            tokens: VecDeque::from([token]),
+        }
+    }
+
+    fn discard_unusable(&mut self) {
+        self.tokens.retain(|token| token.available_uses() > 0);
+    }
+
+    fn available_uses(&self) -> usize {
+        self.tokens.iter().fold(0, |available, token| {
+            available.saturating_add(token.available_uses())
+        })
+    }
+}
+
+/// Authenticated state scoped to one logical provider operation.
+///
+/// AppRole and JWT exchanges produce client tokens that may expire or be
+/// revoked independently of this process. Keeping their reported use budget
+/// here lets requests share logins safely without turning a token into
+/// provider-lifetime authentication state.
+pub(crate) struct KvSession<'a> {
+    provider: &'a KvProvider,
+    tokens: Mutex<TokenPool>,
+}
+
 impl KvProvider {
     /// Creates the shared protocol client while retaining the product identity
     /// needed for environment lookup, diagnostics, and URI serialization.
@@ -369,10 +523,27 @@ impl KvProvider {
         self.http.get_or_init(reqwest::Client::new)
     }
 
+    /// Authenticates for the logical operation that owns the returned session.
+    /// Additional logins are performed only when the issued token's reported
+    /// use budget is exhausted. Dropping the session drops all authentication
+    /// state, so a later operation cannot unknowingly reuse an expired token.
+    fn session(&self) -> Result<KvSession<'_>> {
+        let token = block_on(self.resolve_token())?;
+        Ok(KvSession {
+            provider: self,
+            tokens: Mutex::new(TokenPool::new(token)),
+        })
+    }
+
     /// Injects semantic credentials resolved from another SecretSpec provider.
     /// Explicit credentials outrank every environment fallback.
     pub(crate) fn with_credentials(&mut self, credentials: ProviderCredentials) {
         self.credentials = credentials;
+    }
+
+    /// Native coordinates understood by the shared Vault-compatible KV API.
+    pub(crate) fn supported_coords(&self) -> &'static [&'static str] {
+        &["field"]
     }
 
     /// Compiles SecretSpec's logical address into one KV entry per secret.
@@ -493,14 +664,73 @@ impl KvProvider {
     /// Convention addresses also arrive here after resolving to field `value`.
     pub(crate) fn get(&self, coords: &NativeAddress) -> Result<Option<SecretString>> {
         let field = self.require_field(coords)?;
-        super::block_on(self.get_field_async(&coords.item, field))
+        self.session()?.get_field(&coords.item, field)
+    }
+
+    /// Validates and resolves the parts of a read address that can fail without
+    /// contacting the provider.
+    fn validate_read_address(&self, addr: Address<'_>) -> Result<()> {
+        match addr {
+            Address::Convention {
+                project,
+                profile,
+                key,
+            } => {
+                self.convention_address(project, profile, key)?;
+                Ok(())
+            }
+            Address::Native(coords) => {
+                super::reject_unsupported_coords(
+                    self.product.scheme(),
+                    coords,
+                    self.supported_coords(),
+                )?;
+                self.require_field(coords)?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Reads a batch through one operation-scoped authentication session while
+    /// retaining the provider-wide address deduplication and concurrency cap.
+    pub(crate) fn get_many(
+        &self,
+        requests: &[(&str, Address<'_>)],
+    ) -> Result<HashMap<String, SecretString>> {
+        if requests.is_empty() {
+            return Ok(HashMap::new());
+        }
+        // Login can consume a one-use AppRole SecretID. Reject every local
+        // coordinate error before creating the operation session.
+        for (_, addr) in requests {
+            self.validate_read_address(*addr)?;
+        }
+        let session = self.session()?;
+        super::get_each_with(requests, |addr| match addr {
+            Address::Convention {
+                project,
+                profile,
+                key,
+            } => {
+                let coords = self.convention_address(project, profile, key)?;
+                session.get(&coords)
+            }
+            Address::Native(coords) => {
+                super::reject_unsupported_coords(
+                    self.product.scheme(),
+                    coords,
+                    self.supported_coords(),
+                )?;
+                session.get(coords)
+            }
+        })
     }
 
     /// Writes a complete convention-owned KV entry.
     ///
     /// Callers must run [`Self::check_writable`] before reaching this method.
     pub(crate) fn set(&self, coords: &NativeAddress, value: &SecretString) -> Result<()> {
-        super::block_on(self.set_secret_async(&coords.item, value))
+        self.session()?.set(&coords.item, value)
     }
 
     /// Writes a convention-owned KV entry the store itself will drop once
@@ -526,10 +756,7 @@ impl KvProvider {
                 self.product.scheme()
             )));
         }
-        super::block_on(async {
-            self.set_version_ttl_async(&coords.item, max_age).await?;
-            self.set_secret_async(&coords.item, value).await
-        })
+        self.session()?.set_expiring(&coords.item, value, max_age)
     }
 
     /// Destroys a convention-owned KV path, reporting whether it held anything.
@@ -543,26 +770,7 @@ impl KvProvider {
     /// Callers must run [`Self::check_deletable`] before reaching this method.
     pub(crate) fn delete(&self, coords: &NativeAddress) -> Result<bool> {
         let field = self.require_field(coords)?;
-        super::block_on(async {
-            match self.config.kv_version {
-                // An expired KV v2 version is no longer readable from the data
-                // endpoint, but its metadata and recoverable version history
-                // still exist. Check the metadata path so cache clearing
-                // permanently destroys that history.
-                KvVersion::V2 => {
-                    if !self.metadata_exists_async(&coords.item).await? {
-                        return Ok(false);
-                    }
-                }
-                KvVersion::V1 => {
-                    if self.get_field_async(&coords.item, field).await?.is_none() {
-                        return Ok(false);
-                    }
-                }
-            }
-            self.delete_path_async(&coords.item).await?;
-            Ok(true)
-        })
+        self.session()?.delete(&coords.item, field)
     }
 
     /// Native references are read-only because the current write API replaces
@@ -592,11 +800,13 @@ impl KvProvider {
         }
     }
 
-    /// Resolves a reusable client token with the configured authentication
+    /// Resolves a client token and the use budget known for its authentication
     /// method.
-    async fn resolve_token(&self) -> Result<SecretString> {
+    async fn resolve_token(&self) -> Result<IssuedToken> {
         match self.config.auth {
-            AuthMethod::Token => self.resolve_token_auth(),
+            // A configured token is opaque: SecretSpec cannot mint a
+            // replacement and looking it up would itself consume one use.
+            AuthMethod::Token => self.resolve_token_auth().map(IssuedToken::static_token),
             AuthMethod::AppRole => self.resolve_approle_auth().await,
             AuthMethod::Jwt => self.resolve_jwt_auth().await,
         }
@@ -647,7 +857,7 @@ impl KvProvider {
 
     /// Exchanges AppRole credentials for the short-lived client token used by
     /// subsequent KV requests.
-    async fn resolve_approle_auth(&self) -> Result<SecretString> {
+    async fn resolve_approle_auth(&self) -> Result<IssuedToken> {
         let role_id = credential_or_envs(&self.credentials, ROLE_ID, self.product.role_id_envs())
             .ok_or_else(|| {
             SecretSpecError::ProviderOperationFailed(format!(
@@ -675,6 +885,10 @@ impl KvProvider {
             "secret_id": secret_id,
         });
 
+        // The server-side lease begins while the request is in flight. Anchor
+        // its deadline before sending so response latency cannot extend the
+        // token's perceived lifetime.
+        let login_started_at = Instant::now();
         let response = self
             .build_login_request(&url, &body)?
             .send()
@@ -703,18 +917,11 @@ impl KvProvider {
                 crate::error::display_error_chain(&error)
             ))
         })?;
-        let token = response["auth"]["client_token"].as_str().ok_or_else(|| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "{} AppRole login response missing auth.client_token",
-                self.product.display_name()
-            ))
-        })?;
-
-        Ok(SecretString::new(token.to_string().into()))
+        self.parse_login_token(&response, "AppRole", login_started_at)
     }
 
     /// Exchanges a JWT and role at the standard `auth/jwt/login` endpoint.
-    async fn resolve_jwt_auth(&self) -> Result<SecretString> {
+    async fn resolve_jwt_auth(&self) -> Result<IssuedToken> {
         let role = self.config.role.clone().ok_or_else(|| {
             SecretSpecError::ProviderOperationFailed(format!(
                 "{} JWT authentication requires a role. Set `?role=` in the provider URI or {}.",
@@ -729,6 +936,10 @@ impl KvProvider {
             "role": role,
             "jwt": jwt.expose_secret(),
         });
+        // The server-side lease begins while the request is in flight. Anchor
+        // its deadline before sending so response latency cannot extend the
+        // token's perceived lifetime.
+        let login_started_at = Instant::now();
         let response = self
             .build_login_request(&url, &body)?
             .send()
@@ -757,14 +968,77 @@ impl KvProvider {
                 crate::error::display_error_chain(&error)
             ))
         })?;
-        let token = response["auth"]["client_token"].as_str().ok_or_else(|| {
+        self.parse_login_token(&response, "JWT", login_started_at)
+    }
+
+    /// Extracts a login token and the server-reported request budget.
+    ///
+    /// `num_uses = 0` is the Vault-compatible representation of an unlimited
+    /// use count, not an unlimited lifetime. Missing use or lease metadata is
+    /// treated conservatively so a partial response cannot cause unsafe reuse;
+    /// malformed metadata is a protocol error.
+    fn parse_login_token(
+        &self,
+        response: &serde_json::Value,
+        auth_method: &str,
+        login_started_at: Instant,
+    ) -> Result<IssuedToken> {
+        let auth = response.get("auth").ok_or_else(|| {
             SecretSpecError::ProviderOperationFailed(format!(
-                "{} JWT login response missing auth.client_token",
+                "{} {auth_method} login response missing auth.client_token",
                 self.product.display_name()
             ))
         })?;
+        let token = auth
+            .get("client_token")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "{} {auth_method} login response missing auth.client_token",
+                    self.product.display_name()
+                ))
+            })?;
+        let num_uses = match auth.get("num_uses") {
+            Some(value) => Some(value.as_u64().ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "{} {auth_method} login response has invalid auth.num_uses",
+                    self.product.display_name()
+                ))
+            })?),
+            None => None,
+        };
+        let lease_duration = match auth.get("lease_duration") {
+            Some(value) => Some(value.as_u64().ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "{} {auth_method} login response has invalid auth.lease_duration",
+                    self.product.display_name()
+                ))
+            })?),
+            None => None,
+        };
+        let usable_until = match lease_duration {
+            Some(0) | None => None,
+            Some(seconds) => {
+                let ttl = Duration::from_secs(seconds);
+                // Leave a small window for network transit and server-side
+                // token validation, without making very short leases unusable.
+                let safety_margin = std::cmp::min(Duration::from_secs(5), ttl / 10);
+                let usable_for = ttl.saturating_sub(safety_margin);
+                Some(login_started_at.checked_add(usable_for).ok_or_else(|| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "{} {auth_method} login response has invalid auth.lease_duration",
+                        self.product.display_name()
+                    ))
+                })?)
+            }
+        };
 
-        Ok(SecretString::new(token.to_string().into()))
+        Ok(IssuedToken::login_token(
+            SecretString::new(token.to_string().into()),
+            num_uses,
+            usable_until,
+            lease_duration.is_some(),
+        ))
     }
 
     /// Sources a JWT directly from the product environment or mints one from
@@ -871,36 +1145,28 @@ impl KvProvider {
         Ok(headers)
     }
 
-    /// Builds the raw API path, inserting KV v2's required `/data/` segment.
-    fn build_url(&self, secret_path: &str) -> String {
-        match self.config.kv_version {
-            KvVersion::V2 => format!(
-                "{}/v1/{}/data/{secret_path}",
-                self.config.endpoint, self.config.mount
-            ),
-            KvVersion::V1 => format!(
-                "{}/v1/{}/{secret_path}",
-                self.config.endpoint, self.config.mount
-            ),
-        }
-    }
-
-    /// Sends a request, retrying a few times on connect/timeout errors only.
+    /// Sends one authenticated request, retrying connect and timeout failures.
     ///
-    /// Auth and HTTP status failures are not retried — those are not the
-    /// reverse-proxy connection storm this targets. The builder is reconstructed
-    /// each attempt because `RequestBuilder` is consumed by `send`.
+    /// A connect failure cannot have reached the server, so the same token
+    /// claim remains valid. A later timeout is ambiguous: the server may have
+    /// consumed the request before the response was lost, so a retry claims
+    /// another use. HTTP status failures are not retried.
     async fn send_with_connect_retry(
         &self,
-        mut build: impl FnMut() -> Result<reqwest::RequestBuilder>,
+        session: &KvSession<'_>,
+        mut token: SecretString,
+        mut build: impl FnMut(&SecretString) -> Result<reqwest::RequestBuilder>,
     ) -> Result<reqwest::Response> {
         const ATTEMPTS: usize = 3;
         let mut last_error = None;
         for attempt in 1..=ATTEMPTS {
-            let response = build()?.send().await;
+            let response = build(&token)?.send().await;
             match response {
                 Ok(response) => return Ok(response),
                 Err(error) if attempt < ATTEMPTS && (error.is_connect() || error.is_timeout()) => {
+                    if error.is_timeout() && !error.is_connect() {
+                        token = session.claim_token().await?;
+                    }
                     last_error = Some(error);
                     // get_each already runs each get on its own thread, so a
                     // brief blocking backoff is fine and avoids a tokio/time
@@ -925,6 +1191,20 @@ impl KvProvider {
                 &last_error.expect("connect retry exhausted with an error")
             )
         )))
+    }
+
+    /// Builds the raw API path, inserting KV v2's required `/data/` segment.
+    fn build_url(&self, secret_path: &str) -> String {
+        match self.config.kv_version {
+            KvVersion::V2 => format!(
+                "{}/v1/{}/data/{secret_path}",
+                self.config.endpoint, self.config.mount
+            ),
+            KvVersion::V1 => format!(
+                "{}/v1/{}/{secret_path}",
+                self.config.endpoint, self.config.mount
+            ),
+        }
     }
 
     /// Reads an HTTP body without turning a transport/decompression failure
@@ -952,12 +1232,17 @@ impl KvProvider {
 
     /// Whether a KV v2 path has metadata, including when every version is
     /// soft-deleted and therefore absent from the data endpoint.
-    async fn metadata_exists_async(&self, secret_path: &str) -> Result<bool> {
+    async fn metadata_exists_async(
+        &self,
+        secret_path: &str,
+        session: &KvSession<'_>,
+        token: SecretString,
+    ) -> Result<bool> {
         let url = self.metadata_url(secret_path);
-        let token = self.resolve_token().await?;
-        let headers = self.build_headers(&token)?;
         let response = self
-            .send_with_connect_retry(|| Ok(self.http().get(&url).headers(headers.clone())))
+            .send_with_connect_retry(session, token, |token| {
+                Ok(self.http().get(&url).headers(self.build_headers(token)?))
+            })
             .await?;
 
         match response.status().as_u16() {
@@ -985,16 +1270,20 @@ impl KvProvider {
         &self,
         secret_path: &str,
         max_age: std::time::Duration,
+        session: &KvSession<'_>,
+        token: SecretString,
     ) -> Result<()> {
         let url = self.metadata_url(secret_path);
-        let token = self.resolve_token().await?;
         // Seconds keep the request independent of how the duration was written
         // in the config (`8h` and `480m` are the same policy).
         let body = serde_json::json!({ "delete_version_after": format!("{}s", max_age.as_secs()) });
-        let headers = self.build_headers(&token)?;
         let response = self
-            .send_with_connect_retry(|| {
-                Ok(self.http().post(&url).headers(headers.clone()).json(&body))
+            .send_with_connect_retry(session, token, |token| {
+                Ok(self
+                    .http()
+                    .post(&url)
+                    .headers(self.build_headers(token)?)
+                    .json(&body))
             })
             .await?;
 
@@ -1017,15 +1306,20 @@ impl KvProvider {
 
     /// Removes a KV path outright: for v2 the metadata endpoint, which destroys
     /// every version; for v1 the data path, which is all there is.
-    async fn delete_path_async(&self, secret_path: &str) -> Result<()> {
+    async fn delete_path_async(
+        &self,
+        secret_path: &str,
+        session: &KvSession<'_>,
+        token: SecretString,
+    ) -> Result<()> {
         let url = match self.config.kv_version {
             KvVersion::V2 => self.metadata_url(secret_path),
             KvVersion::V1 => self.build_url(secret_path),
         };
-        let token = self.resolve_token().await?;
-        let headers = self.build_headers(&token)?;
         let response = self
-            .send_with_connect_retry(|| Ok(self.http().delete(&url).headers(headers.clone())))
+            .send_with_connect_retry(session, token, |token| {
+                Ok(self.http().delete(&url).headers(self.build_headers(token)?))
+            })
             .await?;
 
         match response.status().as_u16() {
@@ -1056,12 +1350,14 @@ impl KvProvider {
         &self,
         secret_path: &str,
         field: &str,
+        session: &KvSession<'_>,
+        token: SecretString,
     ) -> Result<Option<SecretString>> {
         let url = self.build_url(secret_path);
-        let token = self.resolve_token().await?;
-        let headers = self.build_headers(&token)?;
         let response = self
-            .send_with_connect_retry(|| Ok(self.http().get(&url).headers(headers.clone())))
+            .send_with_connect_retry(session, token, |token| {
+                Ok(self.http().get(&url).headers(self.build_headers(token)?))
+            })
             .await?;
 
         match response.status().as_u16() {
@@ -1106,17 +1402,25 @@ impl KvProvider {
     /// Writes SecretSpec's single-field convention payload to KV.
     ///
     /// KV v2 wraps user data under `data`; KV v1 accepts the map directly.
-    async fn set_secret_async(&self, secret_path: &str, value: &SecretString) -> Result<()> {
+    async fn set_secret_async(
+        &self,
+        secret_path: &str,
+        value: &SecretString,
+        session: &KvSession<'_>,
+        token: SecretString,
+    ) -> Result<()> {
         let url = self.build_url(secret_path);
-        let token = self.resolve_token().await?;
         let body = match self.config.kv_version {
             KvVersion::V2 => serde_json::json!({ "data": { "value": value.expose_secret() } }),
             KvVersion::V1 => serde_json::json!({ "value": value.expose_secret() }),
         };
-        let headers = self.build_headers(&token)?;
         let response = self
-            .send_with_connect_retry(|| {
-                Ok(self.http().post(&url).headers(headers.clone()).json(&body))
+            .send_with_connect_retry(session, token, |token| {
+                Ok(self
+                    .http()
+                    .post(&url)
+                    .headers(self.build_headers(token)?)
+                    .json(&body))
             })
             .await?;
 
@@ -1139,13 +1443,579 @@ impl KvProvider {
     }
 }
 
+impl KvSession<'_> {
+    async fn claim_token(&self) -> Result<SecretString> {
+        let mut pool = self.tokens.lock().await;
+        loop {
+            while let Some(token) = pool.tokens.front_mut() {
+                if let Some(token) = token.claim() {
+                    return Ok(token);
+                }
+                pool.tokens.pop_front();
+            }
+
+            // Keep the lock across the exchange so concurrent reads cannot
+            // each mint a replacement for the same exhausted or expired
+            // token.
+            pool.tokens.push_back(self.provider.resolve_token().await?);
+        }
+    }
+
+    /// Ensures a multi-request mutation can obtain all of its authentication
+    /// capacity before its first side effect, without reserving tokens so early
+    /// that a short lease can expire before the later request is sent.
+    async fn ensure_claims(&self, count: usize) -> Result<()> {
+        let mut pool = self.tokens.lock().await;
+        let mut additional_logins = 0;
+        loop {
+            pool.discard_unusable();
+            if pool.available_uses() >= count {
+                return Ok(());
+            }
+            if additional_logins >= count {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "{} login tokens expire too quickly to safely perform a {count}-request operation",
+                    self.provider.product.display_name()
+                )));
+            }
+            pool.tokens.push_back(self.provider.resolve_token().await?);
+            additional_logins += 1;
+        }
+    }
+
+    /// Reads one address with authentication scoped to this operation.
+    fn get(&self, coords: &NativeAddress) -> Result<Option<SecretString>> {
+        let field = self.provider.require_field(coords)?;
+        self.get_field(&coords.item, field)
+    }
+
+    fn get_field(&self, secret_path: &str, field: &str) -> Result<Option<SecretString>> {
+        block_on(async {
+            let token = self.claim_token().await?;
+            self.provider
+                .get_field_async(secret_path, field, self, token)
+                .await
+        })
+    }
+
+    fn set(&self, secret_path: &str, value: &SecretString) -> Result<()> {
+        block_on(async {
+            let token = self.claim_token().await?;
+            self.provider
+                .set_secret_async(secret_path, value, self, token)
+                .await
+        })
+    }
+
+    fn set_expiring(
+        &self,
+        secret_path: &str,
+        value: &SecretString,
+        max_age: std::time::Duration,
+    ) -> Result<()> {
+        block_on(async {
+            // Ensure both request claims before changing metadata. If a
+            // limited-use role can no longer log in, no partial expiry policy
+            // is left behind. Claim immediately before each request so an
+            // already preflighted short-lease token can still be refreshed.
+            self.ensure_claims(2).await?;
+            let metadata_token = self.claim_token().await?;
+            self.provider
+                .set_version_ttl_async(secret_path, max_age, self, metadata_token)
+                .await?;
+            let data_token = self.claim_token().await?;
+            self.provider
+                .set_secret_async(secret_path, value, self, data_token)
+                .await
+        })
+    }
+
+    fn delete(&self, secret_path: &str, field: &str) -> Result<bool> {
+        block_on(async {
+            let existence_token = self.claim_token().await?;
+            match self.provider.config.kv_version {
+                // An expired KV v2 version is no longer readable from the data
+                // endpoint, but its metadata and recoverable version history
+                // still exist. Check the metadata path so cache clearing
+                // permanently destroys that history.
+                KvVersion::V2 => {
+                    if !self
+                        .provider
+                        .metadata_exists_async(secret_path, self, existence_token)
+                        .await?
+                    {
+                        return Ok(false);
+                    }
+                }
+                KvVersion::V1 => {
+                    if self
+                        .provider
+                        .get_field_async(secret_path, field, self, existence_token)
+                        .await?
+                        .is_none()
+                    {
+                        return Ok(false);
+                    }
+                }
+            }
+            // The existence check is read-only. Resolve the destructive
+            // request's claim before issuing the delete so an exhausted role
+            // cannot turn into a post-mutation authentication failure.
+            let delete_token = self.claim_token().await?;
+            self.provider
+                .delete_path_async(secret_path, self, delete_token)
+                .await?;
+            Ok(true)
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::Provider;
+    #[cfg(feature = "openbao")]
+    use crate::provider::openbao::{OpenBaoConfig, OpenBaoProvider};
+    #[cfg(feature = "vault")]
+    use crate::provider::vault::{VaultConfig, VaultProvider};
     use crate::tests::EnvVarGuard;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
 
     fn provider_url(spec: &str) -> ProviderUrl {
         ProviderUrl::new(Url::parse(spec).unwrap())
+    }
+
+    #[cfg(feature = "vault")]
+    fn batch_requests() -> [(&'static str, Address<'static>); 2] {
+        [
+            ("FIRST", Address::convention("project", "default", "FIRST")),
+            (
+                "SECOND",
+                Address::convention("project", "default", "SECOND"),
+            ),
+        ]
+    }
+
+    fn api_key_address() -> Address<'static> {
+        Address::convention("project", "default", "API_KEY")
+    }
+
+    fn approle_credentials() -> ProviderCredentials {
+        ProviderCredentials::from([
+            (
+                ROLE_ID.to_string(),
+                SecretString::new("test-role".to_string().into()),
+            ),
+            (
+                SECRET_ID.to_string(),
+                SecretString::new("test-secret".to_string().into()),
+            ),
+        ])
+    }
+
+    fn parse_test_login(auth: serde_json::Value) -> Result<IssuedToken> {
+        KvProvider::new(KvConfig::default(), Product::Vault).parse_login_token(
+            &serde_json::json!({ "auth": auth }),
+            "test",
+            Instant::now(),
+        )
+    }
+
+    #[cfg(feature = "vault")]
+    fn vault_approle_provider(endpoint: SocketAddr) -> VaultProvider {
+        let config = VaultConfig::try_from(&provider_url(&format!(
+            "vault://{endpoint}/secret?tls=false&auth=approle"
+        )))
+        .unwrap();
+        let mut provider = VaultProvider::new(config);
+        provider.with_credentials(approle_credentials());
+        provider
+    }
+
+    #[cfg(feature = "openbao")]
+    fn openbao_jwt_provider(endpoint: SocketAddr) -> OpenBaoProvider {
+        let config = OpenBaoConfig::try_from(&provider_url(&format!(
+            "openbao://{endpoint}/secret?tls=false&auth=jwt&role=ci"
+        )))
+        .unwrap();
+        OpenBaoProvider::new(config)
+    }
+
+    fn read_request(stream: &mut TcpStream) -> String {
+        let mut request = String::new();
+        let mut content_length = 0;
+        {
+            let mut reader = BufReader::new(&mut *stream);
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                if line == "\r\n" || line.is_empty() {
+                    request.push_str(&line);
+                    break;
+                }
+                if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    content_length = value.trim().parse().unwrap();
+                }
+                request.push_str(&line);
+            }
+            let mut body = vec![0; content_length];
+            reader.read_exact(&mut body).unwrap();
+            request.push_str(&String::from_utf8(body).unwrap());
+        }
+        request
+    }
+
+    fn auth_server(
+        request_count: usize,
+        token_num_uses: u64,
+        fail_login: Option<usize>,
+    ) -> (
+        SocketAddr,
+        std::thread::JoinHandle<Vec<(String, Option<String>)>>,
+    ) {
+        auth_server_with_lease(request_count, token_num_uses, fail_login, 3600, None, None)
+    }
+
+    fn auth_server_with_lease(
+        request_count: usize,
+        token_num_uses: u64,
+        fail_login: Option<usize>,
+        lease_duration: u64,
+        first_login_delay: Option<Duration>,
+        first_read_delay: Option<Duration>,
+    ) -> (
+        SocketAddr,
+        std::thread::JoinHandle<Vec<(String, Option<String>)>>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let mut observed = Vec::new();
+            let mut login_count = 0;
+            let mut read_count = 0;
+            for _ in 0..request_count {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request = read_request(&mut stream);
+                let request_line = request.lines().next().unwrap_or_default().to_string();
+                let token = request.lines().find_map(|line| {
+                    line.split_once(':').and_then(|(name, value)| {
+                        name.eq_ignore_ascii_case("X-Vault-Token")
+                            .then(|| value.trim().to_string())
+                    })
+                });
+
+                let (status, body) = if request_line.contains("/v1/auth/") {
+                    login_count += 1;
+                    if login_count == 1
+                        && let Some(delay) = first_login_delay
+                    {
+                        std::thread::sleep(delay);
+                    }
+                    if fail_login == Some(login_count) {
+                        (
+                            "403 Forbidden",
+                            r#"{"errors":["login denied"]}"#.to_string(),
+                        )
+                    } else {
+                        (
+                            "200 OK",
+                            format!(
+                                r#"{{"auth":{{"client_token":"operation-token-{login_count}","num_uses":{token_num_uses},"lease_duration":{lease_duration}}}}}"#
+                            ),
+                        )
+                    }
+                } else if request_line.starts_with("GET ") && request_line.contains("/data/") {
+                    read_count += 1;
+                    if read_count == 1
+                        && let Some(delay) = first_read_delay
+                    {
+                        std::thread::sleep(delay);
+                    }
+                    (
+                        "200 OK",
+                        r#"{"data":{"data":{"value":"resolved"}}}"#.to_string(),
+                    )
+                } else if request_line.starts_with("GET ") {
+                    ("200 OK", String::new())
+                } else {
+                    ("204 No Content", String::new())
+                };
+                observed.push((request_line, token));
+                write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .unwrap();
+            }
+            observed
+        });
+        (endpoint, server)
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn approle_login_is_scoped_to_each_get_many_operation() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let (endpoint, server) = auth_server(6, 2, None);
+        let provider = vault_approle_provider(endpoint);
+        let requests = batch_requests();
+        for _ in 0..2 {
+            let values = provider.get_many(&requests).unwrap();
+            assert_eq!(values.len(), 2);
+            assert_eq!(values["FIRST"].expose_secret(), "resolved");
+            assert_eq!(values["SECOND"].expose_secret(), "resolved");
+        }
+
+        let observed = server.join().unwrap();
+        assert!(observed[0].0.contains("/v1/auth/approle/login"));
+        assert!(observed[3].0.contains("/v1/auth/approle/login"));
+        assert!(
+            observed[1..3]
+                .iter()
+                .all(|(_, token)| token.as_deref() == Some("operation-token-1"))
+        );
+        assert!(
+            observed[4..6]
+                .iter()
+                .all(|(_, token)| token.as_deref() == Some("operation-token-2"))
+        );
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn approle_get_many_runs_inside_a_current_thread_runtime() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let (endpoint, server) = auth_server(3, 2, None);
+        let provider = vault_approle_provider(endpoint);
+        let requests = batch_requests();
+        let outer = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let values = outer
+            .block_on(async { provider.get_many(&requests) })
+            .unwrap();
+
+        assert_eq!(values.len(), 2);
+        assert_eq!(server.join().unwrap().len(), 3);
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn approle_get_many_does_not_oversubscribe_single_use_tokens() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let (endpoint, server) = auth_server(4, 1, None);
+        let provider = vault_approle_provider(endpoint);
+
+        let values = provider.get_many(&batch_requests()).unwrap();
+        assert_eq!(values.len(), 2);
+
+        let observed = server.join().unwrap();
+        assert_eq!(
+            observed
+                .iter()
+                .filter(|(request, _)| request.contains("/v1/auth/approle/login"))
+                .count(),
+            2
+        );
+        let mut read_tokens: Vec<_> = observed
+            .iter()
+            .filter(|(request, _)| request.starts_with("GET ") && request.contains("/data/"))
+            .map(|(_, token)| token.as_deref().unwrap())
+            .collect();
+        read_tokens.sort_unstable();
+        assert_eq!(read_tokens, ["operation-token-1", "operation-token-2"]);
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn approle_get_many_refreshes_a_token_between_slow_waves() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let _concurrency = EnvVarGuard::set(super::super::GET_EACH_CONCURRENCY_ENV, "1");
+        let (endpoint, server) =
+            auth_server_with_lease(4, 0, None, 1, None, Some(Duration::from_millis(1100)));
+        let provider = vault_approle_provider(endpoint);
+
+        let values = provider.get_many(&batch_requests()).unwrap();
+        assert_eq!(values.len(), 2);
+
+        let observed = server.join().unwrap();
+        assert!(observed[0].0.contains("/v1/auth/approle/login"));
+        assert_eq!(observed[1].1.as_deref(), Some("operation-token-1"));
+        assert!(observed[2].0.contains("/v1/auth/approle/login"));
+        assert_eq!(observed[3].1.as_deref(), Some("operation-token-2"));
+    }
+
+    #[cfg(feature = "openbao")]
+    #[test]
+    fn jwt_login_obtains_enough_limited_use_tokens_before_an_expiring_write() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let _jwt = EnvVarGuard::set("BAO_JWT", "test-jwt");
+        let (endpoint, server) = auth_server(4, 1, None);
+        let provider = openbao_jwt_provider(endpoint);
+
+        provider
+            .set_expiring(
+                api_key_address(),
+                &SecretString::new("value".to_string().into()),
+                std::time::Duration::from_secs(3600),
+            )
+            .unwrap();
+
+        let observed = server.join().unwrap();
+        assert!(observed[0].0.contains("/v1/auth/jwt/login"));
+        assert!(observed[1].0.contains("/v1/auth/jwt/login"));
+        assert!(observed[2].0.contains("/v1/secret/metadata/"));
+        assert_eq!(observed[2].1.as_deref(), Some("operation-token-1"));
+        assert!(observed[3].0.contains("/v1/secret/data/"));
+        assert_eq!(observed[3].1.as_deref(), Some("operation-token-2"));
+    }
+
+    #[cfg(feature = "openbao")]
+    #[test]
+    fn expiring_write_stops_before_metadata_when_reauthentication_fails() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let _jwt = EnvVarGuard::set("BAO_JWT", "test-jwt");
+        let (endpoint, server) = auth_server(2, 1, Some(2));
+        let provider = openbao_jwt_provider(endpoint);
+
+        let error = provider
+            .set_expiring(
+                api_key_address(),
+                &SecretString::new("value".to_string().into()),
+                std::time::Duration::from_secs(3600),
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("JWT login returned HTTP 403"));
+        let observed = server.join().unwrap();
+        assert_eq!(observed.len(), 2);
+        assert!(
+            observed
+                .iter()
+                .all(|(request, _)| request.contains("/v1/auth/jwt/login"))
+        );
+    }
+
+    #[cfg(feature = "vault")]
+    #[test]
+    fn delete_reauthenticates_after_a_limited_use_existence_check() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let (endpoint, server) = auth_server(4, 1, None);
+        let provider = vault_approle_provider(endpoint);
+
+        assert!(provider.delete(api_key_address()).unwrap());
+
+        let observed = server.join().unwrap();
+        assert!(observed[0].0.contains("/v1/auth/approle/login"));
+        assert!(observed[1].0.starts_with("GET /v1/secret/metadata/"));
+        assert_eq!(observed[1].1.as_deref(), Some("operation-token-1"));
+        assert!(observed[2].0.contains("/v1/auth/approle/login"));
+        assert!(observed[3].0.starts_with("DELETE /v1/secret/metadata/"));
+        assert_eq!(observed[3].1.as_deref(), Some("operation-token-2"));
+    }
+
+    #[test]
+    fn missing_login_use_count_is_treated_as_single_use() {
+        let mut token = parse_test_login(serde_json::json!({ "client_token": "limited" })).unwrap();
+
+        assert_eq!(token.claim().unwrap().expose_secret(), "limited");
+        assert!(token.claim().is_none());
+    }
+
+    #[test]
+    fn malformed_login_use_count_is_rejected() {
+        let error = parse_test_login(serde_json::json!({
+            "client_token": "limited",
+            "num_uses": "one"
+        }))
+        .err()
+        .expect("malformed num_uses must fail");
+
+        assert!(error.to_string().contains("invalid auth.num_uses"));
+    }
+
+    #[test]
+    fn malformed_login_lease_duration_is_rejected() {
+        let error = parse_test_login(serde_json::json!({
+            "client_token": "limited",
+            "num_uses": 0,
+            "lease_duration": "brief"
+        }))
+        .err()
+        .expect("malformed lease_duration must fail");
+
+        assert!(error.to_string().contains("invalid auth.lease_duration"));
+    }
+
+    #[test]
+    fn approle_login_latency_reduces_the_reported_lease() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let (endpoint, server) =
+            auth_server_with_lease(1, 0, None, 1, Some(Duration::from_millis(1100)), None);
+        let config = KvConfig::parse(
+            &provider_url(&format!("vault://{endpoint}/secret?tls=false&auth=approle")),
+            Product::Vault,
+        )
+        .unwrap();
+        let mut provider = KvProvider::new(config, Product::Vault);
+        provider.with_credentials(approle_credentials());
+
+        let mut token = block_on(provider.resolve_approle_auth()).unwrap();
+
+        assert!(token.claim().is_none());
+        assert_eq!(server.join().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn get_many_validates_every_address_before_authenticating() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let config = KvConfig::parse(
+            &provider_url("vault://127.0.0.1:1/secret?tls=false&auth=approle"),
+            Product::Vault,
+        )
+        .unwrap();
+        let provider = KvProvider::new(config, Product::Vault);
+        let invalid = NativeAddress {
+            item: "app/config".to_string(),
+            ..Default::default()
+        };
+
+        let error = provider
+            .get_many(&[
+                ("VALID", Address::convention("project", "default", "VALID")),
+                ("INVALID", Address::Native(&invalid)),
+            ])
+            .unwrap_err();
+
+        assert!(error.to_string().contains("references need a `field`"));
+        assert!(!error.to_string().contains("role_id credential is required"));
+    }
+
+    #[test]
+    fn block_on_is_safe_inside_a_current_thread_runtime() {
+        let outer = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let answer = outer.block_on(async { block_on(async { 42 }) });
+
+        assert_eq!(answer, 42);
+    }
+
+    #[test]
+    fn vault_compatible_http_work_uses_one_runtime_across_batch_threads() {
+        let first = block_on(async { tokio::runtime::Handle::current().id() });
+        let second =
+            std::thread::spawn(|| block_on(async { tokio::runtime::Handle::current().id() }))
+                .join()
+                .unwrap();
+
+        assert_eq!(first, second);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reuse AppRole and JWT login tokens within each Vault/OpenBao provider operation.
- Share authentication across batched reads and multi-request writes or deletes.
- Re-authenticate when a token reaches its reported use or lease limit.
- Drop dynamic authentication state after each operation rather than caching or renewing tokens indefinitely.

## Rationale

Previously, AppRole and JWT authenticated for every underlying HTTP request, causing redundant login or OIDC requests during batch operations.

Operation-scoped reuse removes that overhead while remaining compatible with finite-use and short-lived tokens. Lease accounting includes time spent completing authentication, and invalid batch addresses are rejected before login so one-use AppRole SecretIDs are not unnecessarily consumed.

The shared HTTP execution also remains safe when called from multi-threaded or current-thread Tokio runtimes.

## Verification

- Full workspace test suite passes.
- Clippy and rustfmt pre-commit checks pass.
- Vault-only and OpenBao-only feature test suites pass.
- Regression tests cover finite-use tokens, lease expiry, delayed login responses, invalid batch addresses, and current-thread Tokio runtimes.
- Live OpenBao 2.6.1 AppRole smoke tests confirmed:
  - One login can serve a two-secret batch, with a fresh login for the next operation.
  - A token_num_uses=1 role re-authenticates as needed to complete a two-secret batch.