### PR TITLE
Add provider-scoped secret refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Windows ARM64 CLI release artifacts (`aarch64-pc-windows-msvc`).
+- Provider aliases can define native `ref` templates and secrets can override
+  coordinates per leaf alias with `refs`, so fallback providers and import
+  sources/destinations resolve independently. `import --delete-source` now
+  preflights the whole migration, verifies all writes before cleanup, and can
+  safely move between distinct entries in the same physical store.
 - Secrets can store values as standard Base64, URL-safe Base64, or hexadecimal
   using `encoding`; writes encode logical text and reads decode stored values,
   while `as_path = true` materializes arbitrary decoded bytes.
@@ -37,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#275](https://github.com/cachix/secretspec/issues/275))
 - `run` preserves non-UTF-8 environment values byte-for-byte when launching
   child processes on Unix.
+- Provider-scoped references now compare provider-defaulted coordinates before
+  destructive imports, apply scoped address overrides before comparing stores,
+  and recognize missing file destinations reached through symlinked parents.
+  They also invalidate caches for every coordinate change without display-format
+  collisions and retain the attempted native location in audit events when a
+  provider read fails. Same-store import validation handles Windows provider
+  paths without treating separators as TOML escapes.
 - SDK pkg-config setup now pins cargo-c's library and metadata install
   directories, so Go, Ruby, and Haskell reliably discover
   `secretspec_ffi.pc` across environments.

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -161,6 +161,30 @@ Provider lists may combine aliases, provider names, and inline provider URIs:
 DATABASE_URL = { description = "Production database", providers = ["onepassword://Production", "keyring"] }
 ```
 
+### Alias ref templates (0.19+)
+
+:::caution[Version compatibility]
+Provider-alias `ref` templates and per-secret `refs` are available starting
+with SecretSpec 0.19.
+:::
+
+A leaf alias can map the logical `{project}`, `{profile}`, and `{key}` into its
+provider's native coordinates. This lets every link in a fallback chain—and
+each side of an import—use a different address:
+
+```toml title="secretspec.toml"
+[providers]
+remote = { uri = "onepassword://Production", ref = { item = "{project}-{profile}", field = "{key}" } }
+local = { uri = "dotenv://.env", ref = { item = "{key}" } }
+
+[profiles.production]
+API_KEY = { description = "API key", providers = ["remote", "local"] }
+```
+
+Use per-secret `refs = { alias = { item = "..." } }` for exceptions. See
+[Secret References](/concepts/references/#different-coordinates-per-provider-019)
+for precedence, import-only source aliases, and cached-route restrictions.
+
 Use the CLI to manage user-level aliases:
 
 ```bash

--- a/docs/src/content/docs/concepts/references.md
+++ b/docs/src/content/docs/concepts/references.md
@@ -80,6 +80,39 @@ file without touching the manifest.
 $ secretspec run --provider dotenv:.env.fixtures -- cargo test
 ```
 
+## Different coordinates per provider (0.19+)
+
+:::caution[Version compatibility]
+Provider-scoped `refs` and provider-alias `ref` templates are available
+starting with SecretSpec 0.19.
+:::
+
+The original `ref` remains useful when every provider understands one address.
+When endpoints organize the same logical secret differently, attach a template
+to each leaf alias and use `refs` only for exceptions:
+
+```toml
+[providers]
+remote = { uri = "onepassword://Production", ref = { item = "{project}-{profile}", field = "{key}" } }
+local = { uri = "dotenv://.env", ref = { item = "{key}" } }
+legacy = "onepassword://Legacy"
+
+[profiles.production]
+API_KEY = { description = "API key", providers = ["remote", "local"], refs = { legacy = { item = "old-api-item", field = "token" } } }
+```
+
+SecretSpec resolves each endpoint independently: `refs.<selected-alias>` wins,
+then that alias's template, then convention naming. This applies to primary and
+fallback reads, writes, and both sides of `import`; the `legacy` ref above can
+therefore describe an import source without adding it to the normal read route.
+Templates support `{project}`, `{profile}`, and `{key}` in every coordinate.
+
+Scoped refs deliberately key on aliases, not resolved URIs. Literal provider
+URIs and bare provider names use convention naming because they have no alias
+identity. Cached route aliases cannot own a template or scoped ref; configure
+their individual leaf aliases instead. `refs` and legacy route-wide `ref` are
+mutually exclusive.
+
 ## How it works
 
 - `item` is required; `field`, `vault`, `section`, and `version` are optional and
@@ -87,8 +120,9 @@ $ secretspec run --provider dotenv:.env.fixtures -- cargo test
 - Reads and writes are symmetric: `secretspec set` and interactive `check` write
   through the coordinates in place wherever the store supports writes. Read-only
   stores fail with a clear error.
-- `ref` is always a table. String and URI forms (`ref = "op://vault/item/field"`)
-  are rejected, with an error that spells out the equivalent table.
+- `ref` and every provider-scoped `refs.<alias>` value are tables. String and
+  URI forms (`ref = "op://vault/item/field"`) are rejected, with an error that
+  spells out the equivalent table.
 - Secrets sharing identical coordinates and store are fetched once, and
   [audit log](/concepts/audit/) events carry the coordinates.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -522,6 +522,11 @@ secretspec import <FROM_PROVIDER> [--delete-source]
 
 The destination provider and profile are determined from your configuration. Secrets that already exist in the destination provider will not be overwritten.
 
+In SecretSpec 0.19+, the source and destination resolve their addresses
+independently. A source alias can use its own [provider `ref` template or
+per-secret scoped ref](/concepts/references/#different-coordinates-per-provider-019),
+while the destination uses its selected alias's mapping.
+
 **Arguments:**
 - `<FROM_PROVIDER>` - Provider to import from (e.g., `env`, `dotenv:/path/to/.env`)
 - `--delete-source` - After copying, delete a source value only when the
@@ -556,12 +561,15 @@ $ secretspec import dotenv:/home/user/old-project/.env --delete-source
 component secrets are imported normally. Available since SecretSpec 0.16.
 
 With `--delete-source`, source and destination must resolve to different
-providers. A value copied during this run is read back before its source is
-deleted. If the destination already contains an identical value, the source is
-also safe to delete; if it differs, SecretSpec retains the source and reports
-the conflict. A source provider that does not support deletion fails explicitly
-instead of pretending the migration completed. This behavior is available
-starting with SecretSpec 0.18.
+physical entries. In SecretSpec 0.19+, distinct scoped refs in the same store
+are allowed. SecretSpec preflights every source and destination, performs all
+writes, reads back and validates every copied value, and only then begins
+source cleanup. If a destination already contains an identical value, the
+source is also safe to delete; if it differs, SecretSpec retains the source and
+reports the conflict. A source provider that does not support deletion fails
+explicitly instead of pretending the migration completed. Source deletion was
+introduced in SecretSpec 0.18; independent endpoint refs and operation-wide
+preflight are available in 0.19+.
 
 ### cache clear (0.17+)
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -132,6 +132,7 @@ Each secret variable is defined as a table with the following fields:
 | `composed` (0.16+) | string | No | Derive a read-only value from other declared secrets using `${UPPERCASE_NAME}` references |
 | `providers` | array[string] | No | List of provider aliases to use in fallback order |
 | `ref` | table | No | Coordinates naming an externally managed secret in the provider's store (e.g. `ref = { item = "db", field = "password" }`) |
+| `refs` (0.19+) | table | No | Provider-alias-scoped coordinates, keyed by leaf alias (e.g. `refs = { source = { item = "old" }, target = { item = "new" } }`); mutually exclusive with `ref` |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
 | `encoding` (0.19+) | `"base64"`, `"base64url"`, or `"hex"` | No | Encode logical values before storage writes and decode stored values after reads |
 | `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
@@ -172,7 +173,8 @@ References form a static dependency graph. Declaration order does not matter,
 and composed secrets may reference other composed secrets. SecretSpec rejects
 unknown references, cycles, malformed references, and source conflicts while
 loading the manifest. A composed secret is read-only and cannot also set
-`default`, `providers`, `ref`, `type`, enabled `generate`, or `encoding` (0.19+).
+`default`, `providers`, `ref`, `refs` (0.19+), `type`, enabled `generate`, or
+`encoding` (0.19+).
 
 Composition intentionally does **not** implement dotenv or shell expansion:
 
@@ -393,6 +395,7 @@ Provider alias tables with `uri` and `credentials` are available since
 SecretSpec 0.15. SecretSpec 0.14 accepts only bare URI strings; when using
 0.14, configure provider credentials through the provider's existing
 environment variables, such as `BWS_ACCESS_TOKEN`.
+Provider alias `ref` templates are available starting with SecretSpec 0.19.
 Cached alias tables with `fallback` and `cache` are available since SecretSpec
 0.17.
 :::
@@ -446,6 +449,7 @@ forms are accepted in the project `[providers]` and user
 |-------|------|----------|-------------|
 | `uri` | string | Yes (table form) | The provider URI. A bare-string alias is shorthand for `{ uri = "..." }`. |
 | `credentials` | table | No | Maps a semantic [provider credential](/reference/provider-credentials/) name to its source. |
+| `ref` (0.19+) | table | No | Native-address template for this leaf alias. Coordinate strings may contain `{project}`, `{profile}`, and `{key}`. |
 
 Each `credentials` value is either a bare provider spec — read at the convention path for the active project and profile — or a table `{ provider = "...", ref = { ... } }` that pins the exact location with the same `ref` coordinates a secret uses.
 
@@ -462,6 +466,24 @@ credentials = { role_id   = { provider = "onepassword", ref = { vault = "Infra",
 ```
 
 Configured credentials take precedence over provider environment fallbacks, credential chains are limited to one hop, and a fetched credential is never written to the environment. Store the credentials with [`secretspec config provider login`](/reference/cli/#config-provider-login). See [Provider credentials](/concepts/providers/#provider-credentials) for the full behavior.
+
+Starting with SecretSpec 0.19, a leaf alias may also compile logical secret
+names into that provider's native coordinates. Templates expand each
+placeholder once; text inserted from a project, profile, or key is never
+interpreted as another placeholder.
+
+```toml title="secretspec.toml"
+[providers]
+remote = { uri = "onepassword://Production", ref = { item = "{project}-{profile}", field = "{key}" } }
+local = { uri = "dotenv://.env", ref = { item = "{key}" } }
+
+[profiles.production]
+API_KEY = { description = "API key", providers = ["remote", "local"] }
+```
+
+Templates belong on the leaf aliases in a cached route, not on the cached
+alias itself. Bare provider names and literal URIs have no alias identity, so
+they use provider convention naming unless the secret declares legacy `ref`.
 
 #### SecretSpec 0.17 cached alias values
 
@@ -649,6 +671,41 @@ TOKEN = { description = "Token", ref = { vault = "Production", item = "infra", f
 Which provider resolves a `ref` follows the ordinary [provider resolution
 order](/concepts/providers/fallback/); a `ref` composes with the `providers` fallback
 chain, and each provider is asked for the same coordinates.
+
+#### Provider-scoped references (0.19+)
+
+:::caution[Version compatibility]
+Provider-scoped `refs` and provider-alias `ref` templates are available
+starting with SecretSpec 0.19.
+:::
+
+Use `refs` when one logical secret already has different native coordinates in
+different providers. Keys are leaf provider aliases; they are identity, not a
+URI lookup, so aliases that happen to resolve to the same URI remain distinct.
+An entry may name an import-only source alias that is absent from the secret's
+ordinary `providers` route.
+
+```toml
+[providers]
+old = "onepassword://Legacy"
+new = { uri = "onepassword://Production", ref = { item = "{project}-{profile}", field = "{key}" } }
+local = "keyring://"
+
+[profiles.production]
+API_KEY = { description = "API key", providers = ["new", "local"], refs = { old = { item = "legacy-api", field = "token" } } }
+```
+
+For each selected endpoint, address resolution is:
+
+1. Legacy route-wide `ref`, when present (for compatibility).
+2. The matching `refs.<alias>` entry.
+3. The matching alias's `ref` template.
+4. The provider's ordinary `{project}/{profile}/{key}` convention.
+
+`ref` and `refs` cannot be combined on one effective secret. Every `refs` key
+must name a defined leaf alias; cached route aliases cannot own templates or be
+used as scoped-ref keys. A literal URI or bare provider name has no alias key,
+so only legacy `ref` or convention naming applies to it.
 
 #### How providers interpret the coordinates
 

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -146,6 +146,18 @@ DATABASE_URL = { description = "PostgreSQL connection string", required = true }
 REDIS_URL = { description = "Redis connection string", required = true }
 ```
 
+SecretSpec 0.19+ can map one logical secret to different native coordinates per
+provider alias, including independent import source and destination refs:
+
+```toml
+[providers]
+remote = { uri = "onepassword://Production", ref = { item = "{project}-{profile}", field = "{key}" } }
+local = "keyring://"
+
+[profiles.production]
+API_KEY = { description = "API key", providers = ["local"], refs = { remote = { item = "legacy-api", field = "token" } } }
+```
+
 See the [configuration reference](https://secretspec.dev/reference/configuration/) for all available options.
 
 ## Profiles

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -309,8 +309,8 @@ pub(crate) fn parse_cache_max_age(value: &str) -> std::result::Result<u64, Strin
 /// myprovider = { fallback = ["azure", "env"], cache = { provider = "local", max_age = "8h" } }
 /// ```
 ///
-/// Leaf aliases round-trip as before: an alias with no credentials serializes
-/// back to a bare string, so existing configs are untouched.
+/// Leaf aliases round-trip as before: an alias with no credentials or ref
+/// template serializes back to a bare string, so existing configs are untouched.
 ///
 /// Construct one through [`ProviderAlias::from_uri`] or
 /// [`ProviderAlias::cached`]; the struct is `#[non_exhaustive]` so a future
@@ -324,6 +324,10 @@ pub struct ProviderAlias {
     /// Empty for a bare string alias, so "declares no credentials" has exactly
     /// one representation.
     pub credentials: HashMap<String, CredentialSource>,
+    /// Provider-scoped native-address template (0.19+). Placeholders compile a
+    /// logical `{project}/{profile}/{key}` address into this alias's own
+    /// coordinates before the provider is contacted.
+    pub reference_template: Option<NativeAddressTemplate>,
     /// Ordered authoritative sources for a cached alias (0.17+). Empty for a
     /// leaf alias.
     pub(crate) fallback: Vec<String>,
@@ -337,6 +341,7 @@ impl ProviderAlias {
         Self {
             uri: uri.into(),
             credentials: HashMap::new(),
+            reference_template: None,
             fallback: Vec::new(),
             cache: None,
         }
@@ -359,6 +364,7 @@ impl ProviderAlias {
         Ok(Self {
             uri: String::new(),
             credentials: HashMap::new(),
+            reference_template: None,
             fallback,
             cache: Some(cache),
         })
@@ -382,6 +388,27 @@ impl ProviderAlias {
     /// `None` for a leaf alias.
     pub fn cache(&self) -> Option<&ProviderCache> {
         self.cache.as_ref()
+    }
+
+    /// The native-address template attached to this leaf alias, if any.
+    pub fn reference_template(&self) -> Option<&NativeAddressTemplate> {
+        self.reference_template.as_ref()
+    }
+
+    /// Attach a validated native-address template to a leaf alias.
+    pub fn with_reference_template(
+        mut self,
+        template: NativeAddressTemplate,
+    ) -> std::result::Result<Self, String> {
+        if self.is_cached() {
+            return Err(
+                "a cached provider alias cannot declare a ref template; put templates on its leaf aliases"
+                    .to_string(),
+            );
+        }
+        template.validate()?;
+        self.reference_template = Some(template);
+        Ok(self)
     }
 }
 
@@ -414,6 +441,9 @@ impl std::fmt::Display for ProviderAlias {
             names.sort();
             write!(f, " (credentials: {})", names.join(", "))?;
         }
+        if let Some(template) = &self.reference_template {
+            write!(f, " (ref template: {})", template.render_description())?;
+        }
         Ok(())
     }
 }
@@ -427,15 +457,20 @@ impl Serialize for ProviderAlias {
             table.serialize_field("cache", cache)?;
             return table.end();
         }
-        if self.credentials.is_empty() {
+        if self.credentials.is_empty() && self.reference_template.is_none() {
             // A bare alias serializes back to the plain-string form, so an alias
             // that was written as a string round-trips unchanged.
             serializer.serialize_str(&self.uri)
         } else {
             use serde::ser::SerializeStruct;
-            let mut table = serializer.serialize_struct("ProviderAlias", 2)?;
+            let mut table = serializer.serialize_struct("ProviderAlias", 3)?;
             table.serialize_field("uri", &self.uri)?;
-            table.serialize_field("credentials", &self.credentials)?;
+            if !self.credentials.is_empty() {
+                table.serialize_field("credentials", &self.credentials)?;
+            }
+            if let Some(template) = &self.reference_template {
+                table.serialize_field("ref", template)?;
+            }
             table.end()
         }
     }
@@ -473,6 +508,8 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                     uri: Option<String>,
                     #[serde(default)]
                     credentials: Option<HashMap<String, CredentialSource>>,
+                    #[serde(default, rename = "ref")]
+                    reference_template: Option<NativeAddressTemplate>,
                     #[serde(default)]
                     fallback: Option<Vec<String>>,
                     #[serde(default)]
@@ -480,17 +517,28 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                 }
                 let table = Table::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
                 match (table.uri, table.fallback, table.cache) {
-                    (Some(uri), None, None) => Ok(ProviderAlias {
-                        uri,
-                        credentials: table.credentials.unwrap_or_default(),
-                        fallback: Vec::new(),
-                        cache: None,
-                    }),
+                    (Some(uri), None, None) => {
+                        if let Some(template) = &table.reference_template {
+                            template.validate().map_err(serde::de::Error::custom)?;
+                        }
+                        Ok(ProviderAlias {
+                            uri,
+                            credentials: table.credentials.unwrap_or_default(),
+                            reference_template: table.reference_template,
+                            fallback: Vec::new(),
+                            cache: None,
+                        })
+                    }
                     (None, Some(fallback), Some(cache)) => {
                         if table.credentials.is_some() {
                             return Err(serde::de::Error::custom(
                                 "a cached provider alias cannot declare credentials; \
                                  put credentials on its leaf fallback aliases",
+                            ));
+                        }
+                        if table.reference_template.is_some() {
+                            return Err(serde::de::Error::custom(
+                                "a cached provider alias cannot declare a ref template; put templates on its leaf aliases",
                             ));
                         }
                         // The remaining shape checks live in the constructor,
@@ -499,7 +547,7 @@ impl<'de> Deserialize<'de> for ProviderAlias {
                         ProviderAlias::cached(fallback, cache).map_err(serde::de::Error::custom)
                     }
                     (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(serde::de::Error::custom(
-                        "a provider alias must use either { uri, credentials } or \
+                        "a provider alias must use either { uri, credentials, ref } or \
                              { fallback, cache }, not both",
                     )),
                     (None, Some(_), None) => Err(serde::de::Error::custom(
@@ -1478,6 +1526,139 @@ impl NativeAddress {
     }
 }
 
+/// A provider-alias template for native secret coordinates (0.19+).
+///
+/// Each coordinate accepts the logical placeholders `{project}`, `{profile}`,
+/// and `{key}`. The template belongs to one provider alias, so fallback links
+/// and import endpoints can map the same logical secret into different native
+/// address shapes without sharing provider-specific coordinates.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NativeAddressTemplate {
+    /// Template for the provider's required `item` coordinate.
+    pub item: String,
+    /// Optional template for a component within the item.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// Optional container template.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vault: Option<String>,
+    /// Optional section template.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    /// Optional version template.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+impl NativeAddressTemplate {
+    pub(crate) fn coordinates(&self) -> [(&'static str, Option<&str>); 5] {
+        [
+            ("vault", self.vault.as_deref()),
+            ("item", Some(self.item.as_str())),
+            ("section", self.section.as_deref()),
+            ("field", self.field.as_deref()),
+            ("version", self.version.as_deref()),
+        ]
+    }
+
+    /// Validate every coordinate and placeholder without provider I/O.
+    pub fn validate(&self) -> std::result::Result<(), String> {
+        for (name, value) in self.coordinates() {
+            let Some(value) = value else {
+                continue;
+            };
+            if value.trim().is_empty() {
+                return Err(format!(
+                    "provider ref template coordinate `{name}` cannot be empty or whitespace"
+                ));
+            }
+            expand_address_template(value, "project", "profile", "KEY").map_err(|error| {
+                format!("invalid provider ref template coordinate `{name}`: {error}")
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Expand this alias template for one logical secret.
+    pub fn expand(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> std::result::Result<NativeAddress, String> {
+        self.validate()?;
+        let expand = |value: &str| expand_address_template(value, project, profile, key);
+        Ok(NativeAddress {
+            item: expand(&self.item)?,
+            field: self.field.as_deref().map(expand).transpose()?,
+            vault: self.vault.as_deref().map(expand).transpose()?,
+            section: self.section.as_deref().map(expand).transpose()?,
+            version: self.version.as_deref().map(expand).transpose()?,
+        })
+    }
+
+    pub(crate) fn render_description(&self) -> String {
+        let mut out = String::new();
+        for (name, value) in self.coordinates() {
+            if let Some(value) = value {
+                if !out.is_empty() {
+                    out.push(' ');
+                }
+                out.push_str(name);
+                out.push('=');
+                out.push_str(value);
+            }
+        }
+        out
+    }
+}
+
+/// Expand one address-template coordinate in a single pass. A compiled parser
+/// is intentionally used instead of chained `replace` calls: logical names may
+/// themselves contain brace-like text and must never be interpreted as another
+/// placeholder after insertion.
+fn expand_address_template(
+    template: &str,
+    project: &str,
+    profile: &str,
+    key: &str,
+) -> std::result::Result<String, String> {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    loop {
+        let Some(open) = rest.find('{') else {
+            if rest.contains('}') {
+                return Err(format!("template '{template}' contains an unmatched `}}`"));
+            }
+            out.push_str(rest);
+            break;
+        };
+        let prefix = &rest[..open];
+        if prefix.contains('}') {
+            return Err(format!("template '{template}' contains an unmatched `}}`"));
+        }
+        out.push_str(prefix);
+        let after_open = &rest[open + 1..];
+        let Some(close) = after_open.find('}') else {
+            return Err(format!("template '{template}' contains an unmatched `{{`"));
+        };
+        let placeholder = &after_open[..close];
+        out.push_str(match placeholder {
+            "project" => project,
+            "profile" => profile,
+            "key" => key,
+            _ => {
+                return Err(format!(
+                    "unknown placeholder `{{{placeholder}}}` in template '{template}'; expected {{project}}, {{profile}}, or {{key}}"
+                ));
+            }
+        });
+        rest = &after_open[close + 1..];
+    }
+    Ok(out)
+}
+
 /// Derived deserialization target for [`NativeAddress`]. The manual
 /// [`Deserialize`] below delegates table input here so serde's precise
 /// `deny_unknown_fields` messages ("unknown field \`filed\`, expected one of
@@ -1682,6 +1863,8 @@ struct SecretSerde {
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     reference: Option<NativeAddress>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    refs: Option<HashMap<String, NativeAddress>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     as_path: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     encoding: Option<SecretEncoding>,
@@ -1765,6 +1948,11 @@ pub struct Secret {
     /// with `generate`: a missing referenced secret is minted and written to
     /// its coordinates. Serialized as `ref` in TOML.
     pub reference: Option<NativeAddress>,
+    /// Provider-alias-scoped native coordinates (0.19+). The selected alias's
+    /// entry overrides its alias-level ref template; aliases absent from this
+    /// map use their template or ordinary convention address. Mutually
+    /// exclusive with the legacy route-wide `ref` field.
+    pub refs: Option<HashMap<String, NativeAddress>>,
     /// Whether to write the secret value to a temporary file and return the path.
     /// If true, the secret will be written to a temporary file and the field
     /// will contain the path to that file instead of the secret value.
@@ -1787,6 +1975,9 @@ impl TryFrom<SecretSerde> for Secret {
     type Error = String;
 
     fn try_from(value: SecretSerde) -> Result<Self, Self::Error> {
+        if value.reference.is_some() && value.refs.is_some() {
+            return Err("`ref` and `refs` cannot both be set; use `refs` for provider-scoped addresses or keep the legacy route-wide `ref`".into());
+        }
         let (required, at_least_one, exactly_one) = match value.required {
             Some(RequiredSetting::Bool(required)) => (Some(required), None, None),
             Some(RequiredSetting::Groups(groups)) => {
@@ -1807,6 +1998,7 @@ impl TryFrom<SecretSerde> for Secret {
             composed: value.composed,
             providers: value.providers,
             reference: value.reference,
+            refs: value.refs,
             as_path: value.as_path,
             encoding: value.encoding,
             secret_type: value.secret_type,
@@ -1833,6 +2025,7 @@ impl From<Secret> for SecretSerde {
             composed: value.composed,
             providers: value.providers,
             reference: value.reference,
+            refs: value.refs,
             as_path: value.as_path,
             encoding: value.encoding,
             secret_type: value.secret_type,
@@ -1937,12 +2130,13 @@ impl Secret {
             if self.default.is_some()
                 || self.providers.is_some()
                 || self.reference.is_some()
+                || self.refs.is_some()
                 || self.encoding.is_some()
                 || self.secret_type.is_some()
                 || self.would_generate()
             {
                 return Err(
-                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `encoding`, `type`, or enabled `generate`"
+                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `refs`, `encoding`, `type`, or enabled `generate`"
                         .into(),
                 );
             }
@@ -1961,6 +2155,27 @@ impl Secret {
                         "`ref` coordinate `{}` cannot be empty or whitespace",
                         name
                     ));
+                }
+            }
+        }
+
+        if self.reference.is_some() && self.refs.is_some() {
+            return Err("`ref` and `refs` cannot both be set; use `refs` for provider-scoped addresses or keep the legacy route-wide `ref`".into());
+        }
+        if let Some(references) = &self.refs {
+            if references.is_empty() {
+                return Err("`refs` must name at least one provider alias".into());
+            }
+            for (alias, reference) in references {
+                if alias.trim().is_empty() {
+                    return Err("`refs` provider alias cannot be empty or whitespace".into());
+                }
+                for (name, value) in reference.coordinates() {
+                    if value.is_some_and(|v| v.trim().is_empty()) {
+                        return Err(format!(
+                            "`refs.{alias}` coordinate `{name}` cannot be empty or whitespace"
+                        ));
+                    }
                 }
             }
         }
@@ -2083,6 +2298,7 @@ impl Secret {
             providers: inherit(current, default, |s| s.providers.clone())
                 .or_else(|| storage_defaults.and_then(|d| d.providers.clone())),
             reference: inherit(current, default, |s| s.reference.clone()),
+            refs: inherit(current, default, |s| s.refs.clone()),
             as_path: inherit(current, default, |s| s.as_path),
             encoding: inherit(current, default, |s| s.encoding),
             secret_type: inherit(current, default, |s| s.secret_type.clone()),
@@ -3266,6 +3482,28 @@ default = "placeholder"
         assert!(s.validate().is_ok());
     }
 
+    #[test]
+    fn scoped_refs_parse_and_cannot_mix_with_legacy_ref() {
+        let secret: Secret = toml::from_str(
+            r#"description = "token"
+providers = ["remote", "local"]
+refs = { remote = { vault = "Production", item = "shared", field = "token" }, local = { item = "TOKEN" } }"#,
+        )
+        .unwrap();
+        let refs = secret.refs.expect("scoped refs present");
+        assert_eq!(refs["remote"].item, "shared");
+        assert_eq!(refs["remote"].field.as_deref(), Some("token"));
+        assert_eq!(refs["local"].item, "TOKEN");
+
+        let error = toml::from_str::<Secret>(
+            r#"description = "token"
+ref = { item = "legacy" }
+refs = { remote = { item = "scoped" } }"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("cannot both be set"), "{error}");
+    }
+
     /// A `ref` supplies naming and `providers` supplies routing; they compose.
     #[test]
     fn secret_validate_accepts_ref_with_providers() {
@@ -3515,6 +3753,48 @@ mod provider_alias_tests {
             .get("access_token")
             .expect("credentials carries the semantic name");
         assert_eq!(source, &CredentialSource::from("keyring"));
+    }
+
+    #[test]
+    fn alias_ref_template_parses_expands_and_round_trips() {
+        let map = parse(
+            r#"op = { uri = "onepassword://Production", ref = { vault = "{profile}", item = "{project}-{key}", field = "password" } }"#,
+        );
+        let alias = &map["op"];
+        let template = alias.reference_template().expect("template present");
+        let expanded = template.expand("web", "prod", "DATABASE_URL").unwrap();
+        assert_eq!(expanded.vault.as_deref(), Some("prod"));
+        assert_eq!(expanded.item, "web-DATABASE_URL");
+        assert_eq!(expanded.field.as_deref(), Some("password"));
+        assert_eq!(
+            template
+                .expand("{key}", "prod", "DATABASE_URL")
+                .unwrap()
+                .item,
+            "{key}-DATABASE_URL",
+            "inserted values must not be interpreted as placeholders"
+        );
+
+        let serialized = toml::to_string(&map).unwrap();
+        assert_eq!(parse(&serialized), map);
+    }
+
+    #[test]
+    fn alias_ref_template_rejects_invalid_placeholders_and_cached_aliases() {
+        let error = toml::from_str::<HashMap<String, ProviderAlias>>(
+            r#"op = { uri = "onepassword://Production", ref = { item = "{secret}" } }"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("unknown placeholder"), "{error}");
+
+        let error = toml::from_str::<HashMap<String, ProviderAlias>>(
+            r#"route = { fallback = ["remote"], cache = { provider = "local", max_age = "1h" }, ref = { item = "{key}" } }"#,
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("cached provider alias"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -19,7 +19,7 @@ use crate::composition::Template;
 use crate::config::{NativeAddress, Secret, SecretEncoding};
 use crate::error::{Result, SecretSpecError};
 use crate::manifest::CompiledSecret;
-use crate::provider::Address;
+use crate::provider::OwnedAddress;
 use crate::secrets::Secrets;
 use std::collections::HashMap;
 
@@ -141,17 +141,6 @@ impl PlannedSecret {
         &self.secret.config
     }
 
-    /// The provider [`Address`] this secret's operations resolve: its native
-    /// `ref` coordinates when it has them, otherwise SecretSpec's own
-    /// `{project}/{profile}/{key}` naming convention. Naming is orthogonal to
-    /// routing: the same address is asked of whichever store [`Route`] selects.
-    pub(crate) fn as_address<'a>(&'a self, project: &'a str, profile: &'a str) -> Address<'a> {
-        match &self.secret.config.reference {
-            Some(native) => Address::Native(native),
-            None => Address::convention(project, profile, &self.name),
-        }
-    }
-
     /// The native `ref` coordinates this secret addresses, if any.
     pub(crate) fn reference(&self) -> Option<&NativeAddress> {
         self.secret.config.reference.as_ref()
@@ -169,10 +158,20 @@ impl PlannedSecret {
         project: &str,
         profile: &str,
     ) -> String {
-        let address = self
-            .reference()
-            .map(NativeAddress::render)
-            .unwrap_or_else(|| "convention".to_string());
+        let address = if let Some(reference) = self.reference() {
+            coordinate_fingerprint("legacy-ref", reference.coordinates())
+        } else if let Some(references) = &self.config().refs {
+            let mut entries = references.iter().collect::<Vec<_>>();
+            entries.sort_by_key(|(alias, _)| alias.as_str());
+            let mut fingerprints = vec!["scoped-refs".to_string()];
+            fingerprints.extend(entries.into_iter().map(|(alias, reference)| {
+                let coordinates = coordinate_fingerprint("native-ref", reference.coordinates());
+                stable_fingerprint(["scoped-ref", alias.as_str(), coordinates.as_str()])
+            }));
+            stable_fingerprint(fingerprints.iter().map(String::as_str))
+        } else {
+            "convention".to_string()
+        };
         stable_fingerprint([
             project,
             profile,
@@ -250,6 +249,76 @@ impl ResolutionPlan {
 }
 
 impl Secrets {
+    /// Resolve one secret's address for one concrete provider endpoint.
+    ///
+    /// Legacy `ref` remains route-wide. The 0.19+ scoped model is deliberately
+    /// different: a concrete `refs.<alias>` wins for that alias, then the
+    /// alias's ref template, then the provider's ordinary convention address.
+    /// Literal provider specs have no alias identity and therefore use
+    /// convention naming. `ref` and `refs` are rejected together by config
+    /// validation, so these two modes never merge implicitly.
+    pub(crate) fn address_for_spec(
+        &self,
+        planned: &PlannedSecret,
+        provider_spec: Option<&str>,
+        project: &str,
+        profile: &str,
+    ) -> Result<OwnedAddress> {
+        if let Some(reference) = planned.reference() {
+            return Ok(OwnedAddress::Native(reference.clone()));
+        }
+
+        let effective_spec = provider_spec
+            .map(str::to_string)
+            .or_else(|| self.configured_default_provider_spec());
+        if let Some(spec) = effective_spec.as_deref()
+            && let Some(alias) = self.lookup_provider_alias_entry(spec)
+            && !alias.is_cached()
+        {
+            if let Some(reference) = planned
+                .config()
+                .refs
+                .as_ref()
+                .and_then(|refs| refs.get(spec))
+            {
+                return Ok(OwnedAddress::Native(reference.clone()));
+            }
+            if let Some(template) = alias.reference_template() {
+                let reference = template.expand(project, profile, &planned.name).map_err(|error| {
+                    SecretSpecError::ProviderOperationFailed(format!(
+                        "provider alias '{spec}' could not expand its ref template for '{}': {error}",
+                        planned.name
+                    ))
+                })?;
+                return Ok(OwnedAddress::Native(reference));
+            }
+        }
+
+        Ok(OwnedAddress::convention(project, profile, &planned.name))
+    }
+
+    /// Validate all provider-scoped refs on a secret, including source-only
+    /// aliases used later by `import`. Validation belongs in planning because
+    /// user-global aliases are unavailable to the standalone `Config` parser.
+    fn validate_scoped_refs(&self, name: &str, secret: &Secret) -> Result<()> {
+        let Some(references) = &secret.refs else {
+            return Ok(());
+        };
+        for alias_name in references.keys() {
+            let Some(alias) = self.lookup_provider_alias_entry(alias_name) else {
+                return Err(SecretSpecError::ProviderNotFound(format!(
+                    "Secret '{name}' defines `refs.{alias_name}`, but provider alias '{alias_name}' is not defined"
+                )));
+            };
+            if alias.is_cached() {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Secret '{name}' defines `refs.{alias_name}`, but '{alias_name}' is a cached route; scoped refs must name leaf provider aliases"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Resolve a whole profile into an immutable [`ResolutionPlan`] without any
     /// I/O: merge the profile, compute each secret's effective config, and
     /// derive its resolved route.
@@ -376,6 +445,7 @@ impl Secrets {
         secret: &CompiledSecret,
         override_spec: &Option<String>,
     ) -> Result<PlannedSecret> {
+        self.validate_scoped_refs(&name, &secret.config)?;
         // A composed secret's value is derived by the executor, so it routes
         // to no store, including an explicit `--provider` override.
         let route = if secret.composition.is_some() {
@@ -527,6 +597,19 @@ impl Secrets {
             .iter()
             .map(|uri| self.canonical_provider_uri(uri))
             .collect::<Result<Vec<_>>>()?;
+        let source_route_fingerprints = alias
+            .fallback()
+            .iter()
+            .zip(&source_route_uris)
+            .map(|(spec, uri)| {
+                let template = self
+                    .lookup_provider_alias_entry(spec)
+                    .and_then(|alias| alias.reference_template())
+                    .map(|template| coordinate_fingerprint("ref-template", template.coordinates()))
+                    .unwrap_or_else(|| "convention".to_string());
+                stable_fingerprint(["source-route", spec, uri, template.as_str()])
+            })
+            .collect::<Vec<_>>();
         let cache_identity = self.canonical_storage_identity(&cache_uri)?;
 
         // The cache entry lives at the same logical address the authoritative
@@ -576,7 +659,9 @@ impl Secrets {
                 spec: cache.provider().to_string(),
                 uri: cache_uri,
                 max_age_secs: cache.max_age_secs(),
-                route_fingerprint: stable_fingerprint(source_route_uris.iter().map(String::as_str)),
+                route_fingerprint: stable_fingerprint(
+                    source_route_fingerprints.iter().map(String::as_str),
+                ),
             }),
         })
     }
@@ -636,10 +721,32 @@ fn stable_fingerprint<'a>(parts: impl IntoIterator<Item = &'a str>) -> String {
     format!("v1-{hash:016x}")
 }
 
+/// Fingerprint native coordinates without routing them through their
+/// human-readable rendering. Each coordinate name, presence marker, and value
+/// is a separately length-delimited hash part, so delimiter-like text inside an
+/// item cannot collide with a real adjacent coordinate.
+fn coordinate_fingerprint<'a>(
+    kind: &'static str,
+    coordinates: impl IntoIterator<Item = (&'static str, Option<&'a str>)>,
+) -> String {
+    let mut parts = vec![kind];
+    for (name, value) in coordinates {
+        parts.push(name);
+        match value {
+            Some(value) => {
+                parts.push("present");
+                parts.push(value);
+            }
+            None => parts.push("absent"),
+        }
+    }
+    stable_fingerprint(parts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ProviderAlias, ProviderCache};
+    use crate::config::{NativeAddressTemplate, ProviderAlias, ProviderCache};
     use crate::error::SecretSpecError;
     use crate::tests::{global_config_with_aliases, scrub_resolution_env};
     use std::collections::HashMap;
@@ -840,19 +947,96 @@ mod tests {
             ("REFERENCED".to_string(), referenced),
             ("PLAIN".to_string(), secret(None)),
         ]);
-        let plan = plan(&spec(secrets, None, &[]));
-
-        match find(&plan, "REFERENCED").as_address("proj", "default") {
-            Address::Native(native) => {
+        let spec = spec(secrets, None, &[]);
+        let plan = plan(&spec);
+        let referenced = find(&plan, "REFERENCED");
+        let referenced_address = spec
+            .address_for_spec(
+                referenced,
+                referenced.route.as_ref().and_then(Route::group_key),
+                "proj",
+                "default",
+            )
+            .unwrap();
+        match referenced_address {
+            OwnedAddress::Native(native) => {
                 assert_eq!(native.item, "db");
                 assert_eq!(native.field.as_deref(), Some("password"));
             }
-            Address::Convention { .. } => panic!("a ref should address native coordinates"),
+            OwnedAddress::Convention { .. } => {
+                panic!("a ref should address native coordinates")
+            }
         }
-        match find(&plan, "PLAIN").as_address("proj", "default") {
-            Address::Convention { key, .. } => assert_eq!(key, "PLAIN"),
-            Address::Native(_) => panic!("no ref should address the naming convention"),
+        let plain = find(&plan, "PLAIN");
+        let plain_address = spec
+            .address_for_spec(
+                plain,
+                plain.route.as_ref().and_then(Route::group_key),
+                "proj",
+                "default",
+            )
+            .unwrap();
+        match plain_address {
+            OwnedAddress::Convention { key, .. } => assert_eq!(key, "PLAIN"),
+            OwnedAddress::Native(_) => panic!("no ref should address the naming convention"),
         }
+    }
+
+    #[test]
+    fn endpoint_address_prefers_scoped_ref_then_alias_template_then_convention() {
+        let _env = scrub_resolution_env();
+        let mut configured = secret(Some(vec!["local"]));
+        configured.refs = Some(HashMap::from([(
+            "remote".to_string(),
+            NativeAddress {
+                item: "legacy-source".to_string(),
+                field: Some("token".to_string()),
+                ..Default::default()
+            },
+        )]));
+        let mut config =
+            crate::tests::resolve_test_config(HashMap::from([("API_KEY".to_string(), configured)]));
+        config.providers = Some(HashMap::from([
+            (
+                "remote".to_string(),
+                ProviderAlias::from("onepassword://Production"),
+            ),
+            (
+                "local".to_string(),
+                ProviderAlias::from("dotenv://.env")
+                    .with_reference_template(NativeAddressTemplate {
+                        item: "{project}_{profile}_{key}".to_string(),
+                        ..Default::default()
+                    })
+                    .unwrap(),
+            ),
+        ]));
+        let spec = Secrets::new(config, None, None, None);
+
+        let plan = spec.build_plan(None).unwrap();
+        let planned = find(&plan, "API_KEY");
+        assert_eq!(
+            spec.address_for_spec(planned, Some("remote"), "app", "prod")
+                .unwrap(),
+            OwnedAddress::Native(NativeAddress {
+                item: "legacy-source".to_string(),
+                field: Some("token".to_string()),
+                ..Default::default()
+            })
+        );
+        assert_eq!(
+            spec.address_for_spec(planned, Some("local"), "app", "prod")
+                .unwrap(),
+            OwnedAddress::Native(NativeAddress {
+                item: "app_prod_API_KEY".to_string(),
+                ..Default::default()
+            })
+        );
+        assert_eq!(
+            spec.address_for_spec(planned, Some("dotenv://other.env"), "app", "prod")
+                .unwrap(),
+            OwnedAddress::convention("app", "prod", "API_KEY")
+        );
     }
 
     #[test]
@@ -1164,6 +1348,88 @@ mod tests {
             fingerprint("lastpass://Work/TeamA/{project}/{profile}/{key}"),
             fingerprint("lastpass://Work/TeamB/{project}/{profile}/{key}"),
             "changing the item template must invalidate the cache"
+        );
+    }
+
+    fn template_fingerprint(template: NativeAddressTemplate) -> String {
+        let source = ProviderAlias::from("env://")
+            .with_reference_template(template)
+            .unwrap();
+        let spec = cached_spec_with(
+            vec!["route"],
+            &[
+                ("source", source),
+                ("route", cached_alias(&["source"], "keyring://", "8h")),
+            ],
+        );
+        let plan = plan(&spec);
+        route(find(&plan, "API_KEY"))
+            .cache()
+            .expect("cached route")
+            .route_fingerprint
+            .clone()
+    }
+
+    #[test]
+    fn coordinate_boundaries_distinguish_alias_template_fingerprints() {
+        let _env = scrub_resolution_env();
+        let embedded_field = NativeAddressTemplate {
+            item: "foo field={key}".to_string(),
+            ..Default::default()
+        };
+        let separate_field = NativeAddressTemplate {
+            item: "foo".to_string(),
+            field: Some("{key}".to_string()),
+            ..Default::default()
+        };
+
+        assert_ne!(
+            template_fingerprint(embedded_field),
+            template_fingerprint(separate_field),
+            "different template coordinates must not collide through display rendering"
+        );
+    }
+
+    fn scoped_ref_cache_fingerprint(reference: NativeAddress) -> String {
+        let mut configured = secret(Some(vec!["route"]));
+        configured.refs = Some(HashMap::from([("source".to_string(), reference)]));
+        let mut config =
+            crate::tests::resolve_test_config(HashMap::from([("API_KEY".to_string(), configured)]));
+        config.providers = Some(HashMap::from([
+            ("source".to_string(), ProviderAlias::from("env://")),
+            ("local".to_string(), ProviderAlias::from("keyring://")),
+            (
+                "route".to_string(),
+                cached_alias(&["source"], "local", "8h"),
+            ),
+        ]));
+        let spec = Secrets::new(config, None, None, None);
+        let plan = plan(&spec);
+        let planned = find(&plan, "API_KEY");
+        planned.cache_fingerprint(
+            route(planned).cache().expect("cached route"),
+            &spec.config().project.name,
+            "default",
+        )
+    }
+
+    #[test]
+    fn coordinate_boundaries_distinguish_scoped_ref_fingerprints() {
+        let _env = scrub_resolution_env();
+        let embedded_field = NativeAddress {
+            item: "foo field=API_KEY".to_string(),
+            ..Default::default()
+        };
+        let separate_field = NativeAddress {
+            item: "foo".to_string(),
+            field: Some("API_KEY".to_string()),
+            ..Default::default()
+        };
+
+        assert_ne!(
+            scoped_ref_cache_fingerprint(embedded_field),
+            scoped_ref_cache_fingerprint(separate_field),
+            "different scoped-ref coordinates must not collide through display rendering"
         );
     }
 

--- a/secretspec/src/provider/bw.rs
+++ b/secretspec/src/provider/bw.rs
@@ -2577,6 +2577,29 @@ impl Provider for BitwardenProvider {
         &["field"]
     }
 
+    fn entry_coordinates<'a>(
+        &self,
+        addr: Address<'a>,
+    ) -> Result<std::borrow::Cow<'a, crate::config::NativeAddress>> {
+        let mut coords = self.resolve_coords(addr)?.into_owned();
+        if coords.field.is_none() {
+            coords.field = Some(
+                match std::env::var("BITWARDEN_DEFAULT_FIELD")
+                    .ok()
+                    .or_else(|| self.config.default_field.clone())
+                {
+                    Some(field) => field,
+                    None => self
+                        .resolved_item_type()?
+                        .unwrap_or(BitwardenItemType::Login)
+                        .default_field()
+                        .to_string(),
+                },
+            );
+        }
+        Ok(std::borrow::Cow::Owned(coords))
+    }
+
     fn with_credentials(&mut self, credentials: ProviderCredentials) {
         self.credentials = credentials;
     }
@@ -2635,6 +2658,22 @@ impl Provider for BitwardenProvider {
             uri.push_str(&params.join("&"));
         }
         uri
+    }
+
+    /// Defaults that compile into native coordinates do not identify the
+    /// Bitwarden vault itself. In particular, a scoped ref can override the
+    /// URI's default field, and the resolved field is compared separately by
+    /// `same_entries`.
+    fn entry_container_identity(&self) -> String {
+        format!(
+            "bw:{:?}",
+            (
+                self.requested_org(),
+                self.requested_collection(),
+                self.resolved_item_type().ok().flatten(),
+                self.config.server.as_deref().map(normalize_server),
+            )
+        )
     }
 
     /// Retrieves a secret from Bitwarden.
@@ -4152,6 +4191,7 @@ mod tests {
             "BITWARDEN_ORGANIZATION",
             "BITWARDEN_COLLECTION",
             "BITWARDEN_DEFAULT_TYPE",
+            "BITWARDEN_DEFAULT_FIELD",
         ]
         .map(|key| (key, std::env::var(key).ok()));
         for (key, _) in &saved {
@@ -5739,6 +5779,59 @@ mod tests {
     fn items_support_field_coordinates() {
         let provider = BitwardenProvider::new(BitwardenConfig::default());
         assert_eq!(provider.supported_coords(), &["field"]);
+    }
+
+    #[test]
+    fn same_entries_treats_an_implicit_login_field_as_password() {
+        with_clean_env(|| {
+            let provider = BitwardenProvider::new(BitwardenConfig {
+                default_item_type: Some(BitwardenItemType::Login),
+                ..Default::default()
+            });
+            let implicit = crate::config::NativeAddress {
+                item: "shared".into(),
+                ..Default::default()
+            };
+            let explicit = crate::config::NativeAddress {
+                item: "shared".into(),
+                field: Some("password".into()),
+                ..Default::default()
+            };
+
+            assert!(
+                provider
+                    .same_entries(
+                        Address::Native(&implicit),
+                        &provider,
+                        Address::Native(&explicit),
+                    )
+                    .unwrap()
+            );
+        });
+    }
+
+    #[test]
+    fn same_entries_uses_explicit_fields_instead_of_provider_defaults() {
+        with_clean_env(|| {
+            let left = BitwardenProvider::new(BitwardenConfig {
+                default_field: Some("left".into()),
+                ..Default::default()
+            });
+            let right = BitwardenProvider::new(BitwardenConfig {
+                default_field: Some("right".into()),
+                ..Default::default()
+            });
+            let address = crate::config::NativeAddress {
+                item: "shared".into(),
+                field: Some("password".into()),
+                ..Default::default()
+            };
+
+            assert!(
+                left.same_entries(Address::Native(&address), &right, Address::Native(&address),)
+                    .unwrap()
+            );
+        });
     }
 
     #[test]

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -380,6 +380,10 @@ impl Provider for DotEnvProvider {
         Ok(true)
     }
 
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        self.check_writable(addr)
+    }
+
     fn reflect(
         &self,
         _context: DiscoveryContext<'_>,

--- a/secretspec/src/provider/kdbx.rs
+++ b/secretspec/src/provider/kdbx.rs
@@ -285,6 +285,17 @@ impl Provider for KdbxProvider {
         &["field"]
     }
 
+    fn entry_coordinates<'a>(
+        &self,
+        addr: Address<'a>,
+    ) -> Result<std::borrow::Cow<'a, NativeAddress>> {
+        let mut coords = self.resolve_coords(addr)?.into_owned();
+        if coords.field.is_none() {
+            coords.field = Some(fields::PASSWORD.to_string());
+        }
+        Ok(std::borrow::Cow::Owned(coords))
+    }
+
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         let _guard = KDBX_IO_LOCK
             .lock()
@@ -389,6 +400,10 @@ impl Provider for KdbxProvider {
             uri.push_str(&ProviderUrl::encode_query(&self.config.prefix));
         }
         uri
+    }
+
+    fn physical_store_path(&self) -> Option<&Path> {
+        Some(&self.config.path)
     }
 
     fn with_base_dir(&mut self, base_dir: &Path) {
@@ -634,6 +649,52 @@ mod tests {
                 .unwrap()
                 .field,
             "UserName"
+        );
+    }
+
+    #[test]
+    fn same_entries_treats_an_implicit_field_as_the_password_field() {
+        let provider = KdbxProvider::new(config(PathBuf::from("vault.kdbx")));
+        let implicit = NativeAddress {
+            item: "shared/login".into(),
+            ..Default::default()
+        };
+        let explicit = NativeAddress {
+            item: "shared/login".into(),
+            field: Some(fields::PASSWORD.into()),
+            ..Default::default()
+        };
+
+        assert!(
+            provider
+                .same_entries(
+                    Address::Native(&implicit),
+                    &provider,
+                    Address::Native(&explicit),
+                )
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn same_entries_ignores_prefixes_overridden_by_native_refs() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("vault.kdbx");
+        let mut left_config = config(path.clone());
+        left_config.prefix = "left/{key}".into();
+        let mut right_config = config(path);
+        right_config.prefix = "right/{key}".into();
+        let left = KdbxProvider::new(left_config);
+        let right = KdbxProvider::new(right_config);
+        let address = NativeAddress {
+            item: "shared/login".into(),
+            field: Some("UserName".into()),
+            ..Default::default()
+        };
+
+        assert!(
+            left.same_entries(Address::Native(&address), &right, Address::Native(&address),)
+                .unwrap()
         );
     }
 

--- a/secretspec/src/provider/keeper.rs
+++ b/secretspec/src/provider/keeper.rs
@@ -239,13 +239,13 @@ impl KeeperProvider {
 
     fn target(&self, addr: Address<'_>) -> Result<KeeperTarget> {
         let native = matches!(addr, Address::Native(_));
-        let coords = self.resolve_coords(addr)?;
+        let coords = self.entry_coordinates(addr)?;
         Ok(KeeperTarget {
             item: coords.item.clone(),
             field: coords
                 .field
                 .clone()
-                .unwrap_or_else(|| DEFAULT_FIELD.to_string()),
+                .expect("entry coordinates always contain the Keeper field"),
             native,
         })
     }
@@ -423,6 +423,17 @@ impl Provider for KeeperProvider {
         &["field"]
     }
 
+    fn entry_coordinates<'a>(
+        &self,
+        addr: Address<'a>,
+    ) -> Result<std::borrow::Cow<'a, NativeAddress>> {
+        let mut coords = self.resolve_coords(addr)?.into_owned();
+        if coords.field.is_none() {
+            coords.field = Some(DEFAULT_FIELD.to_string());
+        }
+        Ok(std::borrow::Cow::Owned(coords))
+    }
+
     fn with_credentials(&mut self, credentials: ProviderCredentials) {
         self.credentials = credentials;
     }
@@ -481,7 +492,7 @@ impl Provider for KeeperProvider {
     }
 
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
-        self.resolve_coords(addr).map(|_| ())
+        self.entry_coordinates(addr).map(|_| ())
     }
 
     fn delete(&self, addr: Address<'_>) -> Result<bool> {
@@ -507,6 +518,26 @@ impl Provider for KeeperProvider {
             client.delete_secret(&record.uid)
         })?;
         Ok(true)
+    }
+
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        if matches!(addr, Address::Native(_)) {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "Keeper secret references cannot be deleted: a reference names a record managed outside SecretSpec, and deleting it would remove the whole record"
+                    .to_string(),
+            ));
+        }
+        let target = self.target(addr)?;
+        let records = self.records()?;
+        if let Some(index) = self.record_index(&records, &target)?
+            && !records[index].is_editable
+        {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Keeper record '{}' is not editable by this application",
+                records[index].title
+            )));
+        }
+        Ok(())
     }
 
     fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
@@ -685,6 +716,34 @@ mod tests {
             .unwrap();
         assert_eq!(address.item, "secretspec/demo/production/DATABASE_URL");
         assert_eq!(address.field.as_deref(), Some("password"));
+    }
+
+    #[test]
+    fn same_entries_treats_an_implicit_field_as_the_password_field() {
+        let provider = KeeperProvider::new(KeeperConfig {
+            folder_uid: "folder".to_string(),
+            config_file: None,
+        });
+        let implicit = NativeAddress {
+            item: "RecordUID".to_string(),
+            ..Default::default()
+        };
+        let explicit = NativeAddress {
+            item: "RecordUID".to_string(),
+            field: Some(DEFAULT_FIELD.to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            provider
+                .same_entries(
+                    Address::Native(&implicit),
+                    &provider,
+                    Address::Native(&explicit),
+                )
+                .unwrap(),
+            "addresses that operations send to one Keeper field must compare equal"
+        );
     }
 
     #[test]

--- a/secretspec/src/provider/keyring.rs
+++ b/secretspec/src/provider/keyring.rs
@@ -106,11 +106,11 @@ impl KeyringProvider {
     /// service, `field` the account, defaulting to the current system
     /// username (the account convention entries live under).
     fn entry_target(&self, addr: Address<'_>) -> Result<(String, String)> {
-        let coords = self.resolve_coords(addr)?;
-        let account = match &coords.field {
-            Some(account) => account.clone(),
-            None => Self::current_username()?,
-        };
+        let coords = self.entry_coordinates(addr)?;
+        let account = coords
+            .field
+            .clone()
+            .expect("entry coordinates always contain the keyring account");
         Ok((coords.item.clone(), account))
     }
 
@@ -144,6 +144,17 @@ impl Provider for KeyringProvider {
     /// `field` is the keyring account within the service entry.
     fn supported_coords(&self) -> &'static [&'static str] {
         &["field"]
+    }
+
+    fn entry_coordinates<'a>(
+        &self,
+        addr: Address<'a>,
+    ) -> Result<std::borrow::Cow<'a, crate::config::NativeAddress>> {
+        let mut coords = self.resolve_coords(addr)?.into_owned();
+        if coords.field.is_none() {
+            coords.field = Some(Self::current_username()?);
+        }
+        Ok(std::borrow::Cow::Owned(coords))
     }
 
     fn name(&self) -> &'static str {
@@ -297,6 +308,31 @@ mod tests {
         let (service, account) = p.entry_target(Address::Native(&addr)).unwrap();
         assert_eq!(service, "com.example.app");
         assert_eq!(account, whoami::username().unwrap());
+    }
+
+    #[test]
+    fn same_entries_treats_the_implicit_account_as_the_current_username() {
+        let provider = KeyringProvider::new(KeyringConfig::default());
+        let implicit = crate::config::NativeAddress {
+            item: "com.example.app".into(),
+            ..Default::default()
+        };
+        let explicit = crate::config::NativeAddress {
+            item: "com.example.app".into(),
+            field: Some(whoami::username().unwrap()),
+            ..Default::default()
+        };
+
+        assert!(
+            provider
+                .same_entries(
+                    Address::Native(&implicit),
+                    &provider,
+                    Address::Native(&explicit),
+                )
+                .unwrap(),
+            "addresses that operations send to one keyring entry must compare equal"
+        );
     }
 
     /// Keyring entries have no versions; the coordinate is rejected.

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -394,7 +394,8 @@ impl ProviderInfo {
 ///
 /// Which stores are consulted is decided entirely by provider resolution
 /// (chains, overrides, defaults); the address only supplies the name to look
-/// up in each.
+/// up in one selected endpoint. SecretSpec may derive a different address for
+/// another provider alias in the same logical route.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Address<'a> {
     /// SecretSpec's `{project}/{profile}/{key}` naming convention.
@@ -405,6 +406,50 @@ pub enum Address<'a> {
     },
     /// Native coordinates of one externally managed secret (a `ref`).
     Native(&'a NativeAddress),
+}
+
+/// Owned counterpart to [`Address`], used by plans that must retain distinct
+/// source and destination addresses before provider operations begin.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum OwnedAddress {
+    Convention {
+        project: String,
+        profile: String,
+        key: String,
+    },
+    Native(NativeAddress),
+}
+
+impl OwnedAddress {
+    pub(crate) fn convention(project: &str, profile: &str, key: &str) -> Self {
+        Self::Convention {
+            project: project.to_string(),
+            profile: profile.to_string(),
+            key: key.to_string(),
+        }
+    }
+
+    pub(crate) fn as_address(&self) -> Address<'_> {
+        match self {
+            Self::Convention {
+                project,
+                profile,
+                key,
+            } => Address::Convention {
+                project,
+                profile,
+                key,
+            },
+            Self::Native(reference) => Address::Native(reference),
+        }
+    }
+
+    pub(crate) fn native(&self) -> Option<&NativeAddress> {
+        match self {
+            Self::Native(reference) => Some(reference),
+            Self::Convention { .. } => None,
+        }
+    }
 }
 
 impl<'a> Address<'a> {
@@ -650,6 +695,18 @@ pub trait Provider: Send + Sync {
         Ok(coords)
     }
 
+    /// Resolves the canonical coordinates an operation uses to identify one
+    /// physical entry. Available since SecretSpec 0.19.
+    ///
+    /// The default is the validated address returned by
+    /// [`resolve_coords`](Provider::resolve_coords). Providers that interpret
+    /// an omitted coordinate as a concrete default must override this method
+    /// and fill that default, so destructive preflight compares the same
+    /// identity that `get`, `set`, and `delete` operate on.
+    fn entry_coordinates<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, NativeAddress>> {
+        self.resolve_coords(addr)
+    }
+
     /// Retrieves the secret named by `addr`.
     ///
     /// See [`Address`] for the two naming schemes. A provider that cannot
@@ -729,6 +786,18 @@ pub trait Provider: Send + Sync {
             "provider '{}' does not support deleting secrets",
             self.name()
         )))
+    }
+
+    /// Reports whether this provider can delete `addr`, without changing the
+    /// store. Available since SecretSpec 0.19.
+    ///
+    /// Destructive multi-secret operations use this during preflight so an
+    /// unsupported native address cannot be discovered only after earlier
+    /// source entries have already been removed. Providers with deletion
+    /// policies beyond coordinate support must override this method and have
+    /// [`delete`](Provider::delete) enforce the same policy.
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        self.resolve_coords(addr).map(|_| ())
     }
 
     /// Reports whether this provider can write to `addr`, and why not when it
@@ -824,18 +893,33 @@ pub trait Provider: Send + Sync {
     /// Returns whether `self` and `other` resolve `addr` to the same physical
     /// secret entry. Available since SecretSpec 0.18.
     ///
+    /// This compatibility method applies one address to both providers. New
+    /// cross-endpoint operations should use [`Self::same_entries`] when source
+    /// and destination can have independent refs.
+    fn same_entry(&self, other: &dyn Provider, addr: Address<'_>) -> Result<bool> {
+        self.same_entries(addr, other, addr)
+    }
+
+    /// Returns whether `self` and `other` resolve their respective addresses to
+    /// the same physical secret entry. Available since SecretSpec 0.19.
+    ///
     /// Destructive cross-provider operations must use this instead of comparing
     /// [`uri`](Provider::uri) strings: one store may have multiple equivalent
     /// spellings, and provider URIs can include convention templates that are
     /// only meaningful after resolving a concrete address. The physical store
     /// and the resolved native coordinates must both match before an entry is
     /// considered shared.
-    fn same_entry(&self, other: &dyn Provider, addr: Address<'_>) -> Result<bool> {
+    fn same_entries(
+        &self,
+        self_addr: Address<'_>,
+        other: &dyn Provider,
+        other_addr: Address<'_>,
+    ) -> Result<bool> {
         let same_store = match (self.physical_store_path(), other.physical_store_path()) {
             (Some(left), Some(right)) => {
                 same_file::is_same_file(left, right).unwrap_or_else(|_| {
-                    let left = std::path::absolute(left).unwrap_or_else(|_| left.to_path_buf());
-                    let right = std::path::absolute(right).unwrap_or_else(|_| right.to_path_buf());
+                    let left = comparable_missing_file_path(left);
+                    let right = comparable_missing_file_path(right);
                     left == right
                 })
             }
@@ -846,7 +930,7 @@ pub trait Provider: Send + Sync {
             return Ok(false);
         }
 
-        Ok(self.resolve_coords(addr)? == other.resolve_coords(addr)?)
+        Ok(self.entry_coordinates(self_addr)? == other.entry_coordinates(other_addr)?)
     }
 
     /// Returns the path that identifies a filesystem-backed store, if any.
@@ -949,6 +1033,23 @@ pub trait Provider: Send + Sync {
     fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
         get_each(self, requests)
     }
+}
+
+/// Returns a stable lexical identity for a filesystem store that may not exist
+/// yet. Canonicalizing the parent resolves symlink aliases without requiring
+/// the destination file itself to exist.
+fn comparable_missing_file_path(path: &std::path::Path) -> std::path::PathBuf {
+    let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    let Some(parent) = absolute.parent() else {
+        return absolute;
+    };
+    let Some(file_name) = absolute.file_name() else {
+        return absolute;
+    };
+
+    std::fs::canonicalize(parent)
+        .map(|parent| parent.join(file_name))
+        .unwrap_or(absolute)
 }
 
 /// Default max concurrent unique-address fetches in [`get_each`].
@@ -1064,6 +1165,9 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn resolve_coords<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, NativeAddress>> {
         (**self).resolve_coords(addr)
     }
+    fn entry_coordinates<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, NativeAddress>> {
+        (**self).entry_coordinates(addr)
+    }
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         (**self).get(addr)
     }
@@ -1081,6 +1185,9 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn delete(&self, addr: Address<'_>) -> Result<bool> {
         (**self).delete(addr)
     }
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        (**self).check_deletable(addr)
+    }
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         (**self).check_writable(addr)
     }
@@ -1095,6 +1202,14 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     }
     fn same_entry(&self, other: &dyn Provider, addr: Address<'_>) -> Result<bool> {
         (**self).same_entry(other, addr)
+    }
+    fn same_entries(
+        &self,
+        self_addr: Address<'_>,
+        other: &dyn Provider,
+        other_addr: Address<'_>,
+    ) -> Result<bool> {
+        (**self).same_entries(self_addr, other, other_addr)
     }
     fn storage_identity(&self) -> String {
         (**self).storage_identity()
@@ -1244,6 +1359,11 @@ impl Provider for PreflightGuard {
         self.inner.resolve_coords(addr)
     }
 
+    fn entry_coordinates<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, NativeAddress>> {
+        // Pure naming, no I/O: needs no auth preflight.
+        self.inner.entry_coordinates(addr)
+    }
+
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
         self.check()?;
         self.inner.get(addr)
@@ -1271,6 +1391,10 @@ impl Provider for PreflightGuard {
         self.inner.delete(addr)
     }
 
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        self.inner.check_deletable(addr)
+    }
+
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         self.inner.check_writable(addr)
     }
@@ -1289,6 +1413,15 @@ impl Provider for PreflightGuard {
 
     fn same_entry(&self, other: &dyn Provider, addr: Address<'_>) -> Result<bool> {
         self.inner.same_entry(other, addr)
+    }
+
+    fn same_entries(
+        &self,
+        self_addr: Address<'_>,
+        other: &dyn Provider,
+        other_addr: Address<'_>,
+    ) -> Result<bool> {
+        self.inner.same_entries(self_addr, other, other_addr)
     }
 
     fn storage_identity(&self) -> String {

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -508,6 +508,16 @@ impl OnePasswordProvider {
             .unwrap_or_else(|| "Private".to_string())
     }
 
+    /// Resolves the vault used by operations without turning a whole-item read
+    /// into a field read. Entry identity adds the write field separately.
+    fn operation_coordinates(&self, addr: Address<'_>) -> Result<crate::config::NativeAddress> {
+        let mut coords = self.resolve_coords(addr)?.into_owned();
+        if coords.vault.is_none() {
+            coords.vault = Some(self.get_vault_name());
+        }
+        Ok(coords)
+    }
+
     /// Renders the full `op://` reference string for `op read`.
     ///
     /// Names are rendered decoded (spaces and all): the reference is passed to
@@ -832,6 +842,17 @@ impl Provider for OnePasswordProvider {
         &["field", "vault", "section"]
     }
 
+    fn entry_coordinates<'a>(
+        &self,
+        addr: Address<'a>,
+    ) -> Result<std::borrow::Cow<'a, crate::config::NativeAddress>> {
+        let mut coords = self.operation_coordinates(addr)?;
+        if coords.field.is_none() && coords.section.is_none() {
+            coords.field = Some("value".to_string());
+        }
+        Ok(std::borrow::Cow::Owned(coords))
+    }
+
     fn with_credentials(&mut self, credentials: ProviderCredentials) {
         // Stored, not folded into the config: the token is resolved where it is
         // consumed (`execute_op_command`, `auth_scope_key`), and `uri()` keeps
@@ -899,6 +920,16 @@ impl Provider for OnePasswordProvider {
         uri
     }
 
+    /// The vault is part of the resolved entry coordinates, not the account
+    /// container identity. Omitting it here lets an explicit `ref.vault`
+    /// override two aliases with different URI defaults.
+    fn entry_container_identity(&self) -> String {
+        match &self.config.account {
+            Some(account) => format!("onepassword://{}@", ProviderUrl::encode(account)),
+            None => "onepassword://".to_string(),
+        }
+    }
+
     /// Retrieves a secret from OnePassword.
     ///
     /// If multiple items exist with the same title, falls back to ID-based
@@ -910,7 +941,7 @@ impl Provider for OnePasswordProvider {
     /// * `Ok(None)` - No secret found at the address
     /// * `Err(_)` - Authentication or retrieval error
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
-        let coords = self.resolve_coords(addr)?;
+        let coords = self.operation_coordinates(addr)?;
         let (vault, reference) = self.native_reference(&coords)?;
         match reference {
             // A field-addressed reference goes through `op read`.
@@ -947,7 +978,7 @@ impl Provider for OnePasswordProvider {
     fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
         let (project, profile, key) = match addr {
             Address::Native(native) => {
-                let coords = self.resolve_coords(addr)?;
+                let coords = self.entry_coordinates(addr)?;
                 let (vault, reference) = self.native_reference(&coords)?;
                 // Writes through a native address go to the existing item in
                 // place (`op item edit` adds a missing field but never creates
@@ -1013,7 +1044,7 @@ impl Provider for OnePasswordProvider {
         let mut whole_items: HashMap<String, Vec<(String, String)>> = HashMap::new();
         let mut field_refs: Vec<(&str, Address<'_>)> = Vec::new();
         for (name, addr) in requests {
-            let coords = self.resolve_coords(*addr)?;
+            let coords = self.operation_coordinates(*addr)?;
             let (vault, reference) = self.native_reference(&coords)?;
             match reference {
                 Some(_) => field_refs.push((name, *addr)),
@@ -1121,6 +1152,79 @@ mod tests {
         let c = config("onepassword://Production");
         assert_eq!(c.account, None);
         assert_eq!(c.default_vault.as_deref(), Some("Production"));
+    }
+
+    #[test]
+    fn same_entries_treats_an_implicit_vault_as_the_configured_default() {
+        let provider = OnePasswordProvider::new(config("onepassword://Production"));
+        let implicit = crate::config::NativeAddress {
+            item: "API Key".to_string(),
+            field: Some("credential".to_string()),
+            ..Default::default()
+        };
+        let explicit = crate::config::NativeAddress {
+            item: "API Key".to_string(),
+            field: Some("credential".to_string()),
+            vault: Some("Production".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            provider
+                .same_entries(
+                    Address::Native(&implicit),
+                    &provider,
+                    Address::Native(&explicit),
+                )
+                .unwrap(),
+            "addresses that operations send to one 1Password field must compare equal"
+        );
+    }
+
+    #[test]
+    fn same_entries_treats_an_implicit_field_as_the_value_field() {
+        let provider = OnePasswordProvider::new(config("onepassword://Production"));
+        let implicit = crate::config::NativeAddress {
+            item: "API Key".to_string(),
+            ..Default::default()
+        };
+        let explicit = crate::config::NativeAddress {
+            item: "API Key".to_string(),
+            field: Some("value".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            provider
+                .same_entries(
+                    Address::Native(&implicit),
+                    &provider,
+                    Address::Native(&explicit),
+                )
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn same_entries_uses_explicit_vaults_instead_of_provider_defaults() {
+        let production = OnePasswordProvider::new(config("onepassword://work@Production"));
+        let development = OnePasswordProvider::new(config("onepassword://work@Development"));
+        let address = crate::config::NativeAddress {
+            item: "API Key".to_string(),
+            field: Some("credential".to_string()),
+            vault: Some("Shared".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            production
+                .same_entries(
+                    Address::Native(&address),
+                    &development,
+                    Address::Native(&address),
+                )
+                .unwrap()
+        );
     }
 
     #[test]

--- a/secretspec/src/provider/openbao.rs
+++ b/secretspec/src/provider/openbao.rs
@@ -194,6 +194,10 @@ impl Provider for OpenBaoProvider {
         self.core.delete(&coords)
     }
 
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        self.core.check_deletable(addr)
+    }
+
     /// Refuses native writes because replacing a KV entry to change one field
     /// would silently discard every sibling field.
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -182,6 +182,10 @@ impl Provider for VaultProvider {
         self.core.delete(&coords)
     }
 
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        self.core.check_deletable(addr)
+    }
+
     /// Refuses native writes because replacing a KV entry to change one field
     /// would silently discard every sibling field.
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -9,7 +9,7 @@ use crate::config::{
 use crate::error::{Result, SecretSpecError};
 use crate::manifest::{CompiledManifest, MissingPolicy};
 use crate::plan::{PlannedSecret, ResolutionPlan, ResolvedCache, Route};
-use crate::provider::{Address, Provider as ProviderTrait, ProviderCredentials};
+use crate::provider::{Address, OwnedAddress, Provider as ProviderTrait, ProviderCredentials};
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
 use crate::validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
@@ -246,7 +246,18 @@ type GroupFetch<'a> = (
     Vec<&'a PlannedSecret>,
     Box<dyn ProviderTrait>,
 );
-type FallbackReadResult = Result<(Option<SecretString>, Option<String>)>;
+type FallbackReadResult = Result<(Option<SecretString>, Option<String>, Option<NativeAddress>)>;
+
+struct PreparedImport {
+    planned: PlannedSecret,
+    target_provider: Box<dyn ProviderTrait>,
+    source_address: OwnedAddress,
+    target_address: OwnedAddress,
+    source_value: Option<SecretString>,
+    target_value: Option<SecretString>,
+    copied: bool,
+    source_deleted: bool,
+}
 
 /// Memoized provider credentials with single-flight population per key.
 ///
@@ -1445,6 +1456,33 @@ impl Secrets {
             .map(|encoding| Self::encode_logical_value(encoding, value))
     }
 
+    /// Validate a stored value before import copies it into another provider.
+    /// Import moves the stored representation verbatim, so an invalid encoded
+    /// source must fail before any target write (and especially before source
+    /// cleanup) instead of creating an unreadable destination.
+    fn validate_import_value(
+        planned: &PlannedSecret,
+        diagnostic_name: &str,
+        value: &SecretString,
+    ) -> Result<()> {
+        let Some(encoding) = planned.encoding() else {
+            return Ok(());
+        };
+        let decoded = Self::decode_stored_value(encoding, diagnostic_name, value)?;
+        if !planned.as_path() {
+            std::str::from_utf8(decoded.expose_secret()).map_err(|error| {
+                SecretSpecError::DecodeFailed {
+                    name: diagnostic_name.to_string(),
+                    encoding: encoding.as_str(),
+                    reason: format!(
+                        "decoded bytes are not valid UTF-8 ({error}); set `as_path = true` to expose binary data"
+                    ),
+                }
+            })?;
+        }
+        Ok(())
+    }
+
     /// Decode a stored representation independently of its exposure shape, then
     /// either return UTF-8 text or materialize the bytes to an owner-only file.
     fn prepare_resolved(
@@ -1954,14 +1992,21 @@ impl Secrets {
     /// coordinates and batches or parallelizes as the store allows. The address
     /// is the one the plan already derived, so naming lives in exactly one place.
     fn fetch_group(
+        &self,
         provider: &dyn ProviderTrait,
+        provider_spec: Option<&str>,
         group: &[&PlannedSecret],
         project: &str,
         profile: &str,
     ) -> Result<HashMap<String, SecretString>> {
+        let addresses = group
+            .iter()
+            .map(|planned| self.address_for_spec(planned, provider_spec, project, profile))
+            .collect::<Result<Vec<_>>>()?;
         let requests: Vec<(&str, Address<'_>)> = group
             .iter()
-            .map(|planned| (planned.name.as_str(), planned.as_address(project, profile)))
+            .zip(&addresses)
+            .map(|(planned, address)| (planned.name.as_str(), address.as_address()))
             .collect();
         provider.get_many(&requests)
     }
@@ -2557,11 +2602,12 @@ impl Secrets {
     /// # Arguments
     ///
     /// * `secret_name` - What a warning may call this secret. Diagnostics only —
-    ///   the read is addressed by `addr` — so a caller resolving a secret the
+    ///   the read is addressed from `planned` and each selected provider spec —
+    ///   so a caller resolving a secret the
     ///   active scope hides passes [`HIDDEN_SECRET_LABEL`] instead of the real
     ///   name (see [`Secrets::diagnostic_secret_name`])
-    /// * `addr` - The secret's [`Address`] (see [`PlannedSecret::as_address`]);
-    ///   the same address is asked of every provider in the chain
+    /// * `planned` - The logical secret and provider-scoped refs used to derive
+    ///   each endpoint's address
     /// * `provider_specs` - Optional chain of provider specs (aliases or inline
     ///   URIs) to try in order, resolved lazily per entry
     /// * `profile` - The profile the read is addressed under; scopes any
@@ -2569,23 +2615,25 @@ impl Secrets {
     ///
     /// # Returns
     ///
-    /// A tuple of the secret value (or `None` if not found in any provider) and
-    /// the URI of the provider to attribute the access to: on a hit, the serving
-    /// provider; on a chain miss/error, the last provider tried. The URI lets
-    /// callers (e.g. the audit log) record which provider actually answered.
+    /// A tuple of the secret value (or `None` if not found in any provider), the
+    /// URI of the provider to attribute the access to, and that endpoint's
+    /// expanded native ref (if any). On a hit, attribution names the serving
+    /// provider; on a chain miss/error, the last provider tried.
     fn get_secret_from_providers(
         &self,
         provider_cache: &ProviderCache,
+        planned: &PlannedSecret,
         secret_name: &str,
-        addr: Address<'_>,
         provider_specs: Option<&[String]>,
-        profile: Option<&str>,
-    ) -> Result<(Option<SecretString>, Option<String>)> {
+        project: &str,
+        profile: &str,
+    ) -> Result<(Option<SecretString>, Option<String>, Option<NativeAddress>)> {
         // If a provider chain is supplied, try it in order.
         if let Some(specs) = provider_specs {
             let mut last_error: Option<SecretSpecError> = None;
             let mut any_healthy = false;
             let mut last_uri: Option<String> = None;
+            let mut last_reference: Option<NativeAddress> = None;
             for spec in specs {
                 // Resolve this link only now, as the chain reaches it. An
                 // undefined alias is one broken link, treated exactly like a
@@ -2607,7 +2655,7 @@ impl Secrets {
                 // Build from the raw spec (not the resolved URI) so an alias's
                 // `credentials` is applied to this chain link too. Shared, not
                 // rebuilt: this walk runs per secret (see [`ProviderCache`]).
-                let provider = match self.shared_provider(provider_cache, spec, profile) {
+                let provider = match self.shared_provider(provider_cache, spec, Some(profile)) {
                     Ok(p) => p,
                     Err(e) => {
                         // Construction failed after resolution, so redact the
@@ -2627,8 +2675,12 @@ impl Secrets {
                 // `uri()` but that `redact_uri` cannot remove from an opaque URI.
                 let provider_uri = provider.uri();
                 last_uri = Some(provider_uri.clone());
-                match provider.get(addr) {
-                    Ok(Some(value)) => return Ok((Some(value), Some(provider_uri))),
+                let address = self.address_for_spec(planned, Some(spec), project, profile)?;
+                last_reference = address.native().cloned();
+                match provider.get(address.as_address()) {
+                    Ok(Some(value)) => {
+                        return Ok((Some(value), Some(provider_uri), last_reference));
+                    }
                     Ok(None) => {
                         any_healthy = true;
                         continue;
@@ -2646,13 +2698,16 @@ impl Secrets {
             // a healthy "not found" — otherwise the secret is genuinely missing.
             match last_error {
                 Some(e) if !any_healthy => Err(e),
-                _ => Ok((None, last_uri)),
+                _ => Ok((None, last_uri, last_reference)),
             }
         } else {
             // No per-secret providers, use default provider
-            let backend = self.get_provider(None, profile)?;
+            let backend = self.get_provider(None, Some(profile))?;
             let uri = backend.uri();
-            backend.get(addr).map(|opt| (opt, Some(uri)))
+            let address = self.address_for_spec(planned, None, project, profile)?;
+            backend
+                .get(address.as_address())
+                .map(|opt| (opt, Some(uri), address.native().cloned()))
         }
     }
 
@@ -2815,7 +2870,13 @@ impl Secrets {
             }
         };
 
-        let addr = planned.as_address(&self.config.project.name, &profile_name);
+        let address = self.address_for_spec(
+            &planned,
+            route.group_key(),
+            &self.config.project.name,
+            &profile_name,
+        )?;
+        let addr = address.as_address();
         // Refuse before prompting for a value. The provider states the reason:
         // a store may be writable through the convention layout yet reject the
         // `ref` this secret names.
@@ -2870,7 +2931,7 @@ impl Secrets {
             name,
             &profile_name,
             Some(backend.uri()),
-            planned.reference(),
+            address.native(),
             None,
         );
         result?;
@@ -2937,13 +2998,19 @@ impl Secrets {
             }
         };
 
-        let result = backend.delete(planned.as_address(&self.config.project.name, &profile_name));
+        let address = self.address_for_spec(
+            &planned,
+            route.group_key(),
+            &self.config.project.name,
+            &profile_name,
+        )?;
+        let result = backend.delete(address.as_address());
         self.audit_delete_result(
             &result,
             name,
             &profile_name,
             Some(backend.uri()),
-            planned.reference(),
+            address.native(),
         );
         let deleted = result?;
         // Even a no-op authoritative delete must invalidate the cache: the
@@ -3042,11 +3109,9 @@ impl Secrets {
         // A fresh cache hit completes the read without constructing or
         // contacting any authoritative provider. Misses and invalid entries
         // fall through to the ordinary ordered provider route.
-        let mut cache_hit = false;
-        let result =
+        let (result, cache_hit) =
             if let Some((value, uri)) = self.read_cached_secret(&planned, route, &profile_name) {
-                cache_hit = true;
-                Ok((Some(value), Some(uri)))
+                (Ok((Some(value), Some(uri), None)), true)
             } else {
                 // Walk the route's chain in order; each entry is resolved lazily and a
                 // broken link is skipped with a warning, so an undefined alias never
@@ -3055,15 +3120,16 @@ impl Secrets {
                 let provider_cache = ProviderCache::default();
                 let result = self.get_secret_from_providers(
                     &provider_cache,
+                    &planned,
                     name,
-                    planned.as_address(&self.config.project.name, &profile_name),
                     read_specs.as_deref(),
-                    Some(&profile_name),
+                    &self.config.project.name,
+                    &profile_name,
                 );
-                if let Ok((Some(value), _)) = &result {
+                if let Ok((Some(value), _, _)) = &result {
                     self.write_cached_secret(&planned, route, &profile_name, value);
                 }
-                result
+                (result, false)
             };
 
         // Audit the access at the provider boundary, before defaults are applied.
@@ -3071,9 +3137,33 @@ impl Secrets {
         // attributes to the last provider tried rather than guessing. The native
         // coordinates (if any) are recorded alongside, since the provider URI
         // names only the store.
-        let reference = (!cache_hit).then(|| planned.reference()).flatten();
+        let attempted_address = if !cache_hit && result.is_err() {
+            let read_specs = route.specs();
+            let provider_spec = read_specs
+                .as_deref()
+                .and_then(|specs| specs.last().map(String::as_str));
+            self.address_for_spec(
+                &planned,
+                provider_spec,
+                &self.config.project.name,
+                &profile_name,
+            )
+            .ok()
+        } else {
+            None
+        };
+        let reference = if cache_hit {
+            None
+        } else {
+            result
+                .as_ref()
+                .ok()
+                .and_then(|(_, _, reference)| reference.as_ref())
+                .or_else(|| attempted_address.as_ref().and_then(OwnedAddress::native))
+                .or_else(|| planned.reference())
+        };
         match &result {
-            Ok((Some(_), uri)) => self.record(
+            Ok((Some(_), uri, _)) => self.record(
                 AuditAction::Get,
                 &profile_name,
                 AuditOutcome::Found,
@@ -3084,7 +3174,7 @@ impl Secrets {
                     ..Default::default()
                 },
             ),
-            Ok((None, uri)) if default.is_some() => self.record(
+            Ok((None, uri, _)) if default.is_some() => self.record(
                 AuditAction::Get,
                 &profile_name,
                 AuditOutcome::Default,
@@ -3095,7 +3185,7 @@ impl Secrets {
                     ..Default::default()
                 },
             ),
-            Ok((None, uri)) => self.record(
+            Ok((None, uri, _)) => self.record(
                 AuditAction::Get,
                 &profile_name,
                 AuditOutcome::Missing,
@@ -3249,16 +3339,19 @@ impl Secrets {
                                 self.write_provider_for_route(route, Some(&profile_display))?;
                             let encoded_value = Self::encoded_for_storage(&planned, &value);
                             let stored_value = encoded_value.as_ref().unwrap_or(&value);
-                            let set_result = backend.set(
-                                planned.as_address(&self.config.project.name, &profile_display),
-                                stored_value,
-                            );
+                            let address = self.address_for_spec(
+                                &planned,
+                                route.group_key(),
+                                &self.config.project.name,
+                                &profile_display,
+                            )?;
+                            let set_result = backend.set(address.as_address(), stored_value);
                             self.audit_write_result(
                                 &set_result,
                                 secret_name,
                                 &profile_display,
                                 Some(backend.uri()),
-                                planned.reference(),
+                                address.native(),
                                 None,
                             );
                             set_result?;
@@ -3484,7 +3577,6 @@ impl Secrets {
 
     fn import_internal(&self, from_provider: &str, delete_source: bool) -> Result<()> {
         self.ensure_reason_for(AuditAction::Import, None)?;
-        // Resolve profile (checks env var, then global config, then defaults to "default")
         let profile_display = self.resolve_profile_name(None);
 
         let mut imported = 0;
@@ -3492,29 +3584,14 @@ impl Secrets {
         let mut not_found = 0;
         let mut deleted_from_source = 0;
         let mut kept_in_source = 0;
-        // Every secret the import reads from the source/target, in iteration
-        // order. An import is one bulk action over this whole set, so it is the
-        // `keys` recorded in the audit log — independent of how many were copied,
-        // so a no-op import (nothing to copy) is still recorded as a read.
         let mut read_names: Vec<String> = Vec::new();
-
-        // Run the copy in an inner closure so that any early error (provider
-        // build, profile resolution, a per-secret get/set) can be audited with
-        // the secrets read so far before the error propagates. `source_uri`
-        // is filled in once the source provider is built.
         let mut source_uri: Option<String> = None;
+
         let copy_result = (|| -> Result<()> {
-            // Create the "from" provider and check availability. `build_provider`
-            // expands a provider alias used as the import source.
             let from_provider_instance =
                 self.build_provider(from_provider.to_string(), Some(&profile_display))?;
             source_uri = Some(from_provider_instance.uri());
 
-            // Deletion support is a registered provider capability. Reject a
-            // source that cannot delete before planning or touching any target;
-            // otherwise the first copied value would leave a partial import
-            // when the trait's default `delete` implementation inevitably
-            // failed.
             if delete_source
                 && !crate::provider::spec_provider_deletes(
                     &self.resolve_provider_spec(from_provider.to_string()),
@@ -3528,195 +3605,287 @@ impl Secrets {
 
             eprintln!(
                 "Importing secrets from {} (profile: {})...\n",
-                from_provider.blue(),
+                from_provider_instance.uri().blue(),
                 profile_display.cyan()
             );
 
-            // Current + default profile secrets. Unscoped: `import` has no
-            // `--scope`, so an ambient SECRETSPEC_SCOPE must not narrow the copy.
             let import_names = self.profile_secret_names_unscoped(Some(&profile_display))?;
+            let mut prepared = Vec::new();
 
-            // Plan every provider-backed secret before copying anything. With
-            // source cleanup enabled this is also a destructive-operation
-            // preflight: reject any same-store destination before an earlier
-            // item can be copied and removed from the source.
-            let mut import_plans = Vec::new();
+            // Resolve and read every endpoint before mutating either store.
+            // This makes failures in a later secret harmless to earlier source
+            // entries and gives --delete-source one destructive preflight.
             for name in import_names {
                 let planned = self
                     .plan_secret(&name, &profile_display, None)?
                     .expect("Secret should exist since we're iterating over it");
-                // A composed secret has no stored value to copy.
-                if planned.route.is_none() {
+                let Some(route) = planned.route.as_ref() else {
                     continue;
+                };
+
+                read_names.push(name.clone());
+                let source_address = self.address_for_spec(
+                    &planned,
+                    Some(from_provider),
+                    &self.config.project.name,
+                    &profile_display,
+                )?;
+                let target_address = self.address_for_spec(
+                    &planned,
+                    route.group_key(),
+                    &self.config.project.name,
+                    &profile_display,
+                )?;
+                let target_provider =
+                    self.write_provider_for_route(route, Some(&profile_display))?;
+
+                if delete_source
+                    && from_provider_instance.same_entries(
+                        source_address.as_address(),
+                        target_provider.as_ref(),
+                        target_address.as_address(),
+                    )?
+                {
+                    return Err(SecretSpecError::ProviderOperationFailed(format!(
+                        "refusing to delete '{}' from the import source because source and destination resolve to the same provider entry ({})",
+                        planned.name,
+                        from_provider_instance.uri()
+                    )));
                 }
-                import_plans.push(planned);
-            }
-            if delete_source {
-                for planned in &import_plans {
-                    let route = planned
-                        .route
+
+                let source_value = from_provider_instance.get(source_address.as_address())?;
+                let target_value = target_provider.get(target_address.as_address())?;
+
+                if let Some(value) = &source_value {
+                    Self::validate_import_value(&planned, &planned.name, value)?;
+                    if target_value.is_none() {
+                        target_provider.check_writable(target_address.as_address())?;
+                    }
+                    let target_will_match = target_value
                         .as_ref()
-                        .expect("composed secrets were filtered above");
-                    let to_provider =
-                        self.write_provider_for_route(route, Some(&profile_display))?;
-                    let addr = planned.as_address(&self.config.project.name, &profile_display);
-                    if from_provider_instance.same_entry(to_provider.as_ref(), addr)? {
+                        .is_none_or(|existing| existing.expose_secret() == value.expose_secret());
+                    if delete_source && target_will_match {
+                        from_provider_instance.check_deletable(source_address.as_address())?;
+                    }
+                }
+
+                prepared.push(PreparedImport {
+                    planned,
+                    target_provider,
+                    source_address,
+                    target_address,
+                    source_value,
+                    target_value,
+                    copied: false,
+                    source_deleted: false,
+                });
+            }
+
+            // A destination is one physical entry, even when aliases, URI
+            // spellings, or templates make the configured endpoints look
+            // different. Reject collisions before copying so two logical
+            // secrets cannot both act on the same stale target snapshot.
+            for left_index in 0..prepared.len() {
+                let left = &prepared[left_index];
+                for right in &prepared[left_index + 1..] {
+                    if left.target_provider.same_entries(
+                        left.target_address.as_address(),
+                        right.target_provider.as_ref(),
+                        right.target_address.as_address(),
+                    )? {
                         return Err(SecretSpecError::ProviderOperationFailed(format!(
-                            "refusing to delete '{}' from the import source because source and destination resolve to the same provider ({})",
-                            planned.name,
-                            from_provider_instance.uri()
+                            "refusing to import '{}' and '{}' because they resolve to the same destination provider entry ({})",
+                            left.planned.name,
+                            right.planned.name,
+                            left.target_provider.uri()
                         )));
                     }
                 }
             }
 
-            // Process each plan using the same write route and address `set`
-            // executes. Sorted names keep the per-secret summary lines stable.
-            for planned in import_plans {
-                let name = planned.name.clone();
-                let route = planned
-                    .route
-                    .as_ref()
-                    .expect("composed secrets were filtered above");
-                read_names.push(name.clone());
-                let description = planned.config().description.as_deref();
-                let label = format_secret_label(&name, description);
+            if delete_source {
+                // Cleanup must not remove any destination in this import. The
+                // per-secret check above protects each source from its own
+                // destination; this cross-product protects it from every other
+                // secret's destination before the first write or deletion.
+                for (source_index, source) in prepared.iter().enumerate() {
+                    let Some(source_value) = &source.source_value else {
+                        continue;
+                    };
+                    let source_will_be_deleted =
+                        source.target_value.as_ref().is_none_or(|target_value| {
+                            source_value.expose_secret() == target_value.expose_secret()
+                        });
+                    if !source_will_be_deleted {
+                        continue;
+                    }
 
-                let to_provider = self.write_provider_for_route(route, Some(&profile_display))?;
-
-                // The secret's address (native `ref` coordinates or convention
-                // naming) applies to both stores: naming is orthogonal to
-                // which store holds the value.
-                let addr = planned.as_address(&self.config.project.name, &profile_display);
-                // First check if the secret exists in the "from" provider
-                match from_provider_instance.get(addr)? {
-                    Some(value) => {
-                        // Secret exists in "from" provider, check if it exists in "to" provider
-                        match to_provider.get(addr)? {
-                            Some(existing) => {
-                                already_exists += 1;
-                                if delete_source
-                                    && existing.expose_secret() == value.expose_secret()
-                                {
-                                    let delete_result = from_provider_instance.delete(addr);
-                                    self.audit_delete_result(
-                                        &delete_result,
-                                        &name,
-                                        &profile_display,
-                                        Some(from_provider_instance.uri()),
-                                        planned.reference(),
-                                    );
-                                    deleted_from_source += usize::from(delete_result?);
-                                    eprintln!(
-                                        "{} {} {} (→ {}; deleted from source)",
-                                        "✓".green(),
-                                        label,
-                                        "(already exists in target)".yellow(),
-                                        to_provider.name().blue()
-                                    );
-                                } else if delete_source {
-                                    kept_in_source += 1;
-                                    eprintln!(
-                                        "{} {} {} (→ {}; source retained)",
-                                        "○".yellow(),
-                                        label,
-                                        "(target value differs)".yellow(),
-                                        to_provider.name().blue()
-                                    );
-                                } else {
-                                    eprintln!(
-                                        "{} {} {} (→ {})",
-                                        "○".yellow(),
-                                        label,
-                                        "(already exists in target)".yellow(),
-                                        to_provider.name().blue()
-                                    );
-                                }
-                            }
-                            None => {
-                                // Secret doesn't exist in "to" provider, import it.
-                                let set_result = to_provider.set(addr, &value);
-                                // Audit each copied secret as a write attributed to the
-                                // target provider, so import writes are recorded like
-                                // `set`/generate/prompt. The bulk Import event below only
-                                // captures the source read, not where secrets were copied.
-                                self.audit_write_result(
-                                    &set_result,
-                                    &name,
-                                    &profile_display,
-                                    Some(to_provider.uri()),
-                                    planned.reference(),
-                                    None,
-                                );
-                                set_result?;
-                                self.sync_cache_after_write(
-                                    &planned,
-                                    route,
-                                    &profile_display,
-                                    &value,
-                                );
-                                imported += 1;
-                                if delete_source {
-                                    let verified = to_provider.get(addr)?.is_some_and(|stored| {
-                                        stored.expose_secret() == value.expose_secret()
-                                    });
-                                    if !verified {
-                                        return Err(SecretSpecError::ProviderOperationFailed(
-                                            format!(
-                                                "destination verification failed for '{name}'; the source value was retained"
-                                            ),
-                                        ));
-                                    }
-                                    let delete_result = from_provider_instance.delete(addr);
-                                    self.audit_delete_result(
-                                        &delete_result,
-                                        &name,
-                                        &profile_display,
-                                        Some(from_provider_instance.uri()),
-                                        planned.reference(),
-                                    );
-                                    deleted_from_source += usize::from(delete_result?);
-                                    eprintln!(
-                                        "{} {} (→ {}; deleted from source)",
-                                        "✓".green(),
-                                        label,
-                                        to_provider.name().blue()
-                                    );
-                                } else {
-                                    eprintln!(
-                                        "{} {} (→ {})",
-                                        "✓".green(),
-                                        label,
-                                        to_provider.name().blue()
-                                    );
-                                }
-                            }
+                    for (target_index, target) in prepared.iter().enumerate() {
+                        if source_index == target_index {
+                            continue;
+                        }
+                        if from_provider_instance.same_entries(
+                            source.source_address.as_address(),
+                            target.target_provider.as_ref(),
+                            target.target_address.as_address(),
+                        )? {
+                            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                                "refusing to delete '{}' from the import source because it resolves to the destination provider entry for '{}' ({})",
+                                source.planned.name,
+                                target.planned.name,
+                                target.target_provider.uri()
+                            )));
                         }
                     }
-                    None => {
-                        // Secret doesn't exist in "from" provider
-                        // Check if it exists in the "to" provider
-                        match to_provider.get(addr)? {
-                            Some(_) => {
-                                eprintln!(
-                                    "{} {} {} (→ {})",
-                                    "○".blue(),
-                                    label,
-                                    "(already in target, not in source)".blue(),
-                                    to_provider.name().blue()
-                                );
-                                already_exists += 1;
-                            }
-                            None => {
-                                eprintln!(
-                                    "{} {} {}",
-                                    "✗".red(),
-                                    label,
-                                    "(not found in source)".red()
-                                );
-                                not_found += 1;
-                            }
+                }
+            }
+
+            // Copy every missing target. No source is deleted in this phase.
+            for entry in &mut prepared {
+                let (Some(value), None) = (&entry.source_value, &entry.target_value) else {
+                    continue;
+                };
+                let route = entry
+                    .planned
+                    .route
+                    .as_ref()
+                    .expect("prepared imports are provider-backed");
+                let set_result = entry
+                    .target_provider
+                    .set(entry.target_address.as_address(), value);
+                self.audit_write_result(
+                    &set_result,
+                    &entry.planned.name,
+                    &profile_display,
+                    Some(entry.target_provider.uri()),
+                    entry.target_address.native(),
+                    None,
+                );
+                set_result?;
+                self.sync_cache_after_write(&entry.planned, route, &profile_display, value);
+                entry.copied = true;
+                imported += 1;
+            }
+
+            // Verify all writes and validate their readable representation
+            // before beginning source cleanup.
+            if delete_source {
+                for entry in prepared.iter_mut().filter(|entry| entry.copied) {
+                    let expected = entry
+                        .source_value
+                        .as_ref()
+                        .expect("copied entries have source values");
+                    let stored = entry
+                        .target_provider
+                        .get(entry.target_address.as_address())?
+                        .ok_or_else(|| {
+                            SecretSpecError::ProviderOperationFailed(format!(
+                                "destination verification failed for '{}'; the source value was retained",
+                                entry.planned.name
+                            ))
+                        })?;
+                    if stored.expose_secret() != expected.expose_secret() {
+                        return Err(SecretSpecError::ProviderOperationFailed(format!(
+                            "destination verification failed for '{}'; the source value was retained",
+                            entry.planned.name
+                        )));
+                    }
+                    Self::validate_import_value(&entry.planned, &entry.planned.name, &stored)?;
+                    entry.target_value = Some(stored);
+                }
+
+                // Deletion is last: every planned target write has succeeded and
+                // every copied value has been read back successfully.
+                for entry in &mut prepared {
+                    let (Some(source), Some(target)) = (&entry.source_value, &entry.target_value)
+                    else {
+                        continue;
+                    };
+                    if source.expose_secret() != target.expose_secret() {
+                        continue;
+                    }
+                    let delete_result =
+                        from_provider_instance.delete(entry.source_address.as_address());
+                    self.audit_delete_result(
+                        &delete_result,
+                        &entry.planned.name,
+                        &profile_display,
+                        Some(from_provider_instance.uri()),
+                        entry.source_address.native(),
+                    );
+                    entry.source_deleted = delete_result?;
+                    deleted_from_source += usize::from(entry.source_deleted);
+                }
+            }
+
+            // Emit stable per-secret results only after the operation phases
+            // above have completed.
+            for entry in &prepared {
+                let name = &entry.planned.name;
+                let label =
+                    format_secret_label(name, entry.planned.config().description.as_deref());
+                let target_name = entry.target_provider.name().blue();
+
+                if entry.copied {
+                    if delete_source && entry.source_deleted {
+                        eprintln!(
+                            "{} {} (→ {}; deleted from source)",
+                            "✓".green(),
+                            label,
+                            target_name
+                        );
+                    } else {
+                        eprintln!("{} {} (→ {})", "✓".green(), label, target_name);
+                    }
+                    continue;
+                }
+
+                match (&entry.source_value, &entry.target_value) {
+                    (Some(source), Some(target)) => {
+                        already_exists += 1;
+                        if delete_source && source.expose_secret() != target.expose_secret() {
+                            kept_in_source += 1;
+                            eprintln!(
+                                "{} {} {} (→ {}; source retained)",
+                                "○".yellow(),
+                                label,
+                                "(target value differs)".yellow(),
+                                target_name
+                            );
+                        } else if delete_source && entry.source_deleted {
+                            eprintln!(
+                                "{} {} {} (→ {}; deleted from source)",
+                                "✓".green(),
+                                label,
+                                "(already exists in target)".yellow(),
+                                target_name
+                            );
+                        } else {
+                            eprintln!(
+                                "{} {} {} (→ {})",
+                                "○".yellow(),
+                                label,
+                                "(already exists in target)".yellow(),
+                                target_name
+                            );
                         }
+                    }
+                    (None, Some(_)) => {
+                        already_exists += 1;
+                        eprintln!(
+                            "{} {} {} (→ {})",
+                            "○".blue(),
+                            label,
+                            "(already in target, not in source)".blue(),
+                            target_name
+                        );
+                    }
+                    (None, None) => {
+                        not_found += 1;
+                        eprintln!("{} {} {}", "✗".red(), label, "(not found in source)".red());
+                    }
+                    (Some(_), None) => {
+                        unreachable!("a prepared missing target was copied or returned an error")
                     }
                 }
             }
@@ -3724,8 +3893,6 @@ impl Secrets {
         })();
 
         if let Err(e) = copy_result {
-            // Record a failed/partial import with the secrets read before the
-            // error (already in sorted order, from the import loop).
             self.record(
                 AuditAction::Import,
                 &profile_display,
@@ -3759,18 +3926,10 @@ impl Secrets {
                 "\n{} Successfully imported {} secrets from {}",
                 "✓".green(),
                 imported,
-                from_provider,
+                source_uri.as_deref().unwrap_or("configured provider"),
             );
         }
 
-        // Always record the import: it read every declared secret from the
-        // source (and target), so the access is logged even when nothing was
-        // copied. Outcome reflects what the read found: `Written` when at least
-        // one secret was copied, `Found` when nothing was copied but secrets were
-        // already present (in source or target), and `Missing` when nothing was
-        // copied and nothing was found anywhere — so a "found nothing" import is
-        // not mislabeled as a successful retrieval. Per-secret copies are also
-        // recorded individually as `Set`/`Written` events above.
         let outcome = if imported > 0 {
             AuditOutcome::Written
         } else if already_exists > 0 {
@@ -3822,14 +3981,18 @@ impl Secrets {
 
         // Store the generated value at the plan's address, through the plan's
         // write route: the same decisions every other write path executes.
-        let addr = planned.as_address(&self.config.project.name, profile_name);
-        let backend = self.write_provider_for_route(
-            planned
-                .route
-                .as_ref()
-                .expect("a generating secret is provider-backed"),
-            Some(profile_name),
+        let route = planned
+            .route
+            .as_ref()
+            .expect("a generating secret is provider-backed");
+        let address = self.address_for_spec(
+            planned,
+            route.group_key(),
+            &self.config.project.name,
+            profile_name,
         )?;
+        let addr = address.as_address();
+        let backend = self.write_provider_for_route(route, Some(profile_name))?;
         // The provider states why a write is refused; wrapping it here would
         // only nest a second "Provider operation failed" prefix.
         backend.check_writable(addr)?;
@@ -3843,7 +4006,7 @@ impl Secrets {
             name,
             profile_name,
             Some(backend.uri()),
-            planned.reference(),
+            address.native(),
             None,
         );
         set_result?;
@@ -4362,8 +4525,12 @@ impl Secrets {
     /// reads the provider's declared supported coordinates and does no I/O for
     /// a native address.
     fn check_single_store_ref_coords(
+        &self,
+        provider_spec: Option<&str>,
         group: &[&PlannedSecret],
         provider: &dyn ProviderTrait,
+        project: &str,
+        profile: &str,
     ) -> Result<()> {
         for planned in group {
             // Only the routes that consult exactly one store; a chain with a
@@ -4375,8 +4542,9 @@ impl Secrets {
             if route.fallback_specs().is_some() {
                 continue;
             }
-            if let Some(native) = planned.reference() {
-                provider.resolve_coords(Address::Native(native))?;
+            let address = self.address_for_spec(planned, provider_spec, project, profile)?;
+            if address.native().is_some() {
+                provider.resolve_coords(address.as_address())?;
             }
         }
         Ok(())
@@ -4494,8 +4662,14 @@ impl Secrets {
         // exactly one store that cannot honor its coordinates: with no fallback
         // to answer instead, the failure is definite and better surfaced now
         // than mid-fetch.
-        for (_, group, provider) in &group_fetches {
-            Self::check_single_store_ref_coords(group, provider.as_ref())?;
+        for (provider_spec, group, provider) in &group_fetches {
+            self.check_single_store_ref_coords(
+                *provider_spec,
+                group,
+                provider.as_ref(),
+                project,
+                profile,
+            )?;
         }
 
         // Fetch the groups concurrently: each group is at least one provider
@@ -4503,24 +4677,25 @@ impl Secrets {
         // providers already do inside `get_many`. A single group (the common
         // case) stays on this thread.
         fn fetch_group<'a>(
+            secrets: &Secrets,
             (provider_uri, group, provider): GroupFetch<'a>,
             project: &str,
             profile: &str,
         ) -> (Option<&'a str>, Result<HashMap<String, SecretString>>) {
-            let result = Secrets::fetch_group(&*provider, &group, project, profile);
+            let result = secrets.fetch_group(&*provider, provider_uri, &group, project, profile);
             (provider_uri, result)
         }
 
         let fetch_results: Vec<(Option<&str>, Result<_>)> = if group_fetches.len() <= 1 {
             group_fetches
                 .into_iter()
-                .map(|group| fetch_group(group, project, profile))
+                .map(|group| fetch_group(self, group, project, profile))
                 .collect()
         } else {
             std::thread::scope(|scope| {
                 let handles: Vec<_> = group_fetches
                     .into_iter()
-                    .map(|group| scope.spawn(|| fetch_group(group, project, profile)))
+                    .map(|group| scope.spawn(|| fetch_group(self, group, project, profile)))
                     .collect();
                 handles
                     .into_iter()
@@ -4575,10 +4750,11 @@ impl Secrets {
                         .expect("pending fallback has fallback specs");
                     let result = self.get_secret_from_providers(
                         &provider_cache,
+                        planned,
                         Self::diagnostic_secret_name(&planned.name, output_filter),
-                        planned.as_address(project, profile),
                         Some(fallback),
-                        Some(profile),
+                        project,
+                        profile,
                     );
                     (planned.name.clone(), result)
                 },
@@ -4639,7 +4815,7 @@ impl Secrets {
                     // concurrently above. Each chain was still tried in order
                     // and received the diagnostic label rather than a hidden
                     // composition input's raw name.
-                    let (fallback_value, fallback_uri) = match route.fallback_specs() {
+                    let (fallback_value, fallback_uri, _) = match route.fallback_specs() {
                         Some(_) => {
                             let resolved = fallback_results
                                 .remove(name)
@@ -4664,7 +4840,7 @@ impl Secrets {
                                 .expect("primary_failed implies entry present");
                             return Err(err);
                         }
-                        None => (None, None),
+                        None => (None, None, None),
                     };
 
                     if let Some(value) = fallback_value {
@@ -6113,7 +6289,13 @@ mod reference_routing_tests {
         let plan = spec.build_plan(None).unwrap();
         for (primary, group) in plan.groups() {
             let provider = spec.get_provider(primary, None).unwrap();
-            Secrets::check_single_store_ref_coords(&group, provider.as_ref())?;
+            spec.check_single_store_ref_coords(
+                primary,
+                &group,
+                provider.as_ref(),
+                &spec.config.project.name,
+                "default",
+            )?;
         }
         Ok(())
     }

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    Config, CredentialSource, GlobalConfig, GlobalDefaults, NativeAddress, ParseError, Profile,
-    Project, ProviderAlias, ProviderCache, RequireReason, Resolved, Secret,
+    Config, CredentialSource, GlobalConfig, GlobalDefaults, NativeAddress, NativeAddressTemplate,
+    ParseError, Profile, Project, ProviderAlias, ProviderCache, RequireReason, Resolved, Secret,
 };
 use crate::error::{Result, SecretSpecError};
 use crate::secrets::Secrets;
@@ -5706,6 +5706,7 @@ fn test_resolve_secret_config_merges_type_and_generate() {
             composed: None,
             providers: None,
             reference: None,
+            refs: None,
             as_path: None,
             encoding: None,
             secret_type: Some("password".to_string()),
@@ -6910,6 +6911,262 @@ Z_SAME = {{ description = "Unsafe same-store route", providers = ["source"] }}
 }
 
 #[test]
+fn import_rejects_duplicate_destinations_before_writing() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let target = temp.path().join("target.env");
+    fs::write(&source, "A_FIRST=one\nB_SECOND=two\n").unwrap();
+    let target_uri = toml::Value::String(format!("dotenv://{}", target.display())).to_string();
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "duplicate-import-destination"
+revision = "1.0"
+
+[providers]
+target = {{ uri = {target_uri}, ref = {{ item = "SHARED" }} }}
+
+[profiles.default]
+A_FIRST = {{ description = "First", providers = ["target"] }}
+B_SECOND = {{ description = "Second", providers = ["target"] }}
+"#
+    ))
+    .unwrap();
+    let spec = Secrets::new(config, None, None, None);
+
+    let error = spec
+        .import(&format!("dotenv://{}", source.display()))
+        .expect_err("two secrets must not silently overwrite one destination");
+
+    assert!(error.to_string().contains("same destination"), "{error}");
+    assert_eq!(
+        read_env_var(&target, "SHARED"),
+        None,
+        "destination collisions must fail before the first write"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn import_rejects_missing_destinations_reached_through_symlinked_parents() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let real_parent = temp.path().join("real");
+    let linked_parent = temp.path().join("linked");
+    fs::create_dir(&real_parent).unwrap();
+    std::os::unix::fs::symlink(&real_parent, &linked_parent).unwrap();
+    fs::write(&source, "A_FIRST=one\nB_SECOND=two\n").unwrap();
+    let real_target = real_parent.join("new.env");
+    let linked_target = linked_parent.join("new.env");
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "symlinked-import-destination"
+revision = "1.0"
+
+[providers]
+real = {{ uri = "dotenv://{}", ref = {{ item = "SHARED" }} }}
+linked = {{ uri = "dotenv://{}", ref = {{ item = "SHARED" }} }}
+
+[profiles.default]
+A_FIRST = {{ description = "First", providers = ["real"] }}
+B_SECOND = {{ description = "Second", providers = ["linked"] }}
+"#,
+        real_target.display(),
+        linked_target.display(),
+    ))
+    .unwrap();
+    let spec = Secrets::new(config, None, None, None);
+
+    let error = spec
+        .import(&format!("dotenv://{}", source.display()))
+        .expect_err("symlinked parents must not hide one missing destination file");
+
+    assert!(error.to_string().contains("same destination"), "{error}");
+    assert!(
+        !real_target.exists(),
+        "the collision must be found before creating the destination"
+    );
+}
+
+#[test]
+fn import_delete_source_rejects_a_source_used_by_another_destination() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let store = temp.path().join("store.env");
+    fs::write(&store, "A_SOURCE=one\nB_SOURCE=two\n").unwrap();
+    let uri = toml::Value::String(format!("dotenv://{}", store.display())).to_string();
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "cross-secret-import-collision"
+revision = "1.0"
+
+[providers]
+source = {uri}
+target = {uri}
+
+[profiles.default]
+A_FIRST = {{ description = "First", providers = ["target"], refs = {{ source = {{ item = "A_SOURCE" }}, target = {{ item = "A_TARGET" }} }} }}
+B_SECOND = {{ description = "Second", providers = ["target"], refs = {{ source = {{ item = "B_SOURCE" }}, target = {{ item = "A_SOURCE" }} }} }}
+"#
+    ))
+    .unwrap();
+    let spec = Secrets::new(config, None, None, None);
+
+    let error = spec
+        .import_with_delete_source("source")
+        .expect_err("deleting A's source would delete B's destination");
+
+    assert!(error.to_string().contains("destination"), "{error}");
+    assert_eq!(read_env_var(&store, "A_SOURCE").as_deref(), Some("one"));
+    assert_eq!(
+        read_env_var(&store, "A_TARGET"),
+        None,
+        "cross-secret collisions must fail before copying or deleting"
+    );
+}
+
+#[test]
+fn import_resolves_source_and_destination_alias_templates_independently() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let target = temp.path().join("target.env");
+    fs::write(&source, "web_default_API_KEY=from-source\n").unwrap();
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "web"
+revision = "1.0"
+
+[providers]
+source = {{ uri = 'dotenv://{}', ref = {{ item = "{{project}}_{{profile}}_{{key}}" }} }}
+target = {{ uri = 'dotenv://{}', ref = {{ item = "target_{{key}}" }} }}
+
+[profiles.default]
+API_KEY = {{ description = "API key", providers = ["target"] }}
+"#,
+        source.display(),
+        target.display()
+    ))
+    .unwrap();
+    let spec = Secrets::new(config, None, None, None);
+
+    spec.import("source").unwrap();
+
+    assert_eq!(
+        read_env_var(&target, "target_API_KEY").as_deref(),
+        Some("from-source")
+    );
+    assert_eq!(
+        read_env_var(&target, "API_KEY"),
+        None,
+        "the destination must use its own alias template"
+    );
+}
+
+#[test]
+fn import_delete_source_allows_one_store_when_scoped_refs_name_distinct_entries() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let store = temp.path().join("store.env");
+    fs::write(&store, "FROM_TOKEN=move-me\n").unwrap();
+    let uri = format!("dotenv://{}", store.display());
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "same-store-distinct-entry"
+revision = "1.0"
+
+[providers]
+source = '{uri}'
+target = '{uri}'
+
+[profiles.default]
+API_KEY = {{ description = "API key", providers = ["target"], refs = {{ source = {{ item = "FROM_TOKEN" }}, target = {{ item = "TO_TOKEN" }} }} }}
+"#
+    ))
+    .unwrap();
+    let spec = Secrets::new(config, None, None, None);
+
+    spec.import_with_delete_source("source").unwrap();
+
+    assert_eq!(read_env_var(&store, "FROM_TOKEN"), None);
+    assert_eq!(read_env_var(&store, "TO_TOKEN").as_deref(), Some("move-me"));
+}
+
+#[test]
+fn import_delete_source_validates_all_encoded_values_before_writing() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let target = temp.path().join("target.env");
+    fs::write(&source, "A_FIRST=keep\nZ_BAD=not-base64!\n").unwrap();
+    let config: Config = toml::from_str(
+        r#"
+[project]
+name = "import-encoding-preflight"
+revision = "1.0"
+
+[profiles.default]
+A_FIRST = { description = "Would otherwise move" }
+Z_BAD = { description = "Invalid encoded source", encoding = "base64" }
+"#,
+    )
+    .unwrap();
+    let spec = Secrets::new(
+        config,
+        None,
+        Some(format!("dotenv://{}", target.display())),
+        None,
+    );
+
+    let error = spec
+        .import_with_delete_source(&format!("dotenv://{}", source.display()))
+        .expect_err("invalid stored encoding must fail the whole preflight");
+    assert!(matches!(error, SecretSpecError::DecodeFailed { .. }));
+    assert_eq!(read_env_var(&source, "A_FIRST").as_deref(), Some("keep"));
+    assert_eq!(
+        read_env_var(&target, "A_FIRST"),
+        None,
+        "a later invalid value must fail before an earlier target write"
+    );
+}
+
+#[test]
+fn fallback_reads_use_each_alias_ref_template() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let primary = temp.path().join("primary.env");
+    let fallback = temp.path().join("fallback.env");
+    fs::write(&primary, "OTHER=miss\n").unwrap();
+    fs::write(&fallback, "FALLBACK_API_KEY=answer\n").unwrap();
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "fallback-ref-templates"
+revision = "1.0"
+
+[providers]
+primary = {{ uri = 'dotenv://{}', ref = {{ item = "PRIMARY_{{key}}" }} }}
+fallback = {{ uri = 'dotenv://{}', ref = {{ item = "FALLBACK_{{key}}" }} }}
+
+[profiles.default]
+API_KEY = {{ description = "API key", providers = ["primary", "fallback"] }}
+"#,
+        primary.display(),
+        fallback.display()
+    ))
+    .unwrap();
+    let spec = Secrets::new(config, None, None, None);
+
+    assert_eq!(resolved_value(&spec, "API_KEY"), "answer");
+}
+
+#[test]
 fn test_import_unknown_source_lists_available_aliases() {
     let temp_dir = TempDir::new().unwrap();
     let source_uri = format!("dotenv://{}", temp_dir.path().join(".env.source").display());
@@ -7211,6 +7468,94 @@ fn audit_get_present_records_found_without_value() {
     assert!(events[0]["provider"].as_str().unwrap().contains("dotenv"));
     // The retrieved value never reaches the log.
     assert!(!lines.lock().unwrap()[0].contains("hunter2"));
+}
+
+#[test]
+fn audit_get_records_the_selected_alias_expanded_ref() {
+    let _env = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    let store = temp_dir.path().join("store.env");
+    fs::write(&store, "prod_REQUIRED=hunter2\n").unwrap();
+    let config: Config = toml::from_str(&format!(
+        r#"
+[project]
+name = "audit-template"
+revision = "1.0"
+
+[providers]
+target = {{ uri = 'dotenv://{}', ref = {{ item = "{{profile}}_{{key}}" }} }}
+
+[profiles.default]
+REQUIRED = {{ description = "required", providers = ["target"] }}
+
+[profiles.prod]
+"#,
+        store.display()
+    ))
+    .unwrap();
+    let mut spec = Secrets::new(config, None, None, Some("prod".to_string()));
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    spec.set_audit_for_test(logger);
+
+    spec.get("REQUIRED").unwrap();
+
+    let events = audit_events(&lines);
+    assert_eq!(events[0]["ref"], "item=prod_REQUIRED");
+    assert!(!lines.lock().unwrap()[0].contains("hunter2"));
+}
+
+#[test]
+fn audit_failed_get_records_scoped_and_alias_template_refs() {
+    let _env = scrub_resolution_env();
+    let temp_dir = TempDir::new().unwrap();
+    let uri = format!("dotenv://{}", temp_dir.path().join("missing.env").display());
+
+    let cases = [
+        (
+            ProviderAlias::from(uri.clone())
+                .with_reference_template(NativeAddressTemplate {
+                    item: "invalid-{key}".to_string(),
+                    ..Default::default()
+                })
+                .unwrap(),
+            None,
+            "item=invalid-REQUIRED",
+        ),
+        (
+            ProviderAlias::from(uri),
+            Some(NativeAddress {
+                item: "invalid-scoped".to_string(),
+                ..Default::default()
+            }),
+            "item=invalid-scoped",
+        ),
+    ];
+
+    for (provider, scoped_ref, expected_ref) in cases {
+        let mut secret = Secret {
+            description: Some("required".to_string()),
+            providers: Some(vec!["target".to_string()]),
+            ..Default::default()
+        };
+        if let Some(reference) = scoped_ref {
+            secret.refs = Some(HashMap::from([("target".to_string(), reference)]));
+        }
+        let mut config = resolve_test_config(HashMap::from([("REQUIRED".to_string(), secret)]));
+        config.providers = Some(HashMap::from([("target".to_string(), provider)]));
+        let mut spec = Secrets::new(config, None, None, None);
+        let (logger, lines) = crate::audit::test_support::collecting_logger();
+        spec.set_audit_for_test(logger);
+
+        assert!(matches!(
+            spec.get("REQUIRED"),
+            Err(SecretSpecError::ProviderOperationFailed(_))
+        ));
+
+        let events = audit_events(&lines);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["outcome"], "error");
+        assert_eq!(events[0]["ref"], expected_ref);
+    }
 }
 
 #[test]
@@ -9193,6 +9538,56 @@ fn a_cached_default_provider_reports_the_store_it_reads_first() {
 
     let report = secrets.report().unwrap();
     assert_eq!(report.provider, format!("dotenv://{}", source.display()));
+}
+
+#[test]
+fn audit_cache_hit_omits_the_authoritative_legacy_ref() {
+    let _env = scrub_resolution_env();
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.env");
+    let cache = temp.path().join("cache.env");
+    fs::write(&source, "REMOTE_API_KEY=remote\n").unwrap();
+    let mut config = resolve_test_config(HashMap::from([(
+        "API_KEY".to_string(),
+        Secret {
+            providers: Some(vec!["myprovider".to_string()]),
+            reference: Some(NativeAddress {
+                item: "REMOTE_API_KEY".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )]));
+    config.providers = Some(cached_dotenv_providers(&[&source], &cache, "8h"));
+    let mut secrets = Secrets::new(config, None, None, None);
+    let (logger, lines) = crate::audit::test_support::collecting_logger();
+    secrets.set_audit_for_test(logger);
+
+    secrets.get("API_KEY").unwrap();
+    secrets.get("API_KEY").unwrap();
+
+    let events: Vec<_> = audit_events(&lines)
+        .into_iter()
+        .filter(|event| event["action"] == "get")
+        .collect();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["ref"], "item=REMOTE_API_KEY");
+    assert!(
+        events[0]["provider"]
+            .as_str()
+            .unwrap()
+            .contains("source.env")
+    );
+    assert!(
+        events[1]["provider"]
+            .as_str()
+            .unwrap()
+            .contains("cache.env")
+    );
+    assert!(
+        events[1].get("ref").is_none(),
+        "the cache store was addressed by SecretSpec convention, not the authoritative ref"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add 0.19+ native `ref` templates to leaf provider aliases, with `{project}`, `{profile}`, and `{key}` placeholders
- add per-secret `refs.<alias>` overrides with explicit precedence over alias templates and convention naming
- resolve primary, fallback, read, write, import source, and import destination addresses independently
- preserve the legacy route-wide `ref` behavior and the existing `Provider::same_entry` API
- include effective refs in cache fingerprints and audit records
- document the new syntax, precedence, restrictions, and import behavior

## Why

The existing model derived one address per logical secret and reused it for every provider. That breaks migrations and fallback chains when providers organize the same secret differently—for example, a structured Bitwarden or 1Password source and a convention-addressed dotenv destination.

Import also performed writes and source deletions per item. A later validation or target failure could therefore leave an earlier source deleted. This change prepares every endpoint first, performs all target writes, verifies copied values, and only then begins source cleanup.

With independent addresses, `import --delete-source` can safely distinguish two entries in the same physical store instead of rejecting the store wholesale.

Closes #289.
Related to #266.

## User impact

Address resolution for a selected alias is now:

1. legacy route-wide `ref`
2. matching `refs.<alias>`
3. that alias's `ref` template
4. provider convention naming

Literal provider specs intentionally have no alias identity and therefore use legacy `ref` or convention naming.

## Validation

- `devenv shell cargo test -p secretspec`
- focused template, fallback, import safety, same-store distinct-entry, encoding, and audit regression tests
- `devenv shell cargo check --all-targets`
- `devenv shell npm --prefix docs run build`
- repository commit hooks: Clippy and rustfmt
