### PR TITLE
Publish SecretSpec 0.18 announcement

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -5,29 +5,36 @@ import starlightLlmsTxt from "starlight-llms-txt";
 import starlightBlog from "starlight-blog";
 
 // Dev-only: `astro dev` (what `devenv up` runs) does not execute worker.js, so
-// /api/stars would 404 and the star pill would stay hidden locally. Mirror the
-// worker's GitHub proxy here so the pill populates during local development.
+// /api/github would 404 and the release/star pills would stay hidden locally.
+// Mirror the worker's GitHub proxy here so both populate during development.
 // Production is unaffected — it is served by worker.js.
-const devStarsApi: PluginOption = {
-  name: "dev-stars-api",
+const devGitHubApi: PluginOption = {
+  name: "dev-github-api",
   apply: "serve",
   enforce: "pre",
   configureServer(server) {
-    server.middlewares.use("/api/stars", async (_req, res) => {
+    server.middlewares.use("/api/github", async (_req, res) => {
       let stars = null;
+      let release = null;
       try {
-        const r = await fetch("https://api.github.com/repos/cachix/secretspec", {
-          headers: { "User-Agent": "secretspec-docs" },
-        });
-        if (r.ok) {
-          const data = await r.json();
+        const headers = { "User-Agent": "secretspec-docs" };
+        const [repoResponse, releaseResponse] = await Promise.all([
+          fetch("https://api.github.com/repos/cachix/secretspec", { headers }),
+          fetch("https://api.github.com/repos/cachix/secretspec/releases/latest", { headers }),
+        ]);
+        if (repoResponse.ok) {
+          const data = await repoResponse.json();
           if (typeof data.stargazers_count === "number") stars = data.stargazers_count;
         }
+        if (releaseResponse.ok) {
+          const data = await releaseResponse.json();
+          if (typeof data.tag_name === "string") release = data.tag_name;
+        }
       } catch {
-        // Degrade to { stars: null } — the pill simply stays hidden.
+        // Degrade to null values — the corresponding pills stay hidden.
       }
       res.setHeader("Content-Type", "application/json");
-      res.end(JSON.stringify({ stars }));
+      res.end(JSON.stringify({ stars, release }));
     });
   },
 };
@@ -40,7 +47,7 @@ export default defineConfig({
     "/ci": "/ci/github-actions",
   },
   vite: {
-    plugins: [devStarsApi],
+    plugins: [devGitHubApi],
   },
   integrations: [
     starlight({

--- a/docs/src/content/docs/blog/secretspec-0-18-secret-lifecycle-bitwarden-keeper-aws-parameter-store-and-swift.md
+++ b/docs/src/content/docs/blog/secretspec-0-18-secret-lifecycle-bitwarden-keeper-aws-parameter-store-and-swift.md
@@ -1,0 +1,246 @@
+---
+title: "SecretSpec 0.18: Secret lifecycle, Bitwarden, Keeper, AWS Parameter Store, and Swift"
+description: Declare, discover, migrate, and delete secrets from the CLI; use four new providers; and resolve the same manifests from Swift.
+date: 2026-08-03
+authors:
+  - domen
+---
+
+[SecretSpec 0.18](https://github.com/cachix/secretspec/releases/tag/v0.18.0 "SecretSpec 0.18 release")
+ships:
+
+- **[Secret lifecycle commands](#secret-lifecycle-commands)**: add
+  declarations, delete stored values, and move secrets between providers
+  without leaving the source copy behind.
+- **[Provider-backed discovery](#provider-backed-discovery)**:
+  initialize a manifest from an age file, an AWS Parameter Store hierarchy, or
+  a Bitwarden collection without writing any values to it.
+- **[Four new providers](#four-new-providers)**: use [Bitwarden Password
+  Manager](/providers/bw/), [Keeper Secrets Manager](/providers/keeper/), [AWS
+  Systems Manager Parameter Store](/providers/awsps/), and
+  [Dashlane](/providers/dashlane/) through the same CLI and SDK interface.
+- **[Swift SDK](#swift-sdk)**: resolve manifests natively on macOS
+  through a checksummed XCFramework that includes the shared Rust resolver.
+- **[Vault and OpenBao authentication](#vault-and-openbao-authentication)**:
+  use custom AppRole and JWT mounts, AppRoles without SecretID binding, and
+  server-configured default JWT roles.
+
+## We have a new logo!
+
+![The new SecretSpec document-and-keyhole logo](../../../assets/logo.png)
+
+## Secret lifecycle commands
+
+SecretSpec has always kept the declaration in `secretspec.toml` separate from
+the stored value. 0.18 brings both sides of that lifecycle into the CLI.
+
+[`secretspec add`](/reference/cli/#add-018) adds a declaration to the selected
+profile while preserving the manifest's comments, formatting, and unrelated
+tables:
+
+```console
+$ secretspec add STRIPE_API_KEY --description "Stripe API access token"
+✓ Added secret 'STRIPE_API_KEY' to profile 'default' in secretspec.toml
+Set its value with: secretspec set STRIPE_API_KEY --profile default
+
+$ secretspec set STRIPE_API_KEY
+Enter value for STRIPE_API_KEY: ********
+✓ Secret 'STRIPE_API_KEY' saved to keyring (profile: default)
+```
+
+`add` never asks for or stores the value. The declaration can be reviewed and
+committed before each developer or deployment supplies its own value.
+
+[`secretspec delete`](/reference/cli/#delete-018) does the inverse on the
+storage side: it removes a value without changing the declaration. The next
+`check` therefore reports the secret as missing instead of quietly removing
+the application's requirement:
+
+```console
+$ secretspec delete STRIPE_API_KEY
+Deleted 'STRIPE_API_KEY'
+Deleted 1 secret value; 0 already absent
+```
+
+Deletion is idempotent, invalidates an associated cache entry, and follows the
+same primary-write-provider routing as `set`. `delete --all` requires an
+interactive confirmation, or an explicit `--yes` in non-interactive use.
+
+Provider migrations can now remove each source value after proving the move
+succeeded:
+
+```bash
+secretspec import dotenv:~/.config/payments/.env --delete-source
+```
+
+[`import --delete-source`](/reference/cli/#import) reads the destination back
+and compares it with the source before deleting anything. An identical value
+already at the destination is safe to remove from the source; a conflicting
+value leaves the source intact. SecretSpec also rejects a source without
+deletion support before writing the destination and recognizes equivalent
+provider spellings as the same store, so a migration cannot delete the value
+it just wrote through another alias.
+
+Together these commands keep the distinction explicit: `add` changes what the
+application declares, `set` and `delete` change one environment's stored
+value, and `import --delete-source` moves that value between stores.
+
+## Provider-backed discovery
+
+The first SecretSpec command in an existing project is often
+`secretspec init --from .env`. In 0.18,
+[`init --from`](/reference/cli/#init) accepts every provider that can discover
+declarations, including age, AWS Parameter Store, and Bitwarden Password
+Manager.
+
+Hierarchical stores also receive an explicit project and profile so SecretSpec
+looks only inside the namespace the new manifest will use:
+
+```console
+$ secretspec init \
+    --from 'awsps://production@us-east-1?template=/{profile}/{project}/{key}' \
+    --project payments \
+    --profile production
+✓ Created secretspec.toml with 12 secrets
+```
+
+For a password-manager vault, scope discovery to the collection and item type
+that belong to the application:
+
+```console
+$ secretspec init --from 'bw://Acme%20Inc@dev-secrets?type=login'
+✓ Created secretspec.toml with 8 secrets
+```
+
+Discovery writes names and generated descriptions, never secret values. After
+reviewing the manifest, keep the discovered provider as the profile's source
+or use `secretspec import` to copy the now-declared values somewhere else.
+
+## Four new providers
+
+0.18 brings SecretSpec to 24 providers, with four additions spanning personal
+password managers, machine-oriented vaults, and cloud parameter storage.
+
+**[Bitwarden Password Manager](/providers/bw/)** is separate from the existing
+Bitwarden Secrets Manager provider. The new `bw://` provider uses the official
+`bw` CLI to read and write regular vault items: logins, secure notes, cards,
+identities, and SSH keys. It can address organizations and collections by name
+or ID, restrict a provider to one item type or field, discover declarations,
+and point [`ref`](/concepts/references/) secrets at existing items. A
+`?server=` guard verifies that the CLI is logged into the expected self-hosted
+instance instead of silently reading the wrong vault.
+
+**[Keeper Secrets Manager](/providers/keeper/)** uses Keeper's official Rust
+SDK, so it does not need a separate CLI. A `keeper://FOLDER_UID` provider reads,
+writes, batches, and deletes convention records shared with a KSM application;
+refs can select an existing record and field. Its client configuration can
+come from `KSM_CONFIG`, a protected configuration file, or SecretSpec
+[provider credentials](/concepts/providers/#provider-credentials).
+
+**[AWS Systems Manager Parameter Store](/providers/awsps/)** stores every
+value as a KMS-encrypted `SecureString`. The `awsps://` provider uses the
+standard AWS credential and region chains and supports shared-config profiles,
+hierarchy prefixes, complete `{project}` / `{profile}` / `{key}` templates,
+customer-managed KMS keys, and parameter tiers. Refs can select an existing
+parameter by name, version, label, or ARN; unversioned name refs are writable,
+while pinned revisions remain read-only. Its bounded hierarchy discovery uses
+`GetParametersByPath` without decrypting values.
+
+**[Dashlane](/providers/dashlane/)** reads secrets, secure notes, and logins
+through the `dcli` CLI. It is intentionally read-only because `dcli` cannot
+create or edit vault items. A ref can address an existing item by title or
+identifier and select one of its fields. CI can provide
+`DASHLANE_SERVICE_DEVICE_KEYS` directly or source the same
+`service_device_keys` input from another SecretSpec provider.
+
+A project can route different secrets through any combination of them:
+
+```toml title="secretspec.toml"
+[providers]
+team_vault = "bw://Acme%20Inc@dev-secrets"
+keeper_ci = "keeper://SHARED_FOLDER_UID"
+parameters = "awsps://production@us-east-1?prefix=/platform"
+dashlane_notes = "dashlane://note"
+```
+
+Provider choice still stays outside application code. The CLI and every SDK
+resolve the same declaration regardless of which of these aliases supplies a
+value.
+
+## Swift SDK
+
+The new [Swift SDK](/sdk/swift/) brings the shared SecretSpec resolver to macOS
+12 or later on Intel and Apple silicon. Add the repository as a Swift package:
+
+```swift
+dependencies: [
+    .package(
+        url: "https://github.com/cachix/secretspec",
+        from: "0.18.0"
+    ),
+]
+```
+
+Then use the same builder vocabulary as the other SDKs:
+
+```swift
+import SecretSpec
+
+let resolved = try SecretSpec.builder()
+    .withProfile("production")
+    .withScope("api")
+    .withReason("boot web app")
+    .load()
+defer { try? resolved.close() }
+
+print(resolved.secrets["DATABASE_URL"]?.get() ?? "")
+try resolved.setAsEnvironment()
+```
+
+The SDK exposes fluent and one-shot resolution, typed failures, value-free
+preflight reports, scopes, provenance, environment export, and JSON input for
+generated Swift models. Calling `close()` deterministically removes temporary
+files created for `as_path` secrets.
+
+The SwiftPM release contains a checksummed XCFramework with the Rust resolver,
+so an application needs neither a Rust toolchain nor a separately installed
+SecretSpec library.
+
+## Vault and OpenBao authentication
+
+[Vault](/providers/vault/) and [OpenBao](/providers/openbao/) deployments do
+not always use the default `approle` and `jwt` mount names. Their provider URIs
+can now choose a mount relative to `/v1/auth`:
+
+```text
+vault://vault.example.com:8200/secret?auth=approle&auth_mount=platform-approle
+openbao://bao.example.com:8200/secret?auth=jwt&auth_mount=ci-jwt&role=deploy
+```
+
+AppRole authentication can omit `secret_id` when the server role is configured
+with `bind_secret_id=false`. JWT authentication can likewise omit its role when
+the selected mount has a server-configured `default_role`. Explicit URI,
+environment, or provider-credential inputs continue to take precedence.
+
+## Upgrading
+
+```bash
+cargo install secretspec
+```
+
+0.18 also makes two local workflows less dependent on machine-specific setup:
+
+- custom [dotenv](/providers/dotenv/) paths accept a leading `~`, resolved to
+  the current user's home directory;
+- Linux [keyring](/providers/keyring/) builds use keyring 4's Rust-native
+  Secret Service transport, so SecretSpec binaries no longer require system
+  `libdbus`.
+
+Existing manifests and providers continue to work unchanged. The new commands,
+providers, and SDK are opt-in.
+
+See the [full changelog](https://github.com/cachix/secretspec/blob/main/CHANGELOG.md)
+for every change and fix in this release.
+
+Questions or feedback? Join us on
+[Discord](https://discord.gg/naMgvexb6q).

--- a/docs/src/overrides/SocialIcons.astro
+++ b/docs/src/overrides/SocialIcons.astro
@@ -1,27 +1,10 @@
 ---
 import { Icon } from '@astrojs/starlight/components';
 import config from 'virtual:starlight/user-config';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 
-// Best-effort: read the workspace version at build time. Anchor to the
-// [workspace.package] section and stop at the next TOML header so we never
-// match a dependency's `version = "..."` pin.
-let version: string | null = null;
-try {
-  const cargoTomlPath = fileURLToPath(new URL('../../../Cargo.toml', import.meta.url));
-  const cargoToml = readFileSync(cargoTomlPath, 'utf-8');
-  const section = cargoToml.match(/\[workspace\.package\]([^\[]*)/);
-  const versionMatch = section?.[1].match(/^\s*version\s*=\s*["']([^"']+)["']/m);
-  version = versionMatch?.[1] ?? null;
-} catch {
-  // Cargo.toml missing or unreadable — degrade to no pill rather than fail the build.
-}
-
-// The star count is fetched at runtime (see the inline script below) from our own
-// /api/stars edge route, which proxies GitHub with edge caching — so we never
-// hit the GitHub API per-visitor. The pill renders hidden and reveals itself
-// once populated; a failed lookup just leaves it hidden.
+// The latest published release and star count are fetched at runtime (see the
+// inline script below) from our edge-cached GitHub proxy. Both pills render
+// hidden and reveal themselves once populated; a failed lookup leaves them hidden.
 
 // The GitHub-mark + star-count pill replaces the standalone GitHub icon, so
 // only render non-GitHub social links here.
@@ -29,15 +12,7 @@ try {
 const otherLinks = (config.social || []).filter((l) => l.icon !== 'github');
 ---
 
-{version && (
-  <a
-    class="release-pill"
-    href={`https://github.com/cachix/secretspec/releases/tag/v${version}`}
-    aria-label={`Latest release: v${version}`}
-  >
-    v{version}
-  </a>
-)}
+<a class="release-pill" data-release-pill hidden></a>
 <a
   class="release-pill stars-pill"
   href="https://github.com/cachix/secretspec"
@@ -55,23 +30,32 @@ const otherLinks = (config.social || []).filter((l) => l.icon !== 'github');
 ))}
 
 <script>
-  // Populate the GitHub star pill from our own edge-cached /api/stars route, so
-  // the GitHub API is never hit per-visitor. Hoisted by Astro, so it runs once
-  // even though this component renders in both the header and the mobile menu.
+  // Populate the release and star pills from our own edge-cached GitHub proxy.
+  // Hoisted by Astro, so this runs once even though the component renders in
+  // both the header and mobile menu.
   (async () => {
     const fmt = (n: number) =>
       n >= 10000 ? (n / 1000).toFixed(0) + 'k'
       : n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k'
       : String(n);
     try {
-      const res = await fetch('/api/stars');
+      const res = await fetch('/api/github');
       if (!res.ok) return;
-      const { stars } = await res.json();
-      if (typeof stars !== 'number') return;
-      for (const pill of document.querySelectorAll<HTMLElement>('[data-stars-pill]')) {
-        const count = pill.querySelector('[data-stars-count]');
-        if (count) count.textContent = fmt(stars);
-        pill.hidden = false;
+      const { stars, release } = await res.json();
+      if (typeof release === 'string') {
+        for (const pill of document.querySelectorAll<HTMLAnchorElement>('[data-release-pill]')) {
+          pill.href = `https://github.com/cachix/secretspec/releases/tag/${encodeURIComponent(release)}`;
+          pill.ariaLabel = `Latest release: ${release}`;
+          pill.textContent = release;
+          pill.hidden = false;
+        }
+      }
+      if (typeof stars === 'number') {
+        for (const pill of document.querySelectorAll<HTMLElement>('[data-stars-pill]')) {
+          const count = pill.querySelector('[data-stars-count]');
+          if (count) count.textContent = fmt(stars);
+          pill.hidden = false;
+        }
       }
     } catch {
       // Leave the pill hidden on any failure.

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -57,3 +57,9 @@
 .sl-markdown-content a:not([class]):hover {
   color: var(--sl-color-accent-high);
 }
+
+/* Swap the release-post logo artwork with the active documentation theme. */
+:root[data-theme="dark"]
+  img[alt="The new SecretSpec document-and-keyhole logo"] {
+  content: url("../assets/logo-dark.png");
+}

--- a/docs/worker.js
+++ b/docs/worker.js
@@ -1,15 +1,16 @@
 /**
  * Cloudflare Worker entry for the docs site.
  *
- * Everything is served from the static `dist/` assets except `/api/stars`,
- * which proxies the GitHub star count. The GitHub response is cached at the
+ * Everything is served from the static `dist/` assets except `/api/github`,
+ * which proxies the GitHub star count and latest published release. The
+ * GitHub responses are cached at the
  * edge (`cf.cacheTtl`), so across all visitors we hit the GitHub API at most
  * about once per hour per data-center — comfortably under the 60 req/hr
  * unauthenticated limit — instead of once per page view.
  *
  * An optional `GITHUB_TOKEN` secret raises the upstream limit further but is
- * not required given the edge cache. Any failure degrades to `{ stars: null }`
- * and the pill simply stays hidden.
+ * not required given the edge cache. Any failed value is returned as `null`
+ * and its pill simply stays hidden.
  */
 const REPO = "cachix/secretspec";
 const TTL = 3600; // seconds
@@ -17,37 +18,46 @@ const TTL = 3600; // seconds
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
-    if (url.pathname === "/api/stars") {
-      return handleStars(env);
+    if (url.pathname === "/api/github") {
+      return handleGitHub(env);
     }
     // Fall back to the static assets (also applies `not_found_handling`).
     return env.ASSETS.fetch(request);
   },
 };
 
-async function handleStars(env) {
+async function handleGitHub(env) {
   let stars = null;
+  let release = null;
   try {
     const headers = { "User-Agent": "secretspec-docs" };
     if (env.GITHUB_TOKEN) headers["Authorization"] = `Bearer ${env.GITHUB_TOKEN}`;
-    const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+    const options = {
       headers,
-      // Cache GitHub's response at the edge, shared across all visitors.
+      // Cache GitHub's responses at the edge, shared across all visitors.
       cf: { cacheTtl: TTL, cacheEverything: true },
-    });
-    if (res.ok) {
-      const data = await res.json();
+    };
+    const [repoResponse, releaseResponse] = await Promise.all([
+      fetch(`https://api.github.com/repos/${REPO}`, options),
+      fetch(`https://api.github.com/repos/${REPO}/releases/latest`, options),
+    ]);
+    if (repoResponse.ok) {
+      const data = await repoResponse.json();
       if (typeof data.stargazers_count === "number") stars = data.stargazers_count;
     }
+    if (releaseResponse.ok) {
+      const data = await releaseResponse.json();
+      if (typeof data.tag_name === "string") release = data.tag_name;
+    }
   } catch {
-    // fall through with stars = null
+    // fall through with null values
   }
 
-  return new Response(JSON.stringify({ stars }), {
+  return new Response(JSON.stringify({ stars, release }), {
     headers: {
       "Content-Type": "application/json",
       // Cache successes; never cache a failed lookup.
-      "Cache-Control": stars !== null ? `public, max-age=${TTL}` : "no-store",
+      "Cache-Control": stars !== null || release !== null ? `public, max-age=${TTL}` : "no-store",
     },
   });
 }


### PR DESCRIPTION
## Summary
- publish the SecretSpec 0.18 release article
- show the latest published GitHub release in the docs header at runtime
- keep the release artwork readable in dark mode

## Verification
- NIXPKGS_ALLOW_INSECURE=1 devenv shell npm --prefix docs run build