### PR TITLE
docs: document v0.17 `age` provider credentials

### DIFF
--- a/docs/src/content/docs/concepts/providers.md
+++ b/docs/src/content/docs/concepts/providers.md
@@ -259,10 +259,10 @@ Provider credentials follow these rules:
 - **Names are provider-specific.** Bitwarden accepts `access_token`; Vault
   accepts `token`, `role_id`, and `secret_id`; 1Password accepts
   `service_account_token`; Azure Key Vault accepts `tenant_id`, `client_id`, and
-  `client_secret`; SOPS (0.17+) accepts `age_key`, `aws_secret_access_key`,
-  `azure_client_secret`, `google_oauth_access_token`, `hc_vault_token`,
-  `huawei_sdk_ak`, and `huawei_sdk_sk`. Unsupported names are rejected before
-  any source is read.
+  `client_secret`; Age (0.17+) accepts `identity`; SOPS (0.17+) accepts `age_key`,
+  `aws_secret_access_key`, `azure_client_secret`, `google_oauth_access_token`,
+  `hc_vault_token`, `huawei_sdk_ak`, and `huawei_sdk_sk`. Unsupported names are
+  rejected before any source is read.
 
 ## Next steps
 


### PR DESCRIPTION
The `age` provider was added in version 0.17. The section of the docs that lists provider credentials was missing an entry for the recently added age provider.

This documents the singular credential accepted by `age` to this docs page; it is the `identity` credential; it is placed meaningfully next to all the other provider credential keys.

This is a minimal update to the docs that brings this bullet point closer to the current state of the rust implementation. See `credential_names: ["identity"],`: https://github.com/cachix/secretspec/blob/e4c54d62730ce2b3d706b83ad5560392a20cb8f2/secretspec/src/provider/age.rs#L167-L175