### PR TITLE
docs: remove redundant version suffix from SOPS label

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -292,7 +292,7 @@ Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files,
               badge: { text: "0.17+", variant: "note" },
             },
             {
-              label: "SOPS (0.17+)",
+              label: "SOPS",
               slug: "providers/sops",
               badge: { text: "0.17+", variant: "note" },
             },


### PR DESCRIPTION
The 0.17+ version is already shown via the sidebar badge