### PR TITLE
Add null provider for defaults and ephemeral generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preflights the whole migration, verifies all writes before cleanup, and can
   safely move between distinct entries in the same physical store.
 - A `null` provider lets non-sensitive, version-controlled environment values
-  use their manifest defaults without reading from or writing to secret storage.
+  use their manifest defaults and lets generated secrets stay ephemeral, with a
+  fresh value returned for each resolution and nothing written to provider
+  storage.
 - Secrets can store values as standard Base64, URL-safe Base64, or hexadecimal
   using `encoding`; writes encode logical text and reads decode stored values,
   while `as_path = true` materializes arbitrary decoded bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sources/destinations resolve independently. `import --delete-source` now
   preflights the whole migration, verifies all writes before cleanup, and can
   safely move between distinct entries in the same physical store.
+- A `null` provider lets non-sensitive, version-controlled environment values
+  use their manifest defaults without reading from or writing to secret storage.
 - Secrets can store values as standard Base64, URL-safe Base64, or hexadecimal
   using `encoding`; writes encode logical text and reads decode stored values,
   while `as_path = true` materializes arbitrary decoded bytes.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -123,7 +123,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+).`,
+Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). The null provider (0.19+) deliberately falls through to manifest defaults without storage.`,
         }),
       ],
       title: "SecretSpec",
@@ -224,6 +224,11 @@ Secrets can be stored in: keyring (default), KeePass KDBX (0.17+), dotenv files,
             },
             { label: "Dotenv", slug: "providers/dotenv" },
             { label: "Environment Variables", slug: "providers/env" },
+            {
+              label: "Null",
+              slug: "providers/null",
+              badge: { text: "0.19+", variant: "note" },
+            },
             {
               label: "systemd Credentials",
               slug: "providers/systemd-credential",

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -123,7 +123,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). The null provider (0.19+) deliberately falls through to manifest defaults without storage.`,
+Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). The null provider (0.19+) uses manifest defaults or ephemeral generation without storage.`,
         }),
       ],
       title: "SecretSpec",

--- a/docs/src/content/docs/concepts/generation.md
+++ b/docs/src/content/docs/concepts/generation.md
@@ -45,8 +45,30 @@ MONGO_KEY = { description = "MongoDB keyfile", type = "command", generate = { co
 - Generation only triggers when a secret is **missing**. Existing secrets are never overwritten.
 - Generated values are stored via the secret's configured provider (or the default provider).
 - Subsequent runs find the stored value and skip generation (idempotent).
+- The `null` provider (0.19+) instead returns a fresh generated value for only the current resolution.
 - `generate` and `default` cannot both be set on the same secret.
 - Setting `type` without `generate` is informational only and does not trigger auto-generation.
+
+## Ephemeral generation with null (0.19+)
+
+:::caution[Version compatibility]
+Ephemeral generation through the `null` provider requires SecretSpec 0.19 or
+newer.
+:::
+
+Use `providers = ["null"]` when the value should be generated on demand and
+never written to provider storage:
+
+```toml
+[profiles.default]
+SESSION_SECRET = { description = "Per-run session secret", type = "base64", generate = { bytes = 32 }, providers = ["null"] }
+```
+
+One materializing resolution receives one value. The next `run`, `get`,
+`check`, or SDK value-carrying resolution receives a new one. Value-free
+reports describe the value as generated without minting it. Use a writable
+provider instead when another process or later invocation must retrieve the
+same value.
 
 ## Example
 

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -43,7 +43,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [kdbx](/providers/kdbx/) (0.17+) | KeePass KDBX file (requires the `kdbx` build feature) | ✓ | KDBX 4 | ✓ | — |
 | [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ | — |
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ | — |
-| [null](/providers/null/) (0.19+) | No storage; always missing so a manifest default applies | ✗ | ✗ | N/A | — |
+| [null](/providers/null/) (0.19+) | No storage; uses a manifest default or ephemeral generation | ✗ | ✗ | N/A | — |
 | [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |
 | [pass](/providers/pass/) | Unix `pass` password store | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [gopass](/providers/gopass/) (0.15+) | `gopass` password store (git-synced, GPG-encrypted) | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -43,6 +43,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [kdbx](/providers/kdbx/) (0.17+) | KeePass KDBX file (requires the `kdbx` build feature) | ✓ | KDBX 4 | ✓ | — |
 | [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ | — |
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ | — |
+| [null](/providers/null/) (0.19+) | No storage; always missing so a manifest default applies | ✗ | ✗ | N/A | — |
 | [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |
 | [pass](/providers/pass/) | Unix `pass` password store | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [gopass](/providers/gopass/) (0.15+) | `gopass` password store (git-synced, GPG-encrypted) | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |

--- a/docs/src/content/docs/development/adding-providers.md
+++ b/docs/src/content/docs/development/adding-providers.md
@@ -33,6 +33,13 @@ pub trait Provider: Send + Sync {
     /// the reason: it is what the user sees.
     fn check_writable(&self, addr: Address<'_>) -> Result<()> { Ok(()) }
 
+    /// SecretSpec 0.19+: optional, defaults to Persist. Return Ephemeral only
+    /// when generated values should be returned for one resolution without
+    /// calling `set`; ordinary writes remain governed by `check_writable`.
+    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
+        GeneratedValuePersistence::Persist
+    }
+
     /// Optional batch read. The default resolves each request's address and
     /// fetches every unique address once, concurrently; override it when the
     /// store has a real bulk surface (one listing, a batch API).
@@ -55,6 +62,13 @@ written for another store fails loudly instead of resolving something else —
 you declare the set, you never write the check. Have `set` call
 `self.check_writable(addr)?` first, so the pre-check and the write agree on
 one refusal message.
+
+SecretSpec 0.19+ also exposes `generated_value_persistence`. Leave its default
+of `Persist` for storage providers. `Ephemeral` is an explicit generation-only
+capability: after a healthy read miss, SecretSpec returns the generated logical
+value for the current materializing resolution without calling `set` or
+refreshing a cache. It does not make ordinary writes succeed and must be a pure,
+I/O-free capability check.
 
 ### Convention templates
 

--- a/docs/src/content/docs/providers/null.md
+++ b/docs/src/content/docs/providers/null.md
@@ -1,15 +1,16 @@
 ---
 title: Null Provider
-description: Use committed manifest defaults without a storage backend
+description: Use committed defaults or ephemeral generation without a storage backend
 ---
 
 :::caution[Version compatibility]
 The `null` provider is added in SecretSpec 0.19.
 :::
 
-The null provider always reports that a value is missing. SecretSpec then
-uses the declaration's `default`. This is useful for non-sensitive environment
-configuration that belongs in `secretspec.toml`, not in a secret store.
+The null provider always reports that a value is missing. SecretSpec then uses
+the declaration's committed `default` or generates a fresh value when
+`generate` is enabled. This is useful for non-sensitive environment
+configuration and secrets that should exist for only one resolution.
 
 ## At a glance
 
@@ -17,8 +18,8 @@ configuration that belongs in `secretspec.toml`, not in a secret store.
 | --- | --- |
 | Provider | `null` (0.19+) |
 | URI | `null://` |
-| Access | Always returns missing; writes are rejected |
-| Best for | Team-shared, non-sensitive defaults |
+| Access | Always returns missing; ordinary writes are rejected |
+| Best for | Team-shared defaults and ephemeral generated values |
 | Storage | None |
 
 ## Quick start
@@ -40,22 +41,45 @@ $ secretspec run --profile staging -- mvn spring-boot:run
 This keeps the application mode aligned with the SecretSpec profile and its
 secrets. The same pattern works for values such as `LOCAL_PORT`.
 
+## Ephemeral generation
+
+:::note[SecretSpec 0.19+]
+Ephemeral generation through `null://` is available starting in SecretSpec
+0.19.
+:::
+
+Route a generated secret to `null` when each materializing resolution should
+receive a fresh value without storing it in a provider:
+
+```toml title="secretspec.toml"
+[profiles.default]
+SESSION_SECRET = { description = "Per-run session secret", type = "base64", generate = { bytes = 32 }, providers = ["null"] }
+```
+
+`secretspec run` generates `SESSION_SECRET` once for the resolved environment
+and gives that value to the child process. A later `run`, `get`, `check`, or SDK
+value-carrying resolution generates a new value. Value-free reports mark the
+secret as generated without minting it.
+
 ## How it works
 
-SecretSpec normally asks the selected provider before using a default. `null`
-cannot read or write values: reads always report a missing value, and every
-write is rejected. The missing read lets SecretSpec use the committed default
-without provider I/O.
+SecretSpec normally asks the selected provider before using a default or
+generating a missing secret. `null` cannot read or store values: reads always
+report a missing value, and every ordinary write is rejected. The missing read
+lets SecretSpec use the committed default or generator without provider I/O.
 
 The provider has no options, credentials, feature flag, or persistent state.
-Use it on declarations with defaults; required declarations without defaults
-remain missing, and writes are rejected.
-
-Do not use `null` for generated secrets. Secret generation writes each new value
-to the configured provider, so generation through `null` fails when that write
-is rejected. Configure a writable provider when using `generate`.
+Use it on declarations with defaults or enabled generation. Required
+declarations with neither remain missing, and explicit writes are rejected.
 
 :::danger[Defaults are public configuration]
-Manifest defaults are committed to version control in plaintext. Use `null`
-only for non-sensitive values. Keep secrets in a real provider.
+Manifest defaults are committed to version control in plaintext. Use `default`
+only for non-sensitive values. Generated values are not committed, but still
+exist in the resolving process and its configured delivery boundary.
+:::
+
+:::caution[Ephemeral means unstable]
+Generated values are shared only within one resolution. Do not use `null` for
+credentials that another process, machine, or later invocation must retrieve.
+Use a writable provider for those values.
 :::

--- a/docs/src/content/docs/providers/null.md
+++ b/docs/src/content/docs/providers/null.md
@@ -1,0 +1,61 @@
+---
+title: Null Provider
+description: Use committed manifest defaults without a storage backend
+---
+
+:::caution[Version compatibility]
+The `null` provider is added in SecretSpec 0.19.
+:::
+
+The null provider always reports that a value is missing. SecretSpec then
+uses the declaration's `default`. This is useful for non-sensitive environment
+configuration that belongs in `secretspec.toml`, not in a secret store.
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `null` (0.19+) |
+| URI | `null://` |
+| Access | Always returns missing; writes are rejected |
+| Best for | Team-shared, non-sensitive defaults |
+| Storage | None |
+
+## Quick start
+
+Route committed defaults to `null`:
+
+```toml title="secretspec.toml"
+[profiles.default]
+SPRING_PROFILES_ACTIVE = { description = "Spring application profile", default = "local", providers = ["null"] }
+
+[profiles.staging]
+SPRING_PROFILES_ACTIVE = { default = "staging" }
+```
+
+```bash
+$ secretspec run --profile staging -- mvn spring-boot:run
+```
+
+This keeps the application mode aligned with the SecretSpec profile and its
+secrets. The same pattern works for values such as `LOCAL_PORT`.
+
+## How it works
+
+SecretSpec normally asks the selected provider before using a default. `null`
+cannot read or write values: reads always report a missing value, and every
+write is rejected. The missing read lets SecretSpec use the committed default
+without provider I/O.
+
+The provider has no options, credentials, feature flag, or persistent state.
+Use it on declarations with defaults; required declarations without defaults
+remain missing, and writes are rejected.
+
+Do not use `null` for generated secrets. Secret generation writes each new value
+to the configured provider, so generation through `null` fails when that write
+is rejected. Configure a writable provider when using `generate`.
+
+:::danger[Defaults are public configuration]
+Manifest defaults are committed to version control in plaintext. Use `null`
+only for non-sensitive values. Keep secrets in a real provider.
+:::

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -105,7 +105,7 @@ $ secretspec config global init  # 0.17+
   keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   dotenv: Traditional .env files
   env: Read-only environment variables
-  null: Use manifest defaults without storage (0.19+)
+  null: Use defaults or ephemeral generation without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -105,6 +105,7 @@ $ secretspec config global init  # 0.17+
   keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   dotenv: Traditional .env files
   env: Read-only environment variables
+  null: Use manifest defaults without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -804,6 +804,7 @@ MANUAL_SECRET = { description = "Manually managed", type = "password" }
 
 - Generation only triggers when a secret is **missing** — existing secrets are never overwritten
 - Generated values are stored via the secret's configured provider (or the default provider)
+- With `providers = ["null"]` (0.19+), a fresh generated value is returned only for the current resolution and is not written to provider storage
 - Subsequent runs find the stored value and skip generation (idempotent)
 - `generate` and `default` cannot both be set on the same secret
 - `type = "command"` requires `generate = { command = "..." }` (not just `generate = true`)

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -34,6 +34,23 @@ env://                       # Current process environment
 
 **Features**: Read-only, no setup required, no persistence
 
+## Null Provider (0.19+)
+
+:::caution[Version compatibility]
+The `null` provider is added in SecretSpec 0.19.
+:::
+
+**URI**: `null://` - Always reports a missing value so the declaration's
+committed `default` applies
+
+```bash
+null://                      # No configuration or storage
+```
+
+**Features**: No I/O, no authentication, no persistence, writes rejected
+**Use case**: Non-sensitive environment configuration that should come from
+the version-controlled manifest rather than a secret backend
+
 ## systemd Credential Provider (0.17+)
 
 :::caution[Version compatibility]
@@ -519,6 +536,7 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 |----------|------------|------------------|----------------|
 | DotEnv | ❌ Plain text | Local filesystem | ❌ No |
 | Environment | ❌ Plain text | Process memory | ❌ No |
+| Null (0.19+) | N/A — no stored value | None | ❌ No |
 | systemd Credential (0.17+) | Depends on unit source | systemd-managed runtime memory | ❌ No |
 | Keyring | ✅ System encryption | System keychain | ❌ No |
 | KeePass KDBX (0.17+) | ✅ KDBX encryption | Local filesystem | ❌ No |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -41,15 +41,16 @@ The `null` provider is added in SecretSpec 0.19.
 :::
 
 **URI**: `null://` - Always reports a missing value so the declaration's
-committed `default` applies
+committed `default` or configured generator supplies the value
 
 ```bash
 null://                      # No configuration or storage
 ```
 
-**Features**: No I/O, no authentication, no persistence, writes rejected
-**Use case**: Non-sensitive environment configuration that should come from
-the version-controlled manifest rather than a secret backend
+**Features**: No I/O, no authentication, no persistence, ordinary writes
+rejected; generated values are returned only for the current resolution
+**Use case**: Non-sensitive configuration from the version-controlled manifest,
+or ephemeral generated values that should be fresh for every resolution
 
 ## systemd Credential Provider (0.17+)
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -63,6 +63,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },
   { slug: 'env', label: 'Environment variables' },
+  { slug: 'null', label: 'Manifest defaults (null, 0.19+)' },
   { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials (0.17+)' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden Secrets Manager' },
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
@@ -520,6 +521,7 @@ const reelScriptData = {
 <span class="landing-prompt">$</span> <span class="landing-cmd"><span class="tok-bin">secretspec</span> <span class="landing-arg">config global init</span></span>
 ? Select your preferred provider backend:
 <span class="landing-provider-cursor" aria-hidden="true">›</span><a class="landing-provider-line is-selected" style="--provider-line-color: var(--syntax-blue)" href="/providers/keyring/"><span class="provider-name">keyring</span>: Uses system keychain (Recommended)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/null/"><span class="provider-name">null</span>: Use manifest defaults without storage (0.19+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-red)" href="/providers/bw/"><span class="provider-name">bw</span>: Bitwarden Password Manager (0.18+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/kdbx/"><span class="provider-name">kdbx</span>: KeePass KDBX databases (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/keeper/"><span class="provider-name">keeper</span>: Keeper Secrets Manager (0.18+) via official Rust SDK</a>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -63,7 +63,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },
   { slug: 'env', label: 'Environment variables' },
-  { slug: 'null', label: 'Manifest defaults (null, 0.19+)' },
+  { slug: 'null', label: 'Defaults / ephemeral generation (null, 0.19+)' },
   { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials (0.17+)' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden Secrets Manager' },
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
@@ -521,7 +521,7 @@ const reelScriptData = {
 <span class="landing-prompt">$</span> <span class="landing-cmd"><span class="tok-bin">secretspec</span> <span class="landing-arg">config global init</span></span>
 ? Select your preferred provider backend:
 <span class="landing-provider-cursor" aria-hidden="true">›</span><a class="landing-provider-line is-selected" style="--provider-line-color: var(--syntax-blue)" href="/providers/keyring/"><span class="provider-name">keyring</span>: Uses system keychain (Recommended)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/null/"><span class="provider-name">null</span>: Use manifest defaults without storage (0.19+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/null/"><span class="provider-name">null</span>: Defaults or ephemeral generation, no storage (0.19+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-red)" href="/providers/bw/"><span class="provider-name">bw</span>: Bitwarden Password Manager (0.18+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/kdbx/"><span class="provider-name">kdbx</span>: KeePass KDBX databases (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/keeper/"><span class="provider-name">keeper</span>: Keeper Secrets Manager (0.18+) via official Rust SDK</a>

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -36,6 +36,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [Gopass](https://secretspec.dev/providers/gopass) (0.15+)
   - [Proton Pass](https://secretspec.dev/providers/protonpass)
   - [environment variables](https://secretspec.dev/providers/env)
+  - [null](https://secretspec.dev/providers/null) (0.19+)
   - [systemd credentials](https://secretspec.dev/providers/systemd-credential) (0.17+)
   - [Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
@@ -77,6 +78,7 @@ $ secretspec config global init  # 0.17+
   keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   dotenv: Traditional .env files
   env: Read-only environment variables
+  null: Use manifest defaults without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
@@ -185,6 +187,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[KeePass KDBX](https://secretspec.dev/providers/kdbx)** (0.17+) - Local KeePass-compatible encrypted database
 - **[.env files](https://secretspec.dev/providers/dotenv)** - Traditional dotenv files
 - **[Environment variables](https://secretspec.dev/providers/env)** - Read-only for CI/CD
+- **[Null](https://secretspec.dev/providers/null)** (0.19+) - Use committed, non-sensitive defaults without secret storage
 - **[systemd credentials](https://secretspec.dev/providers/systemd-credential)** (0.17+) - Read-only credentials passed to the current service
 - **[Pass](https://secretspec.dev/providers/pass)** - Unix password manager with GPG encryption
 - **[Gopass](https://secretspec.dev/providers/gopass)** (0.15+) - GPG-based password manager with git-synced password store

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -78,7 +78,7 @@ $ secretspec config global init  # 0.17+
   keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   dotenv: Traditional .env files
   env: Read-only environment variables
-  null: Use manifest defaults without storage (0.19+)
+  null: Use defaults or ephemeral generation without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
@@ -187,7 +187,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[KeePass KDBX](https://secretspec.dev/providers/kdbx)** (0.17+) - Local KeePass-compatible encrypted database
 - **[.env files](https://secretspec.dev/providers/dotenv)** - Traditional dotenv files
 - **[Environment variables](https://secretspec.dev/providers/env)** - Read-only for CI/CD
-- **[Null](https://secretspec.dev/providers/null)** (0.19+) - Use committed, non-sensitive defaults without secret storage
+- **[Null](https://secretspec.dev/providers/null)** (0.19+) - Use committed defaults or ephemeral generation without secret storage
 - **[systemd credentials](https://secretspec.dev/providers/systemd-credential)** (0.17+) - Read-only credentials passed to the current service
 - **[Pass](https://secretspec.dev/providers/pass)** - Unix password manager with GPG encryption
 - **[Gopass](https://secretspec.dev/providers/gopass)** (0.15+) - GPG-based password manager with git-synced password store

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -76,7 +76,7 @@ pub use config::{GenerateConfig, GenerateOptions, Secret, SecretEncoding};
 
 // Public API exports
 pub use error::{Result, SecretSpecError};
-pub use provider::{DiscoveryContext, Provider};
+pub use provider::{DiscoveryContext, GeneratedValuePersistence, Provider};
 pub use report::{
     RESOLUTION_REPORT_SCHEMA_VERSION, ResolutionReport, ResolutionStatus, SecretResolution,
 };

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -20,7 +20,7 @@
 //! - [`keeper::KeeperProvider`]: Keeper Secrets Manager integration (0.18+)
 //! - [`dotenv::DotEnvProvider`]: `.env` file support
 //! - [`env::EnvProvider`]: Environment variables (read-only)
-//! - [`null::NullProvider`]: Always missing, for manifest defaults (0.19+)
+//! - [`null::NullProvider`]: Defaults or ephemeral generation without storage (0.19+)
 //! - [`pass::PassProvider`]: Pass integration
 //! - [`gopass::GoPassProvider`]: Gopass integration
 //! - [`systemd_credential::SystemdCredentialProvider`]: systemd service credentials (0.17+)
@@ -46,7 +46,7 @@
 //! ```text
 //! keyring://
 //! dotenv://.env.production
-//! null://  # Use manifest defaults, 0.19+
+//! null://  # Use defaults or ephemeral generation without storage, 0.19+
 //! onepassword://vault
 //! lastpass://folder
 //! keeper://SHARED_FOLDER_UID  # Keeper, 0.18+
@@ -630,6 +630,23 @@ impl<'a> DiscoveryContext<'a> {
     }
 }
 
+/// Whether a value minted by a secret's `generate` configuration is written
+/// back to its primary provider.
+///
+/// This capability is available since SecretSpec 0.19. It is deliberately
+/// separate from read and write support: a provider may reject ordinary writes
+/// while explicitly allowing SecretSpec to return a freshly generated value
+/// for the current resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeneratedValuePersistence {
+    /// Store the generated value through [`Provider::set`] and reuse it on
+    /// subsequent resolutions. This is the default for storage providers.
+    Persist,
+    /// Return the generated value only from the current materializing
+    /// resolution. No provider write or cache refresh is performed.
+    Ephemeral,
+}
+
 /// Trait defining the interface for secret storage providers.
 ///
 /// All secret storage backends must implement this trait to integrate with SecretSpec.
@@ -826,6 +843,19 @@ pub trait Provider: Send + Sync {
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         let _ = addr;
         Ok(())
+    }
+
+    /// Controls whether SecretSpec persists a value produced by a declaration's
+    /// `generate` configuration after this provider's read route misses.
+    /// Available since SecretSpec 0.19.
+    ///
+    /// [`GeneratedValuePersistence::Ephemeral`] affects only automatic
+    /// generation. Ordinary [`set`](Provider::set), deletion, imports, and
+    /// provider reads keep their usual behavior. The capability must be pure:
+    /// callers may inspect it without running authentication preflight or other
+    /// provider I/O.
+    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
+        GeneratedValuePersistence::Persist
     }
 
     /// Identifies the shared authentication state this instance's preflight
@@ -1194,6 +1224,9 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         (**self).check_writable(addr)
     }
+    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
+        (**self).generated_value_persistence()
+    }
     fn auth_scope_key(&self) -> Option<String> {
         (**self).auth_scope_key()
     }
@@ -1400,6 +1433,11 @@ impl Provider for PreflightGuard {
 
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         self.inner.check_writable(addr)
+    }
+
+    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
+        // Capability inspection is pure and must not trigger authentication.
+        self.inner.generated_value_persistence()
     }
 
     fn auth_scope_key(&self) -> Option<String> {

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -20,6 +20,7 @@
 //! - [`keeper::KeeperProvider`]: Keeper Secrets Manager integration (0.18+)
 //! - [`dotenv::DotEnvProvider`]: `.env` file support
 //! - [`env::EnvProvider`]: Environment variables (read-only)
+//! - [`null::NullProvider`]: Always missing, for manifest defaults (0.19+)
 //! - [`pass::PassProvider`]: Pass integration
 //! - [`gopass::GoPassProvider`]: Gopass integration
 //! - [`systemd_credential::SystemdCredentialProvider`]: systemd service credentials (0.17+)
@@ -45,6 +46,7 @@
 //! ```text
 //! keyring://
 //! dotenv://.env.production
+//! null://  # Use manifest defaults, 0.19+
 //! onepassword://vault
 //! lastpass://folder
 //! keeper://SHARED_FOLDER_UID  # Keeper, 0.18+
@@ -306,6 +308,7 @@ pub mod keeper;
 #[cfg(feature = "keyring")]
 pub mod keyring;
 pub mod lastpass;
+pub mod null;
 pub mod onepassword;
 #[cfg(feature = "openbao")]
 pub mod openbao;

--- a/secretspec/src/provider/null.rs
+++ b/secretspec/src/provider/null.rs
@@ -1,4 +1,4 @@
-use super::{Address, Provider, ProviderUrl};
+use super::{Address, GeneratedValuePersistence, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the null provider.
 ///
 /// The provider takes no options because it never reads or stores values. It
-/// exists to let SecretSpec continue to a declaration's `default` value.
+/// exists to let SecretSpec continue to a declaration's `default` or ephemeral
+/// generated value.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NullConfig {}
 
@@ -37,18 +38,19 @@ impl TryFrom<&ProviderUrl> for NullConfig {
     }
 }
 
-/// A provider that never contains a value.
+/// A provider that never contains or stores a value.
 ///
 /// A miss lets normal resolution continue to the secret's committed `default`,
-/// making this provider useful for non-sensitive environment configuration that
-/// belongs in `secretspec.toml` but should not be stored in a secret backend.
+/// or lets a configured generator mint a value for only the current resolution.
+/// This makes the provider useful for non-sensitive environment configuration
+/// committed to `secretspec.toml` and for ephemeral generated secrets.
 pub struct NullProvider;
 
 crate::register_provider! {
     struct: NullProvider,
     config: NullConfig,
     name: "null",
-    description: "Use manifest defaults without storage (0.19+)",
+    description: "Use defaults or ephemeral generation without storage (0.19+)",
     schemes: ["null"],
     examples: ["null://"],
 }
@@ -92,9 +94,13 @@ impl Provider for NullProvider {
 
     fn check_writable(&self, _addr: Address<'_>) -> Result<()> {
         Err(SecretSpecError::ProviderOperationFailed(
-            "null provider never stores values; configure a manifest default or choose a writable provider"
+            "null provider never stores values; configure a manifest default or automatic generation, or choose a writable provider"
                 .to_string(),
         ))
+    }
+
+    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
+        GeneratedValuePersistence::Ephemeral
     }
 
     fn name(&self) -> &'static str {
@@ -109,9 +115,12 @@ impl Provider for NullProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Secret;
+    use crate::config::{GenerateConfig, Secret};
+    use crate::resolve::ResolvedSource;
     use secrecy::ExposeSecret;
     use std::collections::HashMap;
+    use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn always_misses_and_rejects_writes() {
@@ -119,6 +128,10 @@ mod tests {
         let addr = Address::convention("project", "development", "LOCAL_PORT");
 
         assert!(provider.get(addr).unwrap().is_none());
+        assert_eq!(
+            provider.generated_value_persistence(),
+            GeneratedValuePersistence::Ephemeral
+        );
         let error = provider
             .set(addr, &SecretString::new("8090".into()))
             .unwrap_err();
@@ -161,6 +174,88 @@ mod tests {
         assert_eq!(
             resolved.with_defaults,
             vec![("LOCAL_PORT".to_string(), "8090".to_string())]
+        );
+    }
+
+    #[test]
+    fn generated_values_are_fresh_and_never_stored() {
+        let _env = crate::tests::scrub_resolution_env();
+        let config = crate::tests::resolve_test_config(HashMap::from([(
+            "SESSION_ID".to_string(),
+            Secret {
+                description: Some("Ephemeral session identifier".to_string()),
+                secret_type: Some("uuid".to_string()),
+                generate: Some(GenerateConfig::Bool(true)),
+                providers: Some(vec!["null".to_string()]),
+                ..Default::default()
+            },
+        )]));
+        let spec = crate::Secrets::new(config, None, None, None);
+
+        let value_free = spec.resolve_without_values().unwrap();
+        assert_eq!(
+            value_free.secrets["SESSION_ID"].source,
+            ResolvedSource::Generated
+        );
+        assert!(value_free.secrets["SESSION_ID"].value.is_none());
+
+        let first = spec.resolve().unwrap();
+        let second = spec.resolve().unwrap();
+        assert_eq!(
+            first.secrets["SESSION_ID"].source,
+            ResolvedSource::Generated
+        );
+        assert_eq!(
+            second.secrets["SESSION_ID"].source,
+            ResolvedSource::Generated
+        );
+        assert_ne!(
+            first.secrets["SESSION_ID"].value, second.secrets["SESSION_ID"].value,
+            "null-backed generation must mint a fresh value for each resolution"
+        );
+
+        // `get` uses the same materializing executor as `run` and SDK resolve.
+        assert!(spec.get("SESSION_ID").is_ok());
+    }
+
+    #[test]
+    fn boxed_provider_wrapper_preserves_ephemeral_capability() {
+        let provider = Box::<dyn Provider>::try_from("null://").unwrap();
+        assert_eq!(
+            provider.generated_value_persistence(),
+            GeneratedValuePersistence::Ephemeral
+        );
+    }
+
+    #[test]
+    fn stored_fallback_wins_before_ephemeral_generation() {
+        let _env = crate::tests::scrub_resolution_env();
+        let temp_dir = TempDir::new().unwrap();
+        let env_file = temp_dir.path().join("fallback.env");
+        fs::write(&env_file, "SESSION_ID=stored-value\n").unwrap();
+        let config = crate::tests::resolve_test_config(HashMap::from([(
+            "SESSION_ID".to_string(),
+            Secret {
+                description: Some("Session identifier".to_string()),
+                secret_type: Some("uuid".to_string()),
+                generate: Some(GenerateConfig::Bool(true)),
+                providers: Some(vec![
+                    "null".to_string(),
+                    format!("dotenv://{}", env_file.display()),
+                ]),
+                ..Default::default()
+            },
+        )]));
+        let spec = crate::Secrets::new(config, None, None, None);
+
+        let resolved = spec.resolve().unwrap();
+        assert_eq!(
+            resolved.secrets["SESSION_ID"].value.as_deref(),
+            Some("stored-value")
+        );
+        assert_eq!(
+            resolved.secrets["SESSION_ID"].source,
+            ResolvedSource::Provider
         );
     }
 

--- a/secretspec/src/provider/null.rs
+++ b/secretspec/src/provider/null.rs
@@ -1,0 +1,174 @@
+use super::{Address, Provider, ProviderUrl};
+use crate::{Result, SecretSpecError};
+use secrecy::SecretString;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the null provider.
+///
+/// The provider takes no options because it never reads or stores values. It
+/// exists to let SecretSpec continue to a declaration's `default` value.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NullConfig {}
+
+impl TryFrom<&ProviderUrl> for NullConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "null" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for null provider",
+                url.scheme()
+            )));
+        }
+
+        let path = url.path();
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || url.host().is_some_and(|host| !host.is_empty())
+            || !path.trim_matches('/').is_empty()
+            || url.has_query()
+        {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "null:// takes no authority, path, or query".to_string(),
+            ));
+        }
+
+        Ok(Self {})
+    }
+}
+
+/// A provider that never contains a value.
+///
+/// A miss lets normal resolution continue to the secret's committed `default`,
+/// making this provider useful for non-sensitive environment configuration that
+/// belongs in `secretspec.toml` but should not be stored in a secret backend.
+pub struct NullProvider;
+
+crate::register_provider! {
+    struct: NullProvider,
+    config: NullConfig,
+    name: "null",
+    description: "Use manifest defaults without storage (0.19+)",
+    schemes: ["null"],
+    examples: ["null://"],
+}
+
+impl NullProvider {
+    pub fn new(_config: NullConfig) -> Self {
+        Self
+    }
+}
+
+impl Provider for NullProvider {
+    fn convention_address(
+        &self,
+        _project: &str,
+        _profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: key.to_string(),
+            ..Default::default()
+        })
+    }
+
+    /// Address coordinates cannot affect an always-missing lookup. Advertising
+    /// every current coordinate keeps `null` usable as an override for any
+    /// declaration without pretending that it maps to a storage concept.
+    fn supported_coords(&self) -> &'static [&'static str] {
+        &["field", "vault", "section", "version"]
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        // Resolve the address so native coordinates receive the same validation
+        // as every other flat provider, even though no storage is consulted.
+        let _ = super::flat_item(self, addr)?;
+        Ok(None)
+    }
+
+    fn set(&self, addr: Address<'_>, _value: &SecretString) -> Result<()> {
+        self.check_writable(addr)
+    }
+
+    fn check_writable(&self, _addr: Address<'_>) -> Result<()> {
+        Err(SecretSpecError::ProviderOperationFailed(
+            "null provider never stores values; configure a manifest default or choose a writable provider"
+                .to_string(),
+        ))
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        "null://".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Secret;
+    use secrecy::ExposeSecret;
+    use std::collections::HashMap;
+
+    #[test]
+    fn always_misses_and_rejects_writes() {
+        let provider = NullProvider::new(NullConfig::default());
+        let addr = Address::convention("project", "development", "LOCAL_PORT");
+
+        assert!(provider.get(addr).unwrap().is_none());
+        let error = provider
+            .set(addr, &SecretString::new("8090".into()))
+            .unwrap_err();
+        assert!(error.to_string().contains("never stores values"), "{error}");
+    }
+
+    #[test]
+    fn native_coordinates_do_not_change_the_miss() {
+        let provider = NullProvider::new(NullConfig::default());
+        let addr = crate::config::NativeAddress {
+            item: "remote-name".to_string(),
+            field: Some("password".to_string()),
+            vault: Some("Production".to_string()),
+            section: Some("database".to_string()),
+            version: Some("latest".to_string()),
+        };
+
+        assert!(provider.get(Address::Native(&addr)).unwrap().is_none());
+    }
+
+    #[test]
+    fn miss_applies_the_manifest_default() {
+        let _env = crate::tests::scrub_resolution_env();
+        let config = crate::tests::resolve_test_config(HashMap::from([(
+            "LOCAL_PORT".to_string(),
+            Secret {
+                description: Some("Local server port".to_string()),
+                default: Some("8090".to_string()),
+                providers: Some(vec!["null".to_string()]),
+                ..Default::default()
+            },
+        )]));
+        let spec = crate::Secrets::new(config, None, None, None);
+
+        let resolved = spec.validate().unwrap().unwrap();
+        assert_eq!(
+            resolved.resolved.secrets["LOCAL_PORT"].expose_secret(),
+            "8090"
+        );
+        assert_eq!(
+            resolved.with_defaults,
+            vec![("LOCAL_PORT".to_string(), "8090".to_string())]
+        );
+    }
+
+    #[test]
+    fn rejects_uri_configuration() {
+        let error = Box::<dyn Provider>::try_from("null://unexpected")
+            .err()
+            .expect("authority must be rejected");
+        assert!(error.to_string().contains("takes no authority"), "{error}");
+    }
+}

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -9,7 +9,10 @@ use crate::config::{
 use crate::error::{Result, SecretSpecError};
 use crate::manifest::{CompiledManifest, MissingPolicy};
 use crate::plan::{PlannedSecret, ResolutionPlan, ResolvedCache, Route};
-use crate::provider::{Address, OwnedAddress, Provider as ProviderTrait, ProviderCredentials};
+use crate::provider::{
+    Address, GeneratedValuePersistence, OwnedAddress, Provider as ProviderTrait,
+    ProviderCredentials,
+};
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
 use crate::validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
@@ -3063,10 +3066,15 @@ impl Secrets {
                 return Err(err);
             }
         };
-        // A composed secret plans no route: resolve its dependency closure
-        // through the batch executor and print the rendered value.
-        let Some(route) = &planned.route else {
-            let names = self.composed_dependency_names(name, &profile_name);
+        // Composed values and generated-on-miss values need the batch executor:
+        // it renders dependency closures and owns the generation policy,
+        // including providers that return a value without storing it.
+        if planned.is_composed() || planned.secret.missing == MissingPolicy::Generate {
+            let names = if planned.is_composed() {
+                self.composed_dependency_names(name, &profile_name)
+            } else {
+                vec![name.to_string()]
+            };
             let plan = self.build_plan_from_names(profile_name.clone(), names)?;
             // No output filter: the closure resolves the target's dependencies
             // and this caller reads only the target from the result.
@@ -3086,12 +3094,22 @@ impl Secrets {
                     }
                     validated.keep_temp_files()?;
                     let value = &validated.resolved.secrets[name];
+                    let source_provider = validated
+                        .resolution
+                        .iter()
+                        .find(|entry| entry.name == name)
+                        .and_then(|entry| entry.source_provider.clone());
                     self.record(
                         AuditAction::Get,
                         &profile_name,
                         AuditOutcome::Found,
                         AuditFields {
                             key: Some(name),
+                            provider_uri: source_provider.clone(),
+                            reference: source_provider
+                                .is_some()
+                                .then(|| planned.reference())
+                                .flatten(),
                             ..Default::default()
                         },
                     );
@@ -3104,7 +3122,11 @@ impl Secrets {
                     Err(err)
                 }
             };
-        };
+        }
+        let route = planned
+            .route
+            .as_ref()
+            .expect("non-composed secrets have a provider route");
         let default = planned.config().default.clone();
         // A fresh cache hit completes the read without constructing or
         // contacting any authoritative provider. Misses and invalid entries
@@ -3993,6 +4015,17 @@ impl Secrets {
         )?;
         let addr = address.as_address();
         let backend = self.write_provider_for_route(route, Some(profile_name))?;
+
+        if backend.generated_value_persistence() == GeneratedValuePersistence::Ephemeral {
+            eprintln!(
+                "{} {} - generated for this resolution without provider storage (profile: {})",
+                "✓".green(),
+                name,
+                profile_name
+            );
+            return Ok(Some(value));
+        }
+
         // The provider states why a write is refused; wrapping it here would
         // only nest a second "Provider operation failed" prefix.
         backend.check_writable(addr)?;


### PR DESCRIPTION
## Summary

- add a built-in `null://` provider that always reports values as missing and rejects ordinary writes
- let non-sensitive environment configuration resolve from committed manifest defaults without contacting secret storage
- add a `GeneratedValuePersistence` provider capability and make `null://` return generated values for one resolution without persisting them
- route `secretspec get` through the same generation executor as `run` and SDK resolution
- document the provider and all ephemeral-generation behavior as available in SecretSpec 0.19+

## Why

Projects replacing mixed-purpose `.env` files still need a clean home for shared, non-sensitive values such as `LOCAL_PORT` or `SPRING_PROFILES_ACTIVE`. They also need session secrets that can be freshly generated for each command without leaving a durable copy. Routing those declarations through `null` makes the manifest default or generator authoritative without polluting keyrings or shared secret backends.

## User impact

Users can set `providers = ["null"]` on declarations with defaults or enabled generation. Defaults resolve from the manifest, while generated values are minted once per materializing resolution and never written to provider storage. Stored fallback values still win before generation. Required declarations with neither a default nor generation remain missing, and explicit writes continue to report that the provider cannot store values.

Custom providers can override `generated_value_persistence`; storage providers retain the safe `Persist` default.

Closes #276.

## Validation

- `cargo test --all`
- `cargo test --package secretspec provider::null::tests`
- `cargo fmt --all -- --check`
- Clippy and rustfmt pre-commit hooks
- `npm --prefix docs run build`
- `git diff --check`
