### PR TITLE
Support linking the SDKs against secretspec-ffi via pkg-config

### DIFF
--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -83,7 +83,9 @@ jobs:
               --ghc-options="-optl${native_libs// / -optl}" \
               --write-ghc-environment-files=always --test-show-details=streaming
             ffi_prefix="$(mktemp -d)"
-            cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$ffi_prefix"
+            bash ../secretspec-ffi/scripts/cinstall.sh "$ffi_prefix"
+            PKG_CONFIG_PATH="$ffi_prefix/lib/pkgconfig" \
+              pkg-config --print-errors --exists secretspec_ffi
             PKG_CONFIG_PATH="$ffi_prefix/lib/pkgconfig" cabal test -f use-pkg-config \
               --write-ghc-environment-files=always --test-show-details=streaming
           '

--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -80,6 +80,10 @@ jobs:
             # quicktype-generated module; SECRETSPEC_BIN lets it run the CLI.
             cabal test --extra-lib-dirs="$hs_lib_dir" "${ghc_optl[@]}" \
               --write-ghc-environment-files=always --test-show-details=streaming
+            ffi_prefix="$(mktemp -d)"
+            cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$ffi_prefix"
+            PKG_CONFIG_PATH="$ffi_prefix/lib/pkgconfig" cabal test -f use-pkg-config \
+              --write-ghc-environment-files=always --test-show-details=streaming
           '
 
   build-windows:

--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -72,13 +72,15 @@ jobs:
               --print native-static-libs 2>&1 | sed -n "s/^note: native-static-libs: //p" | tail -1)"
             hs_lib_dir="$(mktemp -d)"
             cp "$target_dir/debug/libsecretspec_ffi.a" "$hs_lib_dir/"
-            ghc_optl=()
-            for l in $native_libs; do ghc_optl+=("--ghc-options=-optl$l"); done
             cd secretspec-hs
             cabal update
             # --write-ghc-environment-files lets the codegen test compile the
             # quicktype-generated module; SECRETSPEC_BIN lets it run the CLI.
-            cabal test --extra-lib-dirs="$hs_lib_dir" "${ghc_optl[@]}" \
+            # All -optl flags go in ONE --ghc-options occurrence: cabal reverses
+            # the order of repeated occurrences, which breaks `-framework X`
+            # pairs on macOS.
+            cabal test --extra-lib-dirs="$hs_lib_dir" \
+              --ghc-options="-optl${native_libs// / -optl}" \
               --write-ghc-environment-files=always --test-show-details=streaming
             ffi_prefix="$(mktemp -d)"
             cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$ffi_prefix"
@@ -157,8 +159,6 @@ jobs:
           printf '%s\n' "$native_libs" > "$hs_lib_dir/native-static-libs.txt"
           bash scripts/copy-mingw-import-libs.sh \
             "$hs_lib_dir/native-static-libs.txt" "$hs_lib_dir"
-          ghc_optl=()
-          for l in $native_libs; do ghc_optl+=("--ghc-options=-optl$l"); done
           # Resolving pthread symbols from GHC's winpthreads import library
           # makes the test binary import libwinpthread-1.dll at runtime, and
           # cabal does not put GHC's bundled toolchain bin on PATH
@@ -169,7 +169,8 @@ jobs:
           export PATH="$PATH:$mingw_bin"
           cd secretspec-hs
           cabal update
-          cabal test --extra-lib-dirs="$(cygpath -w "$hs_lib_dir")" "${ghc_optl[@]}" \
+          cabal test --extra-lib-dirs="$(cygpath -w "$hs_lib_dir")" \
+            --ghc-options="-optl${native_libs// / -optl}" \
             --write-ghc-environment-files=always --test-show-details=streaming || {
             # cabal keeps the suite's output in a log file; surface it, and
             # run the binary directly to expose a load-time failure's status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Ruby SDK's native extension accepts a new `--enable-pkg-config` build
   flag (`gem install secretspec -- --enable-pkg-config`) that resolves the
   archive through pkg-config.
+- The Go SDK's `-tags static` build accepts a new `pkgconfig` build tag
+  (`go build -tags static,pkgconfig`) that resolves the archive through
+  pkg-config, so it also works for a `go get` dependency.
 - The Haskell SDK declares the archive's macOS system frameworks
   (`SystemConfiguration`, `Security`, `CoreFoundation`) in its cabal file, so
   GHC passes them to every link on macOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Secrets can store values as standard Base64, URL-safe Base64, or hexadecimal
   using `encoding`; writes encode logical text and reads decode stored values,
   while `as_path = true` materializes arbitrary decoded bytes.
+- `secretspec-ffi` installs (via `cargo cinstall`) together with its C header
+  and a `secretspec_ffi.pc`, so consumers can link it — statically or
+  dynamically — without hand-written linker flags.
+- The Haskell SDK's new `use-pkg-config` cabal flag
+  (`cabal build -f use-pkg-config`) resolves the archive through pkg-config.
+- The Haskell SDK declares the archive's macOS system frameworks
+  (`SystemConfiguration`, `Security`, `CoreFoundation`) in its cabal file, so
+  GHC passes them to every link on macOS.
 
 ### Fixed
+
 - The keyring provider no longer intermittently fails with a "No default store
   has been set" error when resolving multiple secrets concurrently.
 - The SOPS provider no longer substitutes a second time into a rendered path
@@ -42,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.18.0] - 2026-08-03
 
 ### Changed
+
 - The keyring provider now uses keyring 4's Rust-native Secret Service
   transport on Linux, so source builds and binaries no longer require system
   libdbus.
@@ -54,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profile namespace.
 
 ### Fixed
+
 - The Bitwarden provider now treats a locked vault or a missing session as a
   clear authentication failure on `get`/`set`, with the same "run `bw login`
   and `bw unlock`, then set `BW_SESSION`" guidance in both cases, instead of
@@ -80,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failures also report the full service error instead of a shortened message.
 
 ### Added
+
 - The dotenv provider accepts a leading `~` in custom paths, such as
   `dotenv:~/.config/my-project/.env`, and resolves it to the user's home
   directory.
@@ -144,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.1] - 2026-08-01
 
 ### Fixed
+
 - Vault and OpenBao AppRole and JWT authentication methods now reuse login
   tokens within each provider operation up to each token's reported use and
   lease limits, including time spent completing authentication, avoiding
@@ -172,6 +186,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.0] - 2026-07-26
 
 ### Fixed
+
 - Cache reads, refreshes, and clears now share one ownership and freshness
   policy, consistently handling expiration boundaries, clock rollback,
   corrupted SecretSpec entries, and values owned by another project or profile.
@@ -188,6 +203,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (not on HTTP 4xx/5xx), with a short backoff between attempts.
 
 ### Added
+
 - SOPS provider (`sops://`, `sops` build feature) for reading and writing
   YAML, JSON, dotenv, and INI files through the SOPS CLI, including templated
   per-project/profile paths and provider-credential injection for encryption
@@ -311,6 +327,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Linux and macOS builds on each release.
 
 ### Changed
+
 - The Bitwarden Secrets Manager provider now invokes the separately installed
   official `bws` CLI instead of linking the Bitwarden SDK. This removes the
   SDK's restricted-license dependency from SecretSpec distributions while
@@ -322,6 +339,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#139](https://github.com/cachix/secretspec/issues/139))
 
 ### Fixed
+
 - BWS CLI writes preserve secret keys and values that begin with `-`, and
   hostless BWS provider URIs stay pinned to Bitwarden's default server even
   when ambient BWS profiles or server settings are configured.
@@ -334,6 +352,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.16.0] - 2026-07-17
 
 ### Added
+
 - Composed secrets derive read-only values such as connection strings from
   other declared secrets using strict `${UPPERCASE_NAME}` templates; names must
   match `[A-Z][A-Z0-9_]*`, `$$` produces a literal dollar sign, and ordinary
@@ -369,6 +388,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.15.0] - 2026-07-16
 
 ### Added
+
 - Gopass provider (`gopass://`) for GPG-based password manager with git-synced password store.
 - `secretspec export` command that resolves every secret for the active profile
   and writes them to stdout without running a command, in a chosen `--format`:
@@ -429,6 +449,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "approle", field = "secret_id" } },
   } }
   ```
+
 - `secretspec config provider login <alias>` prompts for each provider
   credential a provider alias declares and stores it in its source provider, so
   it can be read back on the next resolution. `secretspec config provider add`
@@ -436,6 +457,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sources from the command line.
 
 ### Changed
+
 - Rust SDK validation errors now store their detailed report out of line,
   reducing the size of `SecretSpecError` values while preserving diagnostics.
 - Generated types now describe the values resolution can actually return:
@@ -465,12 +487,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an alias without credentials cannot diverge.
 
 ### Removed
+
 - The unused public `Config::merge_with` and `Profile::merge_with` methods.
   Configuration inheritance (`extends`) is now applied entirely through the
   internal overlay used by the loader, so these self-wins merge helpers no
   longer had any callers.
 
 ### Fixed
+
 - Configuration inheritance now loads an `extends` hierarchy as a DAG. Shared
   ancestors in diamond-shaped graphs are applied once instead of being reported
   as cycles, later entries in `extends` correctly override earlier entries, and
@@ -520,6 +544,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.14.0] - 2026-07-09
 
 ### Added
+
 - **`ref`: native secret references on secrets**: a secret can name one
   externally managed secret by its store's own coordinates, instead of
   SecretSpec's `{project}/{profile}/{key}` naming:
@@ -554,6 +579,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pass through without declaring a `[providers]` alias first.
 
 ### Changed
+
 - **Faster multi-provider resolution**: `check`, `run`, and SDK resolution now
   group secrets by store and fetch the groups concurrently instead of one
   after another; within a group, `ref` secrets batch through the store's bulk
@@ -579,6 +605,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously will now fail with a pointed error.
 
 ### Fixed
+
 - **onepassword**: URIs carrying an item path (e.g. the
   `onepassword://vault/Production` form some older docs showed) previously
   discarded the path silently and targeted a vault literally named `vault`.
@@ -593,6 +620,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.13.0] - 2026-07-03
 
 ### Added
+
 - **Language SDKs for Python, Go, Ruby, Node.js / TypeScript, and Haskell**
   (`secretspec-py`, `secretspec-go`, `secretspec-rb`, `secretspec-node`,
   `secretspec-hs`). Resolve the secrets declared in your `secretspec.toml` from
@@ -623,6 +651,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ValidatedSecrets::report()` / `ValidationErrors::report()`.
 
 ### Fixed
+
 - A per-secret provider chain whose primary provider errors (e.g. an unreachable
   vault) and whose fallback chain yields no value now surfaces that provider error
   instead of silently reporting the secret as `missing_required`, so a provider
@@ -631,12 +660,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.12.2] - 2026-06-22
 
 ### Added
+
 - The `pass` provider accepts a `store_dir` query parameter (e.g.
   `pass://?store_dir=/path/to/store`) to use a password store directory other
   than the default `~/.password-store`. It is applied as `PASSWORD_STORE_DIR`
   scoped to each `pass` invocation.
 
 ### Fixed
+
 - Provider URIs now correctly round-trip query parameters whose values contain
   characters that are significant in a query string (`&`, `+`, `#`, `%`, and
   spaces). Previously such characters in the `awssm` `prefix` (and the new `pass`
@@ -649,6 +680,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.12.1] - 2026-06-15
 
 ### Fixed
+
 - Windows: a `dotenv://` provider URI built from an absolute path (e.g.
   `dotenv://C:\path\.env`) no longer fails to parse with "invalid port number".
   The drive-letter colon was being read as a `host:port` separator; such paths
@@ -672,6 +704,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.12.0] - 2026-06-08
 
 ### Added
+
 - Audit logging for secret access, on by default. Every secret read and write,
   from both the CLI and the Rust SDK, is appended to a local per-user log as JSON
   Lines. Only metadata is recorded (secret names, the serving provider with any
@@ -718,10 +751,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keeps the `bitwarden.com` US cloud default.
 
 ### Changed
+
 - Minimum supported Rust version raised to 1.92 (required by the
   `detect-coding-agent` dependency). The devenv toolchain is pinned accordingly.
 
 ### Fixed
+
 - Proton Pass provider now works with `pass-cli` >= 2.1.0 agent sessions. Since
   2.1.0, audited item operations (`item view`, `item create`, `item delete`)
   fail unless `PROTON_PASS_AGENT_REASON` is set, which made existing secrets
@@ -747,6 +782,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.11.0] - 2026-05-22
 
 ### Added
+
 - AWS Secrets Manager (`awssm`) provider: support for a `?prefix=` query
   parameter in the provider URI (e.g., `awssm://us-east-1?prefix=myteam`).
   The prefix is prepended to all secret names
@@ -763,6 +799,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#90](https://github.com/cachix/secretspec/issues/90).
 
 ### Fixed
+
 - Profile-not-found errors no longer surface as the confusing
   `Secret 'Profile 'X' not found' not found`. They now use the dedicated
   `InvalidProfile` variant and include the list of profiles defined in
@@ -774,6 +811,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.1] - 2026-05-11
 
 ### Fixed
+
 - `secretspec check`: optional secrets that aren't set no longer render with a
   green `✓` and aren't counted as "found" in the trailing summary. They now
   display with the same blue `○ (optional)` styling already used in the
@@ -786,12 +824,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] - 2026-05-11
 
 ### Added
+
 - Proton Pass provider that stores secrets in a Proton Pass vault via the
   `proton-pass` CLI. Configured as `protonpass://<vault>`; items are
   organized per project / profile and read / write both go through the
   CLI.
 
 ### Fixed
+
 - OnePassword provider: the auth preflight now probes `op vault list` instead
   of `op whoami`. Under the 1Password desktop app's delegated-session
   integration, `op whoami` reports `account is not signed in` even when
@@ -816,6 +856,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.1] - 2026-05-07
 
 ### Changed
+
 - Dropped the `serde-envfile` dependency in favor of a small in-tree
   `.env` serializer. The previous git-pinned fork blocked publishing to
   crates.io; the new serializer applies the same escapes (backslash,
@@ -825,6 +866,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.0] - 2026-05-07
 
 ### Fixed
+
 - The `--provider` CLI flag now correctly takes precedence over the
   `SECRETSPEC_PROVIDER` environment variable. Previously the env var was
   consulted before the value forwarded from `--provider` (via `set_provider`),
@@ -865,14 +907,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--provider`. Fixes [#81](https://github.com/cachix/secretspec/issues/81).
 
 ### Added
+
 - BWS (Bitwarden Secrets Manager) provider with async SDK integration, secret caching, and full read-write support (requires `--features bws`)
 
 ### Changed
+
 - `secretspec-derive` now depends on `secretspec` with `default-features = false`, avoiding pulling in CLI and provider features when only the derive macro is used.
 
 ## [0.8.2] - 2026-03-19
 
 ### Changed
+
 - All provider features (`gcsm`, `awssm`, `vault`) are now enabled by default
 - AWS Secrets Manager (`awssm`) provider: batch fetching via `BatchGetSecretValue` API,
   reducing N sequential API calls to ceil(N/20) batched calls. For 30 secrets this means
@@ -882,10 +927,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.1] - 2026-03-15
 
 ### Added
+
 - `rsa_private_key` secret generation type: generates RSA private keys in PKCS1 PEM format,
   defaults to 2048 bits, configurable via `generate = { bits = 4096 }`
 
 ### Fixed
+
 - Check provider authentication (e.g. OnePassword, LastPass) before prompting
   user for secrets, via a `PreflightGuard` that runs the check exactly once
   per provider instance
@@ -893,48 +940,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0] - 2026-03-11
 
 ### Added
+
 - HashiCorp Vault / OpenBao (`vault`) provider for Vault KV v1/v2 secret storage, with support
   for namespaces, TLS configuration, and OpenBao compatibility (requires `--features vault`)
 - AWS Secrets Manager (`awssm`) provider for AWS secret storage integration (requires `--features awssm`)
 - Support running secretspec from subdirectories: the CLI now walks up the directory tree to find the nearest `secretspec.toml`, similar to `cargo` and `git`. Also adds a `-f`/`--file` flag (and `SECRETSPEC_FILE` env var) to explicitly specify the config file path (#59)
 
 ### Changed
+
 - Extract shared `block_on` async helper from AWSSM and GCSM providers into `provider::block_on`
 
 ### Fixed
+
 - GCSM provider no longer panics when called from within an existing tokio runtime
 
 ## [0.7.2] - 2026-02-24
 
 ### Added
+
 - Keyring and pass providers now support `folder_prefix` via URI (e.g., `keyring://secretspec/shared/{profile}/{key}`)
   to share secrets across projects, matching the existing OnePassword and LastPass behavior
 
 ### Changed
+
 - Support `XDG_CONFIG_HOME` on macOS by switching from `directories` to `etcetera` crate.
   Existing macOS configs at `~/Library/Application Support/secretspec/` are automatically
   migrated to `~/.config/secretspec/` (#28)
 
 ### Fixed
+
 - Reject empty values when setting a secret
 
 ## [0.7.1] - 2026-02-08
 
 ### Changed
+
 - Improved interactive prompt for missing secrets: lists all missing secrets upfront with descriptions, adds step counter (`[1/3]`), and uses `inquire::Password` for consistent masked input. Removed `rpassword` dependency.
 
 ### Fixed
+
 - Use a fork of inquire to support setting multi-line secrets (#32)
 
 ## [0.7.0] - 2026-02-08
 
 ### Added
+
 - Declarative secret generation: secrets can now be auto-generated when missing by adding
   `type` and `generate` fields to secret config. Supported types: `password`, `hex`, `base64`,
   `uuid`, and `command` (for arbitrary shell commands). Generation triggers during `check`/`run`
   when a secret is missing, and the generated value is stored via the configured provider.
 
 ### Changed
+
 - OnePassword provider: Significant performance improvement by caching authentication status
   and using batch fetching with parallel threads. Reduces CLI calls from 2N sequential to
   ~2 sequential + N parallel for N secrets.
@@ -942,6 +999,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.2] - 2026-01-27
 
 ### Added
+
 - CLI: Add `--no-prompt` (`-n`) flag to `secretspec check` command for non-interactive mode.
   When used, the command exits with non-zero status if secrets are missing instead of prompting for values.
   Useful for CI/CD pipelines, scripts, and automation. (#55)
@@ -949,6 +1007,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.1] - 2026-01-15
 
 ### Fixed
+
 - OnePassword provider: Fix duplicate item creation when existing item has no extractable value.
   Now uses `op item list` for existence checks and updates by item ID to avoid ambiguity.
 - OnePassword provider: Handle "More than one item matches" error gracefully by falling back to ID-based lookup.
@@ -956,52 +1015,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] - 2026-01-12
 
 ### Added
+
 - Google Cloud Secret Manager (GCSM) provider for GCP secret storage integration (#53)
 
 ### Fixed
+
 - LastPass provider: Fix creating new secrets by using correct `lpass add` command instead of non-existent `lpass set` (#54)
 
 ## [0.5.1] - 2026-01-02
 
 ### Changed
+
 - CI: Updated macOS runners from deprecated macos-13 to macos-15 (Intel) and macos-latest (ARM)
 
 ## [0.5.0] - 2026-01-02
 
 ### Added
+
 - Pass (password-store) provider for Unix password manager integration
 - `ensure_secrets()` method is now public in the Rust SDK
 - Support specifying full file paths (ending in `.toml`) in `extends` field, in addition to directory paths
 
 ### Changed
+
 - Performance: avoid double validation in `check()` for happy path
 
 ### Fixed
+
 - Display correct error message when extended config file is not found, instead of the misleading "No secretspec.toml found in current directory" error
 
 ## [0.4.1] - 2025-11-27
 
 ### Added
+
 - OnePassword provider: Support for `SECRETSPEC_OPCLI_PATH` environment variable to specify custom path to the OnePassword CLI
 - OnePassword provider: Automatic detection of Windows Subsystem for Linux 2 (WSL2) and use of `op.exe` on that platform
 - Documentation for `as_path` option in configuration reference, Rust SDK docs, and landing page
 - Documentation for per-secret providers with fallback chains on landing page
 
 ### Changed
+
 - OnePassword provider: Use stdin instead of temporary files when creating items for WSL2 compatibility (WSL paths are invalid when passed to Windows executables)
 
 ### Fixed
+
 - Output status/progress messages to stderr instead of stdout, fixing direnv integration where stdout was evaluated as shell code
 
 ## [0.4.0] - 2025-11-24
 
 ### Added
+
 - Profile-level default configuration: `profiles.<name>.defaults` section for shared settings across secrets in a profile
 - Default providers for profiles: define common providers once and have all secrets use them unless overridden
 - Default values and required settings can now be specified at profile level to reduce repetition
 - `as_path` option for secrets: write secret values to temporary files and return the file path instead of the value. Temporary files are automatically cleaned up when the resolved secrets are dropped in Rust SDK usage. For CLI commands (`get` and `check`), temporary files are persisted and NOT deleted after the command exits. In the Rust SDK, fields with `as_path = true` are generated as `PathBuf` or `Option<PathBuf>` instead of `String`
 
 ### Changed
+
 - Secret `required` field is now `Option<bool>` to allow profile-level defaults to apply when not explicitly set
 - Secret `default` field can now inherit from profile-level defaults if not specified per-secret
 - Secret `providers` field can now inherit from profile-level defaults if not specified per-secret
@@ -1010,51 +1080,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.4] - 2025-11-09
 
 ### Changed
+
 - `Secrets::check()` now returns `Result<ValidatedSecrets>` instead of `Result<()>`, allowing callers to access the validated secrets
 
 ## [0.3.3] - 2025-09-10
 
 ### Fixed
+
 - CLI: Count optional secrets as "found" in the summary
 
 ## [0.3.2] - 2025-09-10
 
 ### Added
+
 - Support for piping multi-line secrets via stdin
 
 ### Fixed
+
 - Import command now resolves secrets from all profiles, not just the active profile (fixes issue #36)
 - Fix incorrect stats in the summary for certain configurations
 
 ## [0.3.1] - 2025-07-28
 
 ### Fixed
+
 - Installers for arm/linux
 
 ## [0.3.0] - 2025-07-25
 
 ### Added
+
 - Integrate `secrecy` crate for secure secret handling with automatic memory zeroing
 - Add `reflect()` method to Provider trait for provider introspection
 - Export `Provider` trait from secretspec crate for use in derived code
 
 ### Changed
+
 - Made keyring provider optional via `keyring` feature flag (enabled by default)
 - Unified provider parsing logic in init command to support all provider formats consistently
 - Downgraded keyring dependency to 3.6.2
 - Updated `with_provider` in derive macro to accept `TryInto<Box<dyn Provider>>` for consistent provider handling
 
 ### Fixed
+
 - Fixed secret optionality logic: having a default value no longer makes a secret optional in generated types
 
 ## [0.2.0] - 2025-07-17
 
 ### Changed
+
 - SDK: Added `set_provider()` and `set_profile()` methods for configuration
 - SDK: Removed provider/profile parameters from `set()`, `get()`, `check()`, `validate()`, and `run()` methods
 - SDK: Embedded Resolved inside ValidatedSecrets
 
 ### Fixed
+
 - Fix stdin handling for piped input in set/check commands
 - Fix SECRETSPEC_PROFILE and SECRETSPEC_PROVIDER environment variable resolution
 - Ensure CLI arguments take precedence over environment variables
@@ -1064,14 +1144,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2] - 2025-01-17
 
 ### Fixed
+
 - SDK: Hide internal functions
 
 ## [0.1.1] - 2025-07-16
 
 ### Added
+
 - `secretspec --version`
 
 ### Fixed
+
 - Profile inheritance: fields are merged with current profile taking precedence
 
 ## [0.1.0] - 2025-07-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SDK pkg-config setup now pins cargo-c's library and metadata install
+  directories, so Go, Ruby, and Haskell reliably discover
+  `secretspec_ffi.pc` across environments.
 - The keyring provider no longer intermittently fails with a "No default store
   has been set" error when resolving multiple secrets concurrently.
 - The SOPS provider no longer substitutes a second time into a rendered path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dynamically — without hand-written linker flags.
 - The Haskell SDK's new `use-pkg-config` cabal flag
   (`cabal build -f use-pkg-config`) resolves the archive through pkg-config.
+- The Ruby SDK's native extension accepts a new `--enable-pkg-config` build
+  flag (`gem install secretspec -- --enable-pkg-config`) that resolves the
+  archive through pkg-config.
 - The Haskell SDK declares the archive's macOS system frameworks
   (`SystemConfiguration`, `Security`, `CoreFoundation`) in its cabal file, so
   GHC passes them to every link on macOS.

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 // scripts/sync-sdk-versions.sh. Release preparation replaces the checksum
 // after building the versioned XCFramework; see RELEASE.md.
 let secretSpecBinaryVersion = "0.18.0"
-let secretSpecBinaryChecksum = "4113e7aea3d18795e960dadab9f8b338c186391ade65f79c221a079f2ae80adb"
+let secretSpecBinaryChecksum = "3384bb29e60d06aa9a6bf9bbb0eec39e98437fcff10379a5bbf62fd59a6923f1"
 
 let localBinaryPath = "secretspec-swift/Artifacts/CSecretSpec.xcframework"
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()

--- a/devenv.nix
+++ b/devenv.nix
@@ -80,6 +80,9 @@
     pkgs.rustPlatform.bindgenHook
     # For development of the SOPS provider
     pkgs.sops
+    pkgs.pkg-config
+    # Installs the secretspec-ffi archive with its header and pkg-config file
+    pkgs.cargo-c
   ];
 
   # Fully-static musl build of the Go SDK (-tags static + -extldflags -static).

--- a/docs/src/content/docs/development/sdks.md
+++ b/docs/src/content/docs/development/sdks.md
@@ -134,6 +134,16 @@ crates (`libwindows.*.a` from `windows_x86_64_gnu`, `libwinapi_*.a` from
 the archive — the Ruby gem bundles them in `vendor/`, the Haskell job points
 GHC's linker at them.
 
+## Linking through pkg-config (0.19+)
+
+`cargo cinstall -p secretspec-ffi`
+([cargo-c](https://github.com/lu-zero/cargo-c)) installs the libraries, the
+header, and a `secretspec_ffi.pc` carrying the full link line, so pkg-config
+consumers skip the `native-static-libs` capture above. Install with
+`--library-type staticlib` for static linking. The default install also
+carries the shared library, which the linker then prefers — one prefix cannot
+serve both modes.
+
 ## Adding a platform to an SDK
 
 1. Add the platform to the SDK's distribution workflow matrix, and make the

--- a/docs/src/content/docs/sdk/go.md
+++ b/docs/src/content/docs/sdk/go.md
@@ -88,7 +88,7 @@ Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and add
 the `pkgconfig` tag instead of staging:
 
 ```bash
-cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+bash secretspec-ffi/scripts/cinstall.sh "$PREFIX"
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CGO_ENABLED=1 go build -tags static,pkgconfig ./...
 ```
 

--- a/docs/src/content/docs/sdk/go.md
+++ b/docs/src/content/docs/sdk/go.md
@@ -70,3 +70,31 @@ loaded at runtime, not linked. Either install/build `libsecretspec_ffi` and set
 with `-tags embed_lib` for a self-contained binary. The embedded library is
 extracted to a per-user, owner-only cache directory at first use, and is not
 distributed through the Go module proxy.
+
+## Static linking
+
+For a self-contained binary with no runtime library to locate, build with
+`-tags static` instead. This uses cgo and links `libsecretspec_ffi.a` directly
+into the Go binary. In a development checkout:
+
+```bash
+bash scripts/stage-staticlib.sh
+CGO_ENABLED=1 go build -tags static ./...
+```
+
+### pkg-config (0.19+)
+
+Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and add
+the `pkgconfig` tag instead of staging:
+
+```bash
+cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CGO_ENABLED=1 go build -tags static,pkgconfig ./...
+```
+
+Unlike staging, this also works for a `go get` dependency.
+
+### Dynamic linking (0.19+)
+
+Drop `--library-type staticlib` from the install and the binary links the
+shared library instead.

--- a/docs/src/content/docs/sdk/haskell.md
+++ b/docs/src/content/docs/sdk/haskell.md
@@ -83,10 +83,9 @@ LIBDIR="$(mktemp -d)"
 cp "$TARGET/debug/libsecretspec_ffi.a" "$LIBDIR/"
 NATIVE_LIBS="$(cargo rustc -q -p secretspec-ffi --crate-type staticlib -- \
   --print native-static-libs 2>&1 | sed -n 's/^note: native-static-libs: //p' | tail -1)"
-OPTL=(); for l in $NATIVE_LIBS; do OPTL+=("--ghc-options=-optl$l"); done
 
-cabal build --extra-lib-dirs="$LIBDIR" "${OPTL[@]}"
-cabal test  --extra-lib-dirs="$LIBDIR" "${OPTL[@]}"
+cabal build --extra-lib-dirs="$LIBDIR" --ghc-options="-optl${NATIVE_LIBS// / -optl}"
+cabal test  --extra-lib-dirs="$LIBDIR" --ghc-options="-optl${NATIVE_LIBS// / -optl}"
 ```
 
 ### pkg-config (0.19+)

--- a/docs/src/content/docs/sdk/haskell.md
+++ b/docs/src/content/docs/sdk/haskell.md
@@ -69,11 +69,9 @@ secretspec schema | quicktype -s schema --top-level SecretSpec --lang haskell -o
 
 ## Building
 
-The `secretspec-ffi` archive is statically linked at build time, so the resolver
-is embedded in the binary and there is no `cdylib` or `LD_LIBRARY_PATH` at
-runtime. Stage the `.a` in a directory of its own — so `-lsecretspec_ffi`
-resolves to the archive and not the co-located `.so` in `target/debug` — and pass
-the archive's transitive native dependencies through to the linker:
+The build links the `secretspec-ffi` archive statically. Stage the `.a` in a
+directory of its own (so the linker picks the archive, not the co-located
+`.so`) and pass its native dependencies to the linker:
 
 ```bash
 cargo build -p secretspec-ffi
@@ -90,3 +88,20 @@ OPTL=(); for l in $NATIVE_LIBS; do OPTL+=("--ghc-options=-optl$l"); done
 cabal build --extra-lib-dirs="$LIBDIR" "${OPTL[@]}"
 cabal test  --extra-lib-dirs="$LIBDIR" "${OPTL[@]}"
 ```
+
+### pkg-config (0.19+)
+
+Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and
+build with the `use-pkg-config` flag instead of the flags above:
+
+```bash
+cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+cd secretspec-hs
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" cabal build -f use-pkg-config
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" cabal test  -f use-pkg-config
+```
+
+### Dynamic linking (0.19+)
+
+Drop `--library-type staticlib` from the install and the build links the shared
+library instead.

--- a/docs/src/content/docs/sdk/haskell.md
+++ b/docs/src/content/docs/sdk/haskell.md
@@ -94,7 +94,7 @@ Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and
 build with the `use-pkg-config` flag instead of the flags above:
 
 ```bash
-cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+bash secretspec-ffi/scripts/cinstall.sh "$PREFIX"
 cd secretspec-hs
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" cabal build -f use-pkg-config
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" cabal test  -f use-pkg-config

--- a/docs/src/content/docs/sdk/ruby.md
+++ b/docs/src/content/docs/sdk/ruby.md
@@ -4,9 +4,8 @@ description: Resolve SecretSpec secrets from Ruby
 ---
 
 The Ruby SDK (`secretspec`) is a thin client over the `secretspec-ffi` C ABI,
-statically linked into a native C extension at build time (no runtime library to
-locate). Resolution happens in the Rust core, so the SDK inherits every provider
-with no Ruby-side logic.
+linked into a native C extension at build time. Resolution happens in the Rust
+core, so the SDK inherits every provider with no Ruby-side logic.
 
 ## Quick start
 
@@ -53,6 +52,20 @@ puts typed.database_url
 
 ## Native library
 
-The resolver is statically linked into a native C extension built by mkmf, so the
-published platform gem is self-contained — there is no separate `cdylib` to
-locate and no `SECRETSPEC_FFI_LIB` to set at runtime.
+The published platform gems bundle the `secretspec-ffi` archive and statically
+link it into the mkmf extension at install time.
+
+### pkg-config (0.19+)
+
+To build against your own `secretspec-ffi` install instead, install it with
+[cargo-c](https://github.com/lu-zero/cargo-c) and pass `--enable-pkg-config`:
+
+```bash
+cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" gem install secretspec -- --enable-pkg-config
+```
+
+### Dynamic linking (0.19+)
+
+Drop `--library-type staticlib` from the install and the extension links the
+shared library instead.

--- a/docs/src/content/docs/sdk/ruby.md
+++ b/docs/src/content/docs/sdk/ruby.md
@@ -61,7 +61,7 @@ To build against your own `secretspec-ffi` install instead, install it with
 [cargo-c](https://github.com/lu-zero/cargo-c) and pass `--enable-pkg-config`:
 
 ```bash
-cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+bash secretspec-ffi/scripts/cinstall.sh "$PREFIX"
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" gem install secretspec -- --enable-pkg-config
 ```
 

--- a/scripts/ci-sdks.sh
+++ b/scripts/ci-sdks.sh
@@ -29,8 +29,9 @@ export SECRETSPEC_BIN="$target_dir/debug/secretspec"
 echo "==> Installing staticlib + header + pkg-config file"
 SECRETSPEC_FFI_PREFIX="$(mktemp -d)"
 export SECRETSPEC_FFI_PREFIX
-cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$SECRETSPEC_FFI_PREFIX"
+bash secretspec-ffi/scripts/cinstall.sh "$SECRETSPEC_FFI_PREFIX"
 export PKG_CONFIG_PATH="$SECRETSPEC_FFI_PREFIX/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+pkg-config --print-errors --exists secretspec_ffi
 export SECRETSPEC_FFI_STATICLIB="$SECRETSPEC_FFI_PREFIX/lib/libsecretspec_ffi.a"
 export SECRETSPEC_FFI_INCLUDE="$SECRETSPEC_FFI_PREFIX/include"
 # Raw linker flags for the legs that do not call pkg-config. A Rust staticlib

--- a/scripts/ci-sdks.sh
+++ b/scripts/ci-sdks.sh
@@ -56,6 +56,9 @@ echo "==> Go (-tags static: cgo links the archive in)"
 ( cd secretspec-go && SECRETSPEC_FFI_PROFILE=debug bash scripts/stage-staticlib.sh )
 ( cd secretspec-go && CGO_ENABLED=1 go test -tags static ./... )
 
+echo "==> Go (-tags static,pkgconfig: link inputs from secretspec_ffi.pc)"
+( cd secretspec-go && CGO_ENABLED=1 go test -tags static,pkgconfig ./... )
+
 echo "==> Ruby"
 # The Ruby SDK compiles an mkmf C extension that statically links the archive
 # (using the SECRETSPEC_FFI_* contract above); build it once up front.

--- a/scripts/ci-sdks.sh
+++ b/scripts/ci-sdks.sh
@@ -90,13 +90,14 @@ echo "==> Haskell"
   cd secretspec-hs
   hs_lib_dir="$(mktemp -d)"
   cp "$SECRETSPEC_FFI_STATICLIB" "$hs_lib_dir/"
-  ghc_optl=()
-  for l in $SECRETSPEC_FFI_NATIVE_LIBS; do ghc_optl+=("--ghc-options=-optl$l"); done
   cabal update
   # --write-ghc-environment-files lets the codegen test's runghc see aeson and
   # the quicktype-generated module's transitive imports; SECRETSPEC_BIN (set
-  # above) lets it run `secretspec schema`.
-  cabal test --extra-lib-dirs="$hs_lib_dir" "${ghc_optl[@]}" \
+  # above) lets it run `secretspec schema`. All -optl flags go in ONE
+  # --ghc-options occurrence: cabal reverses the order of repeated occurrences,
+  # which breaks two-token `-framework X` pairs on macOS.
+  cabal test --extra-lib-dirs="$hs_lib_dir" \
+    --ghc-options="-optl${SECRETSPEC_FFI_NATIVE_LIBS// / -optl}" \
     --write-ghc-environment-files=always
 )
 

--- a/scripts/ci-sdks.sh
+++ b/scripts/ci-sdks.sh
@@ -24,17 +24,23 @@ export SECRETSPEC_FFI_LIB="$target_dir/debug/$lib_name"
 export SECRETSPEC_BIN="$target_dir/debug/secretspec"
 
 # Static-link contract: SDKs link libsecretspec_ffi.a (the resolver compiled in)
-# instead of dlopening the cdylib. A Rust staticlib does not carry its own native
-# dependency closure, so capture the transitive system libs the archive needs and
-# hand them to every consumer's linker. NEVER hardcode this list -- it drifts as
-# providers change.
-export SECRETSPEC_FFI_STATICLIB="$target_dir/debug/libsecretspec_ffi.a"
-export SECRETSPEC_FFI_INCLUDE="$repo_root/secretspec-ffi/include"
+# instead of dlopening the cdylib. Every leg resolves the archive, its header,
+# and its secretspec_ffi.pc from this one installed prefix.
+echo "==> Installing staticlib + header + pkg-config file"
+SECRETSPEC_FFI_PREFIX="$(mktemp -d)"
+export SECRETSPEC_FFI_PREFIX
+cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$SECRETSPEC_FFI_PREFIX"
+export PKG_CONFIG_PATH="$SECRETSPEC_FFI_PREFIX/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+export SECRETSPEC_FFI_STATICLIB="$SECRETSPEC_FFI_PREFIX/lib/libsecretspec_ffi.a"
+export SECRETSPEC_FFI_INCLUDE="$SECRETSPEC_FFI_PREFIX/include"
+# Raw linker flags for the legs that do not call pkg-config. A Rust staticlib
+# does not carry its own native dependency closure; NEVER hardcode this list --
+# it drifts as providers change.
 SECRETSPEC_FFI_NATIVE_LIBS="$(cargo rustc -q -p secretspec-ffi --crate-type staticlib -- \
   --print native-static-libs 2>&1 | sed -n 's/^note: native-static-libs: //p' | tail -1)"
 export SECRETSPEC_FFI_NATIVE_LIBS
 echo "==> SECRETSPEC_FFI_LIB=$SECRETSPEC_FFI_LIB"
-echo "==> SECRETSPEC_FFI_STATICLIB=$SECRETSPEC_FFI_STATICLIB"
+echo "==> SECRETSPEC_FFI_PREFIX=$SECRETSPEC_FFI_PREFIX"
 echo "==> SECRETSPEC_FFI_NATIVE_LIBS=$SECRETSPEC_FFI_NATIVE_LIBS"
 
 echo "==> Python"
@@ -54,6 +60,12 @@ echo "==> Ruby"
 # The Ruby SDK compiles an mkmf C extension that statically links the archive
 # (using the SECRETSPEC_FFI_* contract above); build it once up front.
 bash secretspec-rb/scripts/build-ext.sh
+( cd secretspec-rb && ruby -e 'Dir["test/test_*.rb"].sort.each { |f| require File.expand_path(f) }' )
+
+echo "==> Ruby (pkg-config discovery)"
+# The same link inputs read from secretspec_ffi.pc in the installed prefix
+# (PKG_CONFIG_PATH above); rebuild the extension and rerun the tests.
+bash secretspec-rb/scripts/build-ext.sh --enable-pkg-config
 ( cd secretspec-rb && ruby -e 'Dir["test/test_*.rb"].sort.each { |f| require File.expand_path(f) }' )
 
 echo "==> Node"
@@ -83,6 +95,12 @@ echo "==> Haskell"
   # above) lets it run `secretspec schema`.
   cabal test --extra-lib-dirs="$hs_lib_dir" "${ghc_optl[@]}" \
     --write-ghc-environment-files=always
+)
+
+echo "==> Haskell (pkg-config discovery)"
+(
+  cd secretspec-hs
+  cabal test -f use-pkg-config --write-ghc-environment-files=always
 )
 
 echo "==> C# / .NET"

--- a/secretspec-ffi/Cargo.toml
+++ b/secretspec-ffi/Cargo.toml
@@ -13,6 +13,30 @@ name = "secretspec_ffi"
 # All expose the same narrow C ABI.
 crate-type = ["cdylib", "staticlib", "lib"]
 
+# cargo-c enables this feature when building the C ABI; the ABI here is
+# unconditional, so it gates nothing.
+[features]
+capi = []
+
+# Read by cargo-c: `cargo cinstall -p secretspec-ffi --library-type staticlib`
+# installs the archive with the C header and a generated secretspec_ffi.pc.
+[package.metadata.capi.library]
+name = "secretspec_ffi"
+
+# The header in include/ is hand-maintained; consumers expect it at the
+# include root as #include "secretspec.h".
+[package.metadata.capi.header]
+generation = false
+subdirectory = ""
+
+[package.metadata.capi.install.include]
+asset = [{ from = "include/secretspec.h", to = "" }]
+
+[package.metadata.capi.pkg_config]
+name = "secretspec_ffi"
+filename = "secretspec_ffi"
+description = "C ABI for SecretSpec: resolve secrets from any language"
+
 [dependencies]
 # The envelope/resolve logic lives in the secretspec crate (resolve_json); this
 # crate is only the C ABI wrapper.

--- a/secretspec-ffi/scripts/cinstall.sh
+++ b/secretspec-ffi/scripts/cinstall.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Install the SecretSpec C ABI into a predictable prefix layout. cargo-c uses
+# lib/<host-triplet> on Debian-like hosts by default, so keep the library and
+# pkg-config directories stable for SDK consumers on every platform.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 PREFIX" >&2
+  exit 2
+fi
+
+prefix="$1"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cargo cinstall -p secretspec-ffi --manifest-path "$repo_root/Cargo.toml" \
+  --library-type staticlib \
+  --prefix "$prefix" \
+  --libdir lib \
+  --pkgconfigdir lib/pkgconfig

--- a/secretspec-go/README.md
+++ b/secretspec-go/README.md
@@ -109,3 +109,20 @@ CGO_ENABLED=1 go build -tags static \
 macOS links the archive in but stays self-contained-except-system-frameworks (no
 static libSystem). Windows stays on the default purego path. The prebuilt
 archives are attached to GitHub releases (`go-static.yml`).
+
+### pkg-config (0.19+)
+
+Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and add
+the `pkgconfig` tag instead of staging:
+
+```bash
+cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CGO_ENABLED=1 go build -tags static,pkgconfig ./...
+```
+
+Unlike staging, this also works for a `go get` dependency.
+
+### Dynamic linking (0.19+)
+
+Drop `--library-type staticlib` from the install and the binary links the
+shared library instead.

--- a/secretspec-go/README.md
+++ b/secretspec-go/README.md
@@ -116,7 +116,7 @@ Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and add
 the `pkgconfig` tag instead of staging:
 
 ```bash
-cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+bash secretspec-ffi/scripts/cinstall.sh "$PREFIX"
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CGO_ENABLED=1 go build -tags static,pkgconfig ./...
 ```
 

--- a/secretspec-go/binding_cgo.go
+++ b/secretspec-go/binding_cgo.go
@@ -4,13 +4,12 @@ package secretspec
 
 // Static binding: cgo links libsecretspec_ffi.a directly into the Go binary, so
 // the Rust resolver is embedded (fully static on Linux/musl with
-// `-ldflags '-linkmode external -extldflags "-static"'`). The archive path and
-// its transitive native deps come from the generated, per-platform
-// cgo_ldflags_<os>_<arch>.go (produced by scripts/stage-staticlib.sh); the header
-// is vendored under include/.
+// `-ldflags '-linkmode external -extldflags "-static"'`). The link inputs come
+// from files staged by scripts/stage-staticlib.sh (cgo_vendored.go and the
+// generated cgo_ldflags_<os>_<arch>.go), or from secretspec_ffi.pc when the
+// pkgconfig tag is also set (cgo_pkgconfig.go).
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/include
 #include <stdlib.h>
 #include "secretspec.h"
 */

--- a/secretspec-go/cgo_pkgconfig.go
+++ b/secretspec-go/cgo_pkgconfig.go
@@ -1,0 +1,11 @@
+//go:build static && pkgconfig
+
+package secretspec
+
+// Every link input comes from secretspec_ffi.pc (installed by
+// `cargo cinstall -p secretspec-ffi --library-type staticlib`).
+
+/*
+#cgo pkg-config: secretspec_ffi
+*/
+import "C"

--- a/secretspec-go/cgo_vendored.go
+++ b/secretspec-go/cgo_vendored.go
@@ -1,0 +1,10 @@
+//go:build static && !pkgconfig
+
+package secretspec
+
+// Vendored header staged by scripts/stage-staticlib.sh.
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/include
+*/
+import "C"

--- a/secretspec-go/scripts/stage-staticlib.sh
+++ b/secretspec-go/scripts/stage-staticlib.sh
@@ -4,6 +4,8 @@
 # per-platform archive (lib/), the C header (include/), and a generated
 # cgo_ldflags_<os>_<arch>.go carrying the archive path + its transitive native
 # deps (captured from `rustc --print native-static-libs`, never hardcoded).
+# A `-tags static,pkgconfig` build skips the staged inputs and reads
+# secretspec_ffi.pc instead.
 #
 # Honors:
 #   SECRETSPEC_FFI_PROFILE  release|debug   (default: debug)
@@ -38,7 +40,7 @@ cp "$repo_root/secretspec-ffi/include/secretspec.h" "$pkg_dir/include/secretspec
 # The cgo LDFLAGS live in a generated per-platform file (the wasmtime-go pattern):
 # the archive is pulled for the referenced symbols, then its native deps follow.
 cat > "$pkg_dir/cgo_ldflags_${goos}_${goarch}.go" <<EOF
-//go:build static && $goos && $goarch
+//go:build static && !pkgconfig && $goos && $goarch
 
 package secretspec
 

--- a/secretspec-hs/README.md
+++ b/secretspec-hs/README.md
@@ -81,10 +81,9 @@ LIBDIR="$(mktemp -d)"
 cp "$TARGET/debug/libsecretspec_ffi.a" "$LIBDIR/"
 NATIVE_LIBS="$(cargo rustc -q -p secretspec-ffi --crate-type staticlib -- \
   --print native-static-libs 2>&1 | sed -n 's/^note: native-static-libs: //p' | tail -1)"
-OPTL=(); for l in $NATIVE_LIBS; do OPTL+=("--ghc-options=-optl$l"); done
 
-cabal build --extra-lib-dirs="$LIBDIR" "${OPTL[@]}"
-cabal test  --extra-lib-dirs="$LIBDIR" "${OPTL[@]}"
+cabal build --extra-lib-dirs="$LIBDIR" --ghc-options="-optl${NATIVE_LIBS// / -optl}"
+cabal test  --extra-lib-dirs="$LIBDIR" --ghc-options="-optl${NATIVE_LIBS// / -optl}"
 ```
 
 ### pkg-config (0.19+)

--- a/secretspec-hs/README.md
+++ b/secretspec-hs/README.md
@@ -92,7 +92,7 @@ Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and
 build with the `use-pkg-config` flag instead of the flags above:
 
 ```bash
-cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+bash secretspec-ffi/scripts/cinstall.sh "$PREFIX"
 cd secretspec-hs
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" cabal build -f use-pkg-config
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" cabal test  -f use-pkg-config

--- a/secretspec-hs/README.md
+++ b/secretspec-hs/README.md
@@ -68,11 +68,9 @@ secretspec schema | quicktype -s schema --top-level SecretSpec --lang haskell -o
 
 ## Building
 
-The `secretspec-ffi` archive is statically linked at build time, so the resolver
-is embedded in the binary — no `cdylib` and no `LD_LIBRARY_PATH` at runtime.
-Stage the `.a` in a directory of its own (so `-lsecretspec_ffi` resolves to the
-archive, not the co-located `.so`) and pass its transitive native dependencies to
-the linker:
+The build links the `secretspec-ffi` archive statically. Stage the `.a` in a
+directory of its own (so the linker picks the archive, not the co-located
+`.so`) and pass its native dependencies to the linker:
 
 ```bash
 cargo build -p secretspec-ffi
@@ -88,3 +86,20 @@ OPTL=(); for l in $NATIVE_LIBS; do OPTL+=("--ghc-options=-optl$l"); done
 cabal build --extra-lib-dirs="$LIBDIR" "${OPTL[@]}"
 cabal test  --extra-lib-dirs="$LIBDIR" "${OPTL[@]}"
 ```
+
+### pkg-config (0.19+)
+
+Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and
+build with the `use-pkg-config` flag instead of the flags above:
+
+```bash
+cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+cd secretspec-hs
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" cabal build -f use-pkg-config
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" cabal test  -f use-pkg-config
+```
+
+### Dynamic linking (0.19+)
+
+Drop `--library-type staticlib` from the install and the build links the shared
+library instead.

--- a/secretspec-hs/secretspec.cabal
+++ b/secretspec-hs/secretspec.cabal
@@ -15,6 +15,14 @@ maintainer:         domen@enlambda.com
 category:           Configuration
 build-type:         Simple
 
+flag use-pkg-config
+  description:
+    Locate libsecretspec_ffi.a and its native dependencies through pkg-config
+    (secretspec_ffi.pc) instead of extra-libraries plus --extra-lib-dirs and
+    -optl flags on the command line.
+  default:            False
+  manual:             True
+
 library
   exposed-modules:    SecretSpec
   hs-source-dirs:     src
@@ -24,13 +32,23 @@ library
                     , containers <1
                     , directory  <2
                     , text       <3
-  -- The native resolver, statically linked at build time. Point --extra-lib-dirs
-  -- at a directory containing ONLY libsecretspec_ffi.a (so -lsecretspec_ffi
-  -- resolves to the archive, not a co-located .so), and pass the archive's
-  -- transitive native deps via --ghc-options=-optl<lib> (capture them with
+  -- The native resolver, statically linked at build time: the Rust code is
+  -- embedded in the binary.
+  --
+  -- Without the flag: point --extra-lib-dirs at a directory containing ONLY
+  -- libsecretspec_ffi.a (so -lsecretspec_ffi resolves to the archive, not a
+  -- co-located .so), and pass the archive's transitive native deps via
+  -- --ghc-options=-optl<lib> (capture them with
   -- `cargo rustc -p secretspec-ffi --crate-type staticlib -- --print native-static-libs`).
-  -- The Rust code is embedded in the binary, so no LD_LIBRARY_PATH is needed.
-  extra-libraries:    secretspec_ffi
+  if flag(use-pkg-config)
+    pkgconfig-depends: secretspec_ffi
+  else
+    extra-libraries:  secretspec_ffi
+  -- The Darwin frameworks among the archive's native dependencies, declared
+  -- so every final link (executable, test-suite, ghci) receives them through
+  -- the compiler driver.
+  if os(darwin)
+    frameworks:       SystemConfiguration Security CoreFoundation
   default-language:   Haskell2010
   ghc-options:        -Wall
 

--- a/secretspec-rb/README.md
+++ b/secretspec-rb/README.md
@@ -1,10 +1,9 @@
 # secretspec (Ruby SDK)
 
 Ruby bindings for [SecretSpec](https://secretspec.dev/), a declarative secrets
-manager. A thin client over the `secretspec-ffi` C ABI, statically linked into a
-native C extension at build time (no runtime library to locate). Resolution
-happens in the Rust core, so the SDK inherits every provider with no Ruby-side
-logic.
+manager. A thin client over the `secretspec-ffi` C ABI, linked into a native C
+extension at build time. Resolution happens in the Rust core, so the SDK
+inherits every provider with no Ruby-side logic.
 
 ```ruby
 require "secretspec"
@@ -50,7 +49,28 @@ report = Secretspec::SecretSpec.builder.with_profile("production").report
 report.secrets.each { |s| puts [s.name, s.status, s.required].join(" ") }
 ```
 
-## Library discovery
+## Building
 
-The native library is found via the `SECRETSPEC_FFI_LIB` environment variable,
-or a Cargo `target` directory found by searching up from the working directory.
+The extension links the `secretspec-ffi` archive statically. In a development
+checkout:
+
+```bash
+bash scripts/build-ext.sh
+```
+
+### pkg-config (0.19+)
+
+Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and pass
+`--enable-pkg-config` to the build:
+
+```bash
+cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" gem install secretspec -- --enable-pkg-config
+```
+
+The same flag works in a checkout: `bash scripts/build-ext.sh --enable-pkg-config`.
+
+### Dynamic linking (0.19+)
+
+Drop `--library-type staticlib` from the install and the extension links the
+shared library instead.

--- a/secretspec-rb/README.md
+++ b/secretspec-rb/README.md
@@ -64,7 +64,7 @@ Install the library with [cargo-c](https://github.com/lu-zero/cargo-c) and pass
 `--enable-pkg-config` to the build:
 
 ```bash
-cargo cinstall -p secretspec-ffi --library-type staticlib --prefix "$PREFIX"
+bash secretspec-ffi/scripts/cinstall.sh "$PREFIX"
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" gem install secretspec -- --enable-pkg-config
 ```
 

--- a/secretspec-rb/ext/secretspec/extconf.rb
+++ b/secretspec-rb/ext/secretspec/extconf.rb
@@ -5,8 +5,25 @@
 # not carry its own native dependency closure, so the archive's transitive system
 # libs (captured from `rustc --print native-static-libs`, never hardcoded) are
 # appended to the link line after it.
+#
+# With --enable-pkg-config every link input comes from secretspec_ffi.pc
+# instead (installed by `cargo cinstall -p secretspec-ffi --library-type
+# staticlib`), and the discovery tiers below are skipped entirely.
 
 require "mkmf"
+
+if enable_config("pkg-config", false)
+  # The .pc's Libs line orders the archive before its native deps; mkmf routes
+  # its -l flags to $libs and the rest (-L, macOS -framework) to $LDFLAGS.
+  unless pkg_config("secretspec_ffi")
+    abort("secretspec: pkg-config could not find secretspec_ffi; point " \
+          "PKG_CONFIG_PATH at the prefix installed by " \
+          "`cargo cinstall -p secretspec-ffi --library-type staticlib`")
+  end
+
+  create_makefile("secretspec/secretspec_ext")
+  return
+end
 
 ext_dir = __dir__
 pkg_dir = File.expand_path("../..", ext_dir) # secretspec-rb
@@ -44,9 +61,12 @@ end
 staticlib = find_staticlib(vendor, repo_root)
 abort("secretspec: could not locate libsecretspec_ffi.a; set SECRETSPEC_FFI_STATICLIB") unless staticlib
 
-# Header: the bundled vendor copy (platform gem) or the ffi crate's include dir.
+# Header: explicit contract, the bundled vendor copy (platform gem), or the
+# ffi crate's include dir.
 include_dir =
-  if File.exist?(File.join(vendor, "secretspec.h"))
+  if (env = ENV["SECRETSPEC_FFI_INCLUDE"]) && !env.empty? && File.directory?(env)
+    env
+  elsif File.exist?(File.join(vendor, "secretspec.h"))
     vendor
   else
     File.join(repo_root, "secretspec-ffi", "include")

--- a/secretspec-rb/scripts/build-ext.sh
+++ b/secretspec-rb/scripts/build-ext.sh
@@ -4,18 +4,21 @@
 # libsecretspec_ffi.a) and place it on the SDK's load path for dev and tests.
 # extconf.rb honors the SECRETSPEC_FFI_STATICLIB / SECRETSPEC_FFI_NATIVE_LIBS /
 # SECRETSPEC_FFI_INCLUDE contract (exported by scripts/ci-sdks.sh); otherwise it
-# builds and locates the debug archive from the Cargo target dir.
+# builds and locates the debug archive from the Cargo target dir. Arguments are
+# forwarded to extconf.rb: pass --enable-pkg-config to read every link input
+# from secretspec_ffi.pc (via PKG_CONFIG_PATH) instead.
 set -euo pipefail
 
 pkg_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_root="$(cd "$pkg_dir/.." && pwd)"
 
-if [ -z "${SECRETSPEC_FFI_STATICLIB:-}" ]; then
+# With pkg-config the .pc names an already-installed archive; nothing to build.
+if [ -z "${SECRETSPEC_FFI_STATICLIB:-}" ] && [[ " $* " != *" --enable-pkg-config "* ]]; then
   cargo build -p secretspec-ffi --manifest-path "$repo_root/Cargo.toml"
 fi
 
 ext_dir="$pkg_dir/ext/secretspec"
-( cd "$ext_dir" && ruby extconf.rb && make --silent )
+( cd "$ext_dir" && ruby extconf.rb "$@" && make --silent )
 
 # The build output lands in ext_dir (target_prefix only affects the install dir);
 # copy it onto the SDK's load path so `require "secretspec/secretspec_ext"` finds it.


### PR DESCRIPTION
- Uses [cargo-c](https://github.com/lu-zero/cargo-c) to install the library, C headers, and compatible `.pc` files
- Ruby:  new `--enable-pkg-config` build flag (`gem install secretspec -- --enable-pkg-config`)
- Haskell: new `use-pkg-config` cabal flag  (`cabal build -f use-pkg-config`)
- Go: new `pkgconfig` build tag (`go build -tags static,pkgconfig`)
- Updated CI to statically link all three of the above SDKs via pkg-config
