### PR TITLE
Release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.18.0] - 2026-08-03
 
 ### Changed
 - The keyring provider now uses keyring 4's Rust-native Secret Service
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provider configurations (including dotenv path aliases) from deleting the
   destination value. Sources without deletion support are also rejected before
   any destination is written.
+- The AWS Secrets Manager provider now authenticates with shared credentials
+  file profiles backed by an active AWS login session, which previously failed
+  because the required AWS SDK feature was not enabled. `BatchGetSecretValue`
+  failures also report the full service error instead of a shortened message.
 
 ### Added
 - The dotenv provider accepts a leading `~` in custom paths, such as
@@ -64,6 +68,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their manifest declarations, while `--all` requires explicit confirmation.
   `secretspec import --delete-source` verifies each destination value before
   deleting its source, and retains the source when an existing target differs.
+- Bitwarden Password Manager provider (`bw://`, `bw` build feature) for reading
+  and writing secrets in a personal or organization vault through the `bw` CLI.
+  Collections and organizations are addressed by name or by id
+  (`bw://myorg@dev-secrets`), `?type=` and `?field=` select an item type and
+  field, and `?server=` asserts which self-hosted server the configuration
+  expects. Every item type is supported (login, secure note, card, identity, SSH
+  key), each with a default field shared by reads and writes. Item names are
+  matched in full and case-insensitively, and an ambiguous name is refused with
+  the colliding ids rather than resolved to an arbitrary item.
 - Dashlane provider (`dashlane://`) for reading secrets from a Dashlane vault
   through the `dcli` CLI. Convention secrets read the item titled
   `secretspec/{project}/{profile}/{key}`, and a `ref` names an existing item by
@@ -83,7 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and updates preserve the JSON types of Keeper fields such as dates,
   checkboxes, hosts, and names.
 - AWS Systems Manager Parameter Store provider (`awsps://`, `awsps` build
-  feature; planned for 0.18) for reading and writing KMS-encrypted
+  feature) for reading and writing KMS-encrypted
   `SecureString` parameters. It supports AWS profiles and regions, an optional
   hierarchy prefix, customer-managed KMS keys, parameter tiers, batched reads,
   and references by parameter name, version, label, or ARN. Unversioned

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "age",
  "aws-config",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-derive"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "http 1.4.0",
  "insta",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-ffi"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "secretspec",
  "serde_json",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-node-native"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-php-native"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "ext-php-rs",
  "secretspec",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-py-native"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "pyo3",
  "secretspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.1"
+version = "0.18.0"
 edition = "2024"
 
 [workspace.dependencies]
@@ -54,8 +54,8 @@ azure_identity = "1.0.0"
 azure_security_keyvault_secrets = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
-secretspec-derive = { version = "0.17.1", path = "./secretspec-derive" }
-secretspec = { version = "0.17.1", path = "./secretspec" }
+secretspec-derive = { version = "0.18.0", path = "./secretspec-derive" }
+secretspec = { version = "0.18.0", path = "./secretspec" }
 rand = "0.9"
 rsa = { version = "0.9", features = ["pem"] }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/secretspec-derive/Cargo.toml
+++ b/secretspec-derive/Cargo.toml
@@ -15,7 +15,7 @@ quote.workspace = true
 proc-macro2.workspace = true
 toml.workspace = true
 serde.workspace = true
-secretspec = { version = "0.17.1", path = "../secretspec", default-features = false }
+secretspec = { version = "0.18.0", path = "../secretspec", default-features = false }
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/secretspec-hs/secretspec.cabal
+++ b/secretspec-hs/secretspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               secretspec
-version:            0.17.1
+version:            0.18.0
 synopsis:           Haskell SDK for SecretSpec, a declarative secrets manager
 description:
   A thin client over the @secretspec-ffi@ C ABI (linked at build time).

--- a/secretspec-node/package.json
+++ b/secretspec-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretspec",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "A declarative interface for every secret provider. Node.js SDK.",
   "license": "Apache-2.0",
   "homepage": "https://secretspec.dev/",

--- a/secretspec-py/pyproject.toml
+++ b/secretspec-py/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "secretspec"
-version = "0.17.1"
+version = "0.18.0"
 description = "A declarative interface for every secret provider. Python SDK."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/secretspec-rb/secretspec.gemspec
+++ b/secretspec-rb/secretspec.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "secretspec"
-  spec.version     = "0.17.1"
+  spec.version     = "0.18.0"
   spec.summary     = "A declarative interface for every secret provider. Ruby SDK."
   spec.description = "Ruby bindings for SecretSpec: a native extension that " \
                      "statically links the secretspec-ffi C ABI."


### PR DESCRIPTION
Bumps the workspace and every SDK packaging file to 0.18.0 and retitles the changelog's `Unreleased` section as `0.18.0`.

Cross-checked `git log v0.17.1..HEAD` against the changelog and added two missing user facing entries:

- **Added**: Bitwarden Password Manager provider (`bw://`, `bw` build feature) — the provider was implemented and documented as 0.18+ but had no changelog entry of its own.
- **Fixed**: AWS Secrets Manager shared credentials login now works (the `aws-config/credentials-login` feature was not enabled), and `BatchGetSecretValue` failures report the full service error.

Also dropped the now stale "planned for 0.18" qualifier from the AWS Parameter Store entry.

Files bumped: `Cargo.toml`, `secretspec-derive/Cargo.toml`, `Cargo.lock`, `secretspec-node/package.json`, `secretspec-py/pyproject.toml`, `secretspec-hs/secretspec.cabal`, `secretspec-rb/secretspec.gemspec`.

`cargo build` passes.

Created by Claude Code — see https://github.com/cli/cli/issues/13904

🤖 Generated with [Claude Code](https://claude.com/claude-code)