### PR TITLE
Add stored secret deletion and import cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vault and OpenBao AppRole authentication now supports roles configured with
   `bind_secret_id=false` by omitting `secret_id` from the login request when no
   SecretID credential is configured.
+- `secretspec import --delete-source` now recognizes equivalent dotenv paths,
+  symlinks, and hard links as the same store, preventing source cleanup from
+  deleting the destination value.
 
 ### Added
 - Vault and OpenBao AppRole and JWT authentication can target non-default auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   environment export, codegen input, and deterministic `as_path` cleanup. Its
   checksummed XCFramework includes the shared Rust resolver, so applications do
   not need a Rust toolchain or separately installed native library.
+- `secretspec delete` removes one or more stored secret values without changing
+  their manifest declarations, while `--all` requires explicit confirmation.
+  `secretspec import --delete-source` verifies each destination value before
+  deleting its source, and retains the source when an existing target differs.
 - Dashlane provider (`dashlane://`) for reading secrets from a Dashlane vault
   through the `dcli` CLI. Convention secrets read the item titled
   `secretspec/{project}/{profile}/{key}`, and a `ref` names an existing item by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vault and OpenBao AppRole authentication now supports roles configured with
   `bind_secret_id=false` by omitting `secret_id` from the login request when no
   SecretID credential is configured.
-- `secretspec import --delete-source` now compares resolved storage entries,
-  preventing equivalent provider configurations (including dotenv path aliases)
-  from deleting the destination value. Sources without deletion support are
-  also rejected before any destination is written.
+- `secretspec import --delete-source` now compares resolved storage entries
+  without conflating distinct cache address spaces, preventing equivalent
+  provider configurations (including dotenv path aliases) from deleting the
+  destination value. Sources without deletion support are also rejected before
+  any destination is written.
 
 ### Added
 - Vault and OpenBao AppRole and JWT authentication can target non-default auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vault and OpenBao AppRole authentication now supports roles configured with
   `bind_secret_id=false` by omitting `secret_id` from the login request when no
   SecretID credential is configured.
-- `secretspec import --delete-source` now recognizes equivalent dotenv paths,
-  symlinks, and hard links as the same store, preventing source cleanup from
-  deleting the destination value.
+- `secretspec import --delete-source` now compares resolved storage entries,
+  preventing equivalent provider configurations (including dotenv path aliases)
+  from deleting the destination value. Sources without deletion support are
+  also rejected before any destination is written.
 
 ### Added
 - Vault and OpenBao AppRole and JWT authentication can target non-default auth

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5234,6 +5234,7 @@ dependencies = [
  "rand 0.9.2",
  "reqwest 0.12.28",
  "rsa",
+ "same-file",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ miette = { version = "7.6", features = ["fancy"] }
 serde_json = "1.0"
 proptest = "1"
 tempfile = "3.0"
+same-file = "1.0"
 http = "1.0"
 url = "2.5.4"
 percent-encoding = "2.3"

--- a/docs/src/content/docs/concepts/audit.md
+++ b/docs/src/content/docs/concepts/audit.md
@@ -58,10 +58,10 @@ and how to turn it off.
 | `ts` | RFC 3339 UTC timestamp |
 | `session_id` | Shared by every event from one `secretspec` invocation |
 | `seq` | Monotonic sequence within that invocation |
-| `action` | The operation: `get`, `set`, `check`, `run`, `import`, `export`, or `cache_clear` / `cache_refresh` (0.17+) |
+| `action` | The operation: `get`, `set`, `check`, `run`, `import`, `export`, `cache_clear` / `cache_refresh` (0.17+), or `delete` (0.18+) |
 | `project` / `profile` | The project and profile in effect |
 | `scope` | The named scope for a scoped `check`, `run`, or `export`; omitted otherwise (SecretSpec 0.17+) |
-| `key` | The secret name for single-secret actions (`get`/`set`); never its value |
+| `key` | The secret name for single-secret actions (`get`/`set`, and `delete` in 0.18+); never its value |
 | `keys` | The set of secret names for bulk actions (`check`/`run`/`import`/`export`) |
 | `command` | For `run`, the executed program (argv[0] only — never its arguments, which may contain secrets) |
 | `provider` | The provider URI that served the access, with credentials redacted |

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -350,6 +350,56 @@ $ secretspec set API_KEY sk-1234567890
 `set` rejects composed secrets because their values are derived and read-only.
 Available since SecretSpec 0.16.
 
+### delete (0.18+)
+
+:::caution[Version compatibility]
+`delete` is available starting with SecretSpec 0.18.
+:::
+
+Delete stored provider values without changing their declarations in
+`secretspec.toml`.
+
+```bash
+secretspec delete <NAME>... [--provider <PROVIDER>] [--profile <PROFILE>]
+secretspec delete --all [--yes] [--provider <PROVIDER>] [--profile <PROFILE>]
+```
+
+**Arguments and options:**
+
+- `<NAME>...` - One or more declared secrets to delete.
+- `--all` - Delete every provider-backed secret declared in the active profile.
+  It cannot be combined with a name.
+- `-y, --yes` - Skip the interactive confirmation for `--all`. Non-interactive
+  use of `--all` requires this option.
+- `-p, --provider <PROVIDER>` - Delete from this provider instead of the
+  manifest's primary write provider.
+- `-P, --profile <PROFILE>` - Profile whose values are addressed.
+
+```bash
+# Delete one value from its primary write provider
+$ secretspec delete API_KEY
+Deleted 'API_KEY'
+Deleted 1 secret value; 0 already absent
+
+# Delete selected values from an old dotenv provider
+$ secretspec delete API_KEY DATABASE_URL --provider dotenv://.env.old
+
+# Explicitly delete every stored value in production
+$ secretspec delete --all --profile production --yes
+```
+
+Deletion is idempotent: an already-absent value is reported as such and does
+not fail the command. Without `--provider`, routing mirrors `set`: only the
+primary write provider is changed, never every provider in a fallback chain.
+Any cache entry declared for the secret is invalidated so it cannot continue to
+serve the deleted value.
+
+The providers that support deletion in 0.18 are keyring, dotenv, pass, gopass,
+Vault, OpenBao, and Keeper Secrets Manager. Other providers return an explicit
+unsupported-operation error. Vault, OpenBao, and Keeper refuse to delete native
+`ref` entries because their backends would have to destroy a whole externally
+managed path or record rather than only the referenced field.
+
 ### run
 Run a command with secrets injected as environment variables.
 
@@ -441,13 +491,16 @@ The `gha` format targets a `secretspec export --format gha` step in a GitHub or 
 Import secrets from one provider to another.
 
 ```bash
-secretspec import <FROM_PROVIDER>
+secretspec import <FROM_PROVIDER> [--delete-source]
 ```
 
 The destination provider and profile are determined from your configuration. Secrets that already exist in the destination provider will not be overwritten.
 
 **Arguments:**
 - `<FROM_PROVIDER>` - Provider to import from (e.g., `env`, `dotenv:/path/to/.env`)
+- `--delete-source` - After copying, delete a source value only when the
+  destination is verified to contain the same value. Available in SecretSpec
+  0.18+.
 
 **Example:**
 ```bash
@@ -463,6 +516,9 @@ Summary: 1 imported, 1 already exists, 1 not found in source
 
 # Import from a specific .env file
 $ secretspec import dotenv:/home/user/old-project/.env
+
+# Move values out of an old provider (SecretSpec 0.18+)
+$ secretspec import dotenv:/home/user/old-project/.env --delete-source
 ```
 
 **Use Cases:**
@@ -472,6 +528,14 @@ $ secretspec import dotenv:/home/user/old-project/.env
 
 `import` skips composed secrets because they have no stored value to copy; their
 component secrets are imported normally. Available since SecretSpec 0.16.
+
+With `--delete-source`, source and destination must resolve to different
+providers. A value copied during this run is read back before its source is
+deleted. If the destination already contains an identical value, the source is
+also safe to delete; if it differs, SecretSpec retains the source and reports
+the conflict. A source provider that does not support deletion fails explicitly
+instead of pretending the migration completed. This behavior is available
+starting with SecretSpec 0.18.
 
 ### cache clear (0.17+)
 
@@ -521,7 +585,7 @@ secretspec audit [--project <NAME>] [--action <ACTION>] [-n <N>] [--json]
 
 **Options:**
 - `--project <NAME>` - Only show entries for this project
-- `--action <ACTION>` - Only show entries for this action (`get`, `set`, `check`, `run`, `import`, `export`, or `cache_clear` and `cache_refresh` in 0.17+)
+- `--action <ACTION>` - Only show entries for this action (`get`, `set`, `check`, `run`, `import`, `export`, `cache_clear` and `cache_refresh` in 0.17+, or `delete` in 0.18+)
 - `-n, --tail <N>` - Show only the last N entries
 - `--json` - Output raw JSON Lines instead of the formatted summary
 

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -31,6 +31,7 @@ inquire.workspace = true
 miette.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+same-file.workspace = true
 url.workspace = true
 percent-encoding.workspace = true
 whoami = { workspace = true, optional = true }

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -269,7 +269,9 @@ secretspec check                  # Verify all secrets are set
 secretspec add KEY --description "Purpose" # Declare a secret (0.18+)
 secretspec set KEY               # Set a secret interactively
 secretspec get KEY               # Retrieve a secret
+secretspec delete KEY            # Delete a stored provider value (0.18+)
 secretspec import PROVIDER       # Import secrets from another provider
+secretspec import PROVIDER --delete-source # Move verified values (0.18+)
 secretspec cache clear [KEY]     # Clear cached provider values (0.17+)
 
 # Run with secrets

--- a/secretspec/src/audit.rs
+++ b/secretspec/src/audit.rs
@@ -45,6 +45,8 @@ pub(crate) enum AuditAction {
     Get,
     /// Write a single secret (`secretspec set`).
     Set,
+    /// Delete a stored secret value (`secretspec delete`, SecretSpec 0.18+).
+    Delete,
     /// Validate availability of all secrets (`secretspec check`).
     Check,
     /// Inject all secrets into a subprocess (`secretspec run`).
@@ -74,7 +76,7 @@ pub(crate) enum AuditOutcome {
     Default,
     /// The secret was written successfully.
     Written,
-    /// A cached secret was deleted successfully.
+    /// A stored secret or cached value was deleted successfully.
     Deleted,
     /// The audited subprocess (`run`) was successfully started with the secrets
     /// injected. Distinct from `found`, which is about a secret lookup.
@@ -122,7 +124,7 @@ pub(crate) struct AuditContext<'a> {
     pub profile: &'a str,
     /// The active named scope for scope-aware bulk actions.
     pub scope: Option<&'a str>,
-    /// The single secret involved (`get`/`set`).
+    /// The single secret involved (`get`/`set`/`delete`).
     pub key: Option<&'a str>,
     /// The set of secrets involved in a bulk action
     /// (`check`/`run`/`import`/`export`).

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -2,9 +2,9 @@ use crate::provider::{Provider, providers, spec_names_known_provider};
 use crate::{Config, ExportFormat, GlobalConfig, GlobalDefaults, Profile, Project, Secrets};
 use clap::{Parser, Subcommand};
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -77,6 +77,24 @@ enum Commands {
         /// Name of the secret
         name: String,
         /// Provider backend to use
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        provider: Option<String>,
+        /// Profile to use
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        profile: Option<String>,
+    },
+    /// Delete stored secret values from a provider (0.18+)
+    Delete {
+        /// Names of the secrets to delete
+        #[arg(required_unless_present = "all", conflicts_with = "all")]
+        names: Vec<String>,
+        /// Delete every provider-backed secret declared in the active profile
+        #[arg(long)]
+        all: bool,
+        /// Skip the confirmation required by --all
+        #[arg(short, long, requires = "all", conflicts_with = "names")]
+        yes: bool,
+        /// Provider backend to delete from
         #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
         provider: Option<String>,
         /// Profile to use
@@ -163,6 +181,9 @@ enum Commands {
     Import {
         /// Provider backend to import from (secrets will be imported to the default provider)
         from_provider: String,
+        /// Delete a source value only after the destination contains the same value (0.18+)
+        #[arg(long)]
+        delete_source: bool,
     },
     /// Manage cached provider values (0.17+)
     Cache {
@@ -174,7 +195,7 @@ enum Commands {
         /// Only show entries for this project
         #[arg(long)]
         project: Option<String>,
-        /// Only show entries for this action (get, set, check, run, import, export, cache_clear)
+        /// Only show entries for this action (get, set, delete, check, run, import, export, cache_clear)
         #[arg(long)]
         action: Option<String>,
         /// Show only the last N entries
@@ -1134,6 +1155,101 @@ pub fn main() -> Result<()> {
                 .wrap_err("Failed to get secret")?;
             Ok(())
         }
+        Commands::Delete {
+            mut names,
+            all,
+            yes,
+            provider,
+            profile,
+        } => {
+            let mut app = load_secrets(&cli.file, &cli.reason)?;
+            if let Some(provider) = provider {
+                app.set_provider(provider);
+            }
+            if let Some(profile) = profile {
+                app.set_profile(profile);
+            }
+
+            if all {
+                names = app
+                    .profile_secret_names_unscoped(None)
+                    .into_diagnostic()
+                    .wrap_err("Failed to list secrets for deletion")?;
+                // Composed secrets have no stored value. An explicit name gets
+                // a useful error from `Secrets::delete`; a whole-profile sweep
+                // simply has nothing to do for them.
+                names.retain(|name| {
+                    app.resolve_secret_config(name, None)
+                        .is_some_and(|secret| secret.composed.is_none())
+                });
+            } else {
+                // Repeating a name should not turn the second occurrence into a
+                // confusing "already absent" result.
+                let mut seen = HashSet::new();
+                names.retain(|name| seen.insert(name.clone()));
+            }
+
+            if all && !yes && !names.is_empty() {
+                if !std::io::stdin().is_terminal() {
+                    return Err(miette!(
+                        "refusing to delete all stored secret values without confirmation; pass --yes for non-interactive use"
+                    ));
+                }
+                use inquire::Confirm;
+                let profile = app.resolve_profile_name(None);
+                let confirmed = Confirm::new(&format!(
+                    "Delete {} stored secret {} from profile '{profile}'?",
+                    names.len(),
+                    if names.len() == 1 { "value" } else { "values" }
+                ))
+                .with_default(false)
+                .prompt()
+                .into_diagnostic()?;
+                if !confirmed {
+                    println!("Cancelled.");
+                    return Ok(());
+                }
+            }
+
+            let mut deleted = 0;
+            let mut absent = 0;
+            let mut failures = Vec::new();
+            for name in names {
+                match app.delete(&name) {
+                    Ok(true) => {
+                        println!("Deleted '{name}'");
+                        deleted += 1;
+                    }
+                    Ok(false) => {
+                        println!("'{name}' was already absent");
+                        absent += 1;
+                    }
+                    Err(error) => failures.push((name, error.to_string())),
+                }
+            }
+
+            println!(
+                "Deleted {deleted} secret {}; {absent} already absent",
+                if deleted == 1 { "value" } else { "values" }
+            );
+            if !failures.is_empty() {
+                return Err(miette!(
+                    "{} secret {} could not be deleted: {}",
+                    failures.len(),
+                    if failures.len() == 1 {
+                        "value"
+                    } else {
+                        "values"
+                    },
+                    failures
+                        .into_iter()
+                        .map(|(name, error)| format!("'{name}': {error}"))
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                ));
+            }
+            Ok(())
+        }
         // Execute a command with secrets injected as environment variables
         Commands::Run {
             command,
@@ -1247,11 +1363,20 @@ pub fn main() -> Result<()> {
             Ok(())
         }
         // Import secrets from one provider to another
-        Commands::Import { from_provider } => {
+        Commands::Import {
+            from_provider,
+            delete_source,
+        } => {
             let app = load_secrets(&cli.file, &cli.reason)?;
-            app.import(&from_provider)
-                .into_diagnostic()
-                .wrap_err("Failed to import secrets")?;
+            if delete_source {
+                app.import_with_delete_source(&from_provider)
+                    .into_diagnostic()
+                    .wrap_err("Failed to import and delete source secrets")?;
+            } else {
+                app.import(&from_provider)
+                    .into_diagnostic()
+                    .wrap_err("Failed to import secrets")?;
+            }
             Ok(())
         }
         Commands::Cache { action } => match action {
@@ -2025,6 +2150,70 @@ API_KEY = { description = "Existing" }
             Commands::Check { no_prompt, .. } => assert!(no_prompt),
             _ => panic!("expected Check command"),
         }
+    }
+
+    #[test]
+    fn delete_requires_names_or_explicit_all() {
+        let cli = Cli::try_parse_from([
+            "secretspec",
+            "delete",
+            "API_KEY",
+            "DATABASE_URL",
+            "--provider",
+            "dotenv://.env",
+            "--profile",
+            "production",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Delete {
+                names,
+                all,
+                yes,
+                provider,
+                profile,
+            } => {
+                assert_eq!(names, vec!["API_KEY", "DATABASE_URL"]);
+                assert!(!all);
+                assert!(!yes);
+                assert_eq!(provider.as_deref(), Some("dotenv://.env"));
+                assert_eq!(profile.as_deref(), Some("production"));
+            }
+            _ => panic!("expected delete"),
+        }
+
+        assert!(Cli::try_parse_from(["secretspec", "delete"]).is_err());
+        let cli = Cli::try_parse_from(["secretspec", "delete", "--all", "--yes"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Delete {
+                names,
+                all: true,
+                yes: true,
+                ..
+            } if names.is_empty()
+        ));
+        assert!(
+            Cli::try_parse_from(["secretspec", "delete", "API_KEY", "--all"]).is_err(),
+            "a named delete and --all must be mutually exclusive"
+        );
+        assert!(
+            Cli::try_parse_from(["secretspec", "delete", "API_KEY", "--yes"]).is_err(),
+            "--yes is meaningful only with --all"
+        );
+    }
+
+    #[test]
+    fn import_parses_delete_source() {
+        let cli = Cli::try_parse_from(["secretspec", "import", "dotenv://.env", "--delete-source"])
+            .unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Import {
+                from_provider,
+                delete_source: true,
+            } if from_provider == "dotenv://.env"
+        ));
     }
 
     #[test]

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -61,7 +61,9 @@ pub enum SecretSpecError {
     SecretNotFound(String),
     #[error("Secret '{0}' is required but not set")]
     RequiredSecretMissing(String),
-    #[error("Composed secret '{0}' is derived from other secrets and cannot be written")]
+    #[error(
+        "Composed secret '{0}' is derived from other secrets and has no stored value to change"
+    )]
     ComposedSecretReadOnly(String),
     #[error("Failed to compose secret: {0}")]
     CompositionFailed(String),

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -303,7 +303,7 @@ impl Secrets {
         })
     }
 
-    /// Plan a single secret the CLI's `get`/`set` operate on, reusing the exact
+    /// Plan a single secret the CLI's `get`/`set`/`delete` operate on, reusing the exact
     /// per-secret decisions batch resolution makes. Returns `Ok(None)` when the
     /// secret is not declared in the (merged) profile, mirroring
     /// [`Secrets::resolve_secret_config`], so the caller can raise its own
@@ -906,7 +906,7 @@ mod tests {
     #[test]
     fn plan_secret_matches_the_batch_plan_for_a_declared_secret() {
         let _env = scrub_resolution_env();
-        // `get`/`set` plan one secret; the decision must match `build_plan`.
+        // `get`/`set`/`delete` plan one secret; the decision must match `build_plan`.
         let secrets = HashMap::from([(
             "API_KEY".to_string(),
             secret(Some(vec!["onepassword://Production", "keyring://"])),

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -244,6 +244,10 @@ impl Provider for DotEnvProvider {
         }
     }
 
+    fn physical_store_path(&self) -> Option<&std::path::Path> {
+        Some(&self.config.path)
+    }
+
     /// Resolves a relative `.env` path against the project root (the directory
     /// containing `secretspec.toml`) rather than the current working directory.
     ///

--- a/secretspec/src/provider/gopass.rs
+++ b/secretspec/src/provider/gopass.rs
@@ -288,6 +288,12 @@ impl Provider for GoPassProvider {
             format!("gopass://{}", prefix)
         }
     }
+
+    /// The URI's folder prefix is compiled into the native entry name and does
+    /// not identify a separate gopass installation.
+    fn storage_identity(&self) -> String {
+        "gopass".to_string()
+    }
 }
 
 #[cfg(test)]

--- a/secretspec/src/provider/gopass.rs
+++ b/secretspec/src/provider/gopass.rs
@@ -291,7 +291,7 @@ impl Provider for GoPassProvider {
 
     /// The URI's folder prefix is compiled into the native entry name and does
     /// not identify a separate gopass installation.
-    fn storage_identity(&self) -> String {
+    fn entry_container_identity(&self) -> String {
         "gopass".to_string()
     }
 }

--- a/secretspec/src/provider/keeper.rs
+++ b/secretspec/src/provider/keeper.rs
@@ -479,6 +479,12 @@ impl Provider for KeeperProvider {
     }
 
     fn delete(&self, addr: Address<'_>) -> Result<bool> {
+        if matches!(addr, Address::Native(_)) {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "Keeper secret references cannot be deleted: a reference names a record managed outside SecretSpec, and deleting it would remove the whole record"
+                    .to_string(),
+            ));
+        }
         let target = self.target(addr)?;
         let mut records = self.records()?;
         let Some(index) = self.record_index(&records, &target)? else {
@@ -939,7 +945,7 @@ mod tests {
     fn sdk_operations_run_outside_tokio_runtimes() {
         let (provider, state) = provider_with_records(vec![record(
             "RecordUID",
-            "existing",
+            "secretspec/demo/default/existing",
             true,
             serde_json::json!([
                 {"type": "password", "label": "", "value": ["old"]}
@@ -969,13 +975,37 @@ mod tests {
                     &SecretString::new("created".to_string().into()),
                 )
                 .unwrap();
-            provider.delete(Address::Native(&native)).unwrap();
+            provider
+                .delete(Address::convention("demo", "default", "existing"))
+                .unwrap();
         });
 
         let state = state.lock().unwrap();
         assert_eq!(state.updated.len(), 1);
         assert_eq!(state.created.len(), 1);
         assert_eq!(state.deleted, ["RecordUID"]);
+    }
+
+    #[test]
+    fn delete_rejects_native_references_before_touching_the_record() {
+        let (provider, state) = provider_with_records(vec![record(
+            "RecordUID",
+            "external-record",
+            true,
+            serde_json::json!([
+                {"type": "password", "label": "", "value": ["value"]}
+            ]),
+            serde_json::json!([]),
+        )]);
+        let native = NativeAddress {
+            item: "RecordUID".to_string(),
+            field: Some("password".to_string()),
+            ..Default::default()
+        };
+
+        let error = provider.delete(Address::Native(&native)).unwrap_err();
+        assert!(error.to_string().contains("whole record"), "{error}");
+        assert!(state.lock().unwrap().deleted.is_empty());
     }
 
     #[test]

--- a/secretspec/src/provider/keeper.rs
+++ b/secretspec/src/provider/keeper.rs
@@ -450,6 +450,12 @@ impl Provider for KeeperProvider {
         uri
     }
 
+    /// Authentication configuration does not change the Keeper shared folder
+    /// in which convention-owned records live.
+    fn storage_identity(&self) -> String {
+        format!("keeper://{}", self.config.folder_uid)
+    }
+
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         let target = self.target(addr)?;
         let records = self.records()?;

--- a/secretspec/src/provider/keeper.rs
+++ b/secretspec/src/provider/keeper.rs
@@ -452,7 +452,7 @@ impl Provider for KeeperProvider {
 
     /// Authentication configuration does not change the Keeper shared folder
     /// in which convention-owned records live.
-    fn storage_identity(&self) -> String {
+    fn entry_container_identity(&self) -> String {
         format!("keeper://{}", self.config.folder_uid)
     }
 

--- a/secretspec/src/provider/keyring.rs
+++ b/secretspec/src/provider/keyring.rs
@@ -160,7 +160,7 @@ impl Provider for KeyringProvider {
 
     /// The configured prefix selects a service entry inside the current user's
     /// keyring; it does not select another keyring store.
-    fn storage_identity(&self) -> String {
+    fn entry_container_identity(&self) -> String {
         "keyring".to_string()
     }
 

--- a/secretspec/src/provider/keyring.rs
+++ b/secretspec/src/provider/keyring.rs
@@ -158,6 +158,12 @@ impl Provider for KeyringProvider {
         }
     }
 
+    /// The configured prefix selects a service entry inside the current user's
+    /// keyring; it does not select another keyring store.
+    fn storage_identity(&self) -> String {
+        "keyring".to_string()
+    }
+
     /// Retrieves a secret from the system keychain.
     ///
     /// The secret is looked up using a hierarchical key structure determined

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -791,20 +791,17 @@ pub trait Provider: Send + Sync {
         self.uri()
     }
 
-    /// Returns whether `other` addresses the same physical secret store.
-    /// Available since SecretSpec 0.18.
+    /// Returns whether `self` and `other` resolve `addr` to the same physical
+    /// secret entry. Available since SecretSpec 0.18.
     ///
     /// Destructive cross-provider operations must use this instead of comparing
     /// [`uri`](Provider::uri) strings: one store may have multiple equivalent
-    /// spellings. Providers backed by a filesystem path can opt into same-file
-    /// checks by returning it from
-    /// [`physical_store_path`](Provider::physical_store_path); other providers
-    /// use their canonical, credential-free URI.
-    fn same_store(&self, other: &dyn Provider) -> bool {
-        if self.name() != other.name() {
-            return false;
-        }
-        match (self.physical_store_path(), other.physical_store_path()) {
+    /// spellings, and provider URIs can include convention templates that are
+    /// only meaningful after resolving a concrete address. The physical store
+    /// and the resolved native coordinates must both match before an entry is
+    /// considered shared.
+    fn same_entry(&self, other: &dyn Provider, addr: Address<'_>) -> Result<bool> {
+        let same_store = match (self.physical_store_path(), other.physical_store_path()) {
             (Some(left), Some(right)) => {
                 same_file::is_same_file(left, right).unwrap_or_else(|_| {
                     let left = std::path::absolute(left).unwrap_or_else(|_| left.to_path_buf());
@@ -812,8 +809,14 @@ pub trait Provider: Send + Sync {
                     left == right
                 })
             }
-            _ => self.uri() == other.uri(),
+            (None, None) => self.storage_identity() == other.storage_identity(),
+            _ => false,
+        };
+        if !same_store {
+            return Ok(false);
         }
+
+        Ok(self.resolve_coords(addr)? == other.resolve_coords(addr)?)
     }
 
     /// Returns the path that identifies a filesystem-backed store, if any.
@@ -821,7 +824,8 @@ pub trait Provider: Send + Sync {
     ///
     /// The path is compared using filesystem identity when it exists, catching
     /// lexical aliases, symlinks, and hard links. Providers that are not backed
-    /// by one file keep the default and are identified by [`uri`](Provider::uri).
+    /// by one path keep the default and are identified by
+    /// [`storage_identity`](Provider::storage_identity).
     fn physical_store_path(&self) -> Option<&std::path::Path> {
         None
     }
@@ -1055,11 +1059,11 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn uri(&self) -> String {
         (**self).uri()
     }
+    fn same_entry(&self, other: &dyn Provider, addr: Address<'_>) -> Result<bool> {
+        (**self).same_entry(other, addr)
+    }
     fn storage_identity(&self) -> String {
         (**self).storage_identity()
-    }
-    fn same_store(&self, other: &dyn Provider) -> bool {
-        (**self).same_store(other)
     }
     fn physical_store_path(&self) -> Option<&std::path::Path> {
         (**self).physical_store_path()
@@ -1243,12 +1247,12 @@ impl Provider for PreflightGuard {
         self.inner.uri()
     }
 
-    fn storage_identity(&self) -> String {
-        self.inner.storage_identity()
+    fn same_entry(&self, other: &dyn Provider, addr: Address<'_>) -> Result<bool> {
+        self.inner.same_entry(other, addr)
     }
 
-    fn same_store(&self, other: &dyn Provider) -> bool {
-        self.inner.same_store(other)
+    fn storage_identity(&self) -> String {
+        self.inner.storage_identity()
     }
 
     fn physical_store_path(&self) -> Option<&std::path::Path> {

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -791,6 +791,19 @@ pub trait Provider: Send + Sync {
         self.uri()
     }
 
+    /// Returns the identity of the container holding a resolved secret entry.
+    /// Available since SecretSpec 0.18.
+    ///
+    /// This differs from [`Self::storage_identity`] only for providers whose
+    /// public URI contains an addressing template. Cache routing must retain
+    /// that template so sibling address spaces remain distinct, while
+    /// destructive operations compare the template's resolved native
+    /// coordinates separately and need the identity of the underlying
+    /// container here.
+    fn entry_container_identity(&self) -> String {
+        self.storage_identity()
+    }
+
     /// Returns whether `self` and `other` resolve `addr` to the same physical
     /// secret entry. Available since SecretSpec 0.18.
     ///
@@ -809,7 +822,7 @@ pub trait Provider: Send + Sync {
                     left == right
                 })
             }
-            (None, None) => self.storage_identity() == other.storage_identity(),
+            (None, None) => self.entry_container_identity() == other.entry_container_identity(),
             _ => false,
         };
         if !same_store {
@@ -1065,6 +1078,9 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn storage_identity(&self) -> String {
         (**self).storage_identity()
     }
+    fn entry_container_identity(&self) -> String {
+        (**self).entry_container_identity()
+    }
     fn physical_store_path(&self) -> Option<&std::path::Path> {
         (**self).physical_store_path()
     }
@@ -1253,6 +1269,10 @@ impl Provider for PreflightGuard {
 
     fn storage_identity(&self) -> String {
         self.inner.storage_identity()
+    }
+
+    fn entry_container_identity(&self) -> String {
+        self.inner.entry_container_identity()
     }
 
     fn physical_store_path(&self) -> Option<&std::path::Path> {

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -791,6 +791,41 @@ pub trait Provider: Send + Sync {
         self.uri()
     }
 
+    /// Returns whether `other` addresses the same physical secret store.
+    /// Available since SecretSpec 0.18.
+    ///
+    /// Destructive cross-provider operations must use this instead of comparing
+    /// [`uri`](Provider::uri) strings: one store may have multiple equivalent
+    /// spellings. Providers backed by a filesystem path can opt into same-file
+    /// checks by returning it from
+    /// [`physical_store_path`](Provider::physical_store_path); other providers
+    /// use their canonical, credential-free URI.
+    fn same_store(&self, other: &dyn Provider) -> bool {
+        if self.name() != other.name() {
+            return false;
+        }
+        match (self.physical_store_path(), other.physical_store_path()) {
+            (Some(left), Some(right)) => {
+                same_file::is_same_file(left, right).unwrap_or_else(|_| {
+                    let left = std::path::absolute(left).unwrap_or_else(|_| left.to_path_buf());
+                    let right = std::path::absolute(right).unwrap_or_else(|_| right.to_path_buf());
+                    left == right
+                })
+            }
+            _ => self.uri() == other.uri(),
+        }
+    }
+
+    /// Returns the path that identifies a filesystem-backed store, if any.
+    /// Available since SecretSpec 0.18.
+    ///
+    /// The path is compared using filesystem identity when it exists, catching
+    /// lexical aliases, symlinks, and hard links. Providers that are not backed
+    /// by one file keep the default and are identified by [`uri`](Provider::uri).
+    fn physical_store_path(&self) -> Option<&std::path::Path> {
+        None
+    }
+
     /// Records a human-readable reason for the secrets access happening in this
     /// session (e.g. "secretspec run: deploy"), set via [`Secrets::with_reason`].
     ///
@@ -1023,6 +1058,12 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn storage_identity(&self) -> String {
         (**self).storage_identity()
     }
+    fn same_store(&self, other: &dyn Provider) -> bool {
+        (**self).same_store(other)
+    }
+    fn physical_store_path(&self) -> Option<&std::path::Path> {
+        (**self).physical_store_path()
+    }
     fn set_reason(&self, reason: Option<String>) {
         (**self).set_reason(reason);
     }
@@ -1204,6 +1245,14 @@ impl Provider for PreflightGuard {
 
     fn storage_identity(&self) -> String {
         self.inner.storage_identity()
+    }
+
+    fn same_store(&self, other: &dyn Provider) -> bool {
+        self.inner.same_store(other)
+    }
+
+    fn physical_store_path(&self) -> Option<&std::path::Path> {
+        self.inner.physical_store_path()
     }
 
     fn set_reason(&self, reason: Option<String>) {

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -697,9 +697,10 @@ pub trait Provider: Send + Sync {
     /// Deletes a secret at `addr`. Available since SecretSpec 0.17.
     ///
     /// Providers opt into deletion explicitly. This is used by cache
-    /// invalidation and defaults to a clear unsupported-operation error so
-    /// adding the method does not silently make destructive behavior available
-    /// to every provider.
+    /// invalidation and, starting in SecretSpec 0.18, by `secretspec delete`
+    /// and `secretspec import --delete-source`. It defaults to a clear
+    /// unsupported-operation error so adding the method does not silently make
+    /// destructive behavior available to every provider.
     ///
     /// Deleting is idempotent: an address that holds nothing is `Ok(false)`,
     /// not an error. The `bool` reports whether an entry was actually removed,

--- a/secretspec/src/provider/pass.rs
+++ b/secretspec/src/provider/pass.rs
@@ -159,6 +159,21 @@ impl Provider for PassProvider {
         }
     }
 
+    /// The folder prefix chooses an entry, not a password store. Keep it out
+    /// of the store identity so a default prefix and the same explicitly
+    /// spelled prefix can still be recognized as one physical entry after
+    /// their convention addresses are resolved.
+    fn storage_identity(&self) -> String {
+        match &self.config.store_dir {
+            Some(store_dir) => format!("pass:{}", store_dir),
+            None => "pass".to_string(),
+        }
+    }
+
+    fn physical_store_path(&self) -> Option<&std::path::Path> {
+        self.config.store_dir.as_deref().map(std::path::Path::new)
+    }
+
     /// Retrieves a secret from the password store.
     ///
     /// # Arguments

--- a/secretspec/src/provider/pass.rs
+++ b/secretspec/src/provider/pass.rs
@@ -163,7 +163,7 @@ impl Provider for PassProvider {
     /// of the store identity so a default prefix and the same explicitly
     /// spelled prefix can still be recognized as one physical entry after
     /// their convention addresses are resolved.
-    fn storage_identity(&self) -> String {
+    fn entry_container_identity(&self) -> String {
         match &self.config.store_dir {
             Some(store_dir) => format!("pass:{}", store_dir),
             None => "pass".to_string(),

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -3337,7 +3337,7 @@ impl Secrets {
                         .expect("composed secrets were filtered above");
                     let to_provider =
                         self.write_provider_for_route(route, Some(&profile_display))?;
-                    if from_provider_instance.uri() == to_provider.uri() {
+                    if from_provider_instance.same_store(to_provider.as_ref()) {
                         return Err(SecretSpecError::ProviderOperationFailed(format!(
                             "refusing to delete '{}' from the import source because source and destination resolve to the same provider ({})",
                             planned.name,

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1124,7 +1124,7 @@ impl Secrets {
     /// Records one audit event with the given variable fields, if auditing is
     /// enabled (a no-op otherwise). Session-constant fields — project, the session
     /// reason, and whether auditing is on — are filled here so call sites specify
-    /// only what varies. Single-secret (`get`/`set`) and bulk
+    /// only what varies. Single-secret (`get`/`set`/`delete`) and bulk
     /// (`check`/`run`/`import`) events go through this one method.
     fn record(
         &self,
@@ -1143,6 +1143,7 @@ impl Secrets {
                 }
                 AuditAction::Get
                 | AuditAction::Set
+                | AuditAction::Delete
                 | AuditAction::Import
                 | AuditAction::CacheClear
                 | AuditAction::CacheRefresh => None,
@@ -1200,7 +1201,37 @@ impl Secrets {
         );
     }
 
-    /// Records a failed single-secret operation (`get`/`set`) as an `Error`
+    /// Audits one durable provider deletion. `Ok(false)` is a successful,
+    /// idempotent no-op and is recorded as `Missing`; cache invalidation has its
+    /// own `CacheClear` events and is never conflated with this operation.
+    fn audit_delete_result(
+        &self,
+        result: &Result<bool>,
+        key: &str,
+        profile: &str,
+        provider_uri: Option<String>,
+        reference: Option<&NativeAddress>,
+    ) {
+        let (outcome, error_kind) = match result {
+            Ok(true) => (AuditOutcome::Deleted, None),
+            Ok(false) => (AuditOutcome::Missing, None),
+            Err(error) => (AuditOutcome::Error, Some(error.kind())),
+        };
+        self.record(
+            AuditAction::Delete,
+            profile,
+            outcome,
+            AuditFields {
+                key: Some(key),
+                provider_uri,
+                reference,
+                error_kind,
+                ..Default::default()
+            },
+        );
+    }
+
+    /// Records a failed single-secret operation (`get`/`set`/`delete`) as an `Error`
     /// event attributed to `key` — and to a provider and native `ref`
     /// coordinates, when they were determined before the failure. The one shape
     /// every `get`/`set` failure path records, so the paths cannot drift on
@@ -2132,6 +2163,57 @@ impl Secrets {
         }
     }
 
+    /// Drop any cache entry that could otherwise keep serving a value after its
+    /// authoritative copy was deleted. As with direct writes, a provider
+    /// override hides the manifest's cached route, so re-plan only when the
+    /// declaration could actually name a cache.
+    fn sync_cache_after_delete(&self, planned: &PlannedSecret, route: &Route, profile: &str) {
+        if route.cache().is_some() {
+            if let Err(error) = self.invalidate_cached_secret(planned, route, profile) {
+                cache_warning(
+                    &planned.name,
+                    format!(
+                        "could not drop the cache entry for the deleted secret: {error}. Run \
+                         `secretspec cache clear {}` — until then a read may serve the deleted value",
+                        planned.name
+                    ),
+                );
+            }
+            return;
+        }
+
+        let default_spec = self.configured_default_provider_spec();
+        let names_cache = planned
+            .config()
+            .providers
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(String::as_str)
+            .chain(default_spec.as_deref())
+            .any(|spec| self.cached_alias(spec).is_some());
+        if !names_cache {
+            return;
+        }
+        let declared = match self.route_for(planned.config(), &None) {
+            Ok(declared) => declared,
+            Err(error) => {
+                cache_warning(&planned.name, error);
+                return;
+            }
+        };
+        if let Err(error) = self.invalidate_cached_secret(planned, &declared, profile) {
+            cache_warning(
+                &planned.name,
+                format!(
+                    "could not drop the cache entry for the deleted secret: {error}. Run \
+                     `secretspec cache clear {}` — until then a read may serve the deleted value",
+                    planned.name
+                ),
+            );
+        }
+    }
+
     /// Builds the provider a write goes to for a resolved [`Route`]: the primary
     /// store, or the default provider when the route sets none. A write never
     /// consults the fallback, so an undefined alias further down the chain does
@@ -2586,6 +2668,71 @@ impl Secrets {
         );
 
         Ok(())
+    }
+
+    /// Deletes one secret value from its authoritative provider. Available
+    /// since SecretSpec 0.18.
+    ///
+    /// The provider route and address are resolved exactly as for [`Self::set`]:
+    /// without an override, only the primary write provider is changed; fallback
+    /// copies are never traversed and deleted implicitly. A successful deletion
+    /// also invalidates the manifest's cache so a later read cannot return the
+    /// removed value. Missing values are an idempotent `Ok(false)`.
+    pub fn delete(&self, name: &str) -> Result<bool> {
+        self.ensure_reason_for(AuditAction::Delete, Some(name))?;
+        let profile_name = self.resolve_profile_name(None);
+        self.require_profile(&profile_name)?;
+
+        let planned = match self.plan_secret(name, &profile_name, None) {
+            Ok(Some(planned)) => planned,
+            Err(error) => {
+                self.record_key_error(AuditAction::Delete, &profile_name, name, None, None, &error);
+                return Err(error);
+            }
+            Ok(None) => {
+                let available = self.profile_secret_names_unscoped(Some(&profile_name))?;
+                let error = SecretSpecError::SecretNotFound(format!(
+                    "Secret '{name}' is not defined in profile '{profile_name}'. Available secrets: {}",
+                    available.join(", ")
+                ));
+                self.record_key_error(AuditAction::Delete, &profile_name, name, None, None, &error);
+                return Err(error);
+            }
+        };
+
+        let Some(route) = &planned.route else {
+            let error = SecretSpecError::ComposedSecretReadOnly(name.to_string());
+            self.record_key_error(AuditAction::Delete, &profile_name, name, None, None, &error);
+            return Err(error);
+        };
+        let backend = match self.write_provider_for_route(route, Some(&profile_name)) {
+            Ok(backend) => backend,
+            Err(error) => {
+                self.record_key_error(
+                    AuditAction::Delete,
+                    &profile_name,
+                    name,
+                    None,
+                    planned.reference(),
+                    &error,
+                );
+                return Err(error);
+            }
+        };
+
+        let result = backend.delete(planned.as_address(&self.config.project.name, &profile_name));
+        self.audit_delete_result(
+            &result,
+            name,
+            &profile_name,
+            Some(backend.uri()),
+            planned.reference(),
+        );
+        let deleted = result?;
+        // Even a no-op authoritative delete must invalidate the cache: the
+        // cache may still contain the only surviving copy of the value.
+        self.sync_cache_after_delete(&planned, route, &profile_name);
+        Ok(deleted)
     }
 
     /// Retrieves and prints a secret value
@@ -3117,6 +3264,19 @@ impl Secrets {
     /// spec.import("dotenv://.env.production").unwrap();
     /// ```
     pub fn import(&self, from_provider: &str) -> Result<()> {
+        self.import_internal(from_provider, false)
+    }
+
+    /// Imports secrets and deletes each source value only after the destination
+    /// is verified to contain the same value. Available since SecretSpec 0.18.
+    ///
+    /// A destination value that already differs is never overwritten and its
+    /// source is retained. The source and destination must be different stores.
+    pub fn import_with_delete_source(&self, from_provider: &str) -> Result<()> {
+        self.import_internal(from_provider, true)
+    }
+
+    fn import_internal(&self, from_provider: &str, delete_source: bool) -> Result<()> {
         self.ensure_reason_for(AuditAction::Import, None)?;
         // Resolve profile (checks env var, then global config, then defaults to "default")
         let profile_display = self.resolve_profile_name(None);
@@ -3124,6 +3284,8 @@ impl Secrets {
         let mut imported = 0;
         let mut already_exists = 0;
         let mut not_found = 0;
+        let mut deleted_from_source = 0;
+        let mut kept_in_source = 0;
         // Every secret the import reads from the source/target, in iteration
         // order. An import is one bulk action over this whole set, so it is the
         // `keys` recorded in the audit log — independent of how many were copied,
@@ -3152,17 +3314,47 @@ impl Secrets {
             // `--scope`, so an ambient SECRETSPEC_SCOPE must not narrow the copy.
             let import_names = self.profile_secret_names_unscoped(Some(&profile_display))?;
 
-            // Process each secret using proper profile resolution: the plan
-            // supplies the same write route and address `set` executes. Sorted
-            // names keep the per-secret summary lines in a stable order.
+            // Plan every provider-backed secret before copying anything. With
+            // source cleanup enabled this is also a destructive-operation
+            // preflight: reject any same-store destination before an earlier
+            // item can be copied and removed from the source.
+            let mut import_plans = Vec::new();
             for name in import_names {
                 let planned = self
                     .plan_secret(&name, &profile_display, None)?
                     .expect("Secret should exist since we're iterating over it");
                 // A composed secret has no stored value to copy.
-                let Some(route) = &planned.route else {
+                if planned.route.is_none() {
                     continue;
-                };
+                }
+                import_plans.push(planned);
+            }
+            if delete_source {
+                for planned in &import_plans {
+                    let route = planned
+                        .route
+                        .as_ref()
+                        .expect("composed secrets were filtered above");
+                    let to_provider =
+                        self.write_provider_for_route(route, Some(&profile_display))?;
+                    if from_provider_instance.uri() == to_provider.uri() {
+                        return Err(SecretSpecError::ProviderOperationFailed(format!(
+                            "refusing to delete '{}' from the import source because source and destination resolve to the same provider ({})",
+                            planned.name,
+                            from_provider_instance.uri()
+                        )));
+                    }
+                }
+            }
+
+            // Process each plan using the same write route and address `set`
+            // executes. Sorted names keep the per-secret summary lines stable.
+            for planned in import_plans {
+                let name = planned.name.clone();
+                let route = planned
+                    .route
+                    .as_ref()
+                    .expect("composed secrets were filtered above");
                 read_names.push(name.clone());
                 let description = planned.config().description.as_deref();
                 let label = format_secret_label(&name, description);
@@ -3178,15 +3370,45 @@ impl Secrets {
                     Some(value) => {
                         // Secret exists in "from" provider, check if it exists in "to" provider
                         match to_provider.get(addr)? {
-                            Some(_) => {
-                                eprintln!(
-                                    "{} {} {} (→ {})",
-                                    "○".yellow(),
-                                    label,
-                                    "(already exists in target)".yellow(),
-                                    to_provider.name().blue()
-                                );
+                            Some(existing) => {
                                 already_exists += 1;
+                                if delete_source
+                                    && existing.expose_secret() == value.expose_secret()
+                                {
+                                    let delete_result = from_provider_instance.delete(addr);
+                                    self.audit_delete_result(
+                                        &delete_result,
+                                        &name,
+                                        &profile_display,
+                                        Some(from_provider_instance.uri()),
+                                        planned.reference(),
+                                    );
+                                    deleted_from_source += usize::from(delete_result?);
+                                    eprintln!(
+                                        "{} {} {} (→ {}; deleted from source)",
+                                        "✓".green(),
+                                        label,
+                                        "(already exists in target)".yellow(),
+                                        to_provider.name().blue()
+                                    );
+                                } else if delete_source {
+                                    kept_in_source += 1;
+                                    eprintln!(
+                                        "{} {} {} (→ {}; source retained)",
+                                        "○".yellow(),
+                                        label,
+                                        "(target value differs)".yellow(),
+                                        to_provider.name().blue()
+                                    );
+                                } else {
+                                    eprintln!(
+                                        "{} {} {} (→ {})",
+                                        "○".yellow(),
+                                        label,
+                                        "(already exists in target)".yellow(),
+                                        to_provider.name().blue()
+                                    );
+                                }
                             }
                             None => {
                                 // Secret doesn't exist in "to" provider, import it.
@@ -3210,13 +3432,41 @@ impl Secrets {
                                     &profile_display,
                                     &value,
                                 );
-                                eprintln!(
-                                    "{} {} (→ {})",
-                                    "✓".green(),
-                                    label,
-                                    to_provider.name().blue()
-                                );
                                 imported += 1;
+                                if delete_source {
+                                    let verified = to_provider.get(addr)?.is_some_and(|stored| {
+                                        stored.expose_secret() == value.expose_secret()
+                                    });
+                                    if !verified {
+                                        return Err(SecretSpecError::ProviderOperationFailed(
+                                            format!(
+                                                "destination verification failed for '{name}'; the source value was retained"
+                                            ),
+                                        ));
+                                    }
+                                    let delete_result = from_provider_instance.delete(addr);
+                                    self.audit_delete_result(
+                                        &delete_result,
+                                        &name,
+                                        &profile_display,
+                                        Some(from_provider_instance.uri()),
+                                        planned.reference(),
+                                    );
+                                    deleted_from_source += usize::from(delete_result?);
+                                    eprintln!(
+                                        "{} {} (→ {}; deleted from source)",
+                                        "✓".green(),
+                                        label,
+                                        to_provider.name().blue()
+                                    );
+                                } else {
+                                    eprintln!(
+                                        "{} {} (→ {})",
+                                        "✓".green(),
+                                        label,
+                                        to_provider.name().blue()
+                                    );
+                                }
                             }
                         }
                     }
@@ -3273,6 +3523,13 @@ impl Secrets {
             already_exists.to_string().yellow(),
             not_found.to_string().red()
         );
+        if delete_source {
+            eprintln!(
+                "Source cleanup: {} deleted, {} retained because the target differs",
+                deleted_from_source.to_string().green(),
+                kept_in_source.to_string().yellow()
+            );
+        }
 
         if imported > 0 {
             eprintln!(

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -3304,6 +3304,22 @@ impl Secrets {
                 self.build_provider(from_provider.to_string(), Some(&profile_display))?;
             source_uri = Some(from_provider_instance.uri());
 
+            // Deletion support is a registered provider capability. Reject a
+            // source that cannot delete before planning or touching any target;
+            // otherwise the first copied value would leave a partial import
+            // when the trait's default `delete` implementation inevitably
+            // failed.
+            if delete_source
+                && !crate::provider::spec_provider_deletes(
+                    &self.resolve_provider_spec(from_provider.to_string()),
+                )
+            {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "provider '{}' does not support deleting secrets and cannot be used with import --delete-source",
+                    from_provider_instance.name()
+                )));
+            }
+
             eprintln!(
                 "Importing secrets from {} (profile: {})...\n",
                 from_provider.blue(),
@@ -3337,7 +3353,8 @@ impl Secrets {
                         .expect("composed secrets were filtered above");
                     let to_provider =
                         self.write_provider_for_route(route, Some(&profile_display))?;
-                    if from_provider_instance.same_store(to_provider.as_ref()) {
+                    let addr = planned.as_address(&self.config.project.name, &profile_display);
+                    if from_provider_instance.same_entry(to_provider.as_ref(), addr)? {
                         return Err(SecretSpecError::ProviderOperationFailed(format!(
                             "refusing to delete '{}' from the import source because source and destination resolve to the same provider ({})",
                             planned.name,

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6231,6 +6231,66 @@ API_KEY = { description = "API key" }
 }
 
 #[test]
+fn import_with_delete_source_rejects_equivalent_dotenv_paths() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let store = temp.path().join("store.env");
+    fs::write(&store, "API_KEY=keep\n").unwrap();
+    let config: Config = toml::from_str(
+        r#"
+[project]
+name = "same-import-path-test"
+revision = "1.0"
+
+[profiles.default]
+API_KEY = { description = "API key" }
+"#,
+    )
+    .unwrap();
+    let mut spec = Secrets::new(config, None, Some("dotenv://store.env".to_string()), None);
+    spec.config_dir = temp.path().to_path_buf();
+
+    let error = spec
+        .import_with_delete_source("dotenv://./store.env")
+        .expect_err("equivalent paths must not bypass the same-store preflight");
+    assert!(error.to_string().contains("same provider"), "{error}");
+    assert_eq!(read_env_var(&store, "API_KEY").as_deref(), Some("keep"));
+}
+
+#[test]
+fn import_with_delete_source_rejects_hard_linked_dotenv_paths() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let target = temp.path().join("target.env");
+    fs::write(&source, "API_KEY=keep\n").unwrap();
+    fs::hard_link(&source, &target).unwrap();
+    let config: Config = toml::from_str(
+        r#"
+[project]
+name = "same-import-file-test"
+revision = "1.0"
+
+[profiles.default]
+API_KEY = { description = "API key" }
+"#,
+    )
+    .unwrap();
+    let spec = Secrets::new(
+        config,
+        None,
+        Some(format!("dotenv://{}", target.display())),
+        None,
+    );
+
+    let error = spec
+        .import_with_delete_source(&format!("dotenv://{}", source.display()))
+        .expect_err("hard links to one file must be treated as the same store");
+    assert!(error.to_string().contains("same provider"), "{error}");
+    assert_eq!(read_env_var(&source, "API_KEY").as_deref(), Some("keep"));
+}
+
+#[test]
 fn import_with_delete_source_preflights_every_destination_before_moving_values() {
     let _env = scrub_resolution_env();
     let temp = TempDir::new().unwrap();

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6083,6 +6083,196 @@ fn test_import_source_literal_uri_still_works() {
 }
 
 #[test]
+fn delete_removes_one_provider_value_and_is_idempotent() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let store = temp.path().join("store.env");
+    fs::write(&store, "API_KEY=secret\nOTHER=keep\n").unwrap();
+    let config: Config = toml::from_str(
+        r#"
+[project]
+name = "delete-test"
+revision = "1.0"
+
+[profiles.default]
+API_KEY = { description = "API key" }
+"#,
+    )
+    .unwrap();
+    let spec = Secrets::new(
+        config,
+        None,
+        Some(format!("dotenv://{}", store.display())),
+        None,
+    );
+
+    assert!(spec.delete("API_KEY").unwrap());
+    assert_eq!(read_env_var(&store, "API_KEY"), None);
+    assert_eq!(read_env_var(&store, "OTHER").as_deref(), Some("keep"));
+    assert!(!spec.delete("API_KEY").unwrap());
+}
+
+#[test]
+fn delete_changes_only_the_primary_write_provider() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let primary = temp.path().join("primary.env");
+    let fallback = temp.path().join("fallback.env");
+    fs::write(&primary, "API_KEY=primary\n").unwrap();
+    fs::write(&fallback, "API_KEY=fallback\n").unwrap();
+    let primary_uri = format!("dotenv://{}", primary.display());
+    let fallback_uri = format!("dotenv://{}", fallback.display());
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "delete-route-test"
+revision = "1.0"
+
+[providers]
+primary = "{primary_uri}"
+fallback = "{fallback_uri}"
+
+[profiles.default]
+API_KEY = {{ description = "API key", providers = ["primary", "fallback"] }}
+"#
+    ))
+    .unwrap();
+    let spec = Secrets::new(config, None, None, None);
+
+    assert!(spec.delete("API_KEY").unwrap());
+    assert_eq!(read_env_var(&primary, "API_KEY"), None);
+    assert_eq!(
+        read_env_var(&fallback, "API_KEY").as_deref(),
+        Some("fallback"),
+        "delete must not walk and destroy fallback copies"
+    );
+    assert_eq!(resolved_value(&spec, "API_KEY"), "fallback");
+}
+
+#[test]
+fn import_with_delete_source_deletes_only_verified_values() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let target = temp.path().join("target.env");
+    fs::write(
+        &source,
+        "COPIED=from-source\nIDENTICAL=same\nCONFLICT=source-value\n",
+    )
+    .unwrap();
+    fs::write(&target, "IDENTICAL=same\nCONFLICT=target-value\n").unwrap();
+    let config: Config = toml::from_str(
+        r#"
+[project]
+name = "import-delete-source-test"
+revision = "1.0"
+
+[profiles.default]
+COPIED = { description = "Copied" }
+IDENTICAL = { description = "Identical" }
+CONFLICT = { description = "Conflict" }
+"#,
+    )
+    .unwrap();
+    let spec = Secrets::new(
+        config,
+        None,
+        Some(format!("dotenv://{}", target.display())),
+        None,
+    );
+
+    spec.import_with_delete_source(&format!("dotenv://{}", source.display()))
+        .unwrap();
+
+    assert_eq!(
+        read_env_var(&target, "COPIED").as_deref(),
+        Some("from-source")
+    );
+    assert_eq!(read_env_var(&target, "IDENTICAL").as_deref(), Some("same"));
+    assert_eq!(
+        read_env_var(&target, "CONFLICT").as_deref(),
+        Some("target-value"),
+        "import must not overwrite an existing target"
+    );
+    assert_eq!(read_env_var(&source, "COPIED"), None);
+    assert_eq!(read_env_var(&source, "IDENTICAL"), None);
+    assert_eq!(
+        read_env_var(&source, "CONFLICT").as_deref(),
+        Some("source-value"),
+        "a differing target must retain the source copy"
+    );
+}
+
+#[test]
+fn import_with_delete_source_rejects_the_same_store() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let store = temp.path().join("store.env");
+    fs::write(&store, "API_KEY=keep\n").unwrap();
+    let store_uri = format!("dotenv://{}", store.display());
+    let config: Config = toml::from_str(
+        r#"
+[project]
+name = "same-import-store-test"
+revision = "1.0"
+
+[profiles.default]
+API_KEY = { description = "API key" }
+"#,
+    )
+    .unwrap();
+    let spec = Secrets::new(config, None, Some(store_uri.clone()), None);
+
+    let error = spec
+        .import_with_delete_source(&store_uri)
+        .expect_err("a move within one store would delete the destination");
+    assert!(error.to_string().contains("same provider"), "{error}");
+    assert_eq!(read_env_var(&store, "API_KEY").as_deref(), Some("keep"));
+}
+
+#[test]
+fn import_with_delete_source_preflights_every_destination_before_moving_values() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let target = temp.path().join("target.env");
+    fs::write(&source, "A_FIRST=keep-at-source\nZ_SAME=also-keep\n").unwrap();
+    let source_uri = format!("dotenv://{}", source.display());
+    let target_uri = format!("dotenv://{}", target.display());
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "preflight-import-store-test"
+revision = "1.0"
+
+[providers]
+target = "{target_uri}"
+source = "{source_uri}"
+
+[profiles.default]
+A_FIRST = {{ description = "Would otherwise move first", providers = ["target"] }}
+Z_SAME = {{ description = "Unsafe same-store route", providers = ["source"] }}
+"#
+    ))
+    .unwrap();
+    let spec = Secrets::new(config, None, None, None);
+
+    let error = spec
+        .import_with_delete_source(&source_uri)
+        .expect_err("all routes must be checked before the first source deletion");
+    assert!(error.to_string().contains("same provider"), "{error}");
+    assert_eq!(
+        read_env_var(&source, "A_FIRST").as_deref(),
+        Some("keep-at-source")
+    );
+    assert_eq!(
+        read_env_var(&target, "A_FIRST"),
+        None,
+        "preflight must happen before any earlier value is copied"
+    );
+}
+
+#[test]
 fn test_import_unknown_source_lists_available_aliases() {
     let temp_dir = TempDir::new().unwrap();
     let source_uri = format!("dotenv://{}", temp_dir.path().join(".env.source").display());
@@ -8464,6 +8654,28 @@ fn set_writes_authoritative_provider_then_refreshes_cache() {
     assert_eq!(source_value, ("API_KEY".to_string(), "written".to_string()));
     fs::remove_file(&source).unwrap();
     assert_eq!(resolved_value(&secrets, "API_KEY"), "written");
+}
+
+#[test]
+fn delete_removes_the_authoritative_value_and_its_cache_entry() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let cache = temp.path().join("cache.env");
+    fs::write(&source, "API_KEY=remote\n").unwrap();
+    let secrets = cached_dotenv_secrets(&[&source], &cache, "1h");
+
+    assert_eq!(resolved_value(&secrets, "API_KEY"), "remote");
+    assert!(cache.exists(), "the first read should populate the cache");
+    assert!(secrets.delete("API_KEY").unwrap());
+
+    assert_eq!(read_env_var(&source, "API_KEY"), None);
+    assert_eq!(read_env_var(&cache, "API_KEY"), None);
+    let errors = match secrets.validate().unwrap() {
+        Ok(_) => panic!("a deleted required secret must no longer resolve from cache"),
+        Err(errors) => errors,
+    };
+    assert_eq!(errors.missing_required, vec!["API_KEY".to_string()]);
 }
 
 #[test]

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6129,8 +6129,8 @@ name = "delete-route-test"
 revision = "1.0"
 
 [providers]
-primary = "{primary_uri}"
-fallback = "{fallback_uri}"
+primary = '{primary_uri}'
+fallback = '{fallback_uri}'
 
 [profiles.default]
 API_KEY = {{ description = "API key", providers = ["primary", "fallback"] }}
@@ -6372,8 +6372,8 @@ name = "preflight-import-store-test"
 revision = "1.0"
 
 [providers]
-target = "{target_uri}"
-source = "{source_uri}"
+target = '{target_uri}'
+source = '{source_uri}'
 
 [profiles.default]
 A_FIRST = {{ description = "Would otherwise move first", providers = ["target"] }}

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6231,6 +6231,72 @@ API_KEY = { description = "API key" }
 }
 
 #[test]
+fn import_with_delete_source_rejects_equivalent_pass_addresses() {
+    let _env = scrub_resolution_env();
+    let config: Config = toml::from_str(
+        r#"
+[project]
+name = "same-import-pass-test"
+revision = "1.0"
+
+[profiles.default]
+API_KEY = { description = "API key" }
+"#,
+    )
+    .unwrap();
+    let spec = Secrets::new(
+        config,
+        None,
+        Some("pass://secretspec/{project}/{profile}/{key}".to_string()),
+        None,
+    );
+
+    let error = spec
+        .import_with_delete_source("pass")
+        .expect_err("the explicit default pass path must resolve to the source entry");
+    assert!(error.to_string().contains("same provider"), "{error}");
+}
+
+#[test]
+fn import_with_delete_source_rejects_non_deleting_source_before_target_writes() {
+    let _env = scrub_resolution_env();
+    let _source = EnvVarGuard::set("A_FIRST", "keep-at-source");
+    let temp = TempDir::new().unwrap();
+    let target = temp.path().join("target.env");
+    let config: Config = toml::from_str(
+        r#"
+[project]
+name = "unsupported-import-source-test"
+revision = "1.0"
+
+[profiles.default]
+A_FIRST = { description = "Would otherwise be copied" }
+"#,
+    )
+    .unwrap();
+    let spec = Secrets::new(
+        config,
+        None,
+        Some(format!("dotenv://{}", target.display())),
+        None,
+    );
+
+    let error = spec
+        .import_with_delete_source("env")
+        .expect_err("a non-deleting source must fail before importing any value");
+    assert!(
+        error
+            .to_string()
+            .contains("does not support deleting secrets"),
+        "{error}"
+    );
+    assert!(
+        !target.exists(),
+        "source capability preflight must happen before the target is created"
+    );
+}
+
+#[test]
 fn import_with_delete_source_rejects_equivalent_dotenv_paths() {
     let _env = scrub_resolution_env();
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- add `secretspec delete <NAME>...` and a guarded `secretspec delete --all`
- expose idempotent deletion through `Secrets::delete`, following the primary write route and invalidating caches
- add `secretspec import <PROVIDER> --delete-source`, deleting source values only after destination verification
- preflight all migration routes, retain source values on conflicts, and reject unsafe same-store moves
- audit deletion operations and document the 0.18+ CLI/SDK behavior

## User impact

Users can remove values through SecretSpec without editing provider storage directly. Provider fallback copies are not implicitly destroyed, bulk deletion requires confirmation, and import cleanup behaves like a verified move rather than an unchecked copy-and-delete.

Closes #229.

## Validation

- `cargo test --all`
- `cargo clippy -p secretspec --no-default-features --features cli -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run build` in `docs/`
- commit hooks: Clippy and rustfmt
