### PR TITLE
ci(workflows): harden release input handling

### DIFF
--- a/.github/workflows/ffi-build.yml
+++ b/.github/workflows/ffi-build.yml
@@ -136,6 +136,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
           mapfile -t assets < <(
@@ -148,4 +149,4 @@ jobs:
             exit 1
           fi
           bash scripts/upload-release-asset.sh \
-            "${{ inputs.release_tag || github.ref_name }}" "${assets[@]}"
+            "$RELEASE_TAG" "${assets[@]}"

--- a/.github/workflows/go-embed.yml
+++ b/.github/workflows/go-embed.yml
@@ -146,6 +146,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
           mapfile -t assets < <(find staged -type f -name 'secretspec_ffi_*' -print | sort)
@@ -155,7 +156,7 @@ jobs:
             exit 1
           fi
           bash scripts/upload-release-asset.sh \
-            "${{ inputs.release_tag || github.ref_name }}" "${assets[@]}"
+            "$RELEASE_TAG" "${assets[@]}"
 
       - name: Publish the Go module tag
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/go-static.yml
+++ b/.github/workflows/go-static.yml
@@ -136,9 +136,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
           asset="secretspec-go-static-x86_64-linux-musl.tar.gz"
           tar -czf "$asset" -C staged .
           bash scripts/upload-release-asset.sh \
-            "${{ inputs.release_tag || github.ref_name }}" "$asset"
+            "$RELEASE_TAG" "$asset"

--- a/.github/workflows/php-ext.yml
+++ b/.github/workflows/php-ext.yml
@@ -148,4 +148,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash scripts/upload-release-asset.sh "${{ inputs.release_tag || github.ref_name }}" "${{ steps.stage.outputs.asset }}"
+          RELEASE_ASSET: ${{ steps.stage.outputs.asset }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+        run: bash scripts/upload-release-asset.sh "$RELEASE_TAG" "$RELEASE_ASSET"

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -173,7 +173,8 @@ jobs:
       - name: Attach the XCFramework to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: >-
           bash scripts/upload-release-asset.sh
-          "${{ inputs.release_tag || github.ref_name }}"
+          "$RELEASE_TAG"
           artifacts/CSecretSpec.xcframework.zip

--- a/scripts/upload-release-asset.sh
+++ b/scripts/upload-release-asset.sh
@@ -10,8 +10,20 @@
 # retry). Needs GH_TOKEN with contents: write.
 set -euo pipefail
 
+if (( $# < 2 )); then
+  echo "usage: upload-release-asset.sh <tag> <asset> [asset...]" >&2
+  exit 2
+fi
+
 tag="$1"
 shift
+
+# Release publication uses version tags. Reject malformed input before it is
+# passed to gh, while allowing SemVer prerelease and build suffixes.
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z][0-9A-Za-z.+-]*)?$ ]]; then
+  echo "invalid release tag: $tag" >&2
+  exit 2
+fi
 
 files=()
 for asset in "$@"; do


### PR DESCRIPTION
## Summary

- pass release tags into shell steps through environment variables
- pass the generated PHP asset name through an environment variable
- quote release-related shell variables before invoking the upload helper
- reject missing arguments and malformed version tags in the shared release asset upload helper

## Rationale

Zizmor reported ten high-confidence template-injection findings across the FFI, Go, PHP, and Swift release upload steps.

GitHub expressions embedded directly in `run:` blocks are expanded before the shell parses the script. Moving these values into step-level environment variables ensures the shell treats them as data rather than executable syntax.

## Validation

- `devenv shell -- actionlint -shellcheck=`
- `shellcheck scripts/upload-release-asset.sh`
- `bash -n scripts/upload-release-asset.sh`
- `devenv shell -- pre-commit run -a`
- exercised valid prerelease/build tag handling and rejection of missing or malformed input
- reran zizmor against the five affected workflows, the ten high/high template-injection findings are no longer reported