### PR TITLE
ci(workflows): pin build container images

### DIFF
--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -44,13 +44,13 @@ jobs:
           - rid: linux-x64
             target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_28_x86_64
+            container: quay.io/pypa/manylinux_2_28_x86_64:2026.08.05-1@sha256:e0b40ace8e818e96026eb47714b01998cbca022a6995797d0905474ce3e82ae8
             library: libsecretspec_ffi.so
             rustflags: -C strip=symbols
           - rid: linux-arm64
             target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
-            container: quay.io/pypa/manylinux_2_28_aarch64
+            container: quay.io/pypa/manylinux_2_28_aarch64:2026.08.05-1@sha256:f766b402889e40f439e7a3ee5788eef1aa3ef399d0110107d27419fa2ba9d905
             library: libsecretspec_ffi.so
             rustflags: -C strip=symbols
           - rid: osx-x64
@@ -164,11 +164,11 @@ jobs:
           - rid: linux-musl-x64
             target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
-            image: quay.io/pypa/musllinux_1_2_x86_64
+            image: quay.io/pypa/musllinux_1_2_x86_64:2026.08.05-1@sha256:c7b2187aa4d095a8da73ea4db96acefd46701a13439a9cc4546f5d61a4b5bba1
           - rid: linux-musl-arm64
             target: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
-            image: quay.io/pypa/musllinux_1_2_aarch64
+            image: quay.io/pypa/musllinux_1_2_aarch64:2026.08.05-1@sha256:668c455aeddf5e363bd6fd801f10b369a634a9f01974876cee8c8c518b44ef10
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -436,7 +436,7 @@ jobs:
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --volume "$RUNNER_TEMP:/runner" \
             --workdir /runner \
-            mcr.microsoft.com/dotnet/sdk:8.0-alpine \
+            mcr.microsoft.com/dotnet/sdk:8.0-alpine@sha256:5f12aa62868b69dcb41de9cd7f8759822f7d1f56c3b31908048ad65df0981e67 \
             sh -c '
               set -eu
               apk add --no-cache build-base clang zlib-dev

--- a/.github/workflows/ffi-build.yml
+++ b/.github/workflows/ffi-build.yml
@@ -44,11 +44,11 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_28_x86_64
+            container: quay.io/pypa/manylinux_2_28_x86_64:2026.08.05-1@sha256:e0b40ace8e818e96026eb47714b01998cbca022a6995797d0905474ce3e82ae8
             artifact: libsecretspec_ffi.so
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
-            container: quay.io/pypa/manylinux_2_28_aarch64
+            container: quay.io/pypa/manylinux_2_28_aarch64:2026.08.05-1@sha256:f766b402889e40f439e7a3ee5788eef1aa3ef399d0110107d27419fa2ba9d905
             artifact: libsecretspec_ffi.so
           - target: aarch64-apple-darwin
             runner: macos-latest

--- a/.github/workflows/go-embed.yml
+++ b/.github/workflows/go-embed.yml
@@ -48,10 +48,10 @@ jobs:
         include:
           - target: linux_amd64
             runner: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_28_x86_64
+            container: quay.io/pypa/manylinux_2_28_x86_64:2026.08.05-1@sha256:e0b40ace8e818e96026eb47714b01998cbca022a6995797d0905474ce3e82ae8
           - target: linux_arm64
             runner: ubuntu-24.04-arm
-            container: quay.io/pypa/manylinux_2_28_aarch64
+            container: quay.io/pypa/manylinux_2_28_aarch64:2026.08.05-1@sha256:f766b402889e40f439e7a3ee5788eef1aa3ef399d0110107d27419fa2ba9d905
           - { target: darwin_arm64, runner: macos-latest }
           - { target: windows_amd64, runner: windows-latest }
 

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -55,11 +55,11 @@ jobs:
           - target: linux-x64
             platform: linux-x64-gnu
             runner: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_28_x86_64
+            container: quay.io/pypa/manylinux_2_28_x86_64:2026.08.05-1@sha256:e0b40ace8e818e96026eb47714b01998cbca022a6995797d0905474ce3e82ae8
           - target: linux-arm64
             platform: linux-arm64-gnu
             runner: ubuntu-24.04-arm
-            container: quay.io/pypa/manylinux_2_28_aarch64
+            container: quay.io/pypa/manylinux_2_28_aarch64:2026.08.05-1@sha256:f766b402889e40f439e7a3ee5788eef1aa3ef399d0110107d27419fa2ba9d905
           - { target: darwin-arm64, platform: darwin-arm64, runner: macos-latest }
           - { target: win32-x64, platform: win32-x64-msvc, runner: windows-latest }
 


### PR DESCRIPTION
## Summary

- pin the manylinux and musllinux build images to immutable digests
- pin the multi-architecture .NET 8 Alpine SDK image used for package testing
- retain readable image tags alongside each digest

This covers 11 references to five unique images across the .NET, FFI, Go, and Node workflows.

## Rationale

The workflows previously referenced mutable container tags. A registry publisher could therefore change the bytes used by pull-request and release builds without any corresponding repository change or review.

Zizmor reported eight high/high `unpinned-images` findings across the four matrix-container workflows. Pinning the resolved manifests makes image changes explicit and reviewable while retaining the original platform and compatibility tags.

No build behavior is intended to change beyond fixing the images to the versions the existing tags resolved to when this change was prepared.

## Maintenance tradeoff

This trades silent upstream image drift for manual refreshes.

Dependabot currently only extracts repository-style `uses:` dependencies from GitHub Actions workflows. It does not update job-container matrix values or image references embedded in `docker run` commands. Adding a Docker ecosystem entry would not cover these workflow files either.

There are five unique images behind the 11 references, so a refresh is mechanical but must currently be initiated manually. I have intentionally not added another dependency bot or prescribed an update schedule in this PR.

A reasonable initial policy could be to refresh these pins during release preparation, in response to relevant security notices, or on an agreed periodic cadence. If that proves burdensome, a dedicated updater or consistency check can follow.

[Dependabot support reference](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#github-actions)

## Validation

- resolved every tag-plus-digest reference directly from its registry
- verified the PyPA image architecture mappings:
  - x86_64 images resolve to `linux/amd64`
  - aarch64 images resolve to `linux/arm64`
- verified the pinned .NET manifest contains both amd64 and arm64 variants
- `devenv shell -- actionlint -shellcheck=`
- `devenv shell -- pre-commit run -a`
- reran zizmor against the four affected workflows; the eight high/high `unpinned-images` findings are no longer reported

Zizmor still emits four low-confidence `unpinned-images` findings because it cannot statically prove that `matrix.container` only resolves to the pinned matrix values. The concrete values are all digest-pinned.