### PR TITLE
fix(providers): allow AppRole without SecretID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vault and OpenBao JWT authentication now allows the role to be omitted when
   the auth mount has a server-configured `default_role`, while explicit URI or
   environment roles continue to take precedence.
+- Vault and OpenBao AppRole authentication now supports roles configured with
+  `bind_secret_id=false` by omitting `secret_id` from the login request when no
+  SecretID credential is configured.
 
 ### Added
 - Vault and OpenBao AppRole and JWT authentication can target non-default auth

--- a/docs/src/content/docs/providers/openbao.md
+++ b/docs/src/content/docs/providers/openbao.md
@@ -65,7 +65,8 @@ $ export BAO_TOKEN=hvs.your-token-here
 
 ### AppRole authentication
 
-Select AppRole with `?auth=approle`:
+Select AppRole with `?auth=approle`. OpenBao roles bind a SecretID by default,
+so the usual configuration provides both inputs:
 
 ```bash
 $ export BAO_ROLE_ID=your-role-id
@@ -84,6 +85,17 @@ uri = "openbao://bao.example.com:8200/secret?auth=approle"
 role_id = { provider = "onepassword", ref = { vault = "Infra", item = "bao-approle", field = "role_id" } }
 secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "bao-approle", field = "secret_id" } }
 ```
+
+:::note[Version compatibility]
+Starting with SecretSpec 0.18, `BAO_SECRET_ID` (or its `VAULT_SECRET_ID`
+fallback) and the `secret_id` provider credential may be omitted when the
+AppRole is configured with `bind_secret_id=false`. SecretSpec then sends only
+`role_id` and lets OpenBao apply the role's remaining login constraints.
+:::
+
+Disabling SecretID binding removes AppRole's usual second credential. Keep the
+server default unless the workload deliberately relies on another trust
+boundary, such as a tightly controlled Agent host and network constraints.
 
 ### Custom authentication mounts (0.18+)
 

--- a/docs/src/content/docs/providers/vault.md
+++ b/docs/src/content/docs/providers/vault.md
@@ -47,7 +47,8 @@ $ export VAULT_TOKEN=hvs.your-token-here
 
 ### AppRole authentication
 
-Select AppRole with `?auth=approle` and provide both environment variables:
+Select AppRole with `?auth=approle`. Vault roles bind a SecretID by default, so
+the usual configuration provides both environment variables:
 
 ```bash
 $ export VAULT_ROLE_ID=your-role-id
@@ -67,6 +68,17 @@ secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-a
 ```
 
 SecretSpec 0.14 supports only `VAULT_ROLE_ID` and `VAULT_SECRET_ID`.
+
+:::note[Version compatibility]
+Starting with SecretSpec 0.18, `VAULT_SECRET_ID` or the `secret_id` provider
+credential may be omitted when the AppRole is configured with
+`bind_secret_id=false`. SecretSpec then sends only `role_id` and lets Vault
+apply the role's remaining login constraints.
+:::
+
+Disabling SecretID binding removes AppRole's usual second credential. Keep the
+server default unless the workload deliberately relies on another trust
+boundary, such as a tightly controlled Agent host and network constraints.
 
 ### Custom authentication mounts (0.18+)
 

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -307,7 +307,7 @@ vault://127.0.0.1:8200/secret?kv=1         # KV v1 engine
 vault://127.0.0.1:8200/secret?tls=false    # Disable TLS (dev mode)
 ```
 
-**Features**: Read/write, KV v1 and v2, namespaces; token and AppRole authentication; JWT/OIDC authentication (0.17+); custom AppRole/JWT mounts and server-default JWT roles (0.18+)
+**Features**: Read/write, KV v1 and v2, namespaces; token and AppRole authentication, including AppRoles without SecretID binding (0.18+); JWT/OIDC authentication (0.17+); custom AppRole/JWT mounts and server-default JWT roles (0.18+)
 **Prerequisites**: Vault server, authentication credentials, build with `--features vault`
 **Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
 
@@ -331,7 +331,7 @@ openbao://bao.example.com:8200/secret?auth=jwt
 openbao://127.0.0.1:8200/secret?kv=1&tls=false
 ```
 
-**Features**: Read/write, KV v1 and v2, namespaces; token, AppRole, and JWT/OIDC authentication; custom AppRole/JWT mounts and server-default JWT roles (0.18+); documented OpenBao CLI variables plus SecretSpec-defined `BAO_*` AppRole/JWT inputs, all with `VAULT_*` compatibility fallbacks
+**Features**: Read/write, KV v1 and v2, namespaces; token, AppRole, and JWT/OIDC authentication; AppRoles without SecretID binding, custom AppRole/JWT mounts, and server-default JWT roles (0.18+); documented OpenBao CLI variables plus SecretSpec-defined `BAO_*` AppRole/JWT inputs, all with `VAULT_*` compatibility fallbacks
 **Prerequisites**: OpenBao server, authentication credentials, build with `--features openbao` (0.17+)
 **Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
 

--- a/secretspec/src/provider/openbao.rs
+++ b/secretspec/src/provider/openbao.rs
@@ -12,10 +12,11 @@
 //!   the compatibility fallback `VAULT_TOKEN`. It then reads the path selected
 //!   by `BAO_TOKEN_PATH` / `VAULT_TOKEN_PATH`, or the OpenBao CLI's default
 //!   `~/.vault-token`.
-//! - AppRole (`?auth=approle`) -- exchanges the `role_id` and `secret_id`
-//!   provider credentials, or SecretSpec's `BAO_ROLE_ID` and `BAO_SECRET_ID`
-//!   inputs, for a client token. The corresponding `VAULT_*` names remain
-//!   compatibility fallbacks.
+//! - AppRole (`?auth=approle`) -- exchanges the required `role_id` and optional
+//!   `secret_id` provider credentials, or SecretSpec's `BAO_ROLE_ID` and
+//!   `BAO_SECRET_ID` inputs, for a client token. Starting with SecretSpec 0.18,
+//!   the SecretID may be omitted when the AppRole has `bind_secret_id=false`.
+//!   The corresponding `VAULT_*` names remain compatibility fallbacks.
 //! - JWT/OIDC (`?auth=jwt`) -- logs in using SecretSpec's `BAO_JWT` input
 //!   (falling back to `VAULT_JWT`) or a short-lived GitHub Actions / Forgejo
 //!   Actions OIDC token. Starting with SecretSpec 0.18, the role may be omitted

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -9,9 +9,10 @@
 //!
 //! - Token (default) -- reads the `token` provider credential, `VAULT_TOKEN`,
 //!   or `~/.vault-token`, in that order.
-//! - AppRole (`?auth=approle`) -- exchanges the `role_id` and `secret_id`
-//!   provider credentials, or `VAULT_ROLE_ID` and `VAULT_SECRET_ID`, for a
-//!   client token.
+//! - AppRole (`?auth=approle`) -- exchanges the required `role_id` and optional
+//!   `secret_id` provider credentials, or `VAULT_ROLE_ID` and
+//!   `VAULT_SECRET_ID`, for a client token. Starting with SecretSpec 0.18, the
+//!   SecretID may be omitted when the AppRole has `bind_secret_id=false`.
 //! - JWT/OIDC (SecretSpec 0.17+, `?auth=jwt`) -- logs in using `VAULT_JWT` or a
 //!   short-lived GitHub Actions / Forgejo Actions OIDC token. Starting with
 //!   SecretSpec 0.18, the role may be omitted when the auth mount has a

--- a/secretspec/src/provider/vault_common.rs
+++ b/secretspec/src/provider/vault_common.rs
@@ -931,21 +931,13 @@ impl KvProvider {
         })?;
 
         let secret_id =
-            credential_or_envs(&self.credentials, SECRET_ID, self.product.secret_id_envs())
-                .ok_or_else(|| {
-                    SecretSpecError::ProviderOperationFailed(format!(
-                        "{} secret_id credential is required for AppRole authentication; configure \
-                 credentials.secret_id or set {}.",
-                        self.product.display_name(),
-                        self.product.secret_id_envs().join(" or ")
-                    ))
-                })?;
+            credential_or_envs(&self.credentials, SECRET_ID, self.product.secret_id_envs());
 
         let url = self.auth_login_url();
-        let body = serde_json::json!({
-            "role_id": role_id,
-            "secret_id": secret_id,
-        });
+        let mut body = serde_json::json!({ "role_id": role_id });
+        if let Some(secret_id) = secret_id {
+            body["secret_id"] = serde_json::Value::String(secret_id);
+        }
 
         // The server-side lease begins while the request is in flight. Anchor
         // its deadline before sending so response latency cannot extend the
@@ -1984,6 +1976,75 @@ mod tests {
             request_json(&observed[0].0),
             serde_json::json!({ "jwt": "test-jwt" })
         );
+    }
+
+    #[test]
+    fn approle_login_includes_a_configured_secret_id() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let (endpoint, server) = auth_server(1, 0, None);
+        let config = KvConfig::parse(
+            &provider_url(&format!("vault://{endpoint}/secret?tls=false&auth=approle")),
+            Product::Vault,
+        )
+        .unwrap();
+        let mut provider = KvProvider::new(config, Product::Vault);
+        provider.with_credentials(approle_credentials());
+
+        block_on(provider.resolve_approle_auth()).unwrap();
+
+        let observed = server.join().unwrap();
+        assert_eq!(observed.len(), 1);
+        assert_eq!(
+            request_json(&observed[0].0),
+            serde_json::json!({
+                "role_id": "test-role",
+                "secret_id": "test-secret"
+            })
+        );
+    }
+
+    #[test]
+    fn approle_login_omits_an_absent_secret_id_for_an_unbound_role() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let (endpoint, server) = auth_server(1, 0, None);
+        let config = KvConfig::parse(
+            &provider_url(&format!(
+                "openbao://{endpoint}/secret?tls=false&auth=approle"
+            )),
+            Product::OpenBao,
+        )
+        .unwrap();
+        let mut provider = KvProvider::new(config, Product::OpenBao);
+        provider.with_credentials(ProviderCredentials::from([(
+            ROLE_ID.to_string(),
+            SecretString::new("test-role".to_string().into()),
+        )]));
+
+        block_on(provider.resolve_approle_auth()).unwrap();
+
+        let observed = server.join().unwrap();
+        assert_eq!(observed.len(), 1);
+        assert_eq!(
+            request_json(&observed[0].0),
+            serde_json::json!({ "role_id": "test-role" })
+        );
+    }
+
+    #[test]
+    fn approle_login_still_requires_a_role_id() {
+        let _lock = crate::tests::scrub_resolution_env();
+        let config = KvConfig::parse(
+            &provider_url("vault://127.0.0.1:1/secret?tls=false&auth=approle"),
+            Product::Vault,
+        )
+        .unwrap();
+        let provider = KvProvider::new(config, Product::Vault);
+
+        let error = block_on(provider.resolve_approle_auth())
+            .err()
+            .expect("AppRole login without a role_id must fail");
+
+        assert!(error.to_string().contains("role_id credential is required"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Allow Vault and OpenBao AppRole authentication to omit `secret_id` when the role is configured with `bind_secret_id=false`.

`role_id` remains required, while configured SecretIDs continue to be sent unchanged.

## Rationale

Both Vault and OpenBao support role-ID-only AppRole authentication. SecretSpec previously rejected this valid configuration before contacting the server.

## Validation

- Vault and OpenBao provider tests
- Full SecretSpec test suite and documentation build
- Live OpenBao 2.6.1 checks with both SecretID-bound and role-ID-only AppRoles