### PR TITLE
feat: attach cache to provider aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- The Rust SDK's `ProviderAlias` now represents leaf, inline-cached, and
-  fallback-cached aliases as distinct non-exhaustive enum variants. Code that
-  constructs credential-bearing aliases should use `ProviderAlias::leaf`;
-  cached fallback aliases continue to use `ProviderAlias::cached`.
+- The Rust SDK's `ProviderAlias` now provides `leaf`, `credentials`, and
+  `credentials_mut` helpers so callers can construct and inspect leaf or
+  inline-cached aliases without depending on their storage representation.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The Rust SDK's `ProviderAlias` now represents leaf, inline-cached, and
+  fallback-cached aliases as distinct non-exhaustive enum variants. Code that
+  constructs credential-bearing aliases should use `ProviderAlias::leaf`;
+  cached fallback aliases continue to use `ProviderAlias::cached`.
+
 ### Added
 
 - Windows ARM64 CLI release artifacts (`aarch64-pc-windows-msvc`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Haskell SDK declares the archive's macOS system frameworks
   (`SystemConfiguration`, `Security`, `CoreFoundation`) in its cabal file, so
   GHC passes them to every link on macOS.
+- A single provider can now attach its cache directly to the same alias with
+  `uri` and `cache`, avoiding a second wrapper alias while retaining provider
+  credentials. Cached `fallback` routes remain available for multiple
+  authoritative providers.
 
 ### Fixed
 

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -291,8 +291,8 @@ Provider credentials follow these rules:
 
 - Learn how [Provider fallback](/concepts/providers/fallback/) selects and
   orders sources.
-- Cache slow remote routes with [Provider caching](/concepts/providers/caching/)
-  (0.17+).
+- Cache slow remote routes and diagnose remaining latency with [Provider
+  caching](/concepts/providers/caching/) (0.17+).
 - Review the URI and authentication details for an individual provider in the
   [Providers](/providers/keyring/) section.
 - Learn how [Profiles](/concepts/profiles/) apply provider defaults to an

--- a/docs/src/content/docs/concepts/providers/caching.md
+++ b/docs/src/content/docs/concepts/providers/caching.md
@@ -8,37 +8,78 @@ Provider caching and `secretspec cache clear` are available starting with
 SecretSpec 0.17.
 :::
 
-Remote providers add network, authentication, or external-CLI latency to every
-read, even when values rarely change. Provider caching stores a time-limited
-copy in a faster local store. Fresh entries return immediately; misses and
-expired entries use the authoritative providers and refill the cache.
+## The problem
 
-Configure caching with a cached alias. `fallback` lists the authoritative
-providers in read order, and `cache.provider` selects the local leaf provider:
+A remote secret read can include authentication, external-process startup,
+DNS, TCP and TLS setup, and one or more network requests. Those fixed costs can
+dominate a command that resolves only a few secrets. Separate SecretSpec CLI
+invocations may pay them again even when the values rarely change.
+
+Latency can also scale with the number of distinct secret addresses. SecretSpec
+groups compatible reads and providers can batch or parallelize them, but the
+remote service, proxy, or provider CLI still determines the cost of each read.
+
+## Cache one provider (0.19+)
+
+Provider caching places a faster local secret store in front of an
+authoritative provider. A fresh cache entry returns without constructing or
+contacting the remote provider; a miss reads the remote value and stores it
+locally for later SecretSpec invocations.
+
+:::caution[Version compatibility]
+Attaching `cache` directly to a provider URI is available starting with
+SecretSpec 0.19. Use a cached fallback alias on SecretSpec 0.17 and 0.18.
+:::
+
+Add `cache` to the remote provider alias and select that same alias normally:
 
 ```toml title="secretspec.toml"
 [providers]
-azure = { uri = "akv://team-vault", credentials = { client_secret = "keyring" } }
+local = "keyring://secretspec/cache/{project}/{profile}/{key}"
+azure = {
+  uri = "akv://team-vault",
+  credentials = { client_secret = "keyring" },
+  cache = { provider = "local", max_age = "8h" }
+}
+
+[profiles.development.defaults]
+providers = ["azure"]
+```
+
+The alias remains the authoritative provider, so its [provider
+credentials](/concepts/providers/#provider-credentials) stay next to `uri` and
+`cache`.
+
+## Cache a fallback route (0.17+)
+
+When more than one provider can authoritatively answer, use a route alias.
+`fallback` lists its providers in read order and `cache.provider` selects the
+local leaf provider:
+
+```toml title="secretspec.toml"
+[providers]
+azure = "akv://team-vault?auth=cli"
 env = "env://"
 local = "keyring://secretspec/cache/{project}/{profile}/{key}"
 
-myprovider = {
+remote = {
   fallback = ["azure", "env"],
   cache = { provider = "local", max_age = "8h" }
 }
 
 [profiles.development.defaults]
-providers = ["myprovider"]
+providers = ["remote"]
 ```
 
 ## Read behavior
 
 SecretSpec reads a cached route in this order:
 
-1. returns a fresh cache entry without constructing or contacting `azure` or
-   `env`;
-2. on a miss, unusable entry, or cache error, tries `azure` and then `env`;
-3. caches the value returned by whichever fallback answers.
+1. returns a fresh cache entry without constructing or contacting an
+   authoritative provider;
+2. on a miss, unusable entry, or cache error, reads the provider URI or tries
+   each `fallback` entry in order;
+3. caches the value returned by the authoritative provider that answers.
 
 Cache failures produce warnings but never block the authoritative route.
 SecretSpec never returns an expired value when all fallbacks fail. It deletes
@@ -51,19 +92,21 @@ or refresh one.
 
 ## Writes
 
-Writes and generated values go to the first fallback (`azure` above), then
-refresh the cache. If the refresh fails, the authoritative write still
-succeeds and SecretSpec deletes the old cache entry. If deletion also fails,
-the warning identifies the `cache clear` command to run.
+Writes and generated values go to the provider URI or the first fallback, then
+refresh the cache. If the refresh fails, the authoritative write still succeeds
+and SecretSpec deletes the old cache entry. If deletion also fails, the warning
+identifies the `cache clear` command to run.
 
-Select a leaf provider to bypass the cache for one command:
+For a cached fallback route, select a leaf provider to bypass the cache for one
+command:
 
 ```bash
 $ secretspec check --provider azure
 ```
 
-A direct write, such as `secretspec set API_KEY --provider azure`, invalidates
-the corresponding cache entry.
+In the fallback example, a direct write such as
+`secretspec set API_KEY --provider azure` invalidates the corresponding cache
+entry.
 
 ## Freshness and invalidation
 
@@ -76,9 +119,9 @@ the value, absolute expiration time, originating `max_age`, format version, and
 a fingerprint of the fallback route and secret reference. Changing the route,
 reference, or `max_age` invalidates it.
 
-The cache must use a distinct store from every provider in `fallback`;
+The cache must use a distinct store from every authoritative provider;
 otherwise, a refresh could overwrite the authoritative secret. SecretSpec
-rejects such routes during planning. The example uses a separate keyring
+rejects such routes during planning. The examples use a separate keyring
 namespace for `local`.
 
 The cache provider must also support deletion: keyring, pass, gopass, dotenv,
@@ -125,7 +168,8 @@ place. Give each project a separate store or path, such as the
 
 ## Where cached aliases can be used
 
-A cached alias works anywhere a complete route is selected:
+An inline cached provider alias or cached fallback alias works anywhere a
+complete route is selected:
 
 - a secret or profile-default `providers` list;
 - the user-global default provider;
@@ -133,12 +177,13 @@ A cached alias works anywhere a complete route is selected:
 - `--provider`.
 
 Because a cached alias defines a complete route, it must be the only entry in a
-`providers` list. Its fallback entries and cache provider may be aliases,
+`providers` list. Fallback entries and the cache provider may be aliases,
 provider names, or URIs, but must resolve to leaf providers; cached aliases
 cannot be nested.
 
-Credentials belong on leaf aliases, such as `azure` above, rather than on
-`myprovider`.
+An inline cached alias can declare credentials next to its `uri`. For a cached
+fallback route, credentials belong on its leaf aliases rather than on the route
+alias.
 
 ## Security
 
@@ -147,10 +192,131 @@ provider such as keyring, pass, or gopass when values must be encrypted at rest.
 Dotenv stores entries as plaintext. Native expiry limits how long a copy exists
 without another SecretSpec run.
 
-## Next steps
+## Reference
 
+- See [`cache clear`](/reference/cli/#cache-clear-017) in the CLI reference.
+- Review the [inline cache fields](/reference/configuration/#secretspec-019-inline-provider-cache)
+  (0.19+) or [cached fallback fields](/reference/configuration/#secretspec-017-cached-fallback-alias-values)
+  in the configuration reference.
 - Review [Provider fallback](/concepts/providers/fallback/) for authoritative
   route and write semantics.
-- See [`cache clear`](/reference/cli/#cache-clear-017) in the CLI reference.
-- Review the [cached alias fields](/reference/configuration/#secretspec-017-cached-alias-values)
-  in the configuration reference.
+
+## Diagnose and improve provider performance
+
+Use these checks when the first cache fill is too slow, the route cannot be
+cached, or you need to understand a platform-specific difference.
+
+### Establish a baseline
+
+Benchmark the same command, profile, and set of secrets each time. `check`
+resolves values without printing them:
+
+```bash
+time secretspec get SECRET_NAME >/dev/null
+time secretspec check --no-prompt
+```
+
+The redirected `get` prevents the value from appearing in the terminal. Compare
+it with the complete profile: similar times suggest a fixed authentication or
+connection cost, while time that grows with the number of secrets points to
+per-secret round trips, provider grouping, or concurrency.
+
+If you have [hyperfine](https://github.com/sharkdp/hyperfine), compare repeated
+runs:
+
+```bash
+hyperfine --warmup 1 'secretspec check --no-prompt'
+```
+
+Record the first run separately. A warmup can hide cold authentication or an
+external CLI's startup cost, while repeated one-shot SecretSpec commands still
+pay that cost in normal use.
+
+### Isolate authentication and network cost
+
+When a provider uses an external CLI, time a harmless authentication command
+without printing its token. For Azure CLI, for example:
+
+```bash
+time az account get-access-token \
+  --scope https://vault.azure.net/.default \
+  --output none
+```
+
+If this takes most of a cache miss, consider another supported authentication
+mode. External CLI sessions are convenient for local development, but direct
+service-principal, managed-identity, workload-identity, token, or SDK
+authentication can avoid the process boundary where appropriate.
+
+For example, the [Azure Key Vault provider](/providers/akv/#authentication)
+supports Azure CLI sessions as well as service principals, managed identity,
+and workload identity. Prefer the identity mode that matches the environment;
+do not replace short-lived or workload-bound credentials with long-lived
+credentials solely to reduce latency.
+
+To distinguish connection setup from the secret API itself, probe the remote
+endpoint without requesting a real secret. This Azure Key Vault example is
+expected to return an authorization error, but still reports DNS, TCP, TLS, and
+time to first byte:
+
+```bash
+curl --silent --show-error --output /dev/null \
+  --write-out 'dns=%{time_namelookup} connect=%{time_connect} tls=%{time_appconnect} ttfb=%{time_starttransfer} total=%{time_total}\n' \
+  'https://VAULT.vault.azure.net/secrets/__probe__?api-version=7.5'
+```
+
+Run the same probe from the host and from WSL or a container to expose a
+platform-specific DNS, VPN, proxy, or TLS delay.
+
+### Keep related secrets on one route
+
+Secrets that use the same store and authentication configuration should select
+the same provider alias. SecretSpec groups those reads into one provider
+operation, deduplicates identical references, and lets providers use a bulk API
+or bounded parallel reads where supported.
+
+Do not merge aliases that intentionally use different identities, endpoints,
+namespaces, or other security settings. Those are distinct routes even if they
+use the same provider type.
+
+### Tune per-address concurrency (0.17+)
+
+Providers using SecretSpec's default per-address fetch path read up to eight
+unique addresses concurrently. Test a few caps when latency grows with the
+number of secrets:
+
+```bash
+SECRETSPEC_PROVIDER_CONCURRENCY=1 secretspec check --no-prompt
+SECRETSPEC_PROVIDER_CONCURRENCY=4 secretspec check --no-prompt
+SECRETSPEC_PROVIDER_CONCURRENCY=16 secretspec check --no-prompt
+```
+
+More concurrency is not always faster. It can increase rate limiting, overload
+a reverse proxy, or create more simultaneous connections. The setting does not
+remove a provider's cold authentication floor, and providers with a true bulk
+API may not use it for their batched reads.
+
+### Check WSL and container overhead
+
+If the same manifest is slower under WSL or in a container:
+
+- use the Linux build of each provider CLI instead of invoking a Windows
+  executable through interoperability;
+- keep the project and provider CLI's configuration and credential cache on
+  the Linux filesystem rather than under `/mnt/c`;
+- compare the endpoint probe with and without `curl -4` to identify an
+  address-family or VPN routing delay before changing system-wide networking;
+- check whether a proxy, VPN, antivirus product, or certificate helper is only
+  active on one side of the host boundary;
+- remember that short-lived containers repeat process startup, authentication,
+  DNS, and TLS setup on every invocation.
+
+### Interpret the results
+
+| Observation | Likely cost | First thing to try |
+| --- | --- | --- |
+| One secret and the full profile take about the same time | Authentication or process startup | Use direct authentication where appropriate, or cache the route |
+| Every SecretSpec invocation has the same fixed delay | External CLI or cold connection setup | Time the auth command and endpoint probe separately |
+| Time grows with the number of secrets | Per-secret network reads | Consolidate equivalent routes and benchmark concurrency |
+| A warm run is much faster than the first | Provider CLI, token, DNS, or connection cache | Preserve the relevant cache and benchmark cold runs separately |
+| Only WSL or a container is slower | Filesystem, DNS, VPN, proxy, or executable interoperability | Compare the host/container probes and move hot files off mounted host paths |

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -485,13 +485,48 @@ Templates belong on the leaf aliases in a cached route, not on the cached
 alias itself. Bare provider names and literal URIs have no alias identity, so
 they use provider convention naming unless the secret declares legacy `ref`.
 
-#### SecretSpec 0.17 cached alias values
+#### SecretSpec 0.19 inline provider cache
+
+:::caution[Version compatibility]
+Attaching `cache` directly to an alias with `uri` is available starting with
+SecretSpec 0.19.
+:::
+
+Use `uri` and `cache` when one provider is authoritative. `credentials` remains
+optional and configures that same provider:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `uri` | string | Yes | Authoritative provider URI. |
+| `credentials` | table | No | Provider-specific credential sources for `uri`. |
+| `cache` | table | Yes | Local cache policy containing `provider` and `max_age`. |
+| `cache.provider` | string | Yes | Leaf provider spec used to store cache entries. Must support deletion and address a different store from `uri`. |
+| `cache.max_age` | string | Yes | Positive duration with `s`, `m`, `h`, `d`, or `w` units, such as `30m`, `8h`, or `1d`. |
+
+```toml title="secretspec.toml"
+[providers]
+local = "keyring://secretspec/cache/{project}/{profile}/{key}"
+azure = {
+  uri = "akv://team-vault",
+  credentials = { client_secret = "keyring" },
+  cache = { provider = "local", max_age = "8h" }
+}
+
+[profiles.development.defaults]
+providers = ["azure"]
+```
+
+The alias remains both the selected cached route and the build key for its
+authoritative provider, so its configured credentials apply normally.
+
+#### SecretSpec 0.17 cached fallback alias values
 
 :::caution[Version compatibility]
 Cached provider aliases are available starting with SecretSpec 0.17.
 :::
 
-A cached alias uses `fallback` and `cache` instead of `uri` and `credentials`:
+A cached fallback alias uses `fallback` and `cache` when more than one provider
+can answer:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -511,15 +546,15 @@ myprovider = { fallback = ["azure", "env"], cache = { provider = "local", max_ag
 providers = ["myprovider"]
 ```
 
-The cached alias is a complete route and must be the only entry when selected
-through `providers`, in any position. Its fallback entries and cache provider
+Every cached alias is a complete route and must be the only entry when selected
+through `providers`, in any position. Fallback entries and the cache provider
 accept aliases, provider names, and URIs, but must resolve to leaf providers;
-cached aliases cannot be nested, and the cache must resolve to a different store
-than the route's own authoritative providers, since it holds its entries at the
-same logical address. The cache provider must also be one SecretSpec can delete
-from — keyring, pass, gopass, dotenv, or a Vault/OpenBao KV v2 mount — since
-every form of invalidation is a delete. Put credentials on leaf aliases rather
-than the cached alias.
+cached aliases cannot be nested, and the cache must resolve to a different
+store than the route's own authoritative providers, since it holds its entries
+at the same logical address. The cache provider must also be one SecretSpec can
+delete from — keyring, pass, gopass, dotenv, or a Vault/OpenBao KV v2 mount —
+since every form of invalidation is a delete. Put credentials on leaf aliases
+rather than the cached fallback alias.
 See [Provider caching](/concepts/providers/caching/)
 for freshness, failure, invalidation, and clearing behavior.
 

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1020,11 +1020,8 @@ pub fn main() -> Result<()> {
                             );
                         }
                         // An empty map keeps the compact bare-string alias form.
-                        let alias_value = crate::config::ProviderAlias {
-                            uri: uri.clone(),
-                            credentials,
-                            ..Default::default()
-                        };
+                        let alias_value =
+                            crate::config::ProviderAlias::leaf(uri.clone(), credentials);
 
                         // Load or create config
                         let mut config =

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -357,6 +357,22 @@ impl ProviderAlias {
         }
     }
 
+    /// A leaf alias carrying a URI and its semantic credential sources.
+    pub fn leaf(uri: impl Into<String>, credentials: HashMap<String, CredentialSource>) -> Self {
+        Self {
+            uri: uri.into(),
+            credentials,
+            reference_template: None,
+            fallback: Vec::new(),
+            cache: None,
+        }
+    }
+
+    /// Semantic credential sources for a leaf or inline cached provider.
+    pub fn credentials(&self) -> Option<&HashMap<String, CredentialSource>> {
+        self.fallback.is_empty().then_some(&self.credentials)
+    }
+
     /// A cached route alias: ordered authoritative sources plus the cache they
     /// are cached in (0.17+).
     ///

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -373,6 +373,11 @@ impl ProviderAlias {
         self.fallback.is_empty().then_some(&self.credentials)
     }
 
+    /// Mutable semantic credential sources for a leaf or inline cached provider.
+    pub fn credentials_mut(&mut self) -> Option<&mut HashMap<String, CredentialSource>> {
+        self.fallback.is_empty().then_some(&mut self.credentials)
+    }
+
     /// A cached route alias: ordered authoritative sources plus the cache they
     /// are cached in (0.17+).
     ///

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -299,8 +299,16 @@ pub(crate) fn parse_cache_max_age(value: &str) -> std::result::Result<u64, Strin
 /// bws = { uri = "bws://project-uuid", credentials = { access_token = "keyring" } }
 /// ```
 ///
-/// A cached route names its authoritative sources in fallback order and a leaf
-/// provider used for the local cache:
+/// SecretSpec 0.19+ can cache one provider directly on its alias:
+///
+/// ```toml
+/// [providers]
+/// azure = { uri = "akv://team-vault", cache = { provider = "local", max_age = "8h" } }
+/// local = "keyring://secretspec/cache/{project}/{profile}/{key}"
+/// ```
+///
+/// A cached fallback route names multiple authoritative sources in order and a
+/// leaf provider used for the local cache:
 ///
 /// ```toml
 /// [providers]
@@ -318,7 +326,8 @@ pub(crate) fn parse_cache_max_age(value: &str) -> std::result::Result<u64, Strin
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub struct ProviderAlias {
-    /// The provider URI (e.g. `keyring://`, `bws://project-uuid`).
+    /// The provider URI (e.g. `keyring://`, `bws://project-uuid`). Also the
+    /// authoritative source when `cache` is set without `fallback` (0.19+).
     pub uri: String,
     /// Semantic credential name to the [`CredentialSource`] that supplies it.
     /// Empty for a bare string alias, so "declares no credentials" has exactly
@@ -328,10 +337,11 @@ pub struct ProviderAlias {
     /// logical `{project}/{profile}/{key}` address into this alias's own
     /// coordinates before the provider is contacted.
     pub reference_template: Option<NativeAddressTemplate>,
-    /// Ordered authoritative sources for a cached alias (0.17+). Empty for a
-    /// leaf alias.
+    /// Ordered authoritative sources for a cached fallback alias (0.17+).
+    /// Empty for a leaf alias and for an inline URI cache (0.19+).
     pub(crate) fallback: Vec<String>,
-    /// Cache policy for a cached alias (0.17+). `None` for a leaf alias.
+    /// Cache policy for a cached alias (0.17+). `None` for an uncached leaf
+    /// alias.
     pub(crate) cache: Option<ProviderCache>,
 }
 
@@ -370,15 +380,33 @@ impl ProviderAlias {
         })
     }
 
+    /// Adds a cache policy to this alias (inline URI form available in 0.19+).
+    ///
+    /// A URI alias retains its URI and credentials as the authoritative
+    /// provider. An existing fallback alias retains its ordered route.
+    pub fn with_cache(mut self, cache: ProviderCache) -> Self {
+        self.cache = Some(cache);
+        self
+    }
+
     /// Whether this alias describes a cached route rather than a leaf provider
     /// (0.17+).
     pub fn is_cached(&self) -> bool {
         self.cache.is_some()
     }
 
+    /// The single authoritative URI this alias names, if it names one.
+    ///
+    /// `Some` for a leaf alias and for the inline cache form (0.19+), where
+    /// the alias itself remains the authoritative provider. `None` for a
+    /// cached fallback alias, whose ordered sources are in [`Self::fallback`].
+    pub fn authoritative_uri(&self) -> Option<&str> {
+        (!self.uri.is_empty()).then_some(self.uri.as_str())
+    }
+
     /// The ordered authoritative sources of a cached alias.
     ///
-    /// Empty for a leaf alias.
+    /// Empty for an uncached leaf alias and for an inline URI cache (0.19+).
     pub fn fallback(&self) -> &[String] {
         &self.fallback
     }
@@ -427,15 +455,27 @@ impl From<&str> for ProviderAlias {
 impl std::fmt::Display for ProviderAlias {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(cache) = &self.cache {
-            return write!(
-                f,
-                "fallback [{}], cached in {} for {}",
-                self.fallback.join(", "),
-                cache.provider,
-                cache.max_age
-            );
+            match self.authoritative_uri() {
+                None => {
+                    // A fallback alias never carries credentials, so the shared
+                    // suffix below does not apply to it.
+                    return write!(
+                        f,
+                        "fallback [{}], cached in {} for {}",
+                        self.fallback.join(", "),
+                        cache.provider,
+                        cache.max_age
+                    );
+                }
+                Some(uri) => write!(
+                    f,
+                    "{}, cached in {} for {}",
+                    uri, cache.provider, cache.max_age
+                )?,
+            }
+        } else {
+            write!(f, "{}", self.uri)?;
         }
-        write!(f, "{}", self.uri)?;
         if !self.credentials.is_empty() {
             let mut names: Vec<&str> = self.credentials.keys().map(String::as_str).collect();
             names.sort();
@@ -452,10 +492,24 @@ impl Serialize for ProviderAlias {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if let Some(cache) = &self.cache {
             use serde::ser::SerializeStruct;
-            let mut table = serializer.serialize_struct("ProviderAlias", 2)?;
-            table.serialize_field("fallback", &self.fallback)?;
-            table.serialize_field("cache", cache)?;
-            return table.end();
+            return match self.authoritative_uri() {
+                Some(uri) => {
+                    let fields = if self.credentials.is_empty() { 2 } else { 3 };
+                    let mut table = serializer.serialize_struct("ProviderAlias", fields)?;
+                    table.serialize_field("uri", uri)?;
+                    if !self.credentials.is_empty() {
+                        table.serialize_field("credentials", &self.credentials)?;
+                    }
+                    table.serialize_field("cache", cache)?;
+                    table.end()
+                }
+                None => {
+                    let mut table = serializer.serialize_struct("ProviderAlias", 2)?;
+                    table.serialize_field("fallback", &self.fallback)?;
+                    table.serialize_field("cache", cache)?;
+                    table.end()
+                }
+            };
         }
         if self.credentials.is_empty() && self.reference_template.is_none() {
             // A bare alias serializes back to the plain-string form, so an alias
@@ -485,7 +539,7 @@ impl<'de> Deserialize<'de> for ProviderAlias {
 
             fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.write_str(
-                    "a provider URI string, a { uri, credentials } table, or a \
+                    "a provider URI string, a { uri, credentials, cache } table, or a \
                      { fallback, cache } table",
                 )
             }
@@ -517,16 +571,21 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                 }
                 let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
                 match (table.uri, table.fallback, table.cache) {
-                    (Some(uri), None, None) => {
+                    (Some(uri), None, cache) => {
                         if let Some(template) = &table.reference_template {
                             template.validate().map_err(serde::de::Error::custom)?;
+                        }
+                        if cache.is_some() && table.reference_template.is_some() {
+                            return Err(serde::de::Error::custom(
+                                "an inline cached provider alias cannot declare a ref template",
+                            ));
                         }
                         Ok(ProviderAlias {
                             uri,
                             credentials: table.credentials.unwrap_or_default(),
                             reference_template: table.reference_template,
                             fallback: Vec::new(),
-                            cache: None,
+                            cache,
                         })
                     }
                     (None, Some(fallback), Some(cache)) => {
@@ -546,15 +605,15 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                         // TOML enforce exactly the same invariants.
                         ProviderAlias::cached(fallback, cache).map_err(serde::de::Error::custom)
                     }
-                    (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(serde::de::Error::custom(
-                        "a provider alias must use either { uri, credentials, ref } or \
+                    (Some(_), Some(_), _) => Err(serde::de::Error::custom(
+                        "a provider alias must use either { uri, credentials, ref, cache } or \
                              { fallback, cache }, not both",
                     )),
                     (None, Some(_), None) => Err(serde::de::Error::custom(
                         "a cached provider alias with fallback also requires cache",
                     )),
                     (None, None, Some(_)) => Err(serde::de::Error::custom(
-                        "a cached provider alias with cache also requires fallback",
+                        "a cached provider alias with cache also requires uri or fallback",
                     )),
                     (None, None, None) => Err(serde::de::Error::custom(
                         "a provider alias table requires uri or fallback plus cache",
@@ -3862,6 +3921,29 @@ mod provider_alias_tests {
         assert_eq!(alias.cache.as_ref().unwrap().max_age_secs(), 8 * 60 * 60);
 
         let serialized = toml::to_string(&map).unwrap();
+        assert_eq!(parse(&serialized), map);
+    }
+
+    #[test]
+    fn inline_cached_uri_parses_and_round_trips_with_credentials() {
+        let map = parse(
+            r#"azure = { uri = "akv://team-vault", credentials = { client_secret = "keyring" }, cache = { provider = "local", max_age = "5m" } }"#,
+        );
+        let alias = &map["azure"];
+        assert_eq!(alias.uri, "akv://team-vault");
+        assert_eq!(
+            alias.credentials.get("client_secret"),
+            Some(&CredentialSource::from("keyring"))
+        );
+        assert!(alias.fallback.is_empty());
+        assert_eq!(
+            alias.cache.as_ref(),
+            Some(&ProviderCache::new("local", "5m").unwrap())
+        );
+
+        let serialized = toml::to_string(&map).unwrap();
+        assert!(serialized.contains("uri = \"akv://team-vault\""));
+        assert!(!serialized.contains("fallback"));
         assert_eq!(parse(&serialized), map);
     }
 

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -561,12 +561,16 @@ impl Secrets {
                 "provider alias '{name}' does not declare a cache policy"
             ))
         })?;
-        let (first, fallback) = alias.fallback().split_first().ok_or_else(|| {
-            SecretSpecError::ProviderOperationFailed(format!(
-                "cached provider alias '{name}' requires at least one authoritative source"
-            ))
-        })?;
 
+        if alias.authoritative_uri().is_some() && !alias.fallback().is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "cached provider alias '{name}' cannot declare both uri and fallback"
+            )));
+        }
+
+        // A cache provider is always a leaf. Explicit fallback entries are too;
+        // the inline form names its own leaf URI and is handled below without
+        // treating the alias as nested inside itself.
         for spec in alias
             .fallback()
             .iter()
@@ -581,11 +585,22 @@ impl Secrets {
             }
         }
 
-        let mut source_uris = Vec::with_capacity(alias.fallback().len());
-        for spec in alias.fallback() {
-            source_uris.push(self.resolve_one_provider(spec)?);
-            self.validate_credential_sources(spec)?;
-        }
+        // The inline form builds under the alias name itself, so the alias's
+        // credentials apply; its label in errors is the authoritative URI.
+        let (source_specs, source_uris) = if let Some(uri) = alias.authoritative_uri() {
+            self.validate_credential_sources(name)?;
+            (
+                vec![name.to_string()],
+                vec![self.resolve_one_provider(uri)?],
+            )
+        } else {
+            let mut source_uris = Vec::with_capacity(alias.fallback().len());
+            for spec in alias.fallback() {
+                source_uris.push(self.resolve_one_provider(spec)?);
+                self.validate_credential_sources(spec)?;
+            }
+            (alias.fallback().to_vec(), source_uris)
+        };
         let cache_uri = self.resolve_one_provider(cache.provider())?;
         self.validate_credential_sources(cache.provider())?;
 
@@ -631,7 +646,11 @@ impl Secrets {
                  authoritative source '{source}'. A cache must be a distinct store, otherwise \
                  refreshing it overwrites the secret it caches.",
                 uri = crate::audit::redact_uri_strict(&cache_uri),
-                source = alias.fallback()[shared],
+                source = crate::audit::redact_uri_strict(
+                    alias
+                        .authoritative_uri()
+                        .unwrap_or_else(|| alias.fallback()[shared].as_str()),
+                ),
             )));
         }
 
@@ -649,12 +668,18 @@ impl Secrets {
             )));
         }
 
+        let mut specs = source_specs.into_iter();
+        let first = specs.next().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "cached provider alias '{name}' requires at least one authoritative source"
+            ))
+        })?;
         Ok(Route {
             primary: Some(ResolvedPrimary {
-                spec: first.clone(),
+                spec: first,
                 uri: source_uris[0].clone(),
             }),
-            fallback: fallback.to_vec(),
+            fallback: specs.collect(),
             cache: Some(ResolvedCache {
                 spec: cache.provider().to_string(),
                 uri: cache_uri,
@@ -697,6 +722,9 @@ impl Secrets {
     pub(crate) fn override_display_uri(&self, spec: &str) -> Result<String> {
         match self.cached_alias(spec) {
             Some(alias) => {
+                if let Some(uri) = alias.authoritative_uri() {
+                    return self.resolve_one_provider(uri);
+                }
                 let first = alias.fallback().first().ok_or_else(|| {
                     SecretSpecError::ProviderOperationFailed(format!(
                         "cached provider alias '{spec}' requires at least one authoritative source"
@@ -1173,6 +1201,25 @@ mod tests {
     }
 
     #[test]
+    fn inline_cached_uri_keeps_alias_as_the_authoritative_build_key() {
+        let _env = scrub_resolution_env();
+        let inline = ProviderAlias::from("akv://team-vault")
+            .with_cache(ProviderCache::new("local", "5m").expect("valid cache policy"));
+        let spec = cached_spec_with(vec!["inline"], &[("inline", inline)]);
+        let plan = plan(&spec);
+        let route = route(find(&plan, "API_KEY"));
+
+        // The alias remains the build key so inline provider credentials are
+        // available when the authoritative provider is constructed.
+        assert_eq!(route.group_key(), Some("inline"));
+        assert_eq!(route.primary(), Some("akv://team-vault"));
+        assert!(route.fallback.is_empty());
+        let cache = route.cache().expect("cached route");
+        assert_eq!(cache.spec, "local");
+        assert_eq!(cache.max_age_secs, 5 * 60);
+    }
+
+    #[test]
     fn cached_alias_is_a_complete_route_not_a_chain_link() {
         let _env = scrub_resolution_env();
         // A cached alias is a whole route, so it cannot be a link in a chain in
@@ -1213,6 +1260,24 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("distinct store"), "{message}");
         assert!(message.contains("mirror"), "{message}");
+    }
+
+    #[test]
+    fn same_store_error_redacts_inline_authoritative_credentials() {
+        let _env = scrub_resolution_env();
+        let source = "vault://team-user:super-sensitive-password@127.0.0.1:8200/secret?tls=false";
+        let inline = ProviderAlias::from(source)
+            .with_cache(ProviderCache::new(source, "8h").expect("valid cache policy"));
+        let spec = cached_spec_with(vec!["route"], &[("route", inline)]);
+
+        let message = spec.build_plan(None).unwrap_err().to_string();
+        assert!(message.contains("distinct store"), "{message}");
+        assert!(
+            message.contains("vault://127.0.0.1:8200/secret"),
+            "{message}"
+        );
+        assert!(!message.contains("team-user"), "{message}");
+        assert!(!message.contains("super-sensitive-password"), "{message}");
     }
 
     #[test]
@@ -1265,7 +1330,10 @@ mod tests {
                 message.contains("distinct store"),
                 "{source} / {cache}: {message}"
             );
-            assert!(message.contains(source), "{source} / {cache}: {message}");
+            assert!(
+                message.contains(&crate::audit::redact_uri_strict(source)),
+                "{source} / {cache}: {message}"
+            );
         }
     }
 

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1002,9 +1002,10 @@ impl Secrets {
     /// Planned execution may unwrap only the inline form into its authoritative
     /// URI; a fallback-based cached alias remains a complete multi-store route.
     fn ensure_provider_use_allowed(&self, spec: &str, allow_inline_cached: bool) -> Result<()> {
-        if self.cached_alias(spec).is_some_and(|alias| {
-            !allow_inline_cached || alias.authoritative_uri().is_none()
-        }) {
+        if self
+            .cached_alias(spec)
+            .is_some_and(|alias| !allow_inline_cached || alias.authoritative_uri().is_none())
+        {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
                 "cached provider alias '{spec}' is a complete route; select it through a \
                  secret's providers list, the default provider, or --provider"

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1002,10 +1002,9 @@ impl Secrets {
     /// Planned execution may unwrap only the inline form into its authoritative
     /// URI; a fallback-based cached alias remains a complete multi-store route.
     fn ensure_provider_use_allowed(&self, spec: &str, allow_inline_cached: bool) -> Result<()> {
-        if self
-            .cached_alias(spec)
-            .is_some_and(|alias| !allow_inline_cached || alias.authoritative_uri().is_none())
-        {
+        if self.cached_alias(spec).is_some_and(|alias| {
+            !allow_inline_cached || alias.authoritative_uri().is_none()
+        }) {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
                 "cached provider alias '{spec}' is a complete route; select it through a \
                  secret's providers list, the default provider, or --provider"
@@ -1066,7 +1065,7 @@ impl Secrets {
         let mut credentials = ProviderCredentials::new();
         let Some(declared) = self
             .lookup_provider_alias_entry(spec)
-            .map(|alias| &alias.credentials)
+            .and_then(ProviderAlias::credentials)
             .filter(|credentials| !credentials.is_empty())
         else {
             return Ok(credentials);
@@ -1143,7 +1142,10 @@ impl Secrets {
         let entry = self
             .lookup_provider_alias_entry(alias)
             .ok_or_else(|| SecretSpecError::ProviderNotFound(alias.to_string()))?;
-        Ok(sorted_credential_entries(&entry.credentials)
+        Ok(entry
+            .credentials()
+            .map(sorted_credential_entries)
+            .unwrap_or_default()
             .into_iter()
             .map(|(name, source)| (name.clone(), source.clone()))
             .collect())
@@ -1203,10 +1205,13 @@ impl Secrets {
         let Some(alias) = self.lookup_provider_alias_entry(spec) else {
             return Ok(());
         };
+        let Some(credentials) = alias.credentials() else {
+            return Ok(());
+        };
         let resolved_target = self.resolve_provider_spec(spec.to_string());
         let supported = crate::provider::credential_names_for_spec(&resolved_target);
         let provider_name = crate::provider::provider_display_name_for_spec(&resolved_target);
-        for (name, source) in sorted_credential_entries(&alias.credentials) {
+        for (name, source) in sorted_credential_entries(credentials) {
             if !supported.contains(&name.as_str()) {
                 let supported_display = if supported.is_empty() {
                     "none".to_string()
@@ -1243,7 +1248,9 @@ impl Secrets {
                 )));
             }
             if let Some(source_alias) = self.lookup_provider_alias_entry(&source.provider)
-                && !source_alias.credentials.is_empty()
+                && source_alias
+                    .credentials()
+                    .is_some_and(|credentials| !credentials.is_empty())
             {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
                     "provider alias '{}' cannot be a credential source for '{spec}' because it \
@@ -6020,14 +6027,13 @@ mod provider_credential_scope_tests {
         // `access_token` is sourced from a writable, profile-namespacing store.
         let providers = HashMap::from([(
             "bws".to_string(),
-            ProviderAlias {
-                uri: "bws://proj".to_string(),
-                credentials: HashMap::from([(
+            ProviderAlias::leaf(
+                "bws://proj",
+                HashMap::from([(
                     "access_token".to_string(),
                     CredentialSource::from("memtest://"),
                 )]),
-                ..Default::default()
-            },
+            ),
         )]);
 
         let mut config =

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -923,10 +923,10 @@ impl Secrets {
         Ok(())
     }
 
-    /// Builds a provider from a spec (name or URI) and applies the session reason.
+    /// Builds a provider from a generic leaf spec (name or URI).
     ///
-    /// All provider construction in this module goes through here so that the
-    /// reason set via [`Secrets::with_reason`] reaches every provider instance.
+    /// Provider construction converges in [`Self::build_provider_with_credentials`]
+    /// so the reason set via [`Secrets::with_reason`] reaches every instance.
     ///
     /// `profile` is the profile the caller resolved for the surrounding
     /// operation (`None` falls back to the session profile): an alias's
@@ -938,6 +938,36 @@ impl Secrets {
         spec: String,
         profile: Option<&str>,
     ) -> Result<Box<dyn ProviderTrait>> {
+        self.build_provider_for_use(spec, profile, false)
+    }
+
+    /// Builds the authoritative leaf selected by a planned route.
+    ///
+    /// The 0.19+ inline cache form is both a complete route and the alias for
+    /// its one authoritative URI. Only planned route execution may unwrap that
+    /// alias into the leaf; generic provider inputs (for example an import
+    /// source) must still reject cached aliases as routes rather than silently
+    /// bypassing their cache policy.
+    fn build_route_provider(
+        &self,
+        spec: String,
+        profile: Option<&str>,
+    ) -> Result<Box<dyn ProviderTrait>> {
+        self.build_provider_for_use(spec, profile, true)
+    }
+
+    fn build_provider_for_use(
+        &self,
+        spec: String,
+        profile: Option<&str>,
+        allow_inline_cached: bool,
+    ) -> Result<Box<dyn ProviderTrait>> {
+        // Reject a route where a leaf is required before resolving any of the
+        // alias's credentials. Besides producing the route-specific error
+        // consistently, this keeps an invalid import/source use from touching
+        // credential stores merely to discover that it cannot build the alias.
+        self.ensure_provider_use_allowed(&spec, allow_inline_cached)?;
+
         // When `spec` names an alias with a `credentials` map, resolve those
         // values from their source providers and hand them to the built provider.
         // Memoized per (profile, spec) so rebuilding a provider (per-secret chain walks,
@@ -949,7 +979,7 @@ impl Secrets {
         let credentials = self
             .provider_credentials_cache
             .get_or_try_init(key, || self.resolve_provider_credentials(&spec, &profile))?;
-        self.build_provider_with_credentials(&spec, credentials)
+        self.build_provider_with_credentials(&spec, credentials, allow_inline_cached)
     }
 
     /// [`Self::build_provider`], memoized within one resolution so repeated
@@ -961,31 +991,49 @@ impl Secrets {
         cache: &ProviderCache,
         spec: &str,
         profile: Option<&str>,
+        allow_inline_cached: bool,
     ) -> Result<Arc<dyn ProviderTrait>> {
         let key = (self.resolve_profile_name(profile), spec.to_string());
-        cache.get_or_try_init(key, || self.build_provider(spec.to_string(), profile))
+        cache.get_or_try_init(key, || {
+            self.build_provider_for_use(spec.to_string(), profile, allow_inline_cached)
+        })
     }
-
-    /// Builds a credential source provider without resolving credentials for it,
-    /// so credential-source chains are at most one hop and cannot recurse.
-    fn build_source_provider(&self, spec: &str) -> Result<Box<dyn ProviderTrait>> {
-        self.build_provider_with_credentials(spec, ProviderCredentials::new())
-    }
-
-    /// The shared construction body behind [`Self::build_provider`] and
-    /// [`Self::build_source_provider`]: alias expansion, error enrichment, and
-    /// the base-dir/reason hooks live only here, so the two paths cannot drift.
-    fn build_provider_with_credentials(
-        &self,
-        spec: &str,
-        credentials: ProviderCredentials,
-    ) -> Result<Box<dyn ProviderTrait>> {
-        if self.cached_alias(spec).is_some() {
+    /// Rejects cached routes in construction contexts that require one leaf.
+    /// Planned execution may unwrap only the inline form into its authoritative
+    /// URI; a fallback-based cached alias remains a complete multi-store route.
+    fn ensure_provider_use_allowed(&self, spec: &str, allow_inline_cached: bool) -> Result<()> {
+        if self
+            .cached_alias(spec)
+            .is_some_and(|alias| !allow_inline_cached || alias.authoritative_uri().is_none())
+        {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
                 "cached provider alias '{spec}' is a complete route; select it through a \
                  secret's providers list, the default provider, or --provider"
             )));
         }
+        Ok(())
+    }
+
+    /// Builds a leaf provider without resolving its declared credentials: for a
+    /// credential source, so credential-source chains are at most one hop and
+    /// cannot recurse, and for cache remediation, where the credential source
+    /// itself may be what failed.
+    fn build_source_provider(&self, spec: &str) -> Result<Box<dyn ProviderTrait>> {
+        self.build_provider_with_credentials(spec, ProviderCredentials::new(), false)
+    }
+
+    /// The shared construction body behind generic, routed, and credential
+    /// source providers: alias expansion, error enrichment, and the
+    /// base-dir/reason hooks live only here, so those paths cannot drift.
+    fn build_provider_with_credentials(
+        &self,
+        spec: &str,
+        credentials: ProviderCredentials,
+        allow_inline_cached: bool,
+    ) -> Result<Box<dyn ProviderTrait>> {
+        // `build_source_provider` calls this body directly, so retain the guard
+        // here as well as before credential initialization in the generic path.
+        self.ensure_provider_use_allowed(spec, allow_inline_cached)?;
         // Resolve provider aliases here, at the single construction chokepoint, so
         // every caller that hands us a user-supplied spec gets alias expansion for
         // free and no new entry point can forget it. Resolution is a no-op on an
@@ -1890,8 +1938,11 @@ impl Secrets {
     /// [`Self::provider_alias_sources`] in order.
     fn lookup_provider_alias(&self, alias: &str) -> Option<String> {
         self.lookup_provider_alias_entry(alias)
-            .filter(|alias| !alias.is_cached())
-            .map(|alias| alias.uri.clone())
+            // An inline cached alias still names one leaf URI. Route planning
+            // sees its cache policy first; provider construction resolves the
+            // same alias to this URI so its credentials remain available.
+            .and_then(|alias| alias.authoritative_uri())
+            .map(str::to_string)
     }
 
     /// The cached route `spec` names, if it names one at all.
@@ -2240,7 +2291,7 @@ impl Secrets {
         let result = match provider {
             Some(provider) => self.delete_cache_entry(provider, &planned.name, profile),
             None => self
-                .build_provider_with_credentials(&cache.spec, ProviderCredentials::new())
+                .build_source_provider(&cache.spec)
                 .and_then(|provider| {
                     self.delete_cache_entry(provider.as_ref(), &planned.name, profile)
                 }),
@@ -2483,7 +2534,7 @@ impl Secrets {
     ) -> Result<Box<dyn ProviderTrait>> {
         // Build from the primary spec (not the resolved URI) so an alias's
         // `credentials` is applied to the write target too.
-        self.get_provider(route.group_key(), profile)
+        self.get_route_provider(route.group_key(), profile)
     }
 
     /// Gets the provider instance to use for secret operations
@@ -2522,6 +2573,19 @@ impl Secrets {
         let provider = self.build_provider(provider_spec, profile)?;
 
         Ok(provider)
+    }
+
+    /// The routed sibling of [`Self::get_provider`]: resolves `provider_arg`
+    /// against the default provider, then builds it as a planned route's
+    /// primary, so an inline cached alias (0.19+) unwraps to its authoritative
+    /// leaf instead of being rejected as a route.
+    fn get_route_provider(
+        &self,
+        provider_arg: Option<&str>,
+        profile: Option<&str>,
+    ) -> Result<Box<dyn ProviderTrait>> {
+        let provider_spec = self.default_provider_spec(provider_arg)?;
+        self.build_route_provider(provider_spec, profile)
     }
 
     /// The raw provider spec [`Self::get_provider`] would build for
@@ -2610,6 +2674,9 @@ impl Secrets {
     ///   each endpoint's address
     /// * `provider_specs` - Optional chain of provider specs (aliases or inline
     ///   URIs) to try in order, resolved lazily per entry
+    /// * `planned_primary_uri` - The already-resolved URI of the first entry
+    ///   when it is a planned route primary. Its presence selects route-aware
+    ///   construction for that entry; fallback-only walks pass `None`.
     /// * `profile` - The profile the read is addressed under; scopes any
     ///   provider credentials fetched when a chain link is built
     ///
@@ -2627,6 +2694,7 @@ impl Secrets {
         provider_specs: Option<&[String]>,
         project: &str,
         profile: &str,
+        planned_primary_uri: Option<&str>,
     ) -> Result<(Option<SecretString>, Option<String>, Option<NativeAddress>)> {
         // If a provider chain is supplied, try it in order.
         if let Some(specs) = provider_specs {
@@ -2634,12 +2702,20 @@ impl Secrets {
             let mut any_healthy = false;
             let mut last_uri: Option<String> = None;
             let mut last_reference: Option<NativeAddress> = None;
-            for spec in specs {
+            for (index, spec) in specs.iter().enumerate() {
+                let is_planned_primary = index == 0 && planned_primary_uri.is_some();
                 // Resolve this link only now, as the chain reaches it. An
                 // undefined alias is one broken link, treated exactly like a
                 // provider that fails to construct or read: warn and try the
                 // next, so a working provider later in the chain still answers.
-                let uri = match self.resolve_one_provider(spec) {
+                // A planned primary was already resolved and validated while
+                // building the route. Reuse that URI: an inline cached alias is
+                // deliberately rejected by the generic leaf-only resolver.
+                let resolved = match planned_primary_uri.filter(|_| is_planned_primary) {
+                    Some(uri) => Ok(uri.to_string()),
+                    None => self.resolve_one_provider(spec),
+                };
+                let uri = match resolved {
                     Ok(uri) => uri,
                     Err(e) => {
                         // Resolution failed, so only the raw spec exists; redact it.
@@ -2653,9 +2729,17 @@ impl Secrets {
                     }
                 };
                 // Build from the raw spec (not the resolved URI) so an alias's
-                // `credentials` is applied to this chain link too. Shared, not
-                // rebuilt: this walk runs per secret (see [`ProviderCache`]).
-                let provider = match self.shared_provider(provider_cache, spec, Some(profile)) {
+                // `credentials` is applied to this chain link too. A planned
+                // primary uses the same route-aware construction as batch
+                // execution, allowing an inline cached alias to unwrap to its
+                // authoritative leaf while keeping generic uses leaf-only. The
+                // provider is shared across this operation's per-secret walks.
+                let provider = match self.shared_provider(
+                    provider_cache,
+                    spec,
+                    Some(profile),
+                    is_planned_primary,
+                ) {
                     Ok(p) => p,
                     Err(e) => {
                         // Construction failed after resolution, so redact the
@@ -3125,6 +3209,7 @@ impl Secrets {
                     read_specs.as_deref(),
                     &self.config.project.name,
                     &profile_name,
+                    route.primary(),
                 );
                 if let Ok((Some(value), _, _)) = &result {
                     self.write_cached_secret(&planned, route, &profile_name, value);
@@ -4640,7 +4725,7 @@ impl Secrets {
             if group.is_empty() {
                 continue;
             }
-            match self.get_provider(provider_uri, Some(&plan.profile)) {
+            match self.get_route_provider(provider_uri, Some(&plan.profile)) {
                 Ok(provider) => {
                     // Attribute primary hits to the provider's own credential-free
                     // `uri()`, never the raw configured alias (which may embed a
@@ -4755,6 +4840,7 @@ impl Secrets {
                         Some(fallback),
                         project,
                         profile,
+                        None,
                     );
                     (planned.name.clone(), result)
                 },
@@ -6288,7 +6374,7 @@ mod reference_routing_tests {
         let spec = Secrets::new(crate::tests::resolve_test_config(secrets), None, None, None);
         let plan = spec.build_plan(None).unwrap();
         for (primary, group) in plan.groups() {
-            let provider = spec.get_provider(primary, None).unwrap();
+            let provider = spec.get_route_provider(primary, None).unwrap();
             spec.check_single_store_ref_coords(
                 primary,
                 &group,

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6434,14 +6434,16 @@ APP_SECRET = { description = "App", required = true }
         .expect("merged config should carry [providers]");
 
     assert_eq!(
-        providers.get("op_infra").map(|alias| alias.uri.as_str()),
+        providers
+            .get("op_infra")
+            .and_then(ProviderAlias::authoritative_uri),
         Some("onepassword://Shared"),
         "alias defined only in extended config should be inherited"
     );
     assert_eq!(
         providers
             .get("op_overridden")
-            .map(|alias| alias.uri.as_str()),
+            .and_then(ProviderAlias::authoritative_uri),
         Some("onepassword://NewVault"),
         "alias defined in both should resolve to the current (extending) config's value"
     );
@@ -7809,11 +7811,7 @@ fn secrets_with_credential_alias(
     let mut config = resolve_test_config(HashMap::new());
     config.providers = Some(HashMap::from([(
         "target".to_string(),
-        ProviderAlias {
-            uri: target_uri.to_string(),
-            credentials,
-            ..Default::default()
-        },
+        ProviderAlias::leaf(target_uri, credentials),
     )]));
     Secrets::new(config, None, None, None)
 }
@@ -8071,25 +8069,23 @@ fn credential_chain_is_limited_to_one_hop() {
         // `chained` itself declares credentials, so it may not be a source.
         (
             "chained".to_string(),
-            ProviderAlias {
-                uri: "keyring://".to_string(),
-                credentials: HashMap::from([(
+            ProviderAlias::leaf(
+                "keyring://",
+                HashMap::from([(
                     "access_token".to_string(),
                     CredentialSource::from("keyring"),
                 )]),
-                ..Default::default()
-            },
+            ),
         ),
         (
             "target".to_string(),
-            ProviderAlias {
-                uri: "bws://00000000-0000-0000-0000-000000000000".to_string(),
-                credentials: HashMap::from([(
+            ProviderAlias::leaf(
+                "bws://00000000-0000-0000-0000-000000000000",
+                HashMap::from([(
                     "access_token".to_string(),
                     CredentialSource::from("chained"),
                 )]),
-                ..Default::default()
-            },
+            ),
         ),
     ]));
     let secrets = Secrets::new(config, None, None, None);
@@ -9695,10 +9691,13 @@ fn invalid_inline_cached_import_does_not_fetch_provider_credentials() {
     let cache = temp.path().join("cache.env");
     let mut route = ProviderAlias::from("bws://project")
         .with_cache(ProviderCache::new("local", "8h").expect("valid cache policy"));
-    route.credentials.insert(
-        "access_token".to_string(),
-        CredentialSource::from("memtest://"),
-    );
+    route
+        .credentials_mut()
+        .expect("inline cached providers carry credentials")
+        .insert(
+            "access_token".to_string(),
+            CredentialSource::from("memtest://"),
+        );
     let providers = HashMap::from([
         ("myprovider".to_string(), route),
         (
@@ -10169,14 +10168,13 @@ fn cache_construction_failure_drops_the_superseded_entry() {
         let mut providers = cached_providers(&[&source], "memtest://", "8h");
         providers.insert(
             "local".to_string(),
-            ProviderAlias {
-                uri: "memtest://".to_string(),
-                credentials: HashMap::from([(
+            ProviderAlias::leaf(
+                "memtest://",
+                HashMap::from([(
                     "test_token".to_string(),
                     CredentialSource::from(format!("dotenv://{}", credential.display())),
                 )]),
-                ..Default::default()
-            },
+            ),
         );
         providers
     };

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -9491,6 +9491,25 @@ fn cached_dotenv_secrets(source_paths: &[&Path], cache_path: &Path, max_age: &st
     )
 }
 
+/// One authoritative dotenv provider with its cache attached directly to the
+/// same alias (0.19+ shorthand).
+fn inline_cached_dotenv_secrets(source_path: &Path, cache_path: &Path, max_age: &str) -> Secrets {
+    cached_secrets_with(
+        "resolve-test",
+        HashMap::from([
+            (
+                "myprovider".to_string(),
+                ProviderAlias::from(format!("dotenv://{}", source_path.display()))
+                    .with_cache(ProviderCache::new("local", max_age).expect("valid cache policy")),
+            ),
+            (
+                "local".to_string(),
+                ProviderAlias::from(format!("dotenv://{}", cache_path.display())),
+            ),
+        ]),
+    )
+}
+
 /// A profile-aware in-memory authoritative store with a shared flat dotenv
 /// cache. This combination exercises the namespace the cache envelope itself
 /// must preserve.
@@ -9618,6 +9637,86 @@ fn cached_route_hits_cache_refreshes_after_clear_and_survives_source_loss() {
         resolved_value(&secrets, "API_KEY"),
         "remote-2",
         "a fresh hit must not contact the now-broken authoritative provider"
+    );
+}
+
+#[test]
+fn inline_cached_uri_reads_refreshes_and_clears_like_a_cached_route() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let cache = temp.path().join("cache.env");
+    fs::write(&source, "API_KEY=remote-1\n").unwrap();
+    let secrets = inline_cached_dotenv_secrets(&source, &cache, "8h");
+
+    assert_eq!(resolved_value(&secrets, "API_KEY"), "remote-1");
+    fs::write(&source, "API_KEY=remote-2\n").unwrap();
+    assert_eq!(
+        resolved_value(&secrets, "API_KEY"),
+        "remote-1",
+        "the inline alias must consult its fresh cache first"
+    );
+
+    assert_eq!(secrets.clear_cache(Some("API_KEY")).unwrap(), 1);
+    assert_eq!(resolved_value(&secrets, "API_KEY"), "remote-2");
+}
+
+#[test]
+fn inline_cached_uri_single_get_populates_an_empty_cache() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let cache = temp.path().join("cache.env");
+    fs::write(&source, "API_KEY=remote\n").unwrap();
+    let secrets = inline_cached_dotenv_secrets(&source, &cache, "8h");
+
+    secrets
+        .get("API_KEY")
+        .expect("single-secret reads must build the planned inline primary");
+    assert!(cache.exists(), "the source hit should populate the cache");
+}
+
+#[test]
+fn inline_cached_alias_is_not_silently_unwrapped_as_an_import_source() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let cache = temp.path().join("cache.env");
+    let secrets = inline_cached_dotenv_secrets(&source, &cache, "8h");
+
+    let error = secrets.import("myprovider").unwrap_err();
+    assert!(error.to_string().contains("complete route"), "{error}");
+}
+
+#[test]
+fn invalid_inline_cached_import_does_not_fetch_provider_credentials() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let cache = temp.path().join("cache.env");
+    let mut route = ProviderAlias::from("bws://project")
+        .with_cache(ProviderCache::new("local", "8h").expect("valid cache policy"));
+    route.credentials.insert(
+        "access_token".to_string(),
+        CredentialSource::from("memtest://"),
+    );
+    let providers = HashMap::from([
+        ("myprovider".to_string(), route),
+        (
+            "local".to_string(),
+            ProviderAlias::from(format!("dotenv://{}", cache.display())),
+        ),
+    ]);
+    let mut secrets = cached_secrets_with("inline-import-test", providers);
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    secrets.set_audit_for_test(logger);
+
+    let error = secrets.import("myprovider").unwrap_err();
+    assert!(error.to_string().contains("complete route"), "{error}");
+    assert!(
+        audit_events(&lines)
+            .iter()
+            .all(|event| event["command"] != "credential"),
+        "rejecting a route as an import source must not read its credential stores"
     );
 }
 


### PR DESCRIPTION
## Summary

- support `uri` and `cache` on the same provider alias in SecretSpec 0.19+, including provider credentials
- preserve the existing `fallback` plus `cache` form for multi-provider authoritative routes
- merge remote-provider performance guidance into the Provider caching guide and remove the standalone page
- present the latency problem first, caching as the solution, and diagnostics at the end

## Validation

- `devenv shell cargo test --package secretspec` (1,070 passed, 4 ignored)
- `devenv shell -- npm --prefix docs run build`
- repository pre-commit Clippy and rustfmt hooks
