### PR TITLE
ci(dependabot): group non-major action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions-minor-and-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     exclude-paths:
       - ".github/workflows/v-release.yml"
     cooldown:


### PR DESCRIPTION
## Summary

- group GitHub Actions minor and patch version updates into one Dependabot PR
- keep major and security updates independently reviewable
- retain the weekly schedule and seven-day cooldown

## Context

The initial action-pinning rollout intentionally left updates ungrouped so the existing major-version backlog could be reviewed and validated independently.

With that backlog merged, routine minor and patch updates no longer need separate pull requests. Grouping them reduces maintenance noise while preserving individual review for potentially breaking major upgrades.

The cargo-dist-generated `.github/workflows/v-release.yml` remains excluded from Dependabot updates.

## Impact

Dependabot can create one grouped pull request for available non-major GitHub Actions updates. Major version and security updates remain separate.

This only changes dependency maintenance behavior, workflows and SecretSpec runtime behavior are unchanged.

## Validation

- parsed `.github/dependabot.yml` with `YAML.safe_load`
- verified the grouping rule, cooldown, and generated-workflow exclusion
- ran `git diff --check`