### PR TITLE
fix(providers): honor JWT default roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is not an authentication state, and the install guidance ("…run 'bw login'
   and 'bw unlock' to authenticate") used to match the not-authenticated
   classifier and mask the real problem.
+- Vault and OpenBao JWT authentication now allows the role to be omitted when
+  the auth mount has a server-configured `default_role`, while explicit URI or
+  environment roles continue to take precedence.
 
 ### Added
 - Vault and OpenBao AppRole and JWT authentication can target non-default auth

--- a/docs/src/content/docs/ci/github-actions.md
+++ b/docs/src/content/docs/ci/github-actions.md
@@ -23,7 +23,11 @@ A missing required secret fails the step before the job runs anything with an in
 
 For secrets kept in a dedicated store, resolve them on the runner with the matching provider, shown here with [Vault or OpenBao](/providers/vault/). Other stores plug in the same way with their own credentials.
 
-Grant the job `id-token: write` and select `?auth=jwt` with a `role`. Vault exchanges the runner's OIDC token for a client token, so nothing is stored on the platform.
+Grant the job `id-token: write` and select `?auth=jwt`. Pinning a `role`, as in
+the example below, keeps the workflow independent of server configuration.
+Starting with SecretSpec 0.18, the role may instead come from the JWT auth
+mount's configured `default_role`. Vault exchanges the runner's OIDC token for
+a client token, so nothing is stored on the platform.
 
 ```yaml
       - uses: cachix/secretspec-action@main

--- a/docs/src/content/docs/providers/openbao.md
+++ b/docs/src/content/docs/providers/openbao.md
@@ -105,13 +105,18 @@ path (`secret` in these examples).
 
 ### JWT / OIDC authentication
 
-Select JWT with `?auth=jwt` and a `role`. The provider performs the
-`auth/jwt/login` exchange itself. The JWT comes from SecretSpec's `BAO_JWT`
-input, then the `VAULT_JWT` compatibility fallback. Otherwise, in a GitHub
-Actions or Forgejo job with `id-token: write`, the provider mints one from the
-runner's OIDC identity.
+Select JWT with `?auth=jwt`. The provider performs the `auth/jwt/login`
+exchange itself. The JWT comes from SecretSpec's `BAO_JWT` input, then the
+`VAULT_JWT` compatibility fallback. Otherwise, in a GitHub Actions or Forgejo
+job with `id-token: write`, the provider mints one from the runner's OIDC
+identity.
 
-- `?role=`, `BAO_JWT_ROLE`, or `VAULT_JWT_ROLE` (required)
+Starting with SecretSpec 0.18, the role may be omitted when the JWT auth mount
+has a `default_role`; OpenBao then selects that role during login. An explicit
+SecretSpec role still takes precedence.
+
+- `?role=`, `BAO_JWT_ROLE`, or `VAULT_JWT_ROLE`; optional with a
+  server-configured `default_role` (0.18+)
 - `?audience=`, `BAO_JWT_AUDIENCE`, or `VAULT_JWT_AUDIENCE`
 
 ## Configuration
@@ -127,7 +132,8 @@ openbao://[namespace@]host[:port][/mount][?key=value&...]
 - `namespace@`: Optional namespace (falls back through `BAO_NAMESPACE`,
   `VAULT_NAMESPACE`)
 - `?auth=approle`: Use AppRole authentication (default: `token`)
-- `?auth=jwt`: Use JWT/OIDC authentication (requires a role)
+- `?auth=jwt`: Use JWT/OIDC authentication; a server-configured `default_role`
+  can supply the role when using SecretSpec 0.18+
 - `?auth_mount=` (0.18+): Non-default AppRole or JWT mount beneath `/v1/auth`
 - `?role=`: OpenBao role for JWT auth
 - `?audience=`: Audience requested from the CI OIDC issuer
@@ -150,6 +156,8 @@ openbao://bao.example.com:8200/secret?auth=approle
 # SecretSpec 0.18+
 openbao://bao.example.com:8200/secret?auth=approle&auth_mount=platform-approle
 openbao://bao.example.com:8200/secret?auth=jwt&role=ci
+# SecretSpec 0.18+, with default_role configured on the JWT auth mount
+openbao://bao.example.com:8200/secret?auth=jwt
 ```
 
 ### Project configuration

--- a/docs/src/content/docs/providers/vault.md
+++ b/docs/src/content/docs/providers/vault.md
@@ -92,16 +92,20 @@ path (`secret` in these examples).
 Added in SecretSpec 0.17.
 :::
 
-Select JWT with `?auth=jwt` and a `role`. The provider performs the
-`auth/jwt/login` exchange itself. The JWT comes from `VAULT_JWT` when set.
-Otherwise, in a GitHub Actions or Forgejo job with `id-token: write`, the
-provider mints one from the runner's OIDC identity, so CI stores no static
-secret.
+Select JWT with `?auth=jwt`. The provider performs the `auth/jwt/login`
+exchange itself. The JWT comes from `VAULT_JWT` when set. Otherwise, in a
+GitHub Actions or Forgejo job with `id-token: write`, the provider mints one
+from the runner's OIDC identity, so CI stores no static secret.
+
+Starting with SecretSpec 0.18, the role may be omitted when the JWT auth mount
+has a `default_role`; Vault then selects that role during login. An explicit
+SecretSpec role still takes precedence.
 
 Both `role` and `audience` accept a URI query parameter or an environment
 variable:
 
-- `?role=` or `VAULT_JWT_ROLE` (required)
+- `?role=` or `VAULT_JWT_ROLE`; optional with a server-configured
+  `default_role` (0.18+)
 - `?audience=` or `VAULT_JWT_AUDIENCE`, matched against the role's
   `bound_audiences`
 
@@ -117,7 +121,8 @@ vault://[namespace@]host[:port][/mount][?key=value&...]
 - `mount`: KV engine mount path (default: `secret`)
 - `namespace@`: Optional Vault namespace (also reads `VAULT_NAMESPACE`)
 - `?auth=approle`: Use AppRole authentication (default: `token`)
-- `?auth=jwt` (0.17+): Use JWT/OIDC authentication (requires `?role=`)
+- `?auth=jwt` (0.17+): Use JWT/OIDC authentication; a server-configured
+  `default_role` can supply the role when using SecretSpec 0.18+
 - `?auth_mount=` (0.18+): Non-default AppRole or JWT mount beneath `/v1/auth`
 - `?role=` (0.17+): Vault role for JWT auth (or `VAULT_JWT_ROLE`)
 - `?audience=` (0.17+): OIDC audience (or `VAULT_JWT_AUDIENCE`)
@@ -141,6 +146,8 @@ vault://vault.example.com:8200/secret?auth=approle
 vault://vault.example.com:8200/secret?auth=approle&auth_mount=platform-approle
 # SecretSpec 0.17+
 vault://vault.example.com:8200/secret?auth=jwt&role=ci
+# SecretSpec 0.18+, with default_role configured on the JWT auth mount
+vault://vault.example.com:8200/secret?auth=jwt
 ```
 
 ### Project configuration

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -301,11 +301,13 @@ vault://vault.example.com:8200/secret?auth=approle
 vault://vault.example.com:8200/secret?auth=jwt&role=ci
 # SecretSpec 0.18+
 vault://vault.example.com:8200/secret?auth=approle&auth_mount=platform-approle
+# SecretSpec 0.18+, with default_role configured on the JWT auth mount
+vault://vault.example.com:8200/secret?auth=jwt
 vault://127.0.0.1:8200/secret?kv=1         # KV v1 engine
 vault://127.0.0.1:8200/secret?tls=false    # Disable TLS (dev mode)
 ```
 
-**Features**: Read/write, KV v1 and v2, namespaces; token and AppRole authentication; JWT/OIDC authentication (0.17+); custom AppRole/JWT mounts (0.18+)
+**Features**: Read/write, KV v1 and v2, namespaces; token and AppRole authentication; JWT/OIDC authentication (0.17+); custom AppRole/JWT mounts and server-default JWT roles (0.18+)
 **Prerequisites**: Vault server, authentication credentials, build with `--features vault`
 **Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
 
@@ -324,10 +326,12 @@ openbao://bao.example.com:8200/secret?auth=approle
 openbao://bao.example.com:8200/secret?auth=jwt&role=ci
 # SecretSpec 0.18+
 openbao://bao.example.com:8200/secret?auth=jwt&auth_mount=ci-jwt&role=ci
+# SecretSpec 0.18+, with default_role configured on the JWT auth mount
+openbao://bao.example.com:8200/secret?auth=jwt
 openbao://127.0.0.1:8200/secret?kv=1&tls=false
 ```
 
-**Features**: Read/write, KV v1 and v2, namespaces; token, AppRole, and JWT/OIDC authentication; custom AppRole/JWT mounts (0.18+); documented OpenBao CLI variables plus SecretSpec-defined `BAO_*` AppRole/JWT inputs, all with `VAULT_*` compatibility fallbacks
+**Features**: Read/write, KV v1 and v2, namespaces; token, AppRole, and JWT/OIDC authentication; custom AppRole/JWT mounts and server-default JWT roles (0.18+); documented OpenBao CLI variables plus SecretSpec-defined `BAO_*` AppRole/JWT inputs, all with `VAULT_*` compatibility fallbacks
 **Prerequisites**: OpenBao server, authentication credentials, build with `--features openbao` (0.17+)
 **Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
 

--- a/secretspec/src/provider/openbao.rs
+++ b/secretspec/src/provider/openbao.rs
@@ -16,9 +16,10 @@
 //!   provider credentials, or SecretSpec's `BAO_ROLE_ID` and `BAO_SECRET_ID`
 //!   inputs, for a client token. The corresponding `VAULT_*` names remain
 //!   compatibility fallbacks.
-//! - JWT/OIDC (`?auth=jwt`) -- logs in with an OpenBao role, using SecretSpec's
-//!   `BAO_JWT` input (falling back to `VAULT_JWT`) or a short-lived GitHub
-//!   Actions / Forgejo Actions OIDC token.
+//! - JWT/OIDC (`?auth=jwt`) -- logs in using SecretSpec's `BAO_JWT` input
+//!   (falling back to `VAULT_JWT`) or a short-lived GitHub Actions / Forgejo
+//!   Actions OIDC token. Starting with SecretSpec 0.18, the role may be omitted
+//!   when the auth mount has a `default_role`.
 //!
 //! For environment variables defined by the OpenBao CLI -- address, namespace,
 //! token, and token path -- `BAO_*` takes precedence and the corresponding
@@ -38,7 +39,8 @@
 //! - `auth_mount` -- non-default AppRole or JWT mount beneath `/v1/auth`
 //!   (SecretSpec 0.18+)
 //! - `role` -- role for JWT auth, falling back through `BAO_JWT_ROLE` and
-//!   `VAULT_JWT_ROLE`
+//!   `VAULT_JWT_ROLE`; optional with a server-configured `default_role`
+//!   (SecretSpec 0.18+)
 //! - `audience` -- audience requested from the CI OIDC issuer, falling back
 //!   through `BAO_JWT_AUDIENCE` and `VAULT_JWT_AUDIENCE`
 //!
@@ -49,6 +51,8 @@
 //! - `openbao://bao.example.com:8200/secret?auth=approle&auth_mount=platform-approle`
 //!   -- custom AppRole mount (SecretSpec 0.18+)
 //! - `openbao://bao.example.com:8200/secret?auth=jwt&role=ci` -- JWT auth
+//! - `openbao://bao.example.com:8200/secret?auth=jwt` -- JWT auth using the
+//!   mount's `default_role` (SecretSpec 0.18+)
 //! - `openbao://team-a@bao.example.com:8200/secret` -- OpenBao namespace
 //! - `openbao://127.0.0.1:8200/secret?kv=1&tls=false` -- local KV v1 server
 //!

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -12,9 +12,10 @@
 //! - AppRole (`?auth=approle`) -- exchanges the `role_id` and `secret_id`
 //!   provider credentials, or `VAULT_ROLE_ID` and `VAULT_SECRET_ID`, for a
 //!   client token.
-//! - JWT/OIDC (SecretSpec 0.17+, `?auth=jwt`) -- logs in with a configured
-//!   Vault role, using `VAULT_JWT` or a short-lived GitHub Actions / Forgejo
-//!   Actions OIDC token.
+//! - JWT/OIDC (SecretSpec 0.17+, `?auth=jwt`) -- logs in using `VAULT_JWT` or a
+//!   short-lived GitHub Actions / Forgejo Actions OIDC token. Starting with
+//!   SecretSpec 0.18, the role may be omitted when the auth mount has a
+//!   `default_role`.
 //!
 //! # URI format
 //!
@@ -27,7 +28,8 @@
 //! - `tls` -- `true` (default) or `false`; the latter is intended for dev mode
 //! - `auth_mount` -- non-default AppRole or JWT mount beneath `/v1/auth`
 //!   (SecretSpec 0.18+)
-//! - `role` -- Vault role for JWT auth, falling back to `VAULT_JWT_ROLE` (0.17+)
+//! - `role` -- Vault role for JWT auth, falling back to `VAULT_JWT_ROLE`;
+//!   optional with a server-configured `default_role` (SecretSpec 0.18+)
 //! - `audience` -- audience requested from the CI OIDC issuer, falling back to
 //!   `VAULT_JWT_AUDIENCE` (0.17+)
 //!
@@ -38,6 +40,8 @@
 //! - `vault://vault.example.com:8200/secret?auth=approle&auth_mount=platform-approle`
 //!   -- custom AppRole mount (SecretSpec 0.18+)
 //! - `vault://vault.example.com:8200/secret?auth=jwt&role=ci` -- JWT auth
+//! - `vault://vault.example.com:8200/secret?auth=jwt` -- JWT auth using the
+//!   mount's `default_role` (SecretSpec 0.18+)
 //! - `vault://team-a@vault.example.com:8200/secret` -- Vault namespace
 //! - `vault://127.0.0.1:8200/secret?kv=1&tls=false` -- local KV v1 server
 //!

--- a/secretspec/src/provider/vault_common.rs
+++ b/secretspec/src/provider/vault_common.rs
@@ -366,12 +366,13 @@ impl KvConfig {
         // Canonical provider URIs omit an explicitly stated default.
         let auth_mount = auth_mount.filter(|mount| Some(mount.as_str()) != auth.default_mount());
 
+        // Empty query values follow the provider-wide convention of being
+        // absent, so `?role=` still permits the environment fallback. When
+        // neither source supplies a role, the JWT auth mount may select its
+        // server-side `default_role` during login.
         let role = url
-            .query_pairs()
-            .find(|(key, _)| key == "role")
-            .map(|(_, value)| value.to_string())
-            .or_else(|| preferred_env(product.jwt_role_envs()))
-            .filter(|value| !value.is_empty());
+            .query_value("role")
+            .or_else(|| preferred_env(product.jwt_role_envs()));
 
         let audience = url
             .query_pairs()
@@ -981,22 +982,15 @@ impl KvProvider {
         self.parse_login_token(&response, "AppRole", login_started_at)
     }
 
-    /// Exchanges a JWT and role at the configured JWT auth mount.
+    /// Exchanges a JWT at the configured auth mount, optionally selecting a role.
     async fn resolve_jwt_auth(&self) -> Result<IssuedToken> {
-        let role = self.config.role.clone().ok_or_else(|| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "{} JWT authentication requires a role. Set `?role=` in the provider URI or {}.",
-                self.product.display_name(),
-                self.product.jwt_role_envs().join(" or ")
-            ))
-        })?;
         let jwt = self.resolve_jwt().await?;
 
         let url = self.auth_login_url();
-        let body = serde_json::json!({
-            "role": role,
-            "jwt": jwt.expose_secret(),
-        });
+        let mut body = serde_json::json!({ "jwt": jwt.expose_secret() });
+        if let Some(role) = &self.config.role {
+            body["role"] = serde_json::Value::String(role.clone());
+        }
         // The server-side lease begins while the request is in flight. Anchor
         // its deadline before sending so response latency cannot extend the
         // token's perceived lifetime.
@@ -1751,6 +1745,13 @@ mod tests {
         request
     }
 
+    fn request_json(request: &str) -> serde_json::Value {
+        let (_, body) = request
+            .split_once("\r\n\r\n")
+            .expect("HTTP request must contain a header/body separator");
+        serde_json::from_str(body).expect("HTTP request body must be JSON")
+    }
+
     fn auth_server(
         request_count: usize,
         token_num_uses: u64,
@@ -1826,7 +1827,7 @@ mod tests {
                 } else {
                     ("204 No Content", String::new())
                 };
-                observed.push((request_line, token));
+                observed.push((request, token));
                 write!(
                     stream,
                     "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -1953,10 +1954,49 @@ mod tests {
         let observed = server.join().unwrap();
         assert!(observed[0].0.contains("/v1/auth/jwt/login"));
         assert!(observed[1].0.contains("/v1/auth/jwt/login"));
+        assert_eq!(request_json(&observed[0].0)["role"], "ci");
+        assert_eq!(request_json(&observed[1].0)["role"], "ci");
         assert!(observed[2].0.contains("/v1/secret/metadata/"));
         assert_eq!(observed[2].1.as_deref(), Some("operation-token-1"));
         assert!(observed[3].0.contains("/v1/secret/data/"));
         assert_eq!(observed[3].1.as_deref(), Some("operation-token-2"));
+    }
+
+    #[test]
+    fn jwt_login_omits_an_absent_role_for_the_server_default() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let _jwt = EnvVarGuard::set("VAULT_JWT", "test-jwt");
+        let _role = EnvVarGuard::remove("VAULT_JWT_ROLE");
+        let (endpoint, server) = auth_server(1, 0, None);
+        let config = KvConfig::parse(
+            &provider_url(&format!("vault://{endpoint}/secret?tls=false&auth=jwt")),
+            Product::Vault,
+        )
+        .unwrap();
+        let provider = KvProvider::new(config, Product::Vault);
+
+        block_on(provider.resolve_jwt_auth()).unwrap();
+
+        let observed = server.join().unwrap();
+        assert_eq!(observed.len(), 1);
+        assert!(observed[0].0.contains("/v1/auth/jwt/login"));
+        assert_eq!(
+            request_json(&observed[0].0),
+            serde_json::json!({ "jwt": "test-jwt" })
+        );
+    }
+
+    #[test]
+    fn empty_jwt_role_query_uses_the_environment_fallback() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let _role = EnvVarGuard::set("VAULT_JWT_ROLE", "ci-from-env");
+        let config = KvConfig::parse(
+            &provider_url("vault://vault.example.com/secret?auth=jwt&role="),
+            Product::Vault,
+        )
+        .unwrap();
+
+        assert_eq!(config.role.as_deref(), Some("ci-from-env"));
     }
 
     #[cfg(feature = "openbao")]


### PR DESCRIPTION
## Summary

- Allow Vault and OpenBao JWT authentication to omit role, using the auth mount’s configured default_role.
- Preserve explicit URI and environment role precedence; an empty ?role= falls through to the environment.
- Document the behavior as available in SecretSpec 0.18+.

## Rationale

Both Vault and OpenBao define the JWT login role as optional and resolve an omitted role from the auth mount’s default_role. SecretSpec previously rejected these valid configurations before contacting the server.

## Testing

- cargo test --package secretspec
- Vault-only and OpenBao-only provider tests
- Documentation build
- Tested against a live OpenBao 2.6.1 dev instance