### PR TITLE
Fix Azure Key Vault fallback resolution performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client and serialize its initial challenge-based authentication, so chains
   such as `providers = ["keyring", "akv"]` no longer fetch every fallback in
   series or launch separate Azure CLI processes for the same resolution.
+- Reusing a `Secrets` instance now refreshes fallback providers for each
+  resolution, so provider-side caches observe rotated values and providers use
+  the latest reason supplied with `with_reason`.
 
 ## [0.18.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   at a new template invalidates its cached values instead of serving the old
   ones until they expire. Single-segment templates are unaffected; cached
   entries for a multi-segment template refetch once, silently, on first run.
+- Provider fallback chains now reuse each provider and resolve independent
+  primary misses concurrently. Azure Key Vault providers also reuse their
+  client and serialize its initial challenge-based authentication, so chains
+  such as `providers = ["keyring", "akv"]` no longer fetch every fallback in
+  series or launch separate Azure CLI processes for the same resolution.
 
 ## [0.18.0] - 2026-08-03
 

--- a/secretspec/src/provider/akv.rs
+++ b/secretspec/src/provider/akv.rs
@@ -74,7 +74,48 @@ use azure_security_keyvault_secrets::{SecretClient, models::SetSecretParameters}
 use data_encoding::BASE32_NOPAD;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::sync::{
+    Arc, Mutex, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
+
+/// Serializes a client's first request while Azure Key Vault discovers its
+/// authentication scope through a 401 challenge.
+///
+/// The Azure bearer-token policy caches tokens with single-flight refreshes,
+/// but the scope starts empty. If a cold client sends a batch concurrently,
+/// every request first receives a 401 and can invalidate a token another
+/// request just acquired, spawning the Azure CLI more than once. Once one
+/// request completes successfully, the client has both its scope and token and
+/// later requests can safely fan out.
+#[derive(Default)]
+struct InitialRequestGate {
+    ready: AtomicBool,
+    lock: Mutex<()>,
+}
+
+impl InitialRequestGate {
+    fn run<T, F>(&self, request: F) -> Result<T>
+    where
+        F: FnOnce() -> Result<T>,
+    {
+        if self.ready.load(Ordering::Acquire) {
+            return request();
+        }
+
+        let guard = self.lock.lock().unwrap();
+        if self.ready.load(Ordering::Acquire) {
+            drop(guard);
+            return request();
+        }
+
+        let result = request();
+        if result.is_ok() {
+            self.ready.store(true, Ordering::Release);
+        }
+        result
+    }
+}
 
 /// Authentication method for the Azure Key Vault provider.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -206,6 +247,14 @@ pub struct AkvProvider {
     config: AkvConfig,
     /// Service-principal credentials supplied by the provider alias.
     credentials: ProviderCredentials,
+    /// One client per provider, so a batch shares the credential's token cache
+    /// instead of authenticating per secret. Every `DeveloperToolsCredential`
+    /// starts with an empty cache, and under `auth=cli` filling it spawns the
+    /// Azure CLI.
+    client: OnceLock<SecretClient>,
+    /// Keeps a cold client's challenge-based authentication to one request, so
+    /// a concurrent batch cannot launch several Azure CLI processes.
+    initial_request: InitialRequestGate,
 }
 
 const TENANT_ID: &str = "tenant_id";
@@ -231,6 +280,8 @@ impl AkvProvider {
         Self {
             config,
             credentials: ProviderCredentials::new(),
+            client: OnceLock::new(),
+            initial_request: InitialRequestGate::default(),
         }
     }
 
@@ -444,6 +495,18 @@ impl AkvProvider {
         })
     }
 
+    /// Returns the shared client, building it on first use.
+    ///
+    /// Concurrent callers may each build one and discard all but the first,
+    /// which costs an extra construction rather than being incorrect.
+    fn client(&self) -> Result<&SecretClient> {
+        if let Some(client) = self.client.get() {
+            return Ok(client);
+        }
+        let created = self.create_client()?;
+        Ok(self.client.get_or_init(|| created))
+    }
+
     /// Checks whether an error indicates the secret was not found, via the
     /// typed HTTP status code rather than string-matching the error's
     /// `Display` output (a genuine 404's message is the service's plain-text
@@ -456,7 +519,7 @@ impl AkvProvider {
 
     /// Retrieves a secret's current value by name, mapping "not found" to `None`.
     async fn get_secret_async(&self, name: &str) -> Result<Option<SecretString>> {
-        let client = self.create_client()?;
+        let client = self.client()?;
         match client.get_secret(name, None).await {
             Ok(response) => {
                 let secret = response.into_model().map_err(|e| {
@@ -486,7 +549,7 @@ impl AkvProvider {
     /// creates a new version if the secret already exists, so create and
     /// update share this one call.
     async fn set_secret_async(&self, name: &str, value: &SecretString) -> Result<()> {
-        let client = self.create_client()?;
+        let client = self.client()?;
         let params = SetSecretParameters {
             value: Some(value.expose_secret().to_string()),
             ..Default::default()
@@ -556,13 +619,15 @@ impl Provider for AkvProvider {
 
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         let item = self.resolve_item(addr)?;
-        super::block_on(self.get_secret_async(&item))
+        self.initial_request
+            .run(|| super::block_on(self.get_secret_async(&item)))
     }
 
     fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
         self.check_writable(addr)?;
         let item = self.resolve_item(addr)?;
-        super::block_on(self.set_secret_async(&item, value))
+        self.initial_request
+            .run(|| super::block_on(self.set_secret_async(&item, value)))
     }
 
     /// Native addresses are read-only: they name a secret managed outside
@@ -582,6 +647,11 @@ mod tests {
     use super::*;
     use crate::tests::EnvVarGuard;
     use azure_core::error::ErrorKind;
+    use std::sync::{
+        Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::{thread, time::Duration};
     use url::Url;
 
     fn config(s: &str) -> AkvConfig {
@@ -598,6 +668,67 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    #[test]
+    fn initial_request_gate_allows_only_one_cold_request() {
+        const CALLERS: usize = 8;
+        let gate = Arc::new(InitialRequestGate::default());
+        let start = Arc::new(Barrier::new(CALLERS));
+        let first_finished = Arc::new(AtomicBool::new(false));
+        let cold_requests = Arc::new(AtomicUsize::new(0));
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let threads: Vec<_> = (0..CALLERS)
+            .map(|_| {
+                let gate = Arc::clone(&gate);
+                let start = Arc::clone(&start);
+                let first_finished = Arc::clone(&first_finished);
+                let cold_requests = Arc::clone(&cold_requests);
+                let active = Arc::clone(&active);
+                let peak = Arc::clone(&peak);
+                thread::spawn(move || {
+                    start.wait();
+                    gate.run(|| {
+                        if !first_finished.load(Ordering::SeqCst) {
+                            cold_requests.fetch_add(1, Ordering::SeqCst);
+                        }
+                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak.fetch_max(current, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(30));
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        first_finished.store(true, Ordering::SeqCst);
+                        Ok(())
+                    })
+                })
+            })
+            .collect();
+
+        for thread in threads {
+            thread.join().unwrap().unwrap();
+        }
+        assert_eq!(cold_requests.load(Ordering::SeqCst), 1);
+        assert!(
+            peak.load(Ordering::SeqCst) >= 2,
+            "requests stayed serialized after the client was warm"
+        );
+        assert!(gate.ready.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn initial_request_gate_retries_after_failure() {
+        let gate = InitialRequestGate::default();
+        let failed = gate.run(|| {
+            Err::<(), _>(SecretSpecError::ProviderOperationFailed(
+                "authentication unavailable".into(),
+            ))
+        });
+        assert!(failed.is_err());
+        assert!(!gate.ready.load(Ordering::Acquire));
+
+        assert!(gate.run(|| Ok(())).is_ok());
+        assert!(gate.ready.load(Ordering::Acquire));
     }
 
     #[test]

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -974,6 +974,36 @@ pub(crate) fn get_each_concurrency() -> usize {
         .unwrap_or(DEFAULT_GET_EACH_CONCURRENCY)
 }
 
+/// Applies `map` in bounded, thread-scoped waves while preserving input order.
+///
+/// Shared by provider batch reads and higher-level fallback-chain reads so both
+/// honor [`GET_EACH_CONCURRENCY_ENV`] without an additional thread-pool
+/// dependency.
+pub(crate) fn map_concurrently<T, R, F>(items: &[T], concurrency: usize, map: F) -> Vec<R>
+where
+    T: Sync,
+    R: Send,
+    F: Fn(&T) -> R + Sync,
+{
+    let concurrency = concurrency.max(1);
+    if items.len() <= 1 || concurrency == 1 {
+        return items.iter().map(map).collect();
+    }
+
+    let mut mapped = Vec::with_capacity(items.len());
+    for chunk in items.chunks(concurrency) {
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = chunk.iter().map(|item| scope.spawn(|| map(item))).collect();
+            mapped.extend(
+                handles
+                    .into_iter()
+                    .map(|handle| handle.join().expect("concurrent map thread panicked")),
+            );
+        });
+    }
+    mapped
+}
+
 /// Shared fallback used by the default [`Provider::get_many`] and by batch
 /// overrides for the part of a request set their bulk surface cannot serve:
 /// deduplicates identical addresses and fetches each unique address once,
@@ -1006,39 +1036,12 @@ where
     let groups: Vec<(Address<'_>, Vec<&str>)> = groups.into_iter().collect();
 
     // One address is the common case (a single secret, or several sharing a
-    // `ref`); fetching it on this thread skips the scope and the spawn.
-    let fetched: Vec<(Vec<&str>, Result<Option<SecretString>>)> = if groups.len() <= 1 {
-        groups
-            .into_iter()
-            .map(|(addr, names)| (names, fetch(addr)))
-            .collect()
-    } else {
-        let concurrency = get_each_concurrency();
-        let mut fetched = Vec::with_capacity(groups.len());
-        // Wave-based fan-out: never more than `concurrency` in-flight gets.
-        // A single unbounded `thread::scope` over dozens of addresses has been
-        // observed to open one TCP(+TLS) handshake per secret against a
-        // reverse-proxied Vault/OpenBao and lose part of the burst.
-        for chunk in groups.chunks(concurrency) {
-            std::thread::scope(|scope| {
-                let handles: Vec<_> = chunk
-                    .iter()
-                    .map(|(addr, names)| {
-                        let addr = *addr;
-                        let fetch = &fetch;
-                        (names, scope.spawn(move || fetch(addr)))
-                    })
-                    .collect();
-                for (names, handle) in handles {
-                    fetched.push((
-                        names.clone(),
-                        handle.join().expect("get_many fetch thread panicked"),
-                    ));
-                }
-            });
-        }
-        fetched
-    };
+    // `ref`); `map_concurrently` keeps it on this thread. Larger sets fan out in
+    // capped waves so they do not stampede a provider.
+    let fetched: Vec<(Vec<&str>, Result<Option<SecretString>>)> =
+        map_concurrently(&groups, get_each_concurrency(), |(addr, names)| {
+            (names.clone(), fetch(*addr))
+        });
 
     let mut results = HashMap::new();
     for (names, result) in fetched {

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -290,6 +290,104 @@ impl Provider for SlowTestProvider {
     }
 }
 
+/// Registered in-memory provider whose first read snapshots [`MEM_STORE`].
+///
+/// This models providers such as BWS that cache a remote listing on the provider
+/// instance: sharing one instance within a resolution is desirable, but reusing
+/// it for a later resolution would return stale secret data. Reads also record
+/// the session reason so tests can verify rebuilt providers receive reason
+/// changes made between operations.
+pub(crate) struct StatefulTestProvider {
+    snapshot: std::sync::OnceLock<HashMap<String, String>>,
+    reason: Mutex<Option<String>>,
+}
+pub(crate) struct StatefulTestConfig;
+
+static STATEFUL_REASON_READS: std::sync::LazyLock<Mutex<HashMap<String, Vec<Option<String>>>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+impl TryFrom<&super::ProviderUrl> for StatefulTestConfig {
+    type Error = crate::SecretSpecError;
+
+    fn try_from(_url: &super::ProviderUrl) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
+impl StatefulTestProvider {
+    fn new(_config: StatefulTestConfig) -> Self {
+        Self {
+            snapshot: std::sync::OnceLock::new(),
+            reason: Mutex::new(None),
+        }
+    }
+}
+
+crate::register_provider! {
+    struct: StatefulTestProvider,
+    config: StatefulTestConfig,
+    name: "statefultest",
+    description: "Stateful in-memory provider for provider-lifetime tests",
+    schemes: ["statefultest"],
+    examples: ["statefultest://"],
+    deletes: true,
+}
+
+impl Provider for StatefulTestProvider {
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        MemTestProvider.convention_address(project, profile, key)
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let item = super::flat_item(self, addr)?.into_owned();
+        STATEFUL_REASON_READS
+            .lock()
+            .unwrap()
+            .entry(item.clone())
+            .or_default()
+            .push(self.reason.lock().unwrap().clone());
+        let snapshot = self
+            .snapshot
+            .get_or_init(|| MEM_STORE.lock().unwrap().clone());
+        Ok(snapshot
+            .get(&item)
+            .map(|value| SecretString::new(value.clone().into())))
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        MemTestProvider.set(addr, value)
+    }
+
+    fn delete(&self, addr: Address<'_>) -> Result<bool> {
+        MemTestProvider.delete(addr)
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        "statefultest://".to_string()
+    }
+
+    fn set_reason(&self, reason: Option<String>) {
+        *self.reason.lock().unwrap() = reason;
+    }
+}
+
+pub(crate) fn take_stateful_reason_reads(item: &str) -> Vec<Option<String>> {
+    STATEFUL_REASON_READS
+        .lock()
+        .unwrap()
+        .remove(item)
+        .unwrap_or_default()
+}
+
 /// Registered provider that reads and deletes [`MEM_STORE`] like `memtest://`
 /// but always fails to write (`failwrite://`).
 ///

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -207,6 +207,89 @@ impl Provider for MemTestProvider {
     }
 }
 
+/// Peak in-flight reads for [`SlowTestProvider`], used to prove fallback-chain
+/// resolution shares the provider and fans reads out under the configured cap.
+static SLOW_CURRENT: AtomicUsize = AtomicUsize::new(0);
+static SLOW_PEAK: AtomicUsize = AtomicUsize::new(0);
+
+pub(crate) fn reset_slow_peak() {
+    SLOW_CURRENT.store(0, Ordering::SeqCst);
+    SLOW_PEAK.store(0, Ordering::SeqCst);
+}
+
+pub(crate) fn slow_peak() -> usize {
+    SLOW_PEAK.load(Ordering::SeqCst)
+}
+
+/// Registered in-memory provider whose reads pause long enough for fallback
+/// concurrency to be observed (`slowtest://`).
+pub(crate) struct SlowTestProvider;
+pub(crate) struct SlowTestConfig;
+
+impl TryFrom<&super::ProviderUrl> for SlowTestConfig {
+    type Error = crate::SecretSpecError;
+
+    fn try_from(_url: &super::ProviderUrl) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
+impl SlowTestProvider {
+    fn new(_config: SlowTestConfig) -> Self {
+        Self
+    }
+}
+
+crate::register_provider! {
+    struct: SlowTestProvider,
+    config: SlowTestConfig,
+    name: "slowtest",
+    description: "Slow in-memory provider for fallback concurrency tests",
+    schemes: ["slowtest"],
+    examples: ["slowtest://"],
+    deletes: true,
+}
+
+impl Provider for SlowTestProvider {
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        MemTestProvider.convention_address(project, profile, key)
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let item = super::flat_item(self, addr)?.into_owned();
+        let current = SLOW_CURRENT.fetch_add(1, Ordering::SeqCst) + 1;
+        SLOW_PEAK.fetch_max(current, Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(50));
+        SLOW_CURRENT.fetch_sub(1, Ordering::SeqCst);
+        Ok(MEM_STORE
+            .lock()
+            .unwrap()
+            .get(&item)
+            .map(|value| SecretString::new(value.clone().into())))
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        MemTestProvider.set(addr, value)
+    }
+
+    fn delete(&self, addr: Address<'_>) -> Result<bool> {
+        MemTestProvider.delete(addr)
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        "slowtest://".to_string()
+    }
+}
+
 /// Registered provider that reads and deletes [`MEM_STORE`] like `memtest://`
 /// but always fails to write (`failwrite://`).
 ///

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -235,11 +235,14 @@ impl CredentialSource {
 
 type ProviderCredentialsKey = (String, String);
 type ProviderCredentialsSlot = Arc<Mutex<Option<ProviderCredentials>>>;
+type ProviderKey = (String, String);
+type ProviderSlot = Arc<Mutex<Option<Arc<dyn ProviderTrait>>>>;
 type GroupFetch<'a> = (
     Option<&'a str>,
     Vec<&'a PlannedSecret>,
     Box<dyn ProviderTrait>,
 );
+type FallbackReadResult = Result<(Option<SecretString>, Option<String>)>;
 
 /// Memoized provider credentials with single-flight population per key.
 ///
@@ -282,6 +285,67 @@ impl ProviderCredentialsCache {
             Err(err) => {
                 // Do not memoize failures: a later operation may succeed after
                 // credentials or provider availability change.
+                drop(cached);
+                let mut entries = self.entries.lock().unwrap();
+                if entries
+                    .get(&key)
+                    .is_some_and(|current| Arc::ptr_eq(current, &slot))
+                {
+                    entries.remove(&key);
+                }
+                Err(err)
+            }
+        }
+    }
+
+    #[cfg(any(feature = "cli", test))]
+    fn clear(&self) {
+        self.entries.lock().unwrap().clear();
+    }
+}
+
+/// Memoized built providers with single-flight construction per key.
+///
+/// A provider memoizes connection state to serve a batch, but a fallback chain
+/// is walked per secret, so rebuilding there discards it every time: with
+/// `akv?auth=cli` each rebuild re-spawns the Azure CLI. Locking mirrors
+/// [`ProviderCredentialsCache`]: the outer mutex guards only the key-to-slot
+/// map, so callers for one spec wait on its first construction while unrelated
+/// specs build concurrently.
+#[derive(Default)]
+struct ProviderCache {
+    entries: Mutex<HashMap<ProviderKey, ProviderSlot>>,
+}
+
+impl ProviderCache {
+    fn get_or_try_init<F>(&self, key: ProviderKey, build: F) -> Result<Arc<dyn ProviderTrait>>
+    where
+        F: FnOnce() -> Result<Box<dyn ProviderTrait>>,
+    {
+        let slot = {
+            let mut entries = self.entries.lock().unwrap();
+            Arc::clone(
+                entries
+                    .entry(key.clone())
+                    .or_insert_with(|| Arc::new(Mutex::new(None))),
+            )
+        };
+
+        let mut cached = slot.lock().unwrap();
+        if let Some(provider) = cached.as_ref() {
+            return Ok(Arc::clone(provider));
+        }
+
+        match build() {
+            Ok(provider) => {
+                let provider: Arc<dyn ProviderTrait> = Arc::from(provider);
+                *cached = Some(Arc::clone(&provider));
+                Ok(provider)
+            }
+            Err(err) => {
+                // Do not memoize failures, for the same reason the credentials
+                // cache does not: a later operation may succeed once provider
+                // availability or credentials change.
                 drop(cached);
                 let mut entries = self.entries.lock().unwrap();
                 if entries
@@ -420,6 +484,11 @@ pub struct Secrets {
     /// read. Cleared by [`Secrets::store_provider_credential`] so a freshly
     /// stored credential is re-read.
     provider_credentials_cache: ProviderCredentialsCache,
+    /// Built providers memoized per (profile, raw provider spec), so a fallback
+    /// chain walked per secret reuses each link's provider instead of
+    /// rebuilding it. Cleared with [`Self::provider_credentials_cache`], since
+    /// a provider captures its credentials at construction.
+    provider_cache: ProviderCache,
 }
 
 /// secretspec's own opt-in for marking the current process as an agent. Lets any
@@ -603,6 +672,7 @@ impl Secrets {
             require_reason: RequireReason::Never,
             audit: None,
             provider_credentials_cache: ProviderCredentialsCache::default(),
+            provider_cache: ProviderCache::default(),
         }
     }
 
@@ -684,6 +754,7 @@ impl Secrets {
             reason: env_reason(),
             audit,
             provider_credentials_cache: ProviderCredentialsCache::default(),
+            provider_cache: ProviderCache::default(),
         })
     }
 
@@ -858,6 +929,16 @@ impl Secrets {
         self.build_provider_with_credentials(&spec, credentials)
     }
 
+    /// [`Self::build_provider`], memoized so repeated builds of one spec share
+    /// one provider and the connection state it holds. Use it where a spec is
+    /// built per secret rather than per batch: the fallback chain walk,
+    /// interactive prompting.
+    fn shared_provider(&self, spec: &str, profile: Option<&str>) -> Result<Arc<dyn ProviderTrait>> {
+        let key = (self.resolve_profile_name(profile), spec.to_string());
+        self.provider_cache
+            .get_or_try_init(key, || self.build_provider(spec.to_string(), profile))
+    }
+
     /// Builds a credential source provider without resolving credentials for it,
     /// so credential-source chains are at most one hop and cannot recurse.
     fn build_source_provider(&self, spec: &str) -> Result<Box<dyn ProviderTrait>> {
@@ -1030,8 +1111,10 @@ impl Secrets {
         );
         result?;
         // The stored credential replaces whatever an earlier resolution
-        // memoized; drop the memo so the next build re-reads it.
+        // memoized; drop the memo so the next build re-reads it. Providers
+        // built from it go too, since they captured the value.
         self.provider_credentials_cache.clear();
+        self.provider_cache.clear();
         Ok(source.location(&project, name))
     }
 
@@ -2391,8 +2474,9 @@ impl Secrets {
                     }
                 };
                 // Build from the raw spec (not the resolved URI) so an alias's
-                // `credentials` is applied to this chain link too.
-                let provider = match self.build_provider(spec.clone(), profile) {
+                // `credentials` is applied to this chain link too. Shared, not
+                // rebuilt: this walk runs per secret (see [`ProviderCache`]).
+                let provider = match self.shared_provider(spec, profile) {
                     Ok(p) => p,
                     Err(e) => {
                         // Construction failed after resolution, so redact the
@@ -4336,6 +4420,48 @@ impl Secrets {
             }
         }
 
+        // Primary misses walk their fallback chains independently, so resolve
+        // those chains concurrently instead of paying one provider round-trip
+        // per secret in series. Each worker still calls
+        // `get_secret_from_providers`, preserving provider order, lazy alias
+        // resolution, warnings, and the healthy-miss/error distinction for its
+        // own secret. Providers themselves are shared through `ProviderCache`.
+        let pending_fallbacks: Vec<&PlannedSecret> = plan
+            .secrets
+            .iter()
+            .filter(|planned| {
+                !fetched_values.contains_key(&planned.name)
+                    && planned
+                        .route
+                        .as_ref()
+                        .and_then(Route::fallback_specs)
+                        .is_some()
+            })
+            .collect();
+        let mut fallback_results: HashMap<String, FallbackReadResult> =
+            crate::provider::map_concurrently(
+                &pending_fallbacks,
+                crate::provider::get_each_concurrency(),
+                |planned| {
+                    let route = planned
+                        .route
+                        .as_ref()
+                        .expect("pending fallback has a provider route");
+                    let fallback = route
+                        .fallback_specs()
+                        .expect("pending fallback has fallback specs");
+                    let result = self.get_secret_from_providers(
+                        Self::diagnostic_secret_name(&planned.name, output_filter),
+                        planned.as_address(project, profile),
+                        Some(fallback),
+                        Some(profile),
+                    );
+                    (planned.name.clone(), result)
+                },
+            )
+            .into_iter()
+            .collect();
+
         // Process each planned secret: apply the fetched value, its fallback
         // chain, generation, or default, and record a value-free provenance entry
         // for the resolution report.
@@ -4383,22 +4509,15 @@ impl Secrets {
                 None => {
                     let primary_failed = failed_primary_uris.contains_key(&primary_uri);
 
-                    // The primary missed, so now walk the fallback — tried in
-                    // order, each entry resolved lazily inside the chain walk; an
-                    // undefined alias is skipped with a warning so a working
-                    // provider after it still answers. An override or the
-                    // default store has no fallback. The chain warns per secret,
-                    // so it is handed the diagnostic label rather than the raw
-                    // name: under a scope this secret may be a hidden
-                    // composition input the consumer must not learn about.
+                    // The primary missed, so consume the fallback result fetched
+                    // concurrently above. Each chain was still tried in order
+                    // and received the diagnostic label rather than a hidden
+                    // composition input's raw name.
                     let (fallback_value, fallback_uri) = match route.fallback_specs() {
-                        Some(fallback) => {
-                            let resolved = self.get_secret_from_providers(
-                                Self::diagnostic_secret_name(name, output_filter),
-                                planned.as_address(project, profile),
-                                Some(fallback),
-                                Some(profile),
-                            )?;
+                        Some(_) => {
+                            let resolved = fallback_results
+                                .remove(name)
+                                .expect("primary miss with fallback was prefetched")?;
                             // A primary that errored plus an exhausted fallback
                             // chain is not "missing": the authoritative provider
                             // is unreachable and might hold the value. Surface the
@@ -5371,6 +5490,119 @@ mod provider_credentials_cache_tests {
             );
         }
         assert_eq!(fetches.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[cfg(test)]
+mod provider_cache_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    fn env_provider() -> Result<Box<dyn ProviderTrait>> {
+        crate::provider::provider_from_spec("env://", ProviderCredentials::new())
+    }
+
+    /// A fallback chain is walked per secret, so N secrets sharing one link
+    /// must not build N providers.
+    #[test]
+    fn one_key_builds_once_and_hands_back_the_same_instance() {
+        let cache = ProviderCache::default();
+        let builds = AtomicUsize::new(0);
+        let key = ("default".to_string(), "env://".to_string());
+
+        let first = cache
+            .get_or_try_init(key.clone(), || {
+                builds.fetch_add(1, Ordering::SeqCst);
+                env_provider()
+            })
+            .unwrap();
+        let second = cache
+            .get_or_try_init(key, || {
+                builds.fetch_add(1, Ordering::SeqCst);
+                env_provider()
+            })
+            .unwrap();
+
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    /// The profile is part of the key: a provider carries the credentials of
+    /// the profile it was built under.
+    #[test]
+    fn distinct_keys_build_independently() {
+        let cache = ProviderCache::default();
+        let builds = AtomicUsize::new(0);
+
+        let build_under = |profile: &str| {
+            cache
+                .get_or_try_init((profile.to_string(), "env://".to_string()), || {
+                    builds.fetch_add(1, Ordering::SeqCst);
+                    env_provider()
+                })
+                .unwrap()
+        };
+        let default = build_under("default");
+        let production = build_under("production");
+
+        assert_eq!(builds.load(Ordering::SeqCst), 2);
+        assert!(!Arc::ptr_eq(&default, &production));
+    }
+
+    /// Failures are not memoized, so a provider that was unavailable can be
+    /// built by a later operation in the same session.
+    #[test]
+    fn failures_are_not_memoized() {
+        let cache = ProviderCache::default();
+        let key = ("default".to_string(), "env://".to_string());
+
+        let failed = cache.get_or_try_init(key.clone(), || {
+            Err(SecretSpecError::ProviderOperationFailed("nope".into()))
+        });
+        assert!(failed.is_err());
+
+        assert!(cache.get_or_try_init(key, env_provider).is_ok());
+    }
+
+    #[test]
+    fn concurrent_construction_for_one_key_is_single_flight() {
+        const CALLERS: usize = 8;
+        let cache = Arc::new(ProviderCache::default());
+        let start = Arc::new(Barrier::new(CALLERS));
+        let builds = Arc::new(AtomicUsize::new(0));
+
+        let threads: Vec<_> = (0..CALLERS)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let start = Arc::clone(&start);
+                let builds = Arc::clone(&builds);
+                thread::spawn(move || {
+                    start.wait();
+                    cache
+                        .get_or_try_init(("default".into(), "env://".into()), || {
+                            builds.fetch_add(1, Ordering::SeqCst);
+                            // Hold the first construction in flight long enough
+                            // for every caller to contend on the same key.
+                            thread::sleep(Duration::from_millis(50));
+                            env_provider()
+                        })
+                        .unwrap()
+                })
+            })
+            .collect();
+
+        let providers: Vec<_> = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect();
+
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+        for provider in &providers {
+            assert!(Arc::ptr_eq(provider, &providers[0]));
+        }
     }
 }
 

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -304,14 +304,15 @@ impl ProviderCredentialsCache {
     }
 }
 
-/// Memoized built providers with single-flight construction per key.
+/// Operation-scoped built providers with single-flight construction per key.
 ///
 /// A provider memoizes connection state to serve a batch, but a fallback chain
 /// is walked per secret, so rebuilding there discards it every time: with
 /// `akv?auth=cli` each rebuild re-spawns the Azure CLI. Locking mirrors
 /// [`ProviderCredentialsCache`]: the outer mutex guards only the key-to-slot
 /// map, so callers for one spec wait on its first construction while unrelated
-/// specs build concurrently.
+/// specs build concurrently. A fresh cache is created for every resolution so
+/// provider-local snapshots cannot leak into a later operation.
 #[derive(Default)]
 struct ProviderCache {
     entries: Mutex<HashMap<ProviderKey, ProviderSlot>>,
@@ -357,11 +358,6 @@ impl ProviderCache {
                 Err(err)
             }
         }
-    }
-
-    #[cfg(any(feature = "cli", test))]
-    fn clear(&self) {
-        self.entries.lock().unwrap().clear();
     }
 }
 
@@ -484,11 +480,6 @@ pub struct Secrets {
     /// read. Cleared by [`Secrets::store_provider_credential`] so a freshly
     /// stored credential is re-read.
     provider_credentials_cache: ProviderCredentialsCache,
-    /// Built providers memoized per (profile, raw provider spec), so a fallback
-    /// chain walked per secret reuses each link's provider instead of
-    /// rebuilding it. Cleared with [`Self::provider_credentials_cache`], since
-    /// a provider captures its credentials at construction.
-    provider_cache: ProviderCache,
 }
 
 /// secretspec's own opt-in for marking the current process as an agent. Lets any
@@ -672,7 +663,6 @@ impl Secrets {
             require_reason: RequireReason::Never,
             audit: None,
             provider_credentials_cache: ProviderCredentialsCache::default(),
-            provider_cache: ProviderCache::default(),
         }
     }
 
@@ -754,7 +744,6 @@ impl Secrets {
             reason: env_reason(),
             audit,
             provider_credentials_cache: ProviderCredentialsCache::default(),
-            provider_cache: ProviderCache::default(),
         })
     }
 
@@ -929,14 +918,18 @@ impl Secrets {
         self.build_provider_with_credentials(&spec, credentials)
     }
 
-    /// [`Self::build_provider`], memoized so repeated builds of one spec share
-    /// one provider and the connection state it holds. Use it where a spec is
-    /// built per secret rather than per batch: the fallback chain walk,
-    /// interactive prompting.
-    fn shared_provider(&self, spec: &str, profile: Option<&str>) -> Result<Arc<dyn ProviderTrait>> {
+    /// [`Self::build_provider`], memoized within one resolution so repeated
+    /// builds of one spec share one provider and the connection state it holds.
+    /// The caller owns the cache to prevent provider-local snapshots and session
+    /// metadata from surviving into a later operation.
+    fn shared_provider(
+        &self,
+        cache: &ProviderCache,
+        spec: &str,
+        profile: Option<&str>,
+    ) -> Result<Arc<dyn ProviderTrait>> {
         let key = (self.resolve_profile_name(profile), spec.to_string());
-        self.provider_cache
-            .get_or_try_init(key, || self.build_provider(spec.to_string(), profile))
+        cache.get_or_try_init(key, || self.build_provider(spec.to_string(), profile))
     }
 
     /// Builds a credential source provider without resolving credentials for it,
@@ -1111,10 +1104,8 @@ impl Secrets {
         );
         result?;
         // The stored credential replaces whatever an earlier resolution
-        // memoized; drop the memo so the next build re-reads it. Providers
-        // built from it go too, since they captured the value.
+        // memoized; drop the memo so the next build re-reads it.
         self.provider_credentials_cache.clear();
-        self.provider_cache.clear();
         Ok(source.location(&project, name))
     }
 
@@ -2445,6 +2436,7 @@ impl Secrets {
     /// callers (e.g. the audit log) record which provider actually answered.
     fn get_secret_from_providers(
         &self,
+        provider_cache: &ProviderCache,
         secret_name: &str,
         addr: Address<'_>,
         provider_specs: Option<&[String]>,
@@ -2476,7 +2468,7 @@ impl Secrets {
                 // Build from the raw spec (not the resolved URI) so an alias's
                 // `credentials` is applied to this chain link too. Shared, not
                 // rebuilt: this walk runs per secret (see [`ProviderCache`]).
-                let provider = match self.shared_provider(spec, profile) {
+                let provider = match self.shared_provider(provider_cache, spec, profile) {
                     Ok(p) => p,
                     Err(e) => {
                         // Construction failed after resolution, so redact the
@@ -2921,7 +2913,9 @@ impl Secrets {
                 // broken link is skipped with a warning, so an undefined alias never
                 // blocks a provider elsewhere in the chain from answering.
                 let read_specs = route.specs();
+                let provider_cache = ProviderCache::default();
                 let result = self.get_secret_from_providers(
+                    &provider_cache,
                     name,
                     planned.as_address(&self.config.project.name, &profile_name),
                     read_specs.as_deref(),
@@ -4426,6 +4420,7 @@ impl Secrets {
         // `get_secret_from_providers`, preserving provider order, lazy alias
         // resolution, warnings, and the healthy-miss/error distinction for its
         // own secret. Providers themselves are shared through `ProviderCache`.
+        let provider_cache = ProviderCache::default();
         let pending_fallbacks: Vec<&PlannedSecret> = plan
             .secrets
             .iter()
@@ -4451,6 +4446,7 @@ impl Secrets {
                         .fallback_specs()
                         .expect("pending fallback has fallback specs");
                     let result = self.get_secret_from_providers(
+                        &provider_cache,
                         Self::diagnostic_secret_name(&planned.name, output_filter),
                         planned.as_address(project, profile),
                         Some(fallback),

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -3947,6 +3947,86 @@ fn test_get_secret_with_fallback_chain() {
     }
 }
 
+#[test]
+fn fallback_chains_resolve_concurrently_under_the_provider_cap() {
+    let _lock = scrub_resolution_env();
+    let _concurrency = EnvVarGuard::set(crate::provider::GET_EACH_CONCURRENCY_ENV, "3");
+    let temp_dir = TempDir::new().unwrap();
+    let primary_file = temp_dir.path().join("empty.env");
+    fs::write(&primary_file, "").unwrap();
+
+    const PROJECT: &str = "fallback-concurrency-test";
+    let names: Vec<String> = (0..8).map(|index| format!("SECRET_{index}")).collect();
+    let fallback = crate::provider::provider_from_spec(
+        "slowtest://",
+        crate::provider::ProviderCredentials::new(),
+    )
+    .unwrap();
+    for name in &names {
+        fallback
+            .set(
+                crate::provider::Address::convention(PROJECT, "default", name),
+                &secrecy::SecretString::new(format!("value-{name}").into()),
+            )
+            .unwrap();
+    }
+    crate::provider::tests::reset_slow_peak();
+
+    let secrets = names
+        .iter()
+        .map(|name| {
+            (
+                name.clone(),
+                Secret {
+                    description: Some(format!("Fallback value for {name}")),
+                    required: Some(true),
+                    providers: Some(vec!["primary".into(), "fallback".into()]),
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
+    let config = Config {
+        project: Project {
+            name: PROJECT.to_string(),
+            ..Default::default()
+        },
+        profiles: HashMap::from([(
+            "default".to_string(),
+            Profile {
+                defaults: None,
+                secrets,
+            },
+        )]),
+        providers: None,
+        scopes: None,
+    };
+    let primary_uri = format!("dotenv://{}", primary_file.display());
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: None,
+            profile: None,
+            providers: Some(aliases_map(&[
+                ("primary", primary_uri.as_str()),
+                ("fallback", "slowtest://"),
+            ])),
+        },
+        audit: None,
+    };
+
+    let validated = Secrets::new(config, Some(global_config), None, None)
+        .validate()
+        .unwrap()
+        .expect("all fallback values should resolve");
+    assert_eq!(validated.resolved.secrets.len(), names.len());
+    let peak = crate::provider::tests::slow_peak();
+    assert!(peak >= 2, "fallback reads stayed serial, peak={peak}");
+    assert!(
+        peak <= 3,
+        "fallback reads exceeded configured cap, peak={peak}"
+    );
+}
+
 /// When the primary provider in a chain errors (e.g. authentication failure),
 /// validation should fall back to the next provider rather than propagating
 /// the error. Simulated here by pointing the primary dotenv at a directory,

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -4027,6 +4027,122 @@ fn fallback_chains_resolve_concurrently_under_the_provider_cap() {
     );
 }
 
+fn stateful_fallback_spec(project: &str, secret_name: &str, primary_file: &Path) -> Secrets {
+    let config = Config {
+        project: Project {
+            name: project.to_string(),
+            ..Default::default()
+        },
+        profiles: HashMap::from([(
+            "default".to_string(),
+            Profile {
+                defaults: None,
+                secrets: HashMap::from([(
+                    secret_name.to_string(),
+                    Secret {
+                        required: Some(true),
+                        providers: Some(vec!["primary".into(), "stateful".into()]),
+                        ..Default::default()
+                    },
+                )]),
+            },
+        )]),
+        providers: None,
+        scopes: None,
+    };
+    let primary_uri = format!("dotenv://{}", primary_file.display());
+    let global_config = GlobalConfig {
+        defaults: GlobalDefaults {
+            provider: None,
+            profile: None,
+            providers: Some(aliases_map(&[
+                ("primary", primary_uri.as_str()),
+                ("stateful", "statefultest://"),
+            ])),
+        },
+        audit: None,
+    };
+    Secrets::new(config, Some(global_config), None, None)
+}
+
+#[test]
+fn operation_scoped_provider_cache_refreshes_snapshots_between_resolutions() {
+    let _lock = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    let primary_file = temp_dir.path().join("empty.env");
+    fs::write(&primary_file, "").unwrap();
+
+    const PROJECT: &str = "provider-operation-lifetime-test";
+    const SECRET: &str = "ROTATING_SECRET";
+    let address = crate::provider::Address::convention(PROJECT, "default", SECRET);
+    let store = crate::provider::provider_from_spec(
+        "statefultest://",
+        crate::provider::ProviderCredentials::new(),
+    )
+    .unwrap();
+    store
+        .set(
+            address,
+            &secrecy::SecretString::new("original".to_string().into()),
+        )
+        .unwrap();
+
+    let spec = stateful_fallback_spec(PROJECT, SECRET, &primary_file);
+    let first = spec.validate().unwrap().expect("first resolution succeeds");
+    assert_eq!(first.resolved.secrets[SECRET].expose_secret(), "original");
+
+    store
+        .set(
+            address,
+            &secrecy::SecretString::new("rotated".to_string().into()),
+        )
+        .unwrap();
+    let second = spec
+        .validate()
+        .unwrap()
+        .expect("second resolution succeeds");
+    assert_eq!(second.resolved.secrets[SECRET].expose_secret(), "rotated");
+}
+
+#[test]
+fn operation_scoped_provider_cache_applies_changed_reason_on_later_resolution() {
+    let _lock = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    let primary_file = temp_dir.path().join("empty.env");
+    fs::write(&primary_file, "").unwrap();
+
+    const PROJECT: &str = "provider-reason-lifetime-test";
+    const SECRET: &str = "AUDITED_SECRET";
+    let item = format!("{PROJECT}/default/{SECRET}");
+    crate::provider::tests::take_stateful_reason_reads(&item);
+    let store = crate::provider::provider_from_spec(
+        "statefultest://",
+        crate::provider::ProviderCredentials::new(),
+    )
+    .unwrap();
+    store
+        .set(
+            crate::provider::Address::convention(PROJECT, "default", SECRET),
+            &secrecy::SecretString::new("value".to_string().into()),
+        )
+        .unwrap();
+
+    let spec = stateful_fallback_spec(PROJECT, SECRET, &primary_file).with_reason("first reason");
+    spec.validate().unwrap().expect("first resolution succeeds");
+    let spec = spec.with_reason("second reason");
+    spec.validate()
+        .unwrap()
+        .expect("second resolution succeeds");
+
+    assert_eq!(
+        crate::provider::tests::take_stateful_reason_reads(&item),
+        vec![
+            Some("first reason".to_string()),
+            Some("second reason".to_string())
+        ]
+    );
+}
+
 /// When the primary provider in a chain errors (e.g. authentication failure),
 /// validation should fall back to the next provider rather than propagating
 /// the error. Simulated here by pointing the primary dotenv at a directory,


### PR DESCRIPTION
## Summary

- reuse fallback provider instances per profile and provider spec
- resolve independent fallback chains concurrently under `SECRETSPEC_PROVIDER_CONCURRENCY`
- reuse one Azure Key Vault client and serialize its cold challenge-based authentication before parallel reads
- add focused provider-cache, concurrency, and AKV authentication-gate regression tests

## Root cause

Fallback providers were constructed once per secret, so provider-local connection and authentication state was discarded between reads. Primary misses then walked their fallback chains serially. Azure Key Vault also created a new client for each operation, and concurrent requests from a cold client could each receive an initial authentication challenge and repeatedly invoke the Azure CLI.

## Impact

A chain such as `providers = ["keyring", "akv"]` now shares its AKV client and token cache across the resolution, performs fallback network reads concurrently under the existing cap, and prevents the initial authentication challenge from launching multiple Azure CLI processes.

Fixes #283.

## Validation

- `cargo test --all`
- repository pre-commit `clippy` hook
- repository pre-commit `rustfmt` hook
- focused fallback ordering/concurrency, provider-cache, and AKV cold-request tests
