### PR TITLE
Allow profiles to opt out of default inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Profiles can opt out of inheriting `[profiles.default]` by setting
+  `inherit = false` in their profile defaults (0.19+), allowing standalone
+  secret sets alongside profiles that still share the default declarations.
 - Windows ARM64 CLI release artifacts (`aarch64-pc-windows-msvc`).
 - Provider aliases can define native `ref` templates and secrets can override
   coordinates per leaf alias with `refs`, so fallback providers and import

--- a/docs/src/content/docs/concepts/inheritance.md
+++ b/docs/src/content/docs/concepts/inheritance.md
@@ -61,6 +61,9 @@ extends = ["../../shared/base", "../../shared/database", "../../shared/auth"]
 - Shared ancestors are applied once, so diamond-shaped inheritance is supported
 - Each profile is merged independently
 - Profile `[defaults]` inherit field by field across source files
+- The `inherit` profile-default field (0.19+) follows that same `extends`
+  precedence. A child profile keeps an inherited `inherit = false` unless a
+  later source explicitly sets it to `true`.
 - A child `[scopes.<name>]` completely replaces the parent scope of the same
   name — its `secrets` list wins outright; the two lists are **not** unioned.
   Scopes defined only in a parent are inherited. (Whole-value replacement is the

--- a/docs/src/content/docs/concepts/overview.md
+++ b/docs/src/content/docs/concepts/overview.md
@@ -11,7 +11,7 @@ A [`secretspec.toml`](/concepts/declarative/) file lists the secrets your projec
 
 ## Use profiles for environments
 
-[Profiles](/concepts/profiles/) let you vary secret requirements per environment. A `production` profile can enforce strict requirements while a `development` profile provides safe defaults. All profiles inherit from `default`, so you only specify what changes.
+[Profiles](/concepts/profiles/) let you vary secret requirements per environment. A `production` profile can enforce strict requirements while a `development` profile provides safe defaults. Non-default profiles inherit from `default` when it exists, so you only specify what changes; SecretSpec 0.19+ also supports standalone profiles that opt out of this inheritance.
 
 ## Store secrets anywhere with providers
 

--- a/docs/src/content/docs/concepts/profiles.md
+++ b/docs/src/content/docs/concepts/profiles.md
@@ -7,7 +7,14 @@ description: Managing environment-specific secret requirements with profiles
 
 Profiles are named configurations that define how secrets behave in different environments. They specify which secrets are required vs optional, provide safe defaults for development, and enforce strict requirements for production.
 
-A key feature of profiles is inheritance: all profiles automatically inherit secrets from the `default` profile. This means you only need to override the specific properties that change between environments, reducing duplication and making your configuration cleaner and easier to maintain.
+A key feature of profiles is inheritance: non-default profiles inherit secrets
+from the `default` profile when it exists. This means you only need to override
+the specific properties that change between related environments. SecretSpec
+0.19+ also lets an unrelated profile opt out and remain standalone.
+
+If a manifest omits `default`, callers must select an existing profile with
+`--profile`, `SECRETSPEC_PROFILE`, or their user config; the final fallback name
+is still `default`.
 
 ## Basic Usage
 
@@ -59,6 +66,37 @@ When using profiles, inheritance works as follows:
 3. **Field-level overrides**: Most explicitly set properties replace the corresponding property from `default`, while omitted properties continue to inherit
 4. **Profile-specific secrets**: Secrets not in the default profile can be added to any profile
 
+### Standalone profiles (0.19+)
+
+:::caution[Version compatibility]
+Profile-level `inherit` is available starting with SecretSpec 0.19.
+:::
+
+Set `inherit = false` in a non-default profile's `defaults` table when its
+secret set is unrelated to `[profiles.default]`:
+
+```toml
+[profiles.default]
+DATABASE_URL = { description = "Development database", default = "sqlite://./dev.db" }
+API_KEY = { description = "Development API key" }
+
+[profiles.production]
+# Inherits both default declarations and overrides only what changes.
+DATABASE_URL = { required = true }
+
+[profiles.deployment.defaults]
+inherit = false # SecretSpec 0.19+
+
+[profiles.deployment]
+# Does not inherit DATABASE_URL, API_KEY, or any of their fields.
+DEPLOY_TOKEN = { description = "Deployment credential", required = true }
+```
+
+The setting disables both automatic inclusion of default secrets and
+field-by-field inheritance for secrets explicitly redeclared in the standalone
+profile. Omitting it preserves the existing inheritance behavior. A standalone
+profile must declare at least one secret.
+
 ### Switching reference models (0.19+)
 
 :::caution[Version compatibility]
@@ -89,6 +127,26 @@ Within one effective secret, `ref` and `refs` remain mutually exclusive. See
 [Secret References](/concepts/references/#different-coordinates-per-provider-019)
 for how each model addresses providers.
 
+## Profiles, Scopes, Providers, and Extends
+
+These features solve different dimensions of a configuration:
+
+- A **profile** chooses an environment or context. It controls requiredness,
+  defaults, provider routes, references, and the `{profile}` storage namespace.
+- A **scope** selects which secrets one service or task receives from the
+  effective profile. It does not create another environment.
+- A secret's **providers** choose where its value is read and written. Provider
+  chains are also the least-privilege boundary: a process only needs access to
+  the stores used by the secrets in its scope.
+- **`extends`** merges separate `secretspec.toml` files. Use it to share
+  manifests across projects, not to express relationships among several
+  profiles in one small manifest.
+
+For an application with `development` and `production` environments plus
+`app`, `public`, and `deploy` consumers, profiles normally model the two
+environments, scopes model the three consumers, and per-secret provider chains
+route each value to the appropriate store.
+
 ## Profile-Level Defaults
 
 To reduce repetition when multiple secrets in a profile share the same settings, use the `profiles.<name>.defaults` section:
@@ -108,7 +166,11 @@ API_KEY = { description = "API Key" }
 SENTRY_DSN = { description = "Error tracking" }
 ```
 
-Profile defaults apply to all secrets in that profile unless explicitly overridden. The precedence order is:
+Profile defaults apply to all secrets in that profile unless explicitly
+overridden. In SecretSpec 0.19+, the same table accepts `inherit = false` to
+make a non-default profile standalone; unlike `required`, `default`, and
+`providers`, this controls the relationship with `[profiles.default]` rather
+than supplying a value to each secret. The precedence order is:
 
 1. **Secret-level configuration** (highest priority) -- explicit settings in the secret definition
 2. **Profile defaults** -- from `profiles.<name>.defaults`

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -121,6 +121,16 @@ $ export SECRETSPEC_PROVIDER=env
 $ secretspec check
 ```
 
+`SECRETSPEC_PROVIDER` is a whole-resolution override: it replaces every
+per-secret fallback chain. Integrations such as devenv should only export it
+when the user explicitly configures a whole-resolution provider override.
+
+When consuming a JSON or SDK resolution, do not feed its top-level `provider`
+display label back into `SECRETSPEC_PROVIDER`; mixed per-secret routes cannot be
+represented by one provider string. Only export `SECRETSPEC_PROVIDER` when the
+user explicitly selected a whole-resolution override. Per-secret
+`source_provider` remains the authoritative provenance.
+
 A provider URI can configure the selected backend more precisely:
 
 ```bash

--- a/docs/src/content/docs/concepts/scopes.md
+++ b/docs/src/content/docs/concepts/scopes.md
@@ -141,6 +141,10 @@ Scopes are orthogonal to profiles and reusable across them. They do not inherit
 from the `default` profile; instead, the selected scope is applied after normal
 profile inheritance produces the effective profile.
 
+In SecretSpec 0.19+, a profile with `defaults.inherit = false` does not include
+any default-profile secrets. A scope still intersects the effective profile, so
+it cannot bring an inherited secret into a standalone profile.
+
 When a project uses [`extends`](/concepts/inheritance/), a child scope replaces
 a parent scope with the same name. The lists are not unioned, so extending a
 configuration cannot silently widen an allowlist. Scopes defined only by a

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -81,17 +81,46 @@ also forwarded to providers that support auditing (e.g. the
 
 ### [profiles.*] Section
 
-Defines secret variables for different environments. At least a `[profiles.default]` section is required.
+Defines secret variables for different environments. At least one profile is
+required. A `default` profile is optional; when present, other profiles inherit
+from it unless they opt out in SecretSpec 0.19+.
 
 ```toml
-[profiles.default]           # Default profile (required)
+[profiles.default]           # Optional shared base profile
 DATABASE_URL = { description = "PostgreSQL connection", required = true }
 API_KEY = { description = "External API key", required = true }
 REDIS_URL = { description = "Redis cache", required = false, default = "redis://localhost:6379" }
 
 [profiles.production]        # Additional profile (optional)
-DATABASE_URL = { description = "Production database", required = true }
+DATABASE_URL = { required = true } # description inherited from default
 ```
+
+#### Profile defaults
+
+`[profiles.<name>.defaults]` supplies settings for secrets declared in that
+profile:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `inherit` (0.19+) | boolean | No | For a non-default profile, whether to inherit declarations and omitted fields from `[profiles.default]` (default: true) |
+| `required` | boolean | No | Default requiredness for secrets declared in this profile |
+| `default` | string | No | Default value for secrets declared in this profile |
+| `providers` | array[string] | No | Default provider chain for secrets declared in this profile |
+
+In SecretSpec 0.19+, set `inherit = false` for a standalone profile:
+
+```toml
+[profiles.deployment.defaults]
+inherit = false
+
+[profiles.deployment]
+DEPLOY_TOKEN = { description = "Deployment credential", required = true }
+```
+
+This excludes every `[profiles.default]` declaration and prevents explicitly
+redeclared secrets from inheriting omitted fields. The setting has no effect on
+the `default` profile itself. A standalone profile must declare at least one
+secret.
 
 #### Cross-secret presence constraints (0.17+)
 
@@ -140,9 +169,9 @@ Each secret variable is defined as a table with the following fields:
 
 Field notes:
 
-- `description` is required in the `default` profile. A secret overriding one
-  that the default profile already declares inherits its `description` (and
-  other omitted fields) and may leave it out.
+- `description` is required on the effective secret. An inheriting profile may
+  omit it when a matching default declaration supplies it. A standalone
+  profile using `inherit = false` (0.19+) must supply its own description.
 - `required` defaults to false when `default` is provided. In 0.17+, its table
   form accepts `at_least_one` and `exactly_one` as a group name or array of names.
 - `default` is invalid with an explicit `required = true`. A defaulted secret is
@@ -852,7 +881,9 @@ MANUAL_SECRET = { description = "Manually managed", type = "password" }
 
 ## Profile Inheritance
 
-- All profiles automatically inherit from `[profiles.default]`
+- Non-default profiles inherit from `[profiles.default]` when it exists;
+  `profiles.<name>.defaults.inherit = false` makes a profile standalone in
+  SecretSpec 0.19+
 - Profile-specific values override default values
 - `ref` and `refs` (0.19+) are alternative forms of one setting: declaring
   either in a profile replaces the form inherited from `[profiles.default]`,

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -136,17 +136,24 @@ revision = "1.0"
 extends = ["../shared/common", "../shared/auth"]
 
 [profiles.default]
-DATABASE_URL = { description = "PostgreSQL connection string", required = true }
-REDIS_URL = { description = "Redis connection string", required = false, default = "redis://localhost:6379" }
+DATABASE_URL = { description = "PostgreSQL connection string" }
+REDIS_URL = { description = "Redis connection string" }
 
 # Profile-specific configurations
 [profiles.development]
-DATABASE_URL = { description = "PostgreSQL connection string", required = false, default = "sqlite://./dev.db" }
-REDIS_URL = { description = "Redis connection string", required = false, default = "redis://localhost:6379" }
+DATABASE_URL = { required = false, default = "sqlite://./dev.db" }
+REDIS_URL = { required = false, default = "redis://localhost:6379" }
 
 [profiles.production]
-DATABASE_URL = { description = "PostgreSQL connection string", required = true }
-REDIS_URL = { description = "Redis connection string", required = true }
+DATABASE_URL = { required = true }
+REDIS_URL = { required = true }
+
+# SecretSpec 0.19+: a profile can use an independent secret set.
+[profiles.deployment.defaults]
+inherit = false
+
+[profiles.deployment]
+DEPLOY_TOKEN = { description = "Deployment credential", required = true }
 ```
 
 SecretSpec 0.19+ can map one logical secret to different native coordinates per

--- a/secretspec/src/codegen.rs
+++ b/secretspec/src/codegen.rs
@@ -251,7 +251,7 @@ pub mod schema {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Profile, Project, Secret};
+    use crate::config::{Profile, ProfileDefaults, Project, Secret};
     use std::collections::HashMap;
 
     fn secret(required: Option<bool>, as_path: Option<bool>, desc: Option<&str>) -> Secret {
@@ -455,6 +455,44 @@ mod tests {
             serde_json::from_str(&schema::emit(&ir, Some("production")).unwrap()).unwrap();
         assert!(schema["properties"]["SHARED_TOKEN"].is_object());
         assert_eq!(schema["additionalProperties"], false);
+    }
+
+    #[test]
+    fn standalone_profile_fields_exclude_default_secrets() {
+        let mut config = config_with(vec![
+            (
+                "default",
+                vec![("SHARED_TOKEN", secret(Some(true), None, None))],
+            ),
+            (
+                "deployment",
+                vec![("DEPLOY_TOKEN", secret(Some(true), None, None))],
+            ),
+        ]);
+        config.profiles.get_mut("deployment").unwrap().defaults = Some(ProfileDefaults {
+            inherit: Some(false),
+            required: None,
+            default: None,
+            providers: None,
+        });
+
+        let ir = build_ir(&config);
+        let deployment = ir
+            .profile_fields
+            .iter()
+            .find(|profile| profile.name == "deployment")
+            .unwrap();
+        let names: Vec<&str> = deployment
+            .fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["DEPLOY_TOKEN"]);
+
+        let schema: serde_json::Value =
+            serde_json::from_str(&schema::emit(&ir, Some("deployment")).unwrap()).unwrap();
+        assert!(schema["properties"]["DEPLOY_TOKEN"].is_object());
+        assert!(schema["properties"].get("SHARED_TOKEN").is_none());
     }
 
     #[test]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -727,11 +727,11 @@ impl Config {
         profile_names.sort();
 
         for profile_name in profile_names {
-            self.profiles[profile_name]
-                .validate_raw(default_profile.is_some())
-                .map_err(|e| {
-                    ParseError::Validation(format!("Profile '{}': {}", profile_name, e))
-                })?;
+            let profile = &self.profiles[profile_name];
+            let can_inherit_secrets = default_profile.is_some() && profile.inherits_default();
+            profile.validate_raw(can_inherit_secrets).map_err(|e| {
+                ParseError::Validation(format!("Profile '{}': {}", profile_name, e))
+            })?;
             validate_compiled_profile(&compiled, profile_name)?;
         }
 
@@ -1355,6 +1355,12 @@ pub struct Scope {
 /// Individual secrets can override any of these defaults.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProfileDefaults {
+    /// Whether this non-default profile inherits declarations and omitted
+    /// fields from `[profiles.default]`. Omitted means `true`. Available since
+    /// SecretSpec 0.19.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inherit: Option<bool>,
+
     /// Default value for the required field of secrets in this profile.
     /// If not specified, secrets default to required=true.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1377,6 +1383,7 @@ impl ProfileDefaults {
     /// defaults table. Lets `extends` inherit `[profiles.*.defaults]` field by
     /// field, with the later (more specific) document winning.
     fn inherit_missing_from(&mut self, earlier: &ProfileDefaults) {
+        self.inherit = self.inherit.or(earlier.inherit);
         self.required = self.required.or(earlier.required);
         if self.default.is_none() {
             self.default = earlier.default.clone();
@@ -1394,6 +1401,15 @@ impl Profile {
             defaults: None,
             secrets: HashMap::new(),
         }
+    }
+
+    /// Whether this profile inherits declarations and omitted secret fields
+    /// from `[profiles.default]`.
+    pub(crate) fn inherits_default(&self) -> bool {
+        self.defaults
+            .as_ref()
+            .and_then(|defaults| defaults.inherit)
+            .unwrap_or(true)
     }
 
     /// Validate declarations before profile/default inheritance is compiled.
@@ -3064,6 +3080,85 @@ ADMIN_PASSWORD = { description = "Password securing the admin page", required = 
         );
         assert_eq!(resolved.required, Some(true));
         assert_eq!(resolved.secret_type.as_deref(), Some("password"));
+    }
+
+    #[test]
+    fn profile_can_disable_default_inheritance() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "standalone"
+revision = "1.0"
+
+[profiles.default]
+SHARED_TOKEN = { description = "Shared token", default = "shared" }
+
+[profiles.deployment.defaults]
+inherit = false
+
+[profiles.deployment]
+DEPLOY_TOKEN = { description = "Deployment token" }
+"#,
+        )
+        .unwrap();
+
+        let compiled = config.validate_and_compile().unwrap();
+        let deployment = compiled.profile("deployment").unwrap();
+        assert!(deployment.secrets.contains_key("DEPLOY_TOKEN"));
+        assert!(!deployment.secrets.contains_key("SHARED_TOKEN"));
+    }
+
+    #[test]
+    fn standalone_profile_does_not_inherit_fields_from_matching_default_secret() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "standalone"
+revision = "1.0"
+
+[profiles.default]
+API_KEY = { description = "Shared API key", default = "shared" }
+
+[profiles.deployment.defaults]
+inherit = false
+
+[profiles.deployment]
+API_KEY = { description = "Deployment API key" }
+"#,
+        )
+        .unwrap();
+
+        let compiled = config.validate_and_compile().unwrap();
+        let api_key = &compiled.profile("deployment").unwrap().secrets["API_KEY"];
+        assert_eq!(
+            api_key.config.description.as_deref(),
+            Some("Deployment API key")
+        );
+        assert_eq!(api_key.config.default, None);
+    }
+
+    #[test]
+    fn empty_standalone_profile_is_rejected() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "standalone"
+revision = "1.0"
+
+[profiles.default]
+SHARED_TOKEN = { description = "Shared token" }
+
+[profiles.deployment.defaults]
+inherit = false
+
+[profiles.deployment]
+"#,
+        )
+        .unwrap();
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("Profile 'deployment'"), "{error}");
+        assert!(error.contains("at least one secret"), "{error}");
     }
 
     #[test]

--- a/secretspec/src/manifest.rs
+++ b/secretspec/src/manifest.rs
@@ -148,7 +148,7 @@ impl CompiledManifest {
         let mut profiles = BTreeMap::new();
 
         for (profile_name, profile) in &config.profiles {
-            let inherited = (profile_name != "default")
+            let inherited = (profile_name != "default" && profile.inherits_default())
                 .then_some(default_profile)
                 .flatten();
             // A `BTreeSet` unions the profile's own names with the inherited

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -1947,6 +1947,7 @@ revision = "1.0"
 PARENT_ONLY = { description = "parent", required = true }
 
 [profiles.production.defaults]
+inherit = false
 required = false
 providers = ["shared"]
 "#,
@@ -1971,6 +1972,7 @@ CHILD_ONLY = { description = "child", required = true }
         .defaults
         .as_ref()
         .expect("profile defaults should be inherited");
+    assert_eq!(defaults.inherit, Some(false));
     assert_eq!(defaults.required, Some(false));
     assert_eq!(
         defaults.providers.as_deref(),
@@ -5796,6 +5798,7 @@ fn build_chain_scenario(
                 "development".to_string(),
                 Profile {
                     defaults: Some(crate::config::ProfileDefaults {
+                        inherit: None,
                         required: None,
                         default: None,
                         providers: Some(vec!["personal".to_string(), "team".to_string()]),


### PR DESCRIPTION
## What changed

- add profile-level `inherit = false` under `[profiles.<name>.defaults]` (0.19+)
- make opted-out profiles standalone: they inherit neither default-profile declarations nor omitted fields
- preserve existing inheritance when the setting is omitted
- carry the policy through `extends`, runtime resolution, generated profile schemas, docs, and validation
- clarify how profile, scope, provider, and `extends` responsibilities differ

The SOPS write-preview work from the original branch is excluded because it shipped separately on `main`.

## Why

Some projects use `default` as their development base and want production to inherit most of it, while other profiles represent unrelated secret sets. The extending profile can now declare that it is standalone without annotating every default secret.

## Review feedback

This follows the requested shape:

```toml
[profiles.standalone.defaults]
inherit = false
```

## Validation

- `cargo test --workspace --all-features`
- `npm --prefix docs run build`
- `cargo fmt --all -- --check`
- `git diff --check`
