### PR TITLE
Add secret encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Secrets can store values as standard Base64, URL-safe Base64, or hexadecimal
+  using `encoding`; writes encode logical text and reads decode stored values,
+  while `as_path = true` materializes arbitrary decoded bytes.
+
 ### Fixed
 - The keyring provider no longer intermittently fails with a "No default store
   has been set" error when resolving multiple secrets concurrently.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -133,6 +133,7 @@ Each secret variable is defined as a table with the following fields:
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
 | `ref` | table | No | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
+| `encoding` (0.19+) | `"base64"`, `"base64url"`, or `"hex"` | No | Encode logical values before storage writes and decode stored values after reads |
 | `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
 | `generate` | boolean or table | No | Enable auto-generation when secret is missing |
 
@@ -149,7 +150,7 @@ Field notes:
 - `type` is required when `generate` is enabled.
 - `generate` and `default` cannot both be set.
 
-#### Composed secrets
+#### Composed Secrets
 
 :::caution[Version compatibility]
 Available since SecretSpec 0.16.
@@ -171,7 +172,7 @@ References form a static dependency graph. Declaration order does not matter,
 and composed secrets may reference other composed secrets. SecretSpec rejects
 unknown references, cycles, malformed references, and source conflicts while
 loading the manifest. A composed secret is read-only and cannot also set
-`default`, `providers`, `ref`, `type`, or enabled `generate`.
+`default`, `providers`, `ref`, `type`, enabled `generate`, or `encoding` (0.19+).
 
 Composition intentionally does **not** implement dotenv or shell expansion:
 
@@ -213,9 +214,9 @@ configuration and resolution behavior.
 Scopes name membership-only subsets of a profile's secrets, so a single service
 or task resolves only what it declares instead of the entire profile. They are
 **orthogonal to profiles**: a profile decides how each secret resolves
-(`required`, `default`, providers, references, generation, `as_path`, and the
-storage namespace); a scope only decides *which* secrets take part in a given
-resolution.
+(`required`, `default`, providers, references, generation, `as_path`,
+`encoding` (0.19+), and the storage namespace); a scope only decides *which*
+secrets take part in a given resolution.
 
 ```toml
 [profiles.default]
@@ -553,11 +554,50 @@ TLS_CERT = { description = "TLS certificate", as_path = true }
 GOOGLE_APPLICATION_CREDENTIALS = { description = "GCP service account", as_path = true }
 ```
 
+When combined with `encoding` (0.19+), the file contains the decoded bytes
+rather than the stored textual representation.
+
 | Context | Behavior |
 |---------|----------|
 | CLI (`get`, `check`, `run`) | Files are persisted (not deleted after command exits) |
 | Rust SDK | Files cleaned up when `ValidatedSecrets` is dropped; use `keep_temp_files()` to persist |
 | Rust SDK types | `PathBuf` or `Option<PathBuf>` instead of `String` |
+
+### Secret Encoding (0.19+)
+
+:::caution[Version compatibility]
+Available starting in SecretSpec 0.19.
+:::
+
+`encoding` (0.19+) defines the textual representation stored by providers and
+the cache. It is independent of `as_path`: decoded UTF-8 remains an ordinary
+environment or SDK value, while arbitrary decoded bytes can be materialized to
+a file.
+
+```toml
+[profiles.default]
+# encoding is available in SecretSpec 0.19+
+TEXT_CONFIG = { description = "Encoded text", encoding = "base64" }
+KEYSTORE = { description = "Binary mTLS keystore", encoding = "base64", as_path = true }
+URL_SAFE_KEY = { description = "URL-safe encoded key", encoding = "base64url", as_path = true }
+HEX_KEY = { description = "Hex-encoded key", encoding = "hex", as_path = true }
+```
+
+| Encoding (0.19+) | Written representation | Accepted stored representation |
+|------------------|------------------------|--------------------------------|
+| `base64` | RFC 4648 standard Base64 with padding | Padded or unpadded standard Base64 |
+| `base64url` | RFC 4648 URL-safe Base64 without padding | Padded or unpadded URL-safe Base64 |
+| `hex` | Lowercase RFC 4648 Base16 | Uppercase, lowercase, or mixed-case Base16 |
+
+Exactly one trailing LF or CRLF is accepted so command-captured values work
+without preprocessing. Other whitespace and non-alphabet characters are
+rejected. Without `as_path = true`, decoded bytes must be valid UTF-8.
+
+`secretspec set`, interactive prompts, and generated secrets provide logical
+text; SecretSpec encodes it before writing to a provider or cache. Defaults and
+composed results are already logical and are not transformed. The
+`secretspec import` command copies the stored representation verbatim, avoiding
+double encoding.
 
 ### Secret References
 

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -1683,10 +1683,38 @@ struct SecretSerde {
     reference: Option<NativeAddress>,
     #[serde(skip_serializing_if = "Option::is_none")]
     as_path: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encoding: Option<SecretEncoding>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     secret_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     generate: Option<GenerateConfig>,
+}
+
+/// Text encoding used for a secret's stored representation.
+///
+/// Available since SecretSpec 0.19.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SecretEncoding {
+    /// RFC 4648 Base64. Writes use padding; reads accept padded or unpadded input.
+    Base64,
+    /// RFC 4648 URL- and filename-safe Base64. Writes omit padding; reads
+    /// accept padded or unpadded input.
+    Base64Url,
+    /// RFC 4648 Base16. Writes use lowercase; reads are case-insensitive.
+    Hex,
+}
+
+impl SecretEncoding {
+    /// Stable manifest spelling used in diagnostics.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Base64 => "base64",
+            Self::Base64Url => "base64url",
+            Self::Hex => "hex",
+        }
+    }
 }
 
 /// Configuration for an individual secret.
@@ -1742,6 +1770,13 @@ pub struct Secret {
     /// will contain the path to that file instead of the secret value.
     /// The temporary file will be cleaned up when the resolved secrets are dropped.
     pub as_path: Option<bool>,
+    /// Encoding used for provider and cache storage. Logical values are encoded
+    /// before writes and decoded after reads. Decoded binary values can be
+    /// materialized with `as_path = true`; without `as_path`, the decoded bytes
+    /// must be valid UTF-8.
+    ///
+    /// Available since SecretSpec 0.19.
+    pub encoding: Option<SecretEncoding>,
     /// The type of secret, used for generation (e.g., "password", "hex", "base64", "uuid", "command", "rsa_private_key")
     pub secret_type: Option<String>,
     /// Auto-generation configuration. Either `true` for defaults or a table with options.
@@ -1773,6 +1808,7 @@ impl TryFrom<SecretSerde> for Secret {
             providers: value.providers,
             reference: value.reference,
             as_path: value.as_path,
+            encoding: value.encoding,
             secret_type: value.secret_type,
             generate: value.generate,
         })
@@ -1798,6 +1834,7 @@ impl From<Secret> for SecretSerde {
             providers: value.providers,
             reference: value.reference,
             as_path: value.as_path,
+            encoding: value.encoding,
             secret_type: value.secret_type,
             generate: value.generate,
         }
@@ -1900,11 +1937,12 @@ impl Secret {
             if self.default.is_some()
                 || self.providers.is_some()
                 || self.reference.is_some()
+                || self.encoding.is_some()
                 || self.secret_type.is_some()
                 || self.would_generate()
             {
                 return Err(
-                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `type`, or enabled `generate`"
+                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `encoding`, `type`, or enabled `generate`"
                         .into(),
                 );
             }
@@ -2046,6 +2084,7 @@ impl Secret {
                 .or_else(|| storage_defaults.and_then(|d| d.providers.clone())),
             reference: inherit(current, default, |s| s.reference.clone()),
             as_path: inherit(current, default, |s| s.as_path),
+            encoding: inherit(current, default, |s| s.encoding),
             secret_type: inherit(current, default, |s| s.secret_type.clone()),
             generate: inherit(current, default, |s| s.generate.clone()),
         })
@@ -2947,6 +2986,21 @@ BAD = { description = "bad", composed = "${A}", providers = ["keyring"] }
         .unwrap();
         let error = conflicting.validate().unwrap_err().to_string();
         assert!(error.contains("cannot also set"), "{error}");
+
+        let encoded: Config = toml::from_str(
+            r#"
+[project]
+name = "composed"
+revision = "1.0"
+
+[profiles.default]
+A = { description = "a" }
+BAD = { description = "bad", composed = "${A}", encoding = "base64" }
+"#,
+        )
+        .unwrap();
+        let error = encoded.validate().unwrap_err().to_string();
+        assert!(error.contains("`encoding`"), "{error}");
     }
 
     #[test]
@@ -3310,6 +3364,52 @@ default = "placeholder"
         })
         .unwrap();
         assert!(!toml.contains("ref"));
+    }
+
+    #[test]
+    fn secret_encoding_parses_round_trips_and_inherits() {
+        for (spelling, expected) in [
+            ("base64", SecretEncoding::Base64),
+            ("base64url", SecretEncoding::Base64Url),
+            ("hex", SecretEncoding::Hex),
+        ] {
+            let secret: Secret = toml::from_str(&format!(
+                "description = \"encoded\"\nencoding = \"{spelling}\""
+            ))
+            .unwrap();
+            assert_eq!(secret.encoding, Some(expected));
+            let rendered = toml::to_string(&secret).unwrap();
+            assert!(
+                rendered.contains(&format!("encoding = \"{spelling}\"")),
+                "{rendered}"
+            );
+        }
+
+        let inherited = Secret::resolved(
+            Some(&Secret {
+                description: Some("production".to_string()),
+                ..Default::default()
+            }),
+            Some(&Secret {
+                description: Some("default".to_string()),
+                encoding: Some(SecretEncoding::Base64),
+                ..Default::default()
+            }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(inherited.encoding, Some(SecretEncoding::Base64));
+    }
+
+    #[test]
+    fn secret_encoding_rejects_unknown_name() {
+        let error = toml::from_str::<Secret>(
+            r#"description = "encoded"
+encoding = "rot13""#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("unknown variant `rot13`"), "{error}");
     }
 
     /// All coordinate keys parse from the inline table form.

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -87,6 +87,12 @@ pub enum SecretSpecError {
     ValidationFailed(Box<ValidationErrors>),
     #[error("Secret generation failed: {0}")]
     GenerationFailed(String),
+    #[error("Failed to decode secret '{name}' using {encoding}: {reason}")]
+    DecodeFailed {
+        name: String,
+        encoding: &'static str,
+        reason: String,
+    },
     #[error(
         "Accessing secrets requires a reason. Provide one with --reason \"<why you are accessing \
          these secrets>\", the SECRETSPEC_REASON environment variable, or Secrets::with_reason() in \
@@ -127,6 +133,7 @@ impl SecretSpecError {
             SecretSpecError::InvalidScope(_) => "invalid_scope",
             SecretSpecError::ValidationFailed(_) => "validation_failed",
             SecretSpecError::GenerationFailed(_) => "generation_failed",
+            SecretSpecError::DecodeFailed { .. } => "decode_failed",
             SecretSpecError::ReasonRequired => "reason_required",
         }
     }
@@ -239,6 +246,14 @@ mod tests {
             (
                 SecretSpecError::GenerationFailed("rng".into()),
                 "generation_failed",
+            ),
+            (
+                SecretSpecError::DecodeFailed {
+                    name: "VALUE".into(),
+                    encoding: "base64",
+                    reason: "invalid length".into(),
+                },
+                "decode_failed",
             ),
             (SecretSpecError::ReasonRequired, "reason_required"),
         ];

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -72,7 +72,7 @@ pub use config::{
 
 // Re-export Secret and generation types for secretspec-derive
 #[doc(hidden)]
-pub use config::{GenerateConfig, GenerateOptions, Secret};
+pub use config::{GenerateConfig, GenerateOptions, Secret, SecretEncoding};
 
 // Public API exports
 pub use error::{Result, SecretSpecError};

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -16,7 +16,7 @@
 //! its own authoritative store. A plan never reads or writes a secret.
 
 use crate::composition::Template;
-use crate::config::{NativeAddress, Secret};
+use crate::config::{NativeAddress, Secret, SecretEncoding};
 use crate::error::{Result, SecretSpecError};
 use crate::manifest::CompiledSecret;
 use crate::provider::Address;
@@ -192,6 +192,11 @@ impl PlannedSecret {
     /// Whether the value is materialized to a temp file and exposed as a path.
     pub(crate) fn as_path(&self) -> bool {
         self.secret.config.as_path.unwrap_or(false)
+    }
+
+    /// Optional encoding applied at the storage boundary.
+    pub(crate) fn encoding(&self) -> Option<SecretEncoding> {
+        self.secret.config.encoding
     }
 
     pub(crate) fn is_composed(&self) -> bool {

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -4,7 +4,7 @@ use crate::audit::{AuditAction, AuditContext, AuditLogger, AuditOutcome};
 use crate::cache::{self, CacheEntryStatus, CacheOwnership};
 use crate::config::{
     Config, CredentialSource, GlobalConfig, NativeAddress, Profile, ProviderAlias, RequireReason,
-    Resolved,
+    Resolved, SecretEncoding,
 };
 use crate::error::{Result, SecretSpecError};
 use crate::manifest::{CompiledManifest, MissingPolicy};
@@ -14,7 +14,10 @@ use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
 use crate::validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
 use colored::Colorize;
-use secrecy::{ExposeSecret, SecretString};
+use data_encoding::{
+    BASE64, BASE64_NOPAD, BASE64URL, BASE64URL_NOPAD, Encoding, HEXLOWER, HEXLOWER_PERMISSIVE,
+};
+use secrecy::{ExposeSecret, SecretSlice, SecretString};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryFrom;
 use std::env;
@@ -396,6 +399,25 @@ enum Materialize {
     /// reported as it *would* resolve, without minting it. Backs `report()` and
     /// `resolve_without_values()`.
     None,
+}
+
+/// A logical value in the shape exposed to callers. Inline values remain
+/// secret strings; file-shaped values carry their owner so the caller decides
+/// whether cleanup follows the resolved-value lifetime or the path is kept.
+enum PreparedSecret {
+    Inline(SecretString),
+    File {
+        owner: tempfile::NamedTempFile,
+        path: String,
+    },
+}
+
+/// Whether a resolved string came from a storage boundary and is eligible for
+/// decoding, or is already the logical value produced inside SecretSpec.
+#[derive(Clone, Copy)]
+enum ResolvedRepresentation {
+    Stored,
+    Logical,
 }
 
 /// Walks up from the current directory looking for `secretspec.toml`.
@@ -1355,24 +1377,137 @@ impl Secrets {
         Ok(())
     }
 
-    /// Inserts a resolved secret into the working set, transparently materializing
-    /// an `as_path` secret to an owner-only temp file whose lifetime is tied to
-    /// `temp_files`. Shared by every resolution branch so the temp-file handling
-    /// cannot drift between them.
+    /// Decode a stored textual representation. Exactly one trailing LF or CRLF
+    /// is ignored to accommodate a value captured from command output; every
+    /// other non-alphabet character remains a hard error.
+    fn decode_stored_value(
+        encoding: SecretEncoding,
+        diagnostic_name: &str,
+        value: &SecretString,
+    ) -> Result<SecretSlice<u8>> {
+        let encoded = value
+            .expose_secret()
+            .strip_suffix("\r\n")
+            .or_else(|| value.expose_secret().strip_suffix('\n'))
+            .unwrap_or_else(|| value.expose_secret());
+
+        fn decode_base(
+            encoded: &[u8],
+            padded: &Encoding,
+            unpadded: &Encoding,
+        ) -> std::result::Result<Vec<u8>, String> {
+            if encoded.contains(&b'=') {
+                padded.decode(encoded).map_err(|error| error.to_string())
+            } else {
+                padded
+                    .decode(encoded)
+                    .or_else(|_| unpadded.decode(encoded))
+                    .map_err(|error| error.to_string())
+            }
+        }
+
+        let decoded = match encoding {
+            SecretEncoding::Base64 => decode_base(encoded.as_bytes(), &BASE64, &BASE64_NOPAD),
+            SecretEncoding::Base64Url => {
+                decode_base(encoded.as_bytes(), &BASE64URL, &BASE64URL_NOPAD)
+            }
+            SecretEncoding::Hex => HEXLOWER_PERMISSIVE
+                .decode(encoded.as_bytes())
+                .map_err(|error| error.to_string()),
+        }
+        .map_err(|reason| SecretSpecError::DecodeFailed {
+            name: diagnostic_name.to_string(),
+            encoding: encoding.as_str(),
+            reason,
+        })?;
+
+        Ok(decoded.into())
+    }
+
+    /// Encode a logical UTF-8 value into the canonical stored representation
+    /// for its declared encoding.
+    fn encode_logical_value(encoding: SecretEncoding, value: &SecretString) -> SecretString {
+        let bytes = value.expose_secret().as_bytes();
+        let encoded = match encoding {
+            SecretEncoding::Base64 => BASE64.encode(bytes),
+            SecretEncoding::Base64Url => BASE64URL_NOPAD.encode(bytes),
+            SecretEncoding::Hex => HEXLOWER.encode(bytes),
+        };
+        SecretString::new(encoded.into())
+    }
+
+    /// Return an encoded copy only when this secret declares an encoding. The
+    /// caller can otherwise pass the original value through without cloning it.
+    fn encoded_for_storage(planned: &PlannedSecret, value: &SecretString) -> Option<SecretString> {
+        planned
+            .encoding()
+            .map(|encoding| Self::encode_logical_value(encoding, value))
+    }
+
+    /// Decode a stored representation independently of its exposure shape, then
+    /// either return UTF-8 text or materialize the bytes to an owner-only file.
+    fn prepare_resolved(
+        &self,
+        planned: &PlannedSecret,
+        diagnostic_name: &str,
+        value: SecretString,
+        representation: ResolvedRepresentation,
+    ) -> Result<PreparedSecret> {
+        let decoded = match (representation, planned.encoding()) {
+            (ResolvedRepresentation::Stored, Some(encoding)) => {
+                let value = Self::decode_stored_value(encoding, diagnostic_name, &value)?;
+                Some((encoding, value))
+            }
+            _ => None,
+        };
+
+        if planned.as_path() {
+            let bytes = decoded
+                .as_ref()
+                .map(|(_, decoded)| decoded.expose_secret())
+                .unwrap_or_else(|| value.expose_secret().as_bytes());
+            let (owner, path) = self.write_secret_to_temp_file(bytes)?;
+            Ok(PreparedSecret::File { owner, path })
+        } else if let Some((encoding, decoded)) = decoded {
+            let text = std::str::from_utf8(decoded.expose_secret()).map_err(|error| {
+                SecretSpecError::DecodeFailed {
+                    name: diagnostic_name.to_string(),
+                    encoding: encoding.as_str(),
+                    reason: format!(
+                        "decoded bytes are not valid UTF-8 ({error}); set `as_path = true` to expose binary data"
+                    ),
+                }
+            })?;
+            Ok(PreparedSecret::Inline(SecretString::new(
+                text.to_owned().into(),
+            )))
+        } else {
+            Ok(PreparedSecret::Inline(value))
+        }
+    }
+
+    /// Inserts a resolved secret into the working set, decoding its optional
+    /// storage encoding when the value crossed a storage boundary, then
+    /// transparently materializing an `as_path` value to an owner-only temp
+    /// file whose lifetime is tied to `temp_files`. Shared by every resolution
+    /// branch so decoding and temp-file handling cannot drift.
     fn insert_resolved(
         &self,
         secrets: &mut HashMap<String, SecretString>,
         temp_files: &mut Vec<tempfile::NamedTempFile>,
-        name: String,
+        planned: &PlannedSecret,
+        diagnostic_name: &str,
         value: SecretString,
-        as_path: bool,
+        representation: ResolvedRepresentation,
     ) -> Result<()> {
-        if as_path {
-            let (temp_file, path_str) = self.write_secret_to_temp_file(&value)?;
-            temp_files.push(temp_file);
-            secrets.insert(name, SecretString::new(path_str.into()));
-        } else {
-            secrets.insert(name, value);
+        match self.prepare_resolved(planned, diagnostic_name, value, representation)? {
+            PreparedSecret::Inline(value) => {
+                secrets.insert(planned.name.clone(), value);
+            }
+            PreparedSecret::File { owner, path } => {
+                temp_files.push(owner);
+                secrets.insert(planned.name.clone(), SecretString::new(path.into()));
+            }
         }
         Ok(())
     }
@@ -2723,7 +2858,9 @@ impl Secrets {
             return Err(err);
         }
 
-        let result = backend.set(addr, &value);
+        let encoded_value = Self::encoded_for_storage(&planned, &value);
+        let stored_value = encoded_value.as_ref().unwrap_or(&value);
+        let result = backend.set(addr, stored_value);
         self.audit_write_result(
             &result,
             name,
@@ -2733,7 +2870,7 @@ impl Secrets {
             None,
         );
         result?;
-        self.sync_cache_after_write(&planned, route, &profile_name, &value);
+        self.sync_cache_after_write(&planned, route, &profile_name, stored_value);
 
         eprintln!(
             "{} Secret '{}' saved to {} (profile: {})",
@@ -2898,8 +3035,6 @@ impl Secrets {
             };
         };
         let default = planned.config().default.clone();
-        let as_path = planned.as_path();
-
         // A fresh cache hit completes the read without constructing or
         // contacting any authoritative provider. Misses and invalid entries
         // fall through to the ordinary ordered provider route.
@@ -2972,48 +3107,30 @@ impl Secrets {
             }
         }
 
-        match result?.0 {
-            Some(value) => {
-                if as_path {
-                    // Write to temp file and persist it (don't auto-delete)
-                    let (temp_file, _path_str) = self.write_secret_to_temp_file(&value)?;
-                    let temp_path = temp_file.into_temp_path();
-                    let persisted_path = temp_path.keep().map_err(|e| {
-                        SecretSpecError::Io(io::Error::other(format!(
-                            "Failed to persist temporary file: {}",
-                            e
-                        )))
-                    })?;
-                    println!("{}", persisted_path.display());
-                } else {
-                    // Use expose_secret() to access the actual value for printing
-                    println!("{}", value.expose_secret());
-                }
-                Ok(())
-            }
-            None => {
-                if let Some(default_value) = default {
-                    if as_path {
-                        // Write default value to temp file and persist it
-                        let (temp_file, _) = self
-                            .write_secret_to_temp_file(&SecretString::new(default_value.into()))?;
-                        let temp_path = temp_file.into_temp_path();
-                        let persisted_path = temp_path.keep().map_err(|e| {
-                            SecretSpecError::Io(io::Error::other(format!(
-                                "Failed to persist temporary file: {}",
-                                e
-                            )))
-                        })?;
-                        println!("{}", persisted_path.display());
-                    } else {
-                        println!("{}", default_value);
-                    }
-                    Ok(())
-                } else {
-                    Err(SecretSpecError::SecretNotFound(name.to_string()))
-                }
+        let (value, representation) = match result?.0 {
+            Some(value) => (value, ResolvedRepresentation::Stored),
+            None => (
+                default
+                    .map(|value| SecretString::new(value.into()))
+                    .ok_or_else(|| SecretSpecError::SecretNotFound(name.to_string()))?,
+                ResolvedRepresentation::Logical,
+            ),
+        };
+        match self.prepare_resolved(&planned, name, value, representation)? {
+            PreparedSecret::Inline(value) => println!("{}", value.expose_secret()),
+            PreparedSecret::File { owner, .. } => {
+                // `get` prints a path for use after this process exits, so unlike
+                // SDK resolution it deliberately persists the backing file.
+                let temp_path = owner.into_temp_path();
+                let persisted_path = temp_path.keep().map_err(|error| {
+                    SecretSpecError::Io(io::Error::other(format!(
+                        "Failed to persist temporary file: {error}"
+                    )))
+                })?;
+                println!("{}", persisted_path.display());
             }
         }
+        Ok(())
     }
 
     /// Ensures all required secrets are present, optionally prompting for missing ones
@@ -3126,9 +3243,11 @@ impl Secrets {
                                 .expect("prompted names are provider-backed leaves");
                             let backend =
                                 self.write_provider_for_route(route, Some(&profile_display))?;
+                            let encoded_value = Self::encoded_for_storage(&planned, &value);
+                            let stored_value = encoded_value.as_ref().unwrap_or(&value);
                             let set_result = backend.set(
                                 planned.as_address(&self.config.project.name, &profile_display),
-                                &value,
+                                stored_value,
                             );
                             self.audit_write_result(
                                 &set_result,
@@ -3139,7 +3258,12 @@ impl Secrets {
                                 None,
                             );
                             set_result?;
-                            self.sync_cache_after_write(&planned, route, &profile_display, &value);
+                            self.sync_cache_after_write(
+                                &planned,
+                                route,
+                                &profile_display,
+                                stored_value,
+                            );
                             eprintln!(
                                 "{} Secret '{}' saved to {} (profile: {})",
                                 "✓".green(),
@@ -3705,7 +3829,9 @@ impl Secrets {
         // The provider states why a write is refused; wrapping it here would
         // only nest a second "Provider operation failed" prefix.
         backend.check_writable(addr)?;
-        let set_result = backend.set(addr, &value);
+        let encoded_value = Self::encoded_for_storage(planned, &value);
+        let stored_value = encoded_value.as_ref().unwrap_or(&value);
+        let set_result = backend.set(addr, stored_value);
         // Generating a secret writes a brand-new value to the provider; record it
         // like any other write so the audit log captures every stored secret.
         self.audit_write_result(
@@ -3724,7 +3850,7 @@ impl Secrets {
                 .as_ref()
                 .expect("a generating secret is provider-backed"),
             profile_name,
-            &value,
+            stored_value,
         );
 
         eprintln!(
@@ -3738,11 +3864,11 @@ impl Secrets {
         Ok(Some(value))
     }
 
-    /// Writes a secret value to a temporary file and returns the file handle and path
+    /// Writes secret bytes to a temporary file and returns the file handle and path
     ///
     /// # Arguments
     ///
-    /// * `secret` - The secret value to write
+    /// * `secret` - The secret bytes to write
     ///
     /// # Returns
     ///
@@ -3753,15 +3879,13 @@ impl Secrets {
     /// Returns an error if the temporary file cannot be created or written to
     fn write_secret_to_temp_file(
         &self,
-        secret: &SecretString,
+        secret: &[u8],
     ) -> Result<(tempfile::NamedTempFile, String)> {
         use std::io::Write;
 
         let mut temp_file = tempfile::NamedTempFile::new().map_err(SecretSpecError::Io)?;
 
-        temp_file
-            .write_all(secret.expose_secret().as_bytes())
-            .map_err(SecretSpecError::Io)?;
+        temp_file.write_all(secret).map_err(SecretSpecError::Io)?;
 
         // Flush to ensure the data is written
         temp_file.flush().map_err(SecretSpecError::Io)?;
@@ -4470,6 +4594,7 @@ impl Secrets {
             let name = &planned.name;
             let required = planned.required();
             let as_path = planned.as_path();
+            let diagnostic_name = Self::diagnostic_secret_name(name, output_filter);
             // The group key (primary spec), matching how `group_uris` and
             // `failed_primary_uris` were keyed from `plan.groups()` above.
             let primary_uri = route.group_key();
@@ -4495,9 +4620,10 @@ impl Secrets {
                         self.insert_resolved(
                             &mut secrets,
                             &mut temp_files,
-                            name.clone(),
+                            planned,
+                            diagnostic_name,
                             value,
-                            as_path,
+                            ResolvedRepresentation::Stored,
                         )?;
                     }
                     status = ResolutionStatus::Resolved;
@@ -4544,9 +4670,10 @@ impl Secrets {
                             self.insert_resolved(
                                 &mut secrets,
                                 &mut temp_files,
-                                name.clone(),
+                                planned,
+                                diagnostic_name,
                                 value,
-                                as_path,
+                                ResolvedRepresentation::Stored,
                             )?;
                         }
                         status = ResolutionStatus::Resolved;
@@ -4564,9 +4691,10 @@ impl Secrets {
                                     self.insert_resolved(
                                         &mut secrets,
                                         &mut temp_files,
-                                        name.clone(),
+                                        planned,
+                                        diagnostic_name,
                                         generated_value,
-                                        as_path,
+                                        ResolvedRepresentation::Logical,
                                     )?;
                                 }
                                 status = ResolutionStatus::Resolved;
@@ -4582,9 +4710,10 @@ impl Secrets {
                                     self.insert_resolved(
                                         &mut secrets,
                                         &mut temp_files,
-                                        name.clone(),
+                                        planned,
+                                        diagnostic_name,
                                         SecretString::new(default_value.clone().into()),
-                                        as_path,
+                                        ResolvedRepresentation::Logical,
                                     )?;
                                     with_defaults.push((name.clone(), default_value.clone()));
                                 }
@@ -4676,9 +4805,10 @@ impl Secrets {
                         self.insert_resolved(
                             &mut secrets,
                             &mut temp_files,
-                            planned.name.clone(),
+                            planned,
+                            Self::diagnostic_secret_name(&planned.name, output_filter),
                             SecretString::new(rendered.into()),
-                            planned.as_path(),
+                            ResolvedRepresentation::Logical,
                         )?;
                     }
                     ResolutionStatus::Resolved
@@ -5771,6 +5901,41 @@ mod config_discovery_tests {
             "../ relative path: {:?}",
             from_parent.err()
         );
+    }
+}
+
+#[cfg(test)]
+mod encoding_tests {
+    use super::*;
+
+    #[test]
+    fn decoding_accepts_exactly_one_trailing_line_ending() {
+        for encoded in ["Zg==\n", "Zg==\r\n"] {
+            let value = SecretString::new(encoded.to_string().into());
+            let decoded =
+                Secrets::decode_stored_value(SecretEncoding::Base64, "VALUE", &value).unwrap();
+            assert_eq!(decoded.expose_secret(), b"f");
+        }
+
+        let value = SecretString::new("Zg==\n\n".to_string().into());
+        let error =
+            Secrets::decode_stored_value(SecretEncoding::Base64, "VALUE", &value).unwrap_err();
+        assert_eq!(error.kind(), "decode_failed");
+    }
+
+    #[test]
+    fn encoding_uses_canonical_storage_representations() {
+        let cases = [
+            (SecretEncoding::Base64, "value", "dmFsdWU="),
+            (SecretEncoding::Base64Url, "hello?", "aGVsbG8_"),
+            (SecretEncoding::Hex, "value", "76616c7565"),
+        ];
+
+        for (encoding, logical, expected) in cases {
+            let logical = SecretString::new(logical.to_string().into());
+            let stored = Secrets::encode_logical_value(encoding, &logical);
+            assert_eq!(stored.expose_secret(), expected);
+        }
     }
 }
 

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -4817,6 +4817,266 @@ CERT_DATA = { description = "Certificate data", as_path = true }
     fs::remove_file(&cert_path).unwrap();
 }
 
+#[test]
+fn test_secret_encodings_are_independent_of_as_path() {
+    use secrecy::ExposeSecret;
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let env_file = temp_dir.path().join(".env");
+    fs::write(
+        &env_file,
+        concat!(
+            "BASE64_FILE=AP9LUw==\n",
+            "BASE64URL_FILE=-_8\n",
+            "HEX_FILE=00fF4b53\n",
+            "BASE64_TEXT=ZGVjb2RlZA\n",
+        ),
+    )
+    .unwrap();
+
+    let config_file = temp_dir.path().join("secretspec.toml");
+    fs::write(
+        &config_file,
+        r#"[project]
+name = "test-encoding-read"
+revision = "1.0"
+
+[profiles.default]
+BASE64_FILE = { description = "standard base64", encoding = "base64", as_path = true }
+BASE64URL_FILE = { description = "URL-safe base64", encoding = "base64url", as_path = true }
+HEX_FILE = { description = "mixed-case hex", encoding = "hex", as_path = true }
+BASE64_TEXT = { description = "decoded text", encoding = "base64" }
+DEFAULT_TEXT = { description = "logical default", encoding = "hex", default = "default" }
+"#,
+    )
+    .unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", env_file.display())),
+            profile: None,
+            providers: None,
+        },
+        audit: None,
+    };
+    let spec = Secrets::new(config, Some(global_config), None, None);
+    let validated = spec.validate().unwrap().unwrap();
+
+    assert_eq!(
+        validated.resolved.secrets["BASE64_TEXT"].expose_secret(),
+        "decoded"
+    );
+    assert_eq!(
+        validated.resolved.secrets["DEFAULT_TEXT"].expose_secret(),
+        "default"
+    );
+
+    for (name, expected) in [
+        ("BASE64_FILE", &[0x00, 0xff, b'K', b'S'][..]),
+        ("BASE64URL_FILE", &[0xfb, 0xff][..]),
+        ("HEX_FILE", &[0x00, 0xff, b'K', b'S'][..]),
+    ] {
+        let path = validated.resolved.secrets[name].expose_secret();
+        assert_eq!(fs::read(path).unwrap(), expected, "{name}");
+    }
+}
+
+#[test]
+fn test_set_encodes_logical_values_before_storage() {
+    use secrecy::ExposeSecret;
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let env_file = temp_dir.path().join(".env");
+    let config_file = temp_dir.path().join("secretspec.toml");
+    fs::write(
+        &config_file,
+        r#"[project]
+name = "test-encode-on-set"
+revision = "1.0"
+
+[profiles.default]
+BASE64_TEXT = { description = "standard base64", encoding = "base64" }
+BASE64URL_TEXT = { description = "URL-safe base64", encoding = "base64url" }
+HEX_TEXT = { description = "lowercase hex", encoding = "hex" }
+"#,
+    )
+    .unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", env_file.display())),
+            profile: None,
+            providers: None,
+        },
+        audit: None,
+    };
+    let spec = Secrets::new(config, Some(global_config), None, None);
+
+    spec.set("BASE64_TEXT", Some("value".to_string())).unwrap();
+    spec.set("BASE64URL_TEXT", Some("hello?".to_string()))
+        .unwrap();
+    spec.set("HEX_TEXT", Some("value".to_string())).unwrap();
+
+    let stored = fs::read_to_string(&env_file).unwrap();
+    let stored_value = |name: &str| {
+        stored
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{name}=")))
+            .map(|value| value.trim_matches('"'))
+            .unwrap_or_else(|| panic!("{name} missing from {stored}"))
+    };
+    assert_eq!(stored_value("BASE64_TEXT"), "dmFsdWU=");
+    assert_eq!(stored_value("BASE64URL_TEXT"), "aGVsbG8_");
+    assert_eq!(stored_value("HEX_TEXT"), "76616c7565");
+
+    let validated = spec.validate().unwrap().unwrap();
+    assert_eq!(
+        validated.resolved.secrets["BASE64_TEXT"].expose_secret(),
+        "value"
+    );
+    assert_eq!(
+        validated.resolved.secrets["BASE64URL_TEXT"].expose_secret(),
+        "hello?"
+    );
+    assert_eq!(
+        validated.resolved.secrets["HEX_TEXT"].expose_secret(),
+        "value"
+    );
+}
+
+#[test]
+fn test_import_copies_encoded_storage_without_double_encoding() {
+    use secrecy::ExposeSecret;
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let source_file = temp_dir.path().join("source.env");
+    let target_file = temp_dir.path().join("target.env");
+    fs::write(&source_file, "VALUE=dmFsdWU=\n").unwrap();
+    let config_file = temp_dir.path().join("secretspec.toml");
+    fs::write(
+        &config_file,
+        r#"[project]
+name = "test-encoded-import"
+revision = "1.0"
+
+[profiles.default]
+VALUE = { description = "encoded value", encoding = "base64" }
+"#,
+    )
+    .unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", target_file.display())),
+            profile: None,
+            providers: None,
+        },
+        audit: None,
+    };
+    let spec = Secrets::new(config, Some(global_config), None, None);
+
+    spec.import(&format!("dotenv://{}", source_file.display()))
+        .unwrap();
+    let stored = fs::read_to_string(&target_file).unwrap();
+    let stored_value = stored
+        .lines()
+        .find_map(|line| line.strip_prefix("VALUE="))
+        .map(|value| value.trim_matches('"'))
+        .expect("imported value should be stored");
+    assert_eq!(stored_value, "dmFsdWU=");
+    assert_ne!(stored_value, "ZG1Gc2RXVT0=");
+
+    let validated = spec.validate().unwrap().unwrap();
+    assert_eq!(validated.resolved.secrets["VALUE"].expose_secret(), "value");
+}
+
+#[test]
+fn test_secret_encoding_rejects_invalid_input_without_exposing_it() {
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let env_file = temp_dir.path().join(".env");
+    fs::write(&env_file, "BAD=%%%\n").unwrap();
+    let config_file = temp_dir.path().join("secretspec.toml");
+    fs::write(
+        &config_file,
+        r#"[project]
+name = "test-invalid-encoding"
+revision = "1.0"
+
+[profiles.default]
+BAD = { description = "invalid base64", encoding = "base64" }
+"#,
+    )
+    .unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", env_file.display())),
+            profile: None,
+            providers: None,
+        },
+        audit: None,
+    };
+    let error = Secrets::new(config, Some(global_config), None, None)
+        .validate()
+        .err()
+        .expect("invalid base64 should fail resolution");
+    assert_eq!(error.kind(), "decode_failed");
+    assert!(
+        error
+            .to_string()
+            .contains("decode secret 'BAD' using base64")
+    );
+    assert!(!error.to_string().contains("%%%"));
+}
+
+#[test]
+fn test_binary_decoded_secret_requires_as_path() {
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let env_file = temp_dir.path().join(".env");
+    fs::write(&env_file, "BINARY=/w==\n").unwrap();
+    let config_file = temp_dir.path().join("secretspec.toml");
+    fs::write(
+        &config_file,
+        r#"[project]
+name = "test-binary-encoding"
+revision = "1.0"
+
+[profiles.default]
+BINARY = { description = "binary value", encoding = "base64" }
+"#,
+    )
+    .unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", env_file.display())),
+            profile: None,
+            providers: None,
+        },
+        audit: None,
+    };
+    let error = Secrets::new(config, Some(global_config), None, None)
+        .validate()
+        .err()
+        .expect("binary inline output should fail resolution");
+    assert_eq!(error.kind(), "decode_failed");
+    assert!(error.to_string().contains("not valid UTF-8"));
+    assert!(error.to_string().contains("set `as_path = true`"));
+    assert!(!error.to_string().contains("/w=="));
+}
+
 #[cfg(unix)]
 #[test]
 fn test_run_cleans_up_as_path_temp_files() {
@@ -5100,6 +5360,60 @@ DB_PASSWORD = { description = "Database password", type = "password", generate =
     assert!(
         s.chars().all(|c| c.is_alphanumeric()),
         "Default password should be alphanumeric"
+    );
+}
+
+#[test]
+fn test_generation_returns_logical_value_and_stores_encoded_value() {
+    use secrecy::ExposeSecret;
+
+    let temp_dir = TempDir::new().unwrap();
+    let env_file = temp_dir.path().join(".env");
+    fs::write(&env_file, "").unwrap();
+
+    let config_file = temp_dir.path().join("secretspec.toml");
+    let toml_content = r#"[project]
+name = "test-gen-encoding"
+revision = "1.0"
+
+[profiles.default]
+DB_PASSWORD = { description = "Database password", type = "password", generate = true, encoding = "base64" }
+"#;
+    fs::write(&config_file, toml_content).unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: Some(format!("dotenv://{}", env_file.display())),
+            profile: None,
+            providers: None,
+        },
+        audit: None,
+    };
+
+    let spec = Secrets::new(config.clone(), Some(global_config.clone()), None, None);
+    let validated = spec.validate().unwrap().unwrap();
+    let logical = validated.resolved.secrets["DB_PASSWORD"]
+        .expose_secret()
+        .to_string();
+
+    let contents = fs::read_to_string(&env_file).unwrap();
+    let stored = contents
+        .lines()
+        .find_map(|line| line.strip_prefix("DB_PASSWORD="))
+        .map(|value| value.trim_matches('"'))
+        .expect("generated secret should be stored");
+    let decoded = data_encoding::BASE64.decode(stored.as_bytes()).unwrap();
+    assert_eq!(decoded, logical.as_bytes());
+    assert_ne!(stored, logical);
+
+    let reloaded = Secrets::new(config, Some(global_config), None, None)
+        .validate()
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        reloaded.resolved.secrets["DB_PASSWORD"].expose_secret(),
+        logical
     );
 }
 
@@ -5393,6 +5707,7 @@ fn test_resolve_secret_config_merges_type_and_generate() {
             providers: None,
             reference: None,
             as_path: None,
+            encoding: None,
             secret_type: Some("password".to_string()),
             generate: Some(crate::config::GenerateConfig::Bool(true)),
         },


### PR DESCRIPTION
## Summary

- add an `encoding` secret option with `base64`, `base64url`, and `hex`
- encode logical values from `set`, interactive prompts, and generation before provider and cache writes
- decode provider and cache values after reads, independently of `as_path`
- keep defaults and composed values logical, while imports copy stored representations without double encoding
- document the 0.19+ configuration and add non-sensitive decode diagnostics

## Why

Binary secrets such as mTLS keystores are commonly stored as Base64 text, but `as_path` previously wrote that encoded text verbatim. Storage representation and exposure shape had no independent transformation boundary, forcing users to decode files in shell hooks.

`encoding` makes the provider boundary symmetric: SecretSpec encodes logical text when it writes and decodes stored text when it reads. `as_path` remains responsible only for whether the logical bytes are exposed inline or materialized in an owner-only file.

Closes #277.

## User impact

Users can configure one storage encoding and continue passing logical text to SecretSpec write commands. Decoded UTF-8 remains available as an ordinary environment or SDK value, while arbitrary decoded bytes can be exposed with `as_path = true`.

## Validation

- pre-commit Clippy and rustfmt hooks
- `cargo test --all --quiet`
- `npm --prefix docs run build`
- `git diff --check`
