### PR TITLE
Store cache expiration deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cache entries now store their absolute expiration time, allowing SecretSpec
+  to remove an expired entry whenever it encounters one, including at an
+  address previously used by another project or profile. Changing `max_age`
+  invalidates entries written under the previous policy. Fresh v2 entries remain
+  usable during migration, while foreign v2 entries remain untouched.
+  ([#275](https://github.com/cachix/secretspec/issues/275))
 - `run` preserves non-UTF-8 environment values byte-for-byte when launching
   child processes on Unix.
 - SDK pkg-config setup now pins cargo-c's library and metadata install

--- a/docs/src/content/docs/concepts/providers/caching.md
+++ b/docs/src/content/docs/concepts/providers/caching.md
@@ -72,8 +72,9 @@ as `1h30m` are accepted.
 
 Entries use SecretSpec's logical `{project}/{profile}/{secret}` address, even
 when the authoritative secret has a provider-native `ref`. Each entry contains
-the value, write time, format version, and a fingerprint of the fallback route
-and secret reference. Changing the route or reference invalidates it.
+the value, absolute expiration time, originating `max_age`, format version, and
+a fingerprint of the fallback route and secret reference. Changing the route,
+reference, or `max_age` invalidates it.
 
 The cache must use a distinct store from every provider in `fallback`;
 otherwise, a refresh could overwrite the authoritative secret. SecretSpec
@@ -98,9 +99,10 @@ SecretSpec requests native expiry where supported, using `max_age`.
 `delete_version_after` metadata. This removes the copy on time even if
 SecretSpec never runs again.
 
-The entry's write time remains the source of truth for freshness on every
-store; a read deletes an entry older than `max_age`. If native expiry cannot be
-configured, for example because a Vault token lacks metadata access or the
+The entry's absolute expiration time remains the source of truth for freshness
+on every store; a read at or after that time deletes the entry. Machines sharing
+a cache should keep their system clocks synchronized. If native expiry cannot
+be configured, for example because a Vault token lacks metadata access or the
 mount uses KV v1, SecretSpec refuses the cache write and uses the authoritative
 route.
 
@@ -110,10 +112,12 @@ Each cache entry records a marker, project, and profile. Because addresses can
 collide in flat stores such as dotenv, SecretSpec changes only entries whose
 ownership it can verify.
 
-Unmarked entries and entries owned by another project or profile are bypassed,
-not overwritten or deleted. [`cache clear`](/reference/cli/#cache-clear-017)
-reports them. A marked but unreadable entry, such as a partial write, can be
-identified as SecretSpec's and replaced.
+Unmarked entries and unexpired entries owned by another project or profile are
+bypassed, not overwritten or deleted.
+[`cache clear`](/reference/cli/#cache-clear-017) reports them. Any expired
+SecretSpec entry can be deleted by the project that encounters it because its
+stored lifetime has ended. A marked but unreadable entry, such as a partial
+write, can be identified as SecretSpec's and replaced.
 
 If clearing reports a foreign entry, two configurations are addressing the same
 place. Give each project a separate store or path, such as the

--- a/secretspec/src/cache.rs
+++ b/secretspec/src/cache.rs
@@ -15,7 +15,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// truncated write leaves something only SecretSpec could have put there, which
 /// is safe to replace; a value with no marker belongs to someone else and must
 /// never be touched.
-pub(crate) const CACHE_ENVELOPE_MARKER: &str = "secretspec-cache-v2:";
+pub(crate) const CACHE_ENVELOPE_MARKER: &str = "secretspec-cache-v3:";
+
+/// The 0.17 envelope recorded when an entry was written rather than when it
+/// expires. Keep recognizing it so an upgrade can replace its own entries
+/// without mistaking another project or profile's entry for ours.
+const LEGACY_CACHE_ENVELOPE_MARKER: &str = "secretspec-cache-v2:";
 
 /// Value stored inside the configured cache provider. The provider remains
 /// responsible for encryption; the envelope adds freshness, route invalidation,
@@ -24,12 +29,32 @@ pub(crate) const CACHE_ENVELOPE_MARKER: &str = "secretspec-cache-v2:";
 struct CacheEnvelope {
     project: String,
     profile: String,
-    cached_at: u64,
+    expires_at: u64,
+    max_age_secs: u64,
     route_fingerprint: String,
     /// The cached plaintext stays in a zeroizing buffer on both serialization
     /// and deserialization.
     #[serde(with = "zeroizing_string")]
     value: Zeroizing<String>,
+}
+
+/// The 0.17 envelope can still serve its owner while it remains fresh under the
+/// active route's policy. Another owner cannot infer its expiry because v2 did
+/// not store the `max_age` that created it, so foreign v2 entries remain
+/// untouched.
+#[derive(serde::Deserialize)]
+struct LegacyCacheEnvelope {
+    project: String,
+    profile: String,
+    cached_at: u64,
+    route_fingerprint: String,
+    #[serde(with = "zeroizing_string")]
+    value: Zeroizing<String>,
+}
+
+enum DecodedEnvelope {
+    Current(CacheEnvelope),
+    Legacy(LegacyCacheEnvelope),
 }
 
 /// Serde for the envelope's plaintext, keeping it in a zeroizing buffer in both
@@ -52,11 +77,14 @@ mod zeroizing_string {
     }
 }
 
-/// Who wrote the value sitting at a cache address.
+/// Whether the caller may change the value sitting at a cache address.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum CacheOwnership {
     /// This project and profile wrote a readable entry.
     Ours,
+    /// A readable SecretSpec entry whose declared lifetime has ended. Its
+    /// original owner no longer has an interest in preserving it.
+    Expired,
     /// Another project or profile wrote the entry.
     Foreign { project: String, profile: String },
     /// The ownership marker is ours, but the payload is damaged or incompatible.
@@ -69,7 +97,8 @@ pub(crate) enum CacheOwnership {
 pub(crate) enum CacheEntryStatus {
     /// Fresh, and written for the expected authoritative route.
     Fresh(SecretString),
-    /// Readable and ours, but expired or written for another route.
+    /// Expired (regardless of owner), or ours but no longer usable because its
+    /// authoritative route or freshness policy changed.
     Stale,
     /// Marked as ours but not readable as this envelope version.
     OursUnreadable,
@@ -84,26 +113,60 @@ pub(crate) enum CacheEntryStatus {
 pub(crate) enum CacheEncodeError {
     #[error(transparent)]
     Clock(#[from] std::time::SystemTimeError),
+    #[error("cache expiration timestamp is too large")]
+    ExpirationOverflow,
     #[error(transparent)]
     Serialize(#[from] serde_json::Error),
 }
 
-fn decode(stored: &SecretString) -> Option<Result<CacheEnvelope, serde_json::Error>> {
+fn decode(stored: &SecretString) -> Option<Result<DecodedEnvelope, serde_json::Error>> {
+    let stored = stored.expose_secret();
+    if let Some(payload) = stored.strip_prefix(CACHE_ENVELOPE_MARKER) {
+        return Some(serde_json::from_str(payload).map(DecodedEnvelope::Current));
+    }
     stored
-        .expose_secret()
-        .strip_prefix(CACHE_ENVELOPE_MARKER)
-        .map(serde_json::from_str)
+        .strip_prefix(LEGACY_CACHE_ENVELOPE_MARKER)
+        .map(|payload| serde_json::from_str(payload).map(DecodedEnvelope::Legacy))
+}
+
+fn unix_timestamp() -> Result<u64, std::time::SystemTimeError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
 }
 
 /// Classify cache ownership without trusting the provider address.
 pub(crate) fn ownership(stored: &SecretString, project: &str, profile: &str) -> CacheOwnership {
+    ownership_at(stored, project, profile, unix_timestamp().ok())
+}
+
+fn ownership_at(
+    stored: &SecretString,
+    project: &str,
+    profile: &str,
+    now: Option<u64>,
+) -> CacheOwnership {
     match decode(stored) {
         None => CacheOwnership::Unrecognized,
         Some(Err(_)) => CacheOwnership::OursUnreadable,
-        Some(Ok(envelope)) if envelope.project == project && envelope.profile == profile => {
+        Some(Ok(DecodedEnvelope::Current(envelope))) => {
+            if now.is_some_and(|now| now >= envelope.expires_at) {
+                CacheOwnership::Expired
+            } else if envelope.project == project && envelope.profile == profile {
+                CacheOwnership::Ours
+            } else {
+                CacheOwnership::Foreign {
+                    project: envelope.project,
+                    profile: envelope.profile,
+                }
+            }
+        }
+        Some(Ok(DecodedEnvelope::Legacy(envelope)))
+            if envelope.project == project && envelope.profile == profile =>
+        {
             CacheOwnership::Ours
         }
-        Some(Ok(envelope)) => CacheOwnership::Foreign {
+        Some(Ok(DecodedEnvelope::Legacy(envelope))) => CacheOwnership::Foreign {
             project: envelope.project,
             profile: envelope.profile,
         },
@@ -127,11 +190,7 @@ pub(crate) fn inspect_entry(
         profile,
         route_fingerprint,
         max_age_secs,
-        || {
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|duration| duration.as_secs())
-        },
+        unix_timestamp,
     )
 }
 
@@ -147,20 +206,53 @@ fn inspect_entry_with_clock<E>(
         return Ok(CacheEntryStatus::Unrecognized);
     };
     let envelope = match decoded {
-        Ok(envelope) if envelope.project == project && envelope.profile == profile => envelope,
-        Ok(envelope) => {
-            return Ok(CacheEntryStatus::Foreign {
-                project: envelope.project,
-                profile: envelope.profile,
-            });
+        Ok(DecodedEnvelope::Current(envelope)) => envelope,
+        Ok(DecodedEnvelope::Legacy(envelope)) => {
+            if envelope.project != project || envelope.profile != profile {
+                return Ok(CacheEntryStatus::Foreign {
+                    project: envelope.project,
+                    profile: envelope.profile,
+                });
+            }
+            if envelope.route_fingerprint != route_fingerprint {
+                return Ok(CacheEntryStatus::Stale);
+            }
+            let now = clock()?;
+            if envelope.cached_at > now || now.saturating_sub(envelope.cached_at) > max_age_secs {
+                return Ok(CacheEntryStatus::Stale);
+            }
+            return Ok(CacheEntryStatus::Fresh(SecretString::new(
+                envelope.value.as_str().into(),
+            )));
         }
         Err(_) => return Ok(CacheEntryStatus::OursUnreadable),
     };
+    let now = clock()?;
+    if now >= envelope.expires_at {
+        // Expiration is intrinsic to a v3 entry, so whoever encounters it can
+        // discard it even when its project/profile no longer has a manifest.
+        return Ok(CacheEntryStatus::Stale);
+    }
+    if envelope.project != project || envelope.profile != profile {
+        return Ok(CacheEntryStatus::Foreign {
+            project: envelope.project,
+            profile: envelope.profile,
+        });
+    }
+    // Reconstructing the write time from the self-contained v3 policy preserves
+    // clock-rollback detection without retaining `cached_at` in the envelope.
+    let Some(cached_at) = envelope.expires_at.checked_sub(envelope.max_age_secs) else {
+        return Ok(CacheEntryStatus::Stale);
+    };
+    if cached_at > now || envelope.max_age_secs != max_age_secs {
+        return Ok(CacheEntryStatus::Stale);
+    }
     if envelope.route_fingerprint != route_fingerprint {
         return Ok(CacheEntryStatus::Stale);
     }
-    let now = clock()?;
-    Ok(inspect_owned_entry_at(envelope, max_age_secs, now))
+    Ok(CacheEntryStatus::Fresh(SecretString::new(
+        envelope.value.as_str().into(),
+    )))
 }
 
 #[cfg(test)]
@@ -183,41 +275,40 @@ fn inspect_entry_at(
     .expect("an infallible test clock cannot fail")
 }
 
-fn inspect_owned_entry_at(
-    envelope: CacheEnvelope,
-    max_age_secs: u64,
-    now: u64,
-) -> CacheEntryStatus {
-    // A timestamp in the future means a clock moved. It is unusable rather than
-    // valid until it happens to fall inside the freshness window.
-    if envelope.cached_at > now || now.saturating_sub(envelope.cached_at) > max_age_secs {
-        return CacheEntryStatus::Stale;
-    }
-    CacheEntryStatus::Fresh(SecretString::new(envelope.value.as_str().into()))
-}
-
 /// Encode an entry using the current wall clock.
 pub(crate) fn encode_entry(
     project: &str,
     profile: &str,
+    max_age_secs: u64,
     route_fingerprint: String,
     value: &SecretString,
 ) -> Result<SecretString, CacheEncodeError> {
-    let cached_at = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-    encode_entry_at(project, profile, cached_at, route_fingerprint, value).map_err(Into::into)
+    encode_entry_at(
+        project,
+        profile,
+        unix_timestamp()?,
+        max_age_secs,
+        route_fingerprint,
+        value,
+    )
 }
 
 fn encode_entry_at(
     project: &str,
     profile: &str,
-    cached_at: u64,
+    now: u64,
+    max_age_secs: u64,
     route_fingerprint: String,
     value: &SecretString,
-) -> Result<SecretString, serde_json::Error> {
+) -> Result<SecretString, CacheEncodeError> {
+    let expires_at = now
+        .checked_add(max_age_secs)
+        .ok_or(CacheEncodeError::ExpirationOverflow)?;
     let envelope = CacheEnvelope {
         project: project.to_string(),
         profile: profile.to_string(),
-        cached_at,
+        expires_at,
+        max_age_secs,
         route_fingerprint,
         value: Zeroizing::new(value.expose_secret().to_string()),
     };
@@ -236,12 +327,15 @@ mod tests {
     const PROFILE: &str = "default";
     const FINGERPRINT: &str = "route-v1";
     const WRITTEN_AT: u64 = 1_000;
+    const MAX_AGE: u64 = 60;
+    const EXPIRES_AT: u64 = 1_060;
 
     fn entry() -> SecretString {
         encode_entry_at(
             PROJECT,
             PROFILE,
             WRITTEN_AT,
+            MAX_AGE,
             FINGERPRINT.to_string(),
             &SecretString::new("sensitive".into()),
         )
@@ -249,44 +343,103 @@ mod tests {
     }
 
     #[test]
-    fn encoded_entry_round_trips_at_the_freshness_boundary() {
+    fn encoded_entry_round_trips_before_expiration() {
         let decoded = decode(&entry())
             .expect("marker present")
             .expect("valid envelope");
-        let status = inspect_owned_entry_at(decoded, 60, WRITTEN_AT + 60);
-        let CacheEntryStatus::Fresh(value) = status else {
-            panic!("an entry is fresh through its exact max-age boundary");
+        let DecodedEnvelope::Current(envelope) = decoded else {
+            panic!("new entries use the current envelope");
         };
+        let status = inspect_entry_at(
+            &entry(),
+            PROJECT,
+            PROFILE,
+            FINGERPRINT,
+            MAX_AGE,
+            EXPIRES_AT - 1,
+        );
+        let CacheEntryStatus::Fresh(value) = status else {
+            panic!("an entry is fresh before its expiration timestamp");
+        };
+        assert_eq!(envelope.expires_at, EXPIRES_AT);
+        assert_eq!(envelope.max_age_secs, MAX_AGE);
         assert_eq!(value.expose_secret(), "sensitive");
     }
 
     #[test]
-    fn entry_is_stale_one_second_past_its_max_age() {
-        let decoded = decode(&entry())
-            .expect("marker present")
-            .expect("valid envelope");
+    fn entry_is_stale_at_its_expiration() {
         assert!(matches!(
-            inspect_owned_entry_at(decoded, 60, WRITTEN_AT + 61),
+            inspect_entry_at(&entry(), PROJECT, PROFILE, FINGERPRINT, MAX_AGE, EXPIRES_AT),
             CacheEntryStatus::Stale
         ));
     }
 
     #[test]
-    fn future_timestamp_is_stale_after_a_clock_change() {
-        let decoded = decode(&entry())
-            .expect("marker present")
-            .expect("valid envelope");
+    fn clock_rollback_makes_an_implausibly_distant_expiration_stale() {
         assert!(matches!(
-            inspect_owned_entry_at(decoded, 60, WRITTEN_AT - 1),
+            inspect_entry_at(
+                &entry(),
+                PROJECT,
+                PROFILE,
+                FINGERPRINT,
+                MAX_AGE,
+                WRITTEN_AT - 1
+            ),
             CacheEntryStatus::Stale
+        ));
+    }
+
+    #[test]
+    fn changed_max_age_invalidates_an_unexpired_entry() {
+        assert!(matches!(
+            inspect_entry_at(
+                &entry(),
+                PROJECT,
+                PROFILE,
+                FINGERPRINT,
+                MAX_AGE / 2,
+                WRITTEN_AT
+            ),
+            CacheEntryStatus::Stale
+        ));
+    }
+
+    #[test]
+    fn encoded_entry_stores_expiration_instead_of_write_time() {
+        let entry = entry();
+        let payload = entry
+            .expose_secret()
+            .strip_prefix(CACHE_ENVELOPE_MARKER)
+            .expect("marker present");
+        let envelope: serde_json::Value = serde_json::from_str(payload).unwrap();
+        assert_eq!(envelope["expires_at"], EXPIRES_AT);
+        assert_eq!(envelope["max_age_secs"], MAX_AGE);
+        assert!(envelope.get("cached_at").is_none());
+    }
+
+    #[test]
+    fn expiration_timestamp_overflow_refuses_the_cache_entry() {
+        assert!(matches!(
+            encode_entry_at(
+                PROJECT,
+                PROFILE,
+                u64::MAX,
+                MAX_AGE,
+                FINGERPRINT.to_string(),
+                &SecretString::new("sensitive".into()),
+            ),
+            Err(CacheEncodeError::ExpirationOverflow)
         ));
     }
 
     #[test]
     fn ownership_distinguishes_ours_foreign_unreadable_and_unrecognized() {
-        assert_eq!(ownership(&entry(), PROJECT, PROFILE), CacheOwnership::Ours);
         assert_eq!(
-            ownership(&entry(), "other-project", PROFILE),
+            ownership_at(&entry(), PROJECT, PROFILE, Some(EXPIRES_AT - 1)),
+            CacheOwnership::Ours
+        );
+        assert_eq!(
+            ownership_at(&entry(), "other-project", PROFILE, Some(EXPIRES_AT - 1)),
             CacheOwnership::Foreign {
                 project: PROJECT.to_string(),
                 profile: PROFILE.to_string(),
@@ -311,6 +464,82 @@ mod tests {
     }
 
     #[test]
+    fn expired_entry_can_be_removed_by_whichever_project_encounters_it() {
+        assert_eq!(
+            ownership_at(&entry(), "other-project", "other-profile", Some(EXPIRES_AT)),
+            CacheOwnership::Expired
+        );
+        assert!(matches!(
+            inspect_entry_at(
+                &entry(),
+                "other-project",
+                "other-profile",
+                "different-route",
+                MAX_AGE,
+                EXPIRES_AT,
+            ),
+            CacheEntryStatus::Stale
+        ));
+    }
+
+    fn legacy_entry() -> SecretString {
+        SecretString::new(
+            format!(
+                "{LEGACY_CACHE_ENVELOPE_MARKER}{}",
+                serde_json::json!({
+                    "project": PROJECT,
+                    "profile": PROFILE,
+                    "cached_at": WRITTEN_AT,
+                    "route_fingerprint": FINGERPRINT,
+                    "value": "sensitive",
+                })
+            )
+            .into(),
+        )
+    }
+
+    #[test]
+    fn legacy_entries_preserve_ownership_during_migration() {
+        let legacy = legacy_entry();
+        assert_eq!(
+            ownership_at(&legacy, PROJECT, PROFILE, Some(EXPIRES_AT)),
+            CacheOwnership::Ours
+        );
+        assert_eq!(
+            ownership_at(&legacy, "other-project", PROFILE, Some(EXPIRES_AT)),
+            CacheOwnership::Foreign {
+                project: PROJECT.to_string(),
+                profile: PROFILE.to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn fresh_legacy_entry_remains_usable_during_migration() {
+        let legacy = legacy_entry();
+        let status = inspect_entry_at(&legacy, PROJECT, PROFILE, FINGERPRINT, MAX_AGE, EXPIRES_AT);
+        let CacheEntryStatus::Fresh(value) = status else {
+            panic!("v2 preserves its original inclusive freshness boundary");
+        };
+        assert_eq!(value.expose_secret(), "sensitive");
+    }
+
+    #[test]
+    fn expired_legacy_entry_is_stale_for_its_owner() {
+        assert!(matches!(
+            inspect_entry_at(
+                &legacy_entry(),
+                PROJECT,
+                PROFILE,
+                FINGERPRINT,
+                MAX_AGE,
+                EXPIRES_AT + 1
+            ),
+            CacheEntryStatus::Stale
+        ));
+    }
+
+    #[test]
     fn changed_route_is_stale_even_inside_the_time_window() {
         assert!(matches!(
             inspect_entry_at(
@@ -318,8 +547,8 @@ mod tests {
                 PROJECT,
                 PROFILE,
                 "different-route",
-                60,
-                WRITTEN_AT
+                MAX_AGE,
+                EXPIRES_AT - 1
             ),
             CacheEntryStatus::Stale
         ));

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -691,7 +691,7 @@ pub trait Provider: Send + Sync {
     /// since SecretSpec 0.17.
     ///
     /// The default ignores the hint and writes a plain value, which is always
-    /// correct: SecretSpec's own cache envelope carries the write time and
+    /// correct: SecretSpec's own cache envelope carries the expiration time and
     /// remains the freshness authority. A provider whose store can drop a value
     /// on its own overrides this, so a cached secret stops existing even if
     /// SecretSpec never runs again — a store-side bound on how long a copy of

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -137,8 +137,9 @@ fn group_names(group: &[&PlannedSecret]) -> String {
 enum CachedEntry {
     /// Fresh, and written for this route: serve it.
     Fresh(SecretString),
-    /// Ours, but no read will serve it: an unreadable format, a different
-    /// authoritative route, or older than the route's `max_age`. Ours to drop.
+    /// A SecretSpec entry no read will serve: expired regardless of owner, or
+    /// ours but unreadable or written for another route or freshness policy.
+    /// Safe to drop.
     Stale,
     /// Not ours to serve *or* to drop: another project's entry, or a value
     /// SecretSpec never wrote.
@@ -148,10 +149,10 @@ enum CachedEntry {
 /// Decide what a stored entry is worth to this read.
 ///
 /// Most cache stores cannot expire a value on their own, so this check *is* the
-/// expiry: the envelope records when it was written and the route carries how
-/// long that stays valid. An entry that merely no longer applies (route change,
-/// expiry) is a silent miss; one that belongs to someone else is warned about,
-/// since it means this route is addressing a store something else writes to.
+/// expiry: the envelope records its absolute expiration time. An entry that
+/// merely no longer applies (route change, expiry) is a silent miss; one that
+/// belongs to someone else is warned about, since it means this route is
+/// addressing a store something else writes to.
 fn cached_entry(
     planned: &PlannedSecret,
     cache: &ResolvedCache,
@@ -2119,6 +2120,7 @@ impl Secrets {
         let serialized = match cache::encode_entry(
             &self.config.project.name,
             profile,
+            cache.max_age_secs,
             planned.cache_fingerprint(cache, &self.config.project.name, profile),
             value,
         ) {
@@ -2137,7 +2139,7 @@ impl Secrets {
         let address = self.cache_address(profile, &planned.name);
         // Ask the store to expire the entry at the same age the envelope does.
         // Providers that cannot expire a value write it plainly; the envelope's
-        // own `cached_at` is the freshness authority either way. A store that
+        // own `expires_at` is the freshness authority either way. A store that
         // *can* expire but fails to arrange it refuses the write, which lands
         // here as a warning and drops the entry — no unexpiring copy is left.
         let result = provider.check_writable(address).and_then(|()| {
@@ -2250,7 +2252,9 @@ impl Secrets {
             return Ok(());
         };
         match cache::ownership(&stored, &self.config.project.name, profile) {
-            CacheOwnership::Ours | CacheOwnership::OursUnreadable => Ok(()),
+            CacheOwnership::Ours | CacheOwnership::Expired | CacheOwnership::OursUnreadable => {
+                Ok(())
+            }
             CacheOwnership::Foreign { project, profile } => {
                 Err(SecretSpecError::ProviderOperationFailed(format!(
                     "the cache holds {project}/{profile}'s entry for '{name}' at this address, so \

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -9251,10 +9251,49 @@ fn expired_cache_entry_falls_back_and_refreshes() {
     let secrets = cached_dotenv_secrets(&[&source], &cache, "8h");
     assert_eq!(resolved_value(&secrets, "API_KEY"), "remote-1");
 
-    backdate_cache_entry(&cache, "resolve-test", "API_KEY");
+    expire_cache_entry(&cache, "resolve-test", "API_KEY");
 
     fs::write(&source, "API_KEY=remote-2\n").unwrap();
     assert_eq!(resolved_value(&secrets, "API_KEY"), "remote-2");
+}
+
+#[test]
+fn changing_cache_max_age_invalidates_the_existing_entry() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let cache = temp.path().join("cache.env");
+    fs::write(&source, "API_KEY=remote-1\n").unwrap();
+    let long_lived = cached_dotenv_secrets(&[&source], &cache, "8h");
+    assert_eq!(resolved_value(&long_lived, "API_KEY"), "remote-1");
+
+    fs::write(&source, "API_KEY=remote-2\n").unwrap();
+    let shorter = cached_dotenv_secrets(&[&source], &cache, "1h");
+    assert_eq!(
+        resolved_value(&shorter, "API_KEY"),
+        "remote-2",
+        "the active max_age policy must invalidate an entry written under another policy"
+    );
+}
+
+#[test]
+fn fresh_v2_cache_entry_remains_available_during_migration() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let cache = temp.path().join("cache.env");
+    fs::write(&source, "API_KEY=remote\n").unwrap();
+    let secrets = cached_dotenv_secrets(&[&source], &cache, "8h");
+    assert_eq!(resolved_value(&secrets, "API_KEY"), "remote");
+    rewrite_cache_entry_as_v2(&cache, "resolve-test", "API_KEY");
+
+    fs::remove_file(&source).unwrap();
+    fs::create_dir(&source).unwrap();
+    assert_eq!(
+        resolved_value(&secrets, "API_KEY"),
+        "remote",
+        "upgrading must not turn a fresh v2 cache hit into an authoritative read"
+    );
 }
 
 #[test]
@@ -9444,8 +9483,8 @@ fn cache_write_failure_does_not_hide_authoritative_value() {
     assert_eq!(resolved_value(&secrets, "API_KEY"), "remote");
 }
 
-/// Rewrite a dotenv-backed cache entry's write time, so it reads as expired.
-fn backdate_cache_entry(cache: &Path, project: &str, name: &str) {
+/// Rewrite a dotenv-backed cache entry's expiration, so it reads as expired.
+fn expire_cache_entry(cache: &Path, project: &str, name: &str) {
     let marker = crate::cache::CACHE_ENVELOPE_MARKER;
     let (_, stored) = dotenvy::from_path_iter(cache)
         .unwrap()
@@ -9456,12 +9495,41 @@ fn backdate_cache_entry(cache: &Path, project: &str, name: &str) {
         .strip_prefix(marker)
         .expect("a cache entry carries the ownership marker");
     let mut envelope: serde_json::Value = serde_json::from_str(payload).unwrap();
-    envelope["cached_at"] = serde_json::json!(0);
+    envelope["expires_at"] = serde_json::json!(0);
     write_cache_entry(
         cache,
         project,
         name,
         &format!("{marker}{}", serde_json::to_string(&envelope).unwrap()),
+    );
+}
+
+/// Rewrite the current dotenv-backed entry in the released v2 envelope format.
+fn rewrite_cache_entry_as_v2(cache: &Path, project: &str, name: &str) {
+    let marker = crate::cache::CACHE_ENVELOPE_MARKER;
+    let (_, stored) = dotenvy::from_path_iter(cache)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+    let payload = stored
+        .strip_prefix(marker)
+        .expect("a cache entry carries the current ownership marker");
+    let mut envelope: serde_json::Value = serde_json::from_str(payload).unwrap();
+    let expires_at = envelope["expires_at"].as_u64().unwrap();
+    let max_age_secs = envelope["max_age_secs"].as_u64().unwrap();
+    envelope["cached_at"] = serde_json::json!(expires_at - max_age_secs);
+    let object = envelope.as_object_mut().unwrap();
+    object.remove("expires_at");
+    object.remove("max_age_secs");
+    write_cache_entry(
+        cache,
+        project,
+        name,
+        &format!(
+            "secretspec-cache-v2:{}",
+            serde_json::to_string(&envelope).unwrap()
+        ),
     );
 }
 
@@ -9495,7 +9563,7 @@ fn an_expired_entry_is_dropped_even_when_nothing_replaces_it() {
     let secrets = cached_dotenv_secrets(&[&source], &cache, "8h");
     assert_eq!(resolved_value(&secrets, "API_KEY"), "remote");
 
-    backdate_cache_entry(&cache, "resolve-test", "API_KEY");
+    expire_cache_entry(&cache, "resolve-test", "API_KEY");
     fs::remove_file(&source).unwrap();
     secrets.report().unwrap();
 
@@ -9678,7 +9746,7 @@ fn a_value_secretspec_did_not_write_is_never_deleted() {
 }
 
 #[test]
-fn another_projects_cache_entry_is_never_deleted() {
+fn another_projects_unexpired_cache_entry_is_never_deleted() {
     let _env = scrub_resolution_env();
     // A flat store gives every project the same key for a given secret name, so
     // an entry found there may be another project's. Clearing must say so rather
@@ -9700,6 +9768,30 @@ fn another_projects_cache_entry_is_never_deleted() {
         stored_cache_entry(&cache).as_deref(),
         Some(entry.as_str()),
         "another project's entry must survive our clear"
+    );
+}
+
+#[test]
+fn another_projects_expired_cache_entry_is_deleted_when_encountered() {
+    let _env = scrub_resolution_env();
+    // Expiration is part of the entry itself, so another project that collides
+    // with it in a flat store can honor that lifetime without knowing the
+    // manifest or max_age that originally created it.
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let cache = temp.path().join("cache.env");
+    fs::write(&source, "API_KEY=remote\n").unwrap();
+
+    let providers = cached_dotenv_providers(&[&source], &cache, "8h");
+    let theirs = cached_secrets_with("their-project", providers.clone());
+    assert_eq!(resolved_value(&theirs, "API_KEY"), "remote");
+    expire_cache_entry(&cache, "their-project", "API_KEY");
+
+    let ours = cached_secrets_with("our-project", providers);
+    ours.report().unwrap();
+    assert!(
+        stored_cache_entry(&cache).is_none(),
+        "an expired SecretSpec entry can be removed by whoever encounters it"
     );
 }
 


### PR DESCRIPTION
## Summary

- write v3 cache envelopes with an absolute expiration deadline and the originating max-age policy
- clean up expired entries regardless of which project encounters them while preserving unexpired foreign ownership
- read fresh v2 entries during migration and leave foreign v2 entries untouched

## Root cause

The v2 envelope stored only cached_at, so determining expiry required the current route max_age. SecretSpec could not safely recognize an expired entry encountered outside the original owner and policy context.

## Impact

Expired entries can now be removed immediately. Changes to max_age invalidate existing cache values, clock rollback cannot extend their lifetime, and upgrading does not turn fresh v2 hits into source reads.

## Validation

- devenv shell cargo fmt --all -- --check
- devenv shell cargo test --package secretspec cache (54 passed)
- devenv shell cargo test --package secretspec --lib (807 passed, 4 ignored)
- commit hooks: Clippy and rustfmt passed

Closes #275