### PR TITLE
fix(lastpass): report the full item template from uri()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolves to the file you configured instead of a different one.
 - Invalid SOPS path templates are now rejected when loading serialized
   provider configurations instead of being accepted without validation.
+- The LastPass provider now reports its full item template rather than only the
+  first segment. A multi-segment template such as
+  `lastpass://Shared/{project}/{profile}/{key}` used to be reported as plain
+  `lastpass`, which reads back as the default `secretspec/{project}/{profile}/{key}`
+  template — a different folder — and `lastpass://Work/TeamA/{key}` read back as
+  the literal item `Work`, one item for every secret. Templates that differ
+  below their first segment are now distinguished, so repointing a cached route
+  at a new template invalidates its cached values instead of serving the old
+  ones until they expire. Single-segment templates are unaffected; cached
+  entries for a multi-segment template refetch once, silently, on first run.
 
 ## [0.18.0] - 2026-08-03
 

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -1109,21 +1109,23 @@ mod tests {
         }
     }
 
+    /// The cache fingerprint of a route reading from `source`.
+    fn fingerprint(source: &str) -> String {
+        let spec = cached_spec_with(
+            vec!["route"],
+            &[("route", cached_alias(&[source], "keyring://", "8h"))],
+        );
+        let plan = plan(&spec);
+        route(find(&plan, "API_KEY"))
+            .cache()
+            .expect("cached route")
+            .route_fingerprint
+            .clone()
+    }
+
     #[test]
     fn vault_compatible_route_configuration_changes_invalidate_the_cache() {
         let _env = scrub_resolution_env();
-        let fingerprint = |source| {
-            let spec = cached_spec_with(
-                vec!["route"],
-                &[("route", cached_alias(&[source], "keyring://", "8h"))],
-            );
-            let plan = plan(&spec);
-            route(find(&plan, "API_KEY"))
-                .cache()
-                .expect("cached route")
-                .route_fingerprint
-                .clone()
-        };
 
         let baseline = fingerprint("vault://bao.example.com:8200/secret");
         for changed in [
@@ -1143,6 +1145,20 @@ mod tests {
             fingerprint("vault://bao.example.com:8200/secret?auth=jwt&role=read"),
             fingerprint("vault://bao.example.com:8200/secret?auth=jwt&role=deploy"),
             "changing the JWT role must invalidate the cache"
+        );
+    }
+
+    /// The fingerprint is built from each source's `uri()`, so a provider that
+    /// reports less than its whole configuration reports two different routes
+    /// as one, and the cache keeps serving the value the old route fetched.
+    #[test]
+    fn lastpass_item_template_changes_invalidate_the_cache() {
+        let _env = scrub_resolution_env();
+
+        assert_ne!(
+            fingerprint("lastpass://Work/TeamA/{project}/{profile}/{key}"),
+            fingerprint("lastpass://Work/TeamB/{project}/{profile}/{key}"),
+            "changing the item template must invalidate the cache"
         );
     }
 

--- a/secretspec/src/provider/lastpass.rs
+++ b/secretspec/src/provider/lastpass.rs
@@ -264,23 +264,23 @@ impl Provider for LastPassProvider {
         Some(String::new())
     }
 
+    /// `TryFrom` reads the whole `host` + `path` as the item template, so the
+    /// whole template is emitted here for it to read back. Emitting less names
+    /// a different template: dropping `/{key}` addresses one item for every
+    /// secret.
     fn uri(&self) -> String {
-        // LastPass can be "lastpass" (default) or "lastpass://folder" or "lastpass://Folder/Subfolder"
-        if let Some(ref prefix) = self.config.folder_prefix {
-            // The folder_prefix might be something like "SecretSpec/{project}/{profile}/{key}"
-            // We want to extract just the folder part for the URI
-            if let Some(folder) = prefix.split('/').next() {
-                if folder.is_empty() || folder == "Shared" {
-                    "lastpass".to_string()
-                } else {
-                    format!("lastpass://{}", ProviderUrl::encode(folder))
-                }
-            } else {
-                "lastpass".to_string()
+        match self.config.folder_prefix.as_deref() {
+            Some(prefix) if !prefix.is_empty() => {
+                format!("lastpass://{}", ProviderUrl::encode(prefix))
             }
-        } else {
-            "lastpass".to_string()
+            _ => "lastpass".to_string(),
         }
+    }
+
+    /// The template selects an item inside the account's own vault; it does not
+    /// select another LastPass store.
+    fn entry_container_identity(&self) -> String {
+        "lastpass".to_string()
     }
 
     /// Retrieves a secret from LastPass.
@@ -432,6 +432,89 @@ impl Default for LastPassProvider {
     /// This is equivalent to calling `LastPassProvider::new(LastPassConfig::default())`.
     fn default() -> Self {
         Self::new(LastPassConfig::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_of(spec: &str) -> Box<dyn Provider> {
+        Box::<dyn Provider>::try_from(spec).expect("the spec must be valid")
+    }
+
+    fn uri_of(spec: &str) -> String {
+        provider_of(spec).uri()
+    }
+
+    /// The item a spec addresses, for comparing two spellings of one store.
+    /// `LastPassConfig` has no `PartialEq`, and the rendered item is what the
+    /// template exists to produce.
+    fn addressed_item(spec: &str) -> String {
+        provider_of(spec)
+            .convention_address("my-app", "production", "API_KEY")
+            .expect("a convention address")
+            .item
+    }
+
+    #[test]
+    fn format_item_name_default_pattern() {
+        let provider = LastPassProvider::new(LastPassConfig::default());
+        assert_eq!(
+            provider.format_item_name("myproj", "API_KEY", "prod"),
+            "secretspec/myproj/prod/API_KEY"
+        );
+    }
+
+    #[test]
+    fn format_item_name_custom_prefix() {
+        let provider = LastPassProvider::new(LastPassConfig {
+            folder_prefix: Some("Work/{profile}/{key}".to_string()),
+        });
+        assert_eq!(
+            provider.format_item_name("myproj", "API_KEY", "prod"),
+            "Work/prod/API_KEY"
+        );
+    }
+
+    #[test]
+    fn uri_round_trips_the_item_template() {
+        // `uri()` is the provider's identity: SecretSpec fingerprints cached
+        // routes with it, names the answering store with it in audit records,
+        // and the derive macro hands it back as a provider spec. Emitting only
+        // the first segment made different templates indistinguishable --
+        // `Shared/{project}/{profile}/{key}` read back as the default
+        // `secretspec/{project}/{profile}/{key}`, a different folder, and
+        // `Work/TeamA/{key}` read back as the literal item `Work`, one item for
+        // every secret in the profile.
+        for spec in [
+            "lastpass",
+            "lastpass://",
+            "lastpass://Work",
+            "lastpass://Shared",
+            "lastpass://Shared/{project}/{profile}/{key}",
+            "lastpass://Shared-SecretSpec/{project}/{profile}/{key}",
+            "lastpass://Work/TeamA/{project}/{profile}/{key}",
+            "lastpass://Shared Items/dev/{key}",
+        ] {
+            let rendered = uri_of(spec);
+            assert_eq!(
+                addressed_item(&rendered),
+                addressed_item(spec),
+                "{spec} rendered as {rendered}, which does not read back as the same item",
+            );
+        }
+    }
+
+    /// Two templates under one folder must stay distinguishable, or the cache
+    /// fingerprints both routes alike and keeps serving the first one's values
+    /// after the source is repointed at the second.
+    #[test]
+    fn uri_distinguishes_two_templates_under_one_folder() {
+        assert_ne!(
+            uri_of("lastpass://Work/TeamA/{project}/{profile}/{key}"),
+            uri_of("lastpass://Work/TeamB/{project}/{profile}/{key}"),
+        );
     }
 }
 

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1403,6 +1403,19 @@ mod integration_tests {
     }
 
     #[test]
+    fn test_lastpass_with_folder_prefix() {
+        let provider =
+            Box::<dyn Provider>::try_from("lastpass://Work/SecretSpec/{profile}/{key}").unwrap();
+        assert_eq!(provider.name(), "lastpass");
+        assert_eq!(provider.uri(), "lastpass://Work/SecretSpec/{profile}/{key}");
+
+        // Without folder_prefix, should use default URI
+        let provider = Box::<dyn Provider>::try_from("lastpass://").unwrap();
+        assert_eq!(provider.name(), "lastpass");
+        assert_eq!(provider.uri(), "lastpass");
+    }
+
+    #[test]
     fn test_pass_with_folder_prefix() {
         let provider =
             Box::<dyn Provider>::try_from("pass://secretspec/shared/{profile}/{key}").unwrap();


### PR DESCRIPTION
## Summary

- `uri()` emits the whole item template, not just its first segment.
- Adds `entry_container_identity()`, matching keyring/gopass/pass now that the URI carries a template.
- Adds `uri()` tests for this provider, which had none.

## Rationale

`uri()` reported only the first segment of the item template, and that string is read back as a provider spec — `secretspec-derive` hands it to `set_provider`, and cached routes are fingerprinted with it. So a template read back as something else entirely: `lastpass://Shared/{project}/{profile}/{key}` as the default `secretspec/{project}/{profile}/{key}`, a different folder, and `lastpass://Work/TeamA/{key}` as the literal item `Work` — one item for every secret in the profile. Templates differing below their first segment also fingerprinted alike, so repointing a cached route kept serving the old template's values until they expired. (#272 called this reporting-only; that was wrong.)

Keyring had the same truncation until dd755d2, which fixed keyring and re-encoded lastpass's truncated folder without removing the truncation. This finishes that.

Two notes. The removed `folder == "Shared"` branch is what mapped `Shared/…` onto the default template; it dates to 1dad1c7, where keyring's `uri()` was an unconditional constant too, so I don't think it encodes LastPass semantics — happy to restore it if it does. And templates differing only by a literal `%20` versus a space still collide, since `URI_ENCODE_SET` doesn't escape `%`; that's shared with keyring and gopass and wants its own change.

Closes #272.
