### PR TITLE
fix(keyring): avoid concurrent initialization race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The keyring provider no longer intermittently fails with a "No default store
+  has been set" error when resolving multiple secrets concurrently.
+
 ## [0.18.0] - 2026-08-03
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.1.5"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298a59b384c540e408a600c8b375a09b49c3f97debc080e2c30675d79a6368a"
+checksum = "72585bb6cc9bc370d1d545b7e23fcce71dfd4461c5e15275e3cf51bdfd9a980a"
 dependencies = [
  "apple-native-keyring-store",
  "keyring-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 
 [workspace.dependencies]
 clap = { version = "4.0", features = ["derive", "env"] }
-keyring = "4"
+keyring = "4.1.6"
 keepass = { version = "0.13.17", features = ["save_kdbx4"] }
 keeper-secrets-manager-core = { version = "17.3.0", default-features = false, features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Require keyring 4.1.6, which fixes concurrent initialization of the default credential store.
- Update the lockfile to keyring 4.1.6.
- Document the user-facing fix in the changelog.

## Root cause

SecretSpec resolves multiple secrets concurrently. In keyring 4.1.5, concurrent initialization could allow one caller to observe the process-wide default store before it had been installed, resulting in an intermittent:

  > No default store has been set

The synchronization issue was fixed upstream in keyring 4.1.6. Setting the minimum dependency version prevents Cargo from resolving to an affected release.

Upstream fix: https://github.com/open-source-cooperative/keyring-rs/issues/343

## Validation

- Reproduced 3 failures across 30 runs with keyring 4.1.5.
- Observed no failures across 100 runs with keyring 4.1.6 at the default concurrency.
- `cargo build --locked --package secretspec --bin secretspec`
- `cargo test --locked --package secretspec provider::keyring`
- `devenv shell -- pre-commit run -a`

Closes #268