### PR TITLE
fix(devenv): use maintained Docker 29 client

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -71,7 +71,8 @@
     # Vaultwarden + TLS proxy containers. Client only: the harness talks to
     # whatever runtime the developer already provides (Docker Desktop, colima,
     # or a podman machine exposing /var/run/docker.sock).
-    pkgs.docker-client
+    # docker-client currently aliases the insecure Docker 28 package.
+    (pkgs.docker_29.override { clientOnly = true; })
     # Building the secretspec-php-native extension (ext-php-rs) needs php-config +
     # the PHP dev headers, and bindgenHook wires libclang/clang system headers so
     # ext-php-rs's bindgen step can parse php.h.


### PR DESCRIPTION
## Summary

- select Docker 29 explicitly for the development toolchain
- preserve the existing client-only installation used by the Vaultwarden test harness

## Context

Following the recent `devenv.lock` refresh, nixpkgs' generic
`docker-client` alias resolves to Docker 28.5.2. Nixpkgs marks that version
as insecure and refuses to evaluate the development shell:

> docker_28 has been unmaintained since November 2025, use docker_29 or newer instead

This currently blocks CI on `main` and obscures the results of the open
Dependabot action upgrades:

- [#258 — `actions/setup-dotnet`](https://github.com/cachix/secretspec/pull/258)
- [#259 — `actions/download-artifact`](https://github.com/cachix/secretspec/pull/259)
- [#260 — `actions/upload-artifact`](https://github.com/cachix/secretspec/pull/260)
- [#261 — `cachix/cachix-action`](https://github.com/cachix/secretspec/pull/261)
- [#262 — `actions/setup-go`](https://github.com/cachix/secretspec/pull/262)
- [#263 — `actions/checkout`](https://github.com/cachix/secretspec/pull/263)

Once this change lands, those PRs can be rebased onto `main` so their CI
results reflect the action upgrades themselves.

## Impact

The development shell and CI use a maintained Docker CLI while retaining
client-only behavior. No Docker daemon is added and SecretSpec runtime
behavior is unchanged.

## Validation

- parsed `devenv.nix` with `nix-instantiate`
- evaluated the selected package against the locked nixpkgs revision for
  `x86_64-linux`: Docker 29.6.0 with no known vulnerabilities
- ran `git diff --check`
