### PR TITLE
Add file provider and generic JSON secret extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `file` provider stores each secret as one plaintext UTF-8 file beneath an
   explicitly configured relative or absolute directory, with project/profile
   isolation and support for existing file-mounted secrets through `ref.item`.
+- Secrets can select values from stored JSON documents with RFC 6901 pointers
+  using `extract`. Extraction composes with provider-native references and
+  storage decoding; selected values are read-only so sibling document data is
+  never overwritten or deleted.
 - Secrets can store values as standard Base64, URL-safe Base64, or hexadecimal
   using `encoding`; writes encode logical text and reads decode stored values,
   while `as_path = true` materializes arbitrary decoded bytes.
@@ -76,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   paths without treating separators as TOML escapes.
 - Profile overrides can switch between legacy `ref` and provider-scoped `refs`
   without retaining both inherited address models and failing validation.
+- JSON extraction from file-backed documents now handles Windows store paths
+  without treating path separators as TOML escapes.
 - SDK pkg-config setup now pins cargo-c's library and metadata install
   directories, so Go, Ruby, and Haskell reliably discover
   `secretspec_ffi.pc` across environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `secretspec set` and interactive `secretspec check` now preview the resolved
   write destination before reading the value, including the exact file and
   selector for SOPS.
+- A `file` provider stores each secret as one plaintext UTF-8 file beneath an
+  explicitly configured relative or absolute directory, with project/profile
+  isolation and support for existing file-mounted secrets through `ref.item`.
 - Secrets can store values as standard Base64, URL-safe Base64, or hexadecimal
   using `encoding`; writes encode logical text and reads decode stored values,
   while `as_path = true` materializes arbitrary decoded bytes.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -123,7 +123,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). The null provider (0.19+) uses manifest defaults or ephemeral generation without storage.`,
+Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). The null provider (0.19+) uses manifest defaults or ephemeral generation without storage.`,
         }),
       ],
       title: "SecretSpec",
@@ -223,6 +223,11 @@ Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv fil
               badge: { text: "0.17+", variant: "note" },
             },
             { label: "Dotenv", slug: "providers/dotenv" },
+            {
+              label: "Files",
+              slug: "providers/file",
+              badge: { text: "0.19+", variant: "note" },
+            },
             { label: "Environment Variables", slug: "providers/env" },
             {
               label: "Null",

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -42,6 +42,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [keyring](/providers/keyring/) | [macOS Keychain](https://support.apple.com/guide/security/keychain-data-protection-secb0694df1a/web), [Windows Credential Manager](https://learn.microsoft.com/windows/win32/secauthn/credentials-management), or [Linux Secret Service](https://gnome.pages.gitlab.gnome.org/libsecret/) | ✓ | ✓ | ✓ | — |
 | [kdbx](/providers/kdbx/) (0.17+) | KeePass KDBX file (requires the `kdbx` build feature) | ✓ | KDBX 4 | ✓ | — |
 | [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ | — |
+| [file](/providers/file/) (0.19+) | One plaintext UTF-8 file per secret | ✓ | ✓ | ✗ | — |
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ | — |
 | [null](/providers/null/) (0.19+) | No storage; uses a manifest default or ephemeral generation | ✗ | ✗ | N/A | — |
 | [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |

--- a/docs/src/content/docs/providers/file.md
+++ b/docs/src/content/docs/providers/file.md
@@ -144,6 +144,42 @@ Referenced files are writable when filesystem permissions allow it. Treat
 runtime-managed mounts as read-only unless their owner explicitly permits
 SecretSpec to replace or delete entries.
 
+## Extract from JSON (0.19+)
+
+:::caution[Version compatibility]
+Structured `extract` is available starting in SecretSpec 0.19.
+:::
+
+Several declarations can select values from one JSON file without making JSON
+part of the provider itself:
+
+```toml title="secretspec.toml"
+[providers]
+runtime_files = "file:///run/secrets"
+
+[profiles.production]
+# extract is available in SecretSpec 0.19+
+DATABASE_USER = {
+  description = "Database user",
+  providers = ["runtime_files"],
+  ref = { item = "application.json" },
+  extract = { format = "json", pointer = "/database/user" }
+}
+DATABASE_PASSWORD = {
+  description = "Database password",
+  providers = ["runtime_files"],
+  ref = { item = "application.json" },
+  extract = { format = "json", pointer = "/database/password" }
+}
+```
+
+The file provider returns the complete UTF-8 document; SecretSpec then applies
+the RFC 6901 pointer as a provider-independent stored-value transform. Extracted
+declarations are read-only in 0.19 so `set`, `delete`, generation, prompting,
+and import cannot overwrite or remove the containing file. See
+[Structured Extraction](/reference/configuration/#structured-extraction-019)
+for value rendering, error behavior, and composition with `encoding`.
+
 ## CI/CD and containers
 
 Use a read-only mounted directory with explicit refs when the runtime already

--- a/docs/src/content/docs/providers/file.md
+++ b/docs/src/content/docs/providers/file.md
@@ -1,0 +1,176 @@
+---
+title: File Provider
+description: Store each secret in one plaintext file beneath a local directory
+---
+
+The file provider reads and writes one plaintext UTF-8 file per secret.
+
+:::caution[Version compatibility]
+The `file` provider is added in SecretSpec 0.19.
+:::
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `file` (0.19+) |
+| URI | `file:ROOT` |
+| Access | Read, write, and delete |
+| Best for | Local fixtures and file-mounted secrets |
+| Authentication | Filesystem permissions |
+| Availability | Built in (0.19+) |
+| Storage root | Required; relative to `secretspec.toml` or absolute |
+
+## Quick start
+
+Choose a directory, exclude it from version control, and route a declaration
+to it:
+
+```text title=".gitignore"
+/.secrets/
+```
+
+```toml title="secretspec.toml"
+[providers]
+local_files = "file:./.secrets"
+
+[profiles.development]
+API_TOKEN = { description = "Local API token", providers = ["local_files"] }
+```
+
+```bash
+$ secretspec set API_TOKEN --profile development
+$ secretspec get API_TOKEN --profile development
+$ secretspec run --profile development -- npm start
+```
+
+The stored value is `.secrets/<project>/development/API_TOKEN`, where
+`<project>` is `[project].name` from the manifest.
+
+## Setup
+
+The provider has no external dependency or credential. The SecretSpec process
+needs read access to the configured directory and write access for `set`,
+generated values, imports, cache writes, and deletes.
+
+Relative roots resolve from the directory containing `secretspec.toml`, not
+from the shell's current directory. Every `file` provider URI must include a
+root; the bare `file` provider name is rejected.
+
+## Configuration
+
+### URI format
+
+```text
+file:ROOT
+```
+
+`ROOT` is required and names the directory that contains the project/profile
+tree. It can be relative, absolute, or home-relative. The URI accepts no query
+options or user information.
+
+### URI examples
+
+```text
+file:./.secrets            # .secrets beside secretspec.toml
+file:///var/lib/app/secrets # Absolute directory
+file:~/.local/share/myapp  # Home-relative directory
+```
+
+Use `file:./...` for relative paths containing spaces. SecretSpec percent-
+encodes the path when reporting the provider URI.
+
+### Project configuration
+
+Check in the provider alias, but never the directory's plaintext contents:
+
+```toml title="secretspec.toml"
+[providers]
+local_files = "file:./.secrets"
+
+[profiles.default]
+DATABASE_URL = { description = "Database connection string", providers = ["local_files"] }
+```
+
+The alias is shared configuration. Each machine supplies its own directory
+contents.
+
+## Storage model
+
+Convention addresses use this path beneath `ROOT`:
+
+```text
+{project}/{profile}/{key}
+```
+
+Project and profile are therefore isolated even when one user-global file
+provider serves several projects. Each component must be one safe filename;
+slashes, backslashes, `.` and `..` are rejected in convention components.
+
+Values are read and written exactly as UTF-8 text. Leading and trailing
+whitespace, newlines, CRLF line endings, and multiline content are preserved.
+Binary files are rejected by the provider's text interface; use a SecretSpec
+0.19+ `encoding` when the stored file should contain a textual encoding of
+binary data.
+
+Writes use a temporary file in the destination directory and atomically
+replace the entry after flushing it. On Unix, SecretSpec creates new
+directories with mode `0700` and new entry files with mode `0600`. Existing
+directory permissions are not changed.
+
+## Use existing files
+
+A native `ref.item` is a relative path beneath `ROOT`. It replaces the entire
+`{project}/{profile}/{key}` convention path:
+
+```toml title="secretspec.toml"
+[providers]
+runtime_files = "file:///run/secrets"
+
+[profiles.production]
+DATABASE_PASSWORD = {
+  description = "Database password mounted by the runtime",
+  providers = ["runtime_files"],
+  ref = { item = "database/password" }
+}
+```
+
+This reads `/run/secrets/database/password`. `item` may contain nested relative
+components, but absolute paths, empty components, `.`, `..`, backslashes, and
+symbolic links inside the configured root are rejected. `field`, `vault`,
+`section`, and `version` do not have file equivalents and are rejected.
+
+Referenced files are writable when filesystem permissions allow it. Treat
+runtime-managed mounts as read-only unless their owner explicitly permits
+SecretSpec to replace or delete entries.
+
+## CI/CD and containers
+
+Use a read-only mounted directory with explicit refs when the runtime already
+publishes one file per secret. For example, mount the source at `/run/secrets`
+and use `file:///run/secrets` as the provider alias. SecretSpec reads only the
+files declared by the active profile; it does not enumerate or inject every
+file in the mount.
+
+The ordinary convention is useful when SecretSpec owns the directory. Give
+each job a private root and let `{project}/{profile}/{key}` keep jobs and
+environments separate.
+
+## Security considerations
+
+:::danger[Plaintext storage]
+The file provider does not encrypt values. Keep its root out of version
+control, backups, build artifacts, container layers, and shared directories.
+Use an encrypted provider when the filesystem is not an acceptable trust
+boundary.
+:::
+
+SecretSpec rejects symbolic links within the configured store so an entry
+cannot deliberately redirect reads or writes outside its root. It also rejects
+lexical traversal through `ref.item`. The configured root itself remains the
+operator's trust boundary: protect it with filesystem ownership and mount
+permissions, and do not let untrusted processes modify it while SecretSpec is
+running.
+
+Deleting an entry removes only its file. Empty project and profile directories
+remain in place.

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -104,6 +104,7 @@ $ secretspec config global init  # 0.17+
   onepassword: OnePassword password manager
   keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   dotenv: Traditional .env files
+  file: Plaintext files, one per secret (0.19+)
   env: Read-only environment variables
   null: Use defaults or ephemeral generation without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -718,7 +718,7 @@ Stores fall into two groups for `field`:
 
 | Store | Shape of one secret | `field` |
 |-------|---------------------|---------|
-| dotenv, env, pass, LastPass, Proton Pass, Bitwarden, AWS Parameter Store (0.18+) | a single value | Rejected: there is nothing to select |
+| dotenv, file (0.19+), env, pass, LastPass, Proton Pass, Bitwarden, AWS Parameter Store (0.18+) | a single value | Rejected: there is nothing to select |
 | 1Password, Keeper (0.18+), Vault KV, AWS Secrets Manager, keyring | a record of named parts | Selects the part: field label, map key, JSON key, account |
 
 `vault` is the only container coordinate. For every store except 1Password the
@@ -785,6 +785,7 @@ entry declares neither, it inherits whichever form `[profiles.default]` uses.
 | [Keeper (0.18+)](/providers/keeper/#use-existing-records) | Record UID or exact title | Standard field type/label or custom field label | Reads `password` | ✅ for existing records and fields |
 | [keyring](/providers/keyring/#use-existing-secrets) | Service | Account (defaults to the current system username) | Current user's entry | ✅ |
 | [dotenv](/providers/dotenv/#use-existing-secrets) | `.env` key | Rejected | Reads the key | ✅ |
+| [file (0.19+)](/providers/file/#use-existing-files) | Relative file path beneath the configured root | Rejected | Reads the complete UTF-8 file | ✅ |
 | [env](/providers/env/#use-existing-secrets) | Variable name | Rejected | Reads the variable | — (read-only) |
 | [systemd credentials (0.17+)](/providers/systemd-credential/#use-an-existing-credential-name) | Credential filename | Rejected | Reads the credential | — (read-only) |
 | [pass](/providers/pass/#use-existing-secrets) | Entry path | Rejected | Reads the entry | ✅ |

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -164,6 +164,7 @@ Each secret variable is defined as a table with the following fields:
 | `refs` (0.19+) | table | No | Provider-alias-scoped coordinates, keyed by leaf alias (e.g. `refs = { source = { item = "old" }, target = { item = "new" } }`); mutually exclusive with `ref` |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
 | `encoding` (0.19+) | `"base64"`, `"base64url"`, or `"hex"` | No | Encode logical values before storage writes and decode stored values after reads |
+| `extract` (0.19+) | table | No | Select one logical value from stored structured data, for example `extract = { format = "json", pointer = "/database/password" }` |
 | `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
 | `generate` | boolean or table | No | Enable auto-generation when secret is missing |
 
@@ -179,6 +180,8 @@ Field notes:
   though the provider does not have to supply it.
 - `type` is required when `generate` is enabled.
 - `generate` and `default` cannot both be set.
+- `extract` (0.19+) is read-only and cannot be combined with enabled
+  `generate`.
 
 #### Composed Secrets
 
@@ -202,8 +205,8 @@ References form a static dependency graph. Declaration order does not matter,
 and composed secrets may reference other composed secrets. SecretSpec rejects
 unknown references, cycles, malformed references, and source conflicts while
 loading the manifest. A composed secret is read-only and cannot also set
-`default`, `providers`, `ref`, `refs` (0.19+), `type`, enabled `generate`, or
-`encoding` (0.19+).
+`default`, `providers`, `ref`, `refs` (0.19+), `type`, enabled `generate`,
+`encoding` (0.19+), or `extract` (0.19+).
 
 Composition intentionally does **not** implement dotenv or shell expansion:
 
@@ -246,8 +249,8 @@ Scopes name membership-only subsets of a profile's secrets, so a single service
 or task resolves only what it declares instead of the entire profile. They are
 **orthogonal to profiles**: a profile decides how each secret resolves
 (`required`, `default`, providers, references, generation, `as_path`,
-`encoding` (0.19+), and the storage namespace); a scope only decides *which*
-secrets take part in a given resolution.
+`encoding` (0.19+), `extract` (0.19+), and the storage namespace); a scope only
+decides *which* secrets take part in a given resolution.
 
 ```toml
 [profiles.default]
@@ -641,7 +644,8 @@ GOOGLE_APPLICATION_CREDENTIALS = { description = "GCP service account", as_path 
 ```
 
 When combined with `encoding` (0.19+), the file contains the decoded bytes
-rather than the stored textual representation.
+rather than the stored textual representation. When combined with `extract`
+(0.19+), it contains only the selected logical value.
 
 | Context | Behavior |
 |---------|----------|
@@ -684,6 +688,63 @@ text; SecretSpec encodes it before writing to a provider or cache. Defaults and
 composed results are already logical and are not transformed. The
 `secretspec import` command copies the stored representation verbatim, avoiding
 double encoding.
+
+### Structured Extraction (0.19+)
+
+:::caution[Version compatibility]
+Available starting in SecretSpec 0.19.
+:::
+
+`extract` (0.19+) selects one logical secret from structured text read from a
+provider or cache. JSON is the initial supported format, and `pointer` is an
+[RFC 6901 JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901):
+
+```toml
+[providers]
+documents = "file:./secrets"
+
+[profiles.default]
+# extract is available in SecretSpec 0.19+
+DB_USER = {
+  description = "Database user",
+  providers = ["documents"],
+  ref = { item = "application.json" },
+  extract = { format = "json", pointer = "/database/user" }
+}
+DB_PASSWORD = {
+  description = "Database password",
+  providers = ["documents"],
+  ref = { item = "application.json" },
+  extract = { format = "json", pointer = "/database/password" }
+}
+```
+
+Both declarations read the same document. `/database/password` walks nested
+objects, `/hosts/0` selects an array element, and `/a~1b/~0key` selects the key
+`~key` beneath an `a/b` object. The empty pointer selects the complete document.
+
+JSON strings become their unquoted contents. Numbers, booleans, and `null` use
+their JSON spelling; objects and arrays become compact JSON. Invalid JSON or a
+pointer that does not match is a decoding error. Once a provider returns a
+document, extraction failure is not treated as a provider miss and does not
+continue along a fallback chain.
+
+Stored-value transforms run in this order:
+
+```text
+provider or cache → encoding decode → structured extraction → as_path
+```
+
+This makes a Base64-encoded JSON document valid input when a declaration sets
+both `encoding = "base64"` (0.19+) and `extract` (0.19+). A provider-native
+`ref.field` is also resolved first, so a field whose contents are JSON can be
+selected further. Defaults and composed values are already logical and are not
+extracted.
+
+Extracted secrets are read-only in 0.19. `set`, `delete`, interactive prompting,
+generation, and `import` reject them rather than replacing or removing the
+containing document and its sibling values. Update the document through its
+owning system instead.
 
 ### Secret References
 

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -24,6 +24,29 @@ dotenv://~/.config/app/.env  # Home-relative path (0.18+)
 
 **Features**: Read/write, profiles, human-readable, no encryption
 
+## File Provider (0.19+)
+
+:::caution[Version compatibility]
+The `file` provider is added in SecretSpec 0.19.
+:::
+
+**URI**: `file:ROOT` - Stores one plaintext UTF-8 file per secret beneath an
+explicitly configured local directory
+
+`ROOT` is required. The bare `file` provider name is rejected.
+
+```bash
+file:./.secrets              # Relative to secretspec.toml
+file:///run/secrets          # Absolute directory
+```
+
+**Features**: Read/write/delete, project and profile isolation, exact UTF-8
+text, atomic writes, nested relative `ref.item` paths
+**Storage**: `ROOT/{project}/{profile}/{key}` by convention. A `ref.item`
+replaces the convention path with a relative path beneath `ROOT`.
+**Security**: No encryption. New files use mode `0600` on Unix; traversal and
+symbolic links inside the configured store are rejected.
+
 ## Environment Provider
 
 **URI**: `env://` - Read-only access to system environment variables
@@ -539,6 +562,7 @@ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Provider | Encryption | Storage Location | Network Access |
 |----------|------------|------------------|----------------|
 | DotEnv | ❌ Plain text | Local filesystem | ❌ No |
+| File (0.19+) | ❌ Plain text | Local filesystem | ❌ No |
 | Environment | ❌ Plain text | Process memory | ❌ No |
 | Null (0.19+) | N/A — no stored value | None | ❌ No |
 | systemd Credential (0.17+) | Depends on unit source | systemd-managed runtime memory | ❌ No |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -62,6 +62,7 @@ const providerMetadata: ProviderMetadata[] = [
   { slug: 'protonpass', label: 'Proton Pass' },
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },
+  { slug: 'file', label: 'Plaintext files (0.19+)' },
   { slug: 'env', label: 'Environment variables' },
   { slug: 'null', label: 'Defaults / ephemeral generation (null, 0.19+)' },
   { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials (0.17+)' },
@@ -522,6 +523,7 @@ const reelScriptData = {
 ? Select your preferred provider backend:
 <span class="landing-provider-cursor" aria-hidden="true">›</span><a class="landing-provider-line is-selected" style="--provider-line-color: var(--syntax-blue)" href="/providers/keyring/"><span class="provider-name">keyring</span>: Uses system keychain (Recommended)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/null/"><span class="provider-name">null</span>: Defaults or ephemeral generation, no storage (0.19+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/file/"><span class="provider-name">file</span>: Plaintext files, one per secret (0.19+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-red)" href="/providers/bw/"><span class="provider-name">bw</span>: Bitwarden Password Manager (0.18+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/kdbx/"><span class="provider-name">kdbx</span>: KeePass KDBX databases (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/keeper/"><span class="provider-name">keeper</span>: Keeper Secrets Manager (0.18+) via official Rust SDK</a>

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -28,6 +28,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [Keyring](https://secretspec.dev/providers/keyring)
   - [KeePass KDBX](https://secretspec.dev/providers/kdbx) (0.17+)
   - [.env](https://secretspec.dev/providers/dotenv)
+  - [plaintext files](https://secretspec.dev/providers/file) (0.19+)
   - [OnePassword](https://secretspec.dev/providers/onepassword)
   - [Keeper Secrets Manager](https://secretspec.dev/providers/keeper) (0.18+)
   - [LastPass](https://secretspec.dev/providers/lastpass)
@@ -78,6 +79,7 @@ $ secretspec config global init  # 0.17+
   onepassword: OnePassword password manager
   keeper: Keeper Secrets Manager (0.18+) via official Rust SDK
   dotenv: Traditional .env files
+  file: Plaintext files, one per secret (0.19+)
   env: Read-only environment variables
   null: Use defaults or ephemeral generation without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
@@ -194,6 +196,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Keyring](https://secretspec.dev/providers/keyring)** - System credential store (recommended)
 - **[KeePass KDBX](https://secretspec.dev/providers/kdbx)** (0.17+) - Local KeePass-compatible encrypted database
 - **[.env files](https://secretspec.dev/providers/dotenv)** - Traditional dotenv files
+- **[Plaintext files](https://secretspec.dev/providers/file)** (0.19+) - One UTF-8 file per secret in a local directory tree
 - **[Environment variables](https://secretspec.dev/providers/env)** - Read-only for CI/CD
 - **[Null](https://secretspec.dev/providers/null)** (0.19+) - Use committed defaults or ephemeral generation without secret storage
 - **[systemd credentials](https://secretspec.dev/providers/systemd-credential)** (0.17+) - Read-only credentials passed to the current service

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -743,6 +743,9 @@ fn select_config_init_provider(provider: Option<String>) -> Result<String> {
                 available.join(", ")
             ));
         }
+        if provider.split(':').next() == Some("file") {
+            Box::<dyn Provider>::try_from(provider).into_diagnostic()?;
+        }
         return Ok(provider.to_string());
     }
 
@@ -756,11 +759,27 @@ fn select_config_init_provider(provider: Option<String>) -> Result<String> {
         .prompt()
         .into_diagnostic()?;
 
-    Ok(selected_choice
+    let selected_provider = selected_choice
         .split(':')
         .next()
         .unwrap_or("keyring")
-        .to_string())
+        .to_string();
+
+    if selected_provider == "file" {
+        use inquire::Text;
+
+        let directory = Text::new("File provider root directory:")
+            .with_help_message("Use a relative path such as ./.secrets or an absolute path")
+            .prompt()
+            .into_diagnostic()?;
+        let spec = format!("file:{}", directory.trim());
+        Box::<dyn Provider>::try_from(spec.as_str())
+            .into_diagnostic()
+            .wrap_err("Invalid file provider configuration")?;
+        Ok(spec)
+    } else {
+        Ok(selected_provider)
+    }
 }
 
 /// Resolves an explicitly supplied config-init profile or prompts for one.
@@ -2388,6 +2407,16 @@ API_KEY = { description = "Existing" }
                 .unwrap_err()
                 .to_string()
                 .contains("Provider backend 'unknown' not found")
+        );
+        assert_eq!(
+            select_config_init_provider(Some("file:./.secrets".to_string())).unwrap(),
+            "file:./.secrets"
+        );
+        assert!(
+            select_config_init_provider(Some("file".to_string()))
+                .unwrap_err()
+                .to_string()
+                .contains("requires an explicit relative or absolute directory path")
         );
 
         assert_eq!(

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -1964,6 +1964,8 @@ struct SecretSerde {
     as_path: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     encoding: Option<SecretEncoding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extract: Option<SecretExtract>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     secret_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1994,6 +1996,76 @@ impl SecretEncoding {
             Self::Hex => "hex",
         }
     }
+}
+
+/// A structured-data format from which one logical secret can be extracted.
+///
+/// Available since SecretSpec 0.19.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExtractFormat {
+    /// A JSON document selected with an RFC 6901 JSON Pointer.
+    Json,
+}
+
+impl ExtractFormat {
+    /// Stable manifest spelling used in diagnostics.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Selects one logical secret from a structured stored value.
+///
+/// Extraction is applied after [`SecretEncoding`] is decoded and only to
+/// values read from providers or caches. Defaults and composed values are
+/// already logical and are not extracted.
+///
+/// Available since SecretSpec 0.19.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretExtract {
+    /// The structured-data format of the stored value.
+    pub format: ExtractFormat,
+    /// RFC 6901 JSON Pointer selecting the logical value.
+    pub pointer: String,
+}
+
+impl SecretExtract {
+    fn validate(&self) -> Result<(), String> {
+        match self.format {
+            ExtractFormat::Json => validate_json_pointer(&self.pointer),
+        }
+    }
+}
+
+/// Validate the JSON Pointer grammar independently of any particular document.
+/// An empty pointer selects the whole document; every non-empty pointer starts
+/// with `/`, and `~` escapes only `~0` and `~1`.
+fn validate_json_pointer(pointer: &str) -> Result<(), String> {
+    if pointer.is_empty() {
+        return Ok(());
+    }
+    if !pointer.starts_with('/') {
+        return Err("`extract.pointer` must be empty or start with `/` (RFC 6901)".into());
+    }
+
+    let mut chars = pointer.char_indices();
+    while let Some((index, ch)) = chars.next() {
+        if ch == '~' {
+            match chars.next() {
+                Some((_, '0' | '1')) => {}
+                _ => {
+                    return Err(format!(
+                        "`extract.pointer` has an invalid `~` escape at byte {index}; use `~0` for `~` or `~1` for `/`"
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Configuration for an individual secret.
@@ -2061,6 +2133,13 @@ pub struct Secret {
     ///
     /// Available since SecretSpec 0.19.
     pub encoding: Option<SecretEncoding>,
+    /// Structured stored-value extraction applied after optional decoding.
+    /// JSON extraction uses an RFC 6901 pointer. Extracted secrets are
+    /// read-only because a selected value cannot reconstruct its containing
+    /// document for a storage write.
+    ///
+    /// Available since SecretSpec 0.19.
+    pub extract: Option<SecretExtract>,
     /// The type of secret, used for generation (e.g., "password", "hex", "base64", "uuid", "command", "rsa_private_key")
     pub secret_type: Option<String>,
     /// Auto-generation configuration. Either `true` for defaults or a table with options.
@@ -2097,6 +2176,7 @@ impl TryFrom<SecretSerde> for Secret {
             refs: value.refs,
             as_path: value.as_path,
             encoding: value.encoding,
+            extract: value.extract,
             secret_type: value.secret_type,
             generate: value.generate,
         })
@@ -2124,6 +2204,7 @@ impl From<Secret> for SecretSerde {
             refs: value.refs,
             as_path: value.as_path,
             encoding: value.encoding,
+            extract: value.extract,
             secret_type: value.secret_type,
             generate: value.generate,
         }
@@ -2228,11 +2309,22 @@ impl Secret {
                 || self.reference.is_some()
                 || self.refs.is_some()
                 || self.encoding.is_some()
+                || self.extract.is_some()
                 || self.secret_type.is_some()
                 || self.would_generate()
             {
                 return Err(
-                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `refs`, `encoding`, `type`, or enabled `generate`"
+                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `refs`, `encoding`, `extract`, `type`, or enabled `generate`"
+                        .into(),
+                );
+            }
+        }
+
+        if let Some(extract) = &self.extract {
+            extract.validate()?;
+            if self.would_generate() {
+                return Err(
+                    "`extract` cannot be combined with enabled `generate`; extracted secrets are read-only"
                         .into(),
                 );
             }
@@ -2409,6 +2501,7 @@ impl Secret {
             refs,
             as_path: inherit(current, default, |s| s.as_path),
             encoding: inherit(current, default, |s| s.encoding),
+            extract: inherit(current, default, |s| s.extract.clone()),
             secret_type: inherit(current, default, |s| s.secret_type.clone()),
             generate: inherit(current, default, |s| s.generate.clone()),
         })
@@ -3404,6 +3497,21 @@ BAD = { description = "bad", composed = "${A}", encoding = "base64" }
         .unwrap();
         let error = encoded.validate().unwrap_err().to_string();
         assert!(error.contains("`encoding`"), "{error}");
+
+        let extracted: Config = toml::from_str(
+            r#"
+[project]
+name = "composed"
+revision = "1.0"
+
+[profiles.default]
+A = { description = "a" }
+BAD = { description = "bad", composed = "${A}", extract = { format = "json", pointer = "/value" } }
+"#,
+        )
+        .unwrap();
+        let error = extracted.validate().unwrap_err().to_string();
+        assert!(error.contains("`extract`"), "{error}");
     }
 
     #[test]
@@ -3867,6 +3975,95 @@ encoding = "rot13""#,
         .unwrap_err()
         .to_string();
         assert!(error.contains("unknown variant `rot13`"), "{error}");
+    }
+
+    #[test]
+    fn secret_extract_parses_round_trips_and_inherits() {
+        let secret: Secret = toml::from_str(
+            r#"description = "selected"
+extract = { format = "json", pointer = "/database/password" }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            secret.extract,
+            Some(SecretExtract {
+                format: ExtractFormat::Json,
+                pointer: "/database/password".to_string(),
+            })
+        );
+        let rendered = toml::to_string(&secret).unwrap();
+        assert!(rendered.contains("format = \"json\""), "{rendered}");
+        assert!(
+            rendered.contains("pointer = \"/database/password\""),
+            "{rendered}"
+        );
+
+        let inherited = Secret::resolved(
+            Some(&Secret {
+                description: Some("production".to_string()),
+                ..Default::default()
+            }),
+            Some(&Secret {
+                description: Some("default".to_string()),
+                extract: secret.extract.clone(),
+                ..Default::default()
+            }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(inherited.extract, secret.extract);
+    }
+
+    #[test]
+    fn secret_extract_validates_json_pointer_and_table_shape() {
+        for pointer in ["database/password", "/bad~", "/bad~2escape"] {
+            let secret: Secret = toml::from_str(&format!(
+                "description = \"selected\"\nextract = {{ format = \"json\", pointer = \"{pointer}\" }}"
+            ))
+            .unwrap();
+            let error = secret.validate().unwrap_err();
+            assert!(error.contains("`extract.pointer`"), "{error}");
+        }
+
+        let error = toml::from_str::<Secret>(
+            r#"description = "selected"
+extract = { format = "json", pointer = "/x", unknown = true }"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("unknown field"), "{error}");
+
+        let error = toml::from_str::<Secret>(
+            r#"description = "selected"
+extract = { format = "yaml", pointer = "/x" }"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("unknown variant `yaml`"), "{error}");
+    }
+
+    #[test]
+    fn secret_extract_accepts_root_and_escaped_json_pointers() {
+        for pointer in ["", "/a~1b/~0key", "/items/0"] {
+            let secret: Secret = toml::from_str(&format!(
+                "description = \"selected\"\nextract = {{ format = \"json\", pointer = \"{pointer}\" }}"
+            ))
+            .unwrap();
+            secret.validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn secret_extract_rejects_generation() {
+        let secret: Secret = toml::from_str(
+            r#"description = "selected"
+type = "password"
+generate = true
+extract = { format = "json", pointer = "/password" }"#,
+        )
+        .unwrap();
+        let error = secret.validate().unwrap_err();
+        assert!(error.contains("extracted secrets are read-only"), "{error}");
     }
 
     /// All coordinate keys parse from the inline table form.

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -65,6 +65,10 @@ pub enum SecretSpecError {
         "Composed secret '{0}' is derived from other secrets and has no stored value to change"
     )]
     ComposedSecretReadOnly(String),
+    #[error(
+        "Secret '{0}' uses `extract` and is read-only; update its containing document in the source provider instead"
+    )]
+    ExtractedSecretReadOnly(String),
     #[error("Failed to compose secret: {0}")]
     CompositionFailed(String),
     #[error("No secretspec.toml found in current or any parent directory")]
@@ -122,6 +126,7 @@ impl SecretSpecError {
             SecretSpecError::SecretNotFound(_) => "secret_not_found",
             SecretSpecError::RequiredSecretMissing(_) => "required_secret_missing",
             SecretSpecError::ComposedSecretReadOnly(_) => "composed_secret_read_only",
+            SecretSpecError::ExtractedSecretReadOnly(_) => "extracted_secret_read_only",
             SecretSpecError::CompositionFailed(_) => "composition_failed",
             SecretSpecError::NoManifest => "no_manifest",
             SecretSpecError::ExtendedConfigNotFound(_) => "extended_config_not_found",
@@ -224,6 +229,10 @@ mod tests {
             (
                 SecretSpecError::ComposedSecretReadOnly("X".into()),
                 "composed_secret_read_only",
+            ),
+            (
+                SecretSpecError::ExtractedSecretReadOnly("X".into()),
+                "extracted_secret_read_only",
             ),
             (
                 SecretSpecError::CompositionFailed("too large".into()),

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -72,7 +72,9 @@ pub use config::{
 
 // Re-export Secret and generation types for secretspec-derive
 #[doc(hidden)]
-pub use config::{GenerateConfig, GenerateOptions, Secret, SecretEncoding};
+pub use config::{
+    ExtractFormat, GenerateConfig, GenerateOptions, Secret, SecretEncoding, SecretExtract,
+};
 
 // Public API exports
 pub use error::{Result, SecretSpecError};

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -16,7 +16,7 @@
 //! its own authoritative store. A plan never reads or writes a secret.
 
 use crate::composition::Template;
-use crate::config::{NativeAddress, Secret, SecretEncoding};
+use crate::config::{NativeAddress, Secret, SecretEncoding, SecretExtract};
 use crate::error::{Result, SecretSpecError};
 use crate::manifest::CompiledSecret;
 use crate::provider::OwnedAddress;
@@ -196,6 +196,11 @@ impl PlannedSecret {
     /// Optional encoding applied at the storage boundary.
     pub(crate) fn encoding(&self) -> Option<SecretEncoding> {
         self.secret.config.encoding
+    }
+
+    /// Optional structured extraction applied at the storage boundary.
+    pub(crate) fn extract(&self) -> Option<&SecretExtract> {
+        self.secret.config.extract.as_ref()
     }
 
     pub(crate) fn is_composed(&self) -> bool {

--- a/secretspec/src/provider/file.rs
+++ b/secretspec/src/provider/file.rs
@@ -1,0 +1,677 @@
+use super::{Address, Provider, ProviderUrl};
+use crate::config::{NativeAddress, expand_tilde};
+use crate::{Result, SecretSpecError};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+
+pub(crate) const MISSING_DIRECTORY_ERROR: &str = "file provider requires an explicit relative or absolute directory path (for example, 'file:./.secrets' or 'file:///run/secrets')";
+
+/// Configuration for the plaintext file provider.
+///
+/// Each secret is stored in its own UTF-8 file beneath `directory`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileConfig {
+    /// Root directory containing the provider's files.
+    pub directory: PathBuf,
+}
+
+impl TryFrom<&ProviderUrl> for FileConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "file" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for file provider",
+                url.scheme()
+            )));
+        }
+
+        if !url.username().is_empty() || url.password().is_some() || url.has_query() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "file provider URIs take only a directory path; user information and query options are not supported"
+                    .to_string(),
+            ));
+        }
+
+        let path = url.path();
+        #[cfg(windows)]
+        let path = if path.as_bytes().first() == Some(&b'/')
+            && path.as_bytes().get(2) == Some(&b':')
+            && path.as_bytes().get(1).is_some_and(u8::is_ascii_alphabetic)
+        {
+            path[1..].to_string()
+        } else {
+            path
+        };
+        let directory = if !path.is_empty() {
+            if let Some(host) = url.host() {
+                if host == "." {
+                    PathBuf::from(path.trim_start_matches('/'))
+                } else {
+                    PathBuf::from(format!("{host}{path}"))
+                }
+            } else {
+                PathBuf::from(path)
+            }
+        } else if let Some(host) = url.host() {
+            PathBuf::from(host)
+        } else {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                MISSING_DIRECTORY_ERROR.to_string(),
+            ));
+        };
+
+        Ok(Self { directory })
+    }
+}
+
+/// Stores each secret as one plaintext file in a local directory tree.
+///
+/// Convention addresses are isolated by project and profile at
+/// `{project}/{profile}/{key}`. A native address uses `item` as a relative path
+/// beneath the configured directory, which supports existing file-mounted
+/// secrets without allowing the address to escape the store.
+pub struct FileProvider {
+    config: FileConfig,
+}
+
+crate::register_provider! {
+    struct: FileProvider,
+    config: FileConfig,
+    name: "file",
+    description: "Plaintext files, one per secret (0.19+)",
+    schemes: ["file"],
+    examples: ["file:./.secrets", "file:///run/secrets"],
+    deletes: true,
+}
+
+impl FileProvider {
+    pub fn new(mut config: FileConfig) -> Self {
+        config.directory = expand_tilde(config.directory);
+        Self { config }
+    }
+
+    fn operation_error(message: impl Into<String>) -> SecretSpecError {
+        SecretSpecError::ProviderOperationFailed(message.into())
+    }
+
+    fn validate_convention_component(value: &str, coordinate: &str) -> Result<()> {
+        let mut components = Path::new(value).components();
+        let is_one_normal_component = matches!(
+            (components.next(), components.next()),
+            (Some(Component::Normal(component)), None) if component == OsStr::new(value)
+        );
+        if value.is_empty()
+            || value.contains(['/', '\\', '\0'])
+            || value == "."
+            || value == ".."
+            || !is_one_normal_component
+        {
+            return Err(Self::operation_error(format!(
+                "the file provider cannot map {coordinate} '{value}' to one safe path component"
+            )));
+        }
+        Ok(())
+    }
+
+    fn relative_item(item: &str) -> Result<PathBuf> {
+        let path = Path::new(item);
+        let segments_are_safe = !item.is_empty()
+            && !item.contains(['\\', '\0'])
+            && item
+                .split('/')
+                .all(|segment| !segment.is_empty() && segment != "." && segment != "..");
+        let components_are_normal = path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)));
+
+        if !segments_are_safe || path.is_absolute() || !components_are_normal {
+            return Err(Self::operation_error(format!(
+                "invalid file provider item '{item}': expected a relative path without empty, '.', '..', or backslash components"
+            )));
+        }
+
+        Ok(path.to_path_buf())
+    }
+
+    fn entry_path(&self, addr: Address<'_>) -> Result<PathBuf> {
+        let item = super::flat_item(self, addr)?;
+        Ok(self.config.directory.join(Self::relative_item(&item)?))
+    }
+
+    fn inspect_directory(path: &Path, label: &str) -> Result<bool> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                Err(Self::operation_error(format!(
+                    "file provider {label} '{}' is a symbolic link; symbolic links inside the store are not followed",
+                    path.display()
+                )))
+            }
+            Ok(metadata) if !metadata.is_dir() => Err(Self::operation_error(format!(
+                "file provider {label} '{}' is not a directory",
+                path.display()
+            ))),
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(Self::operation_error(format!(
+                "failed to inspect file provider {label} '{}': {error}",
+                path.display()
+            ))),
+        }
+    }
+
+    /// Verifies every existing component beneath the configured root without
+    /// following symlinks. Returns `false` as soon as a component is absent.
+    fn inspect_parent_chain(&self, parent: &Path) -> Result<bool> {
+        if !Self::inspect_directory(&self.config.directory, "root")? {
+            return Ok(false);
+        }
+
+        let relative = parent.strip_prefix(&self.config.directory).map_err(|_| {
+            Self::operation_error(format!(
+                "file provider path '{}' escaped its configured root '{}'",
+                parent.display(),
+                self.config.directory.display()
+            ))
+        })?;
+        let mut current = self.config.directory.clone();
+        for component in relative.components() {
+            let Component::Normal(component) = component else {
+                return Err(Self::operation_error(format!(
+                    "file provider path '{}' is not beneath its configured root",
+                    parent.display()
+                )));
+            };
+            current.push(component);
+            if !Self::inspect_directory(&current, "directory")? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    /// Inspects one entry without following a final symlink.
+    fn inspect_entry(&self, path: &Path) -> Result<bool> {
+        let parent = path.parent().ok_or_else(|| {
+            Self::operation_error(format!(
+                "file provider entry '{}' has no parent directory",
+                path.display()
+            ))
+        })?;
+        if !self.inspect_parent_chain(parent)? {
+            return Ok(false);
+        }
+
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                Err(Self::operation_error(format!(
+                    "file provider entry '{}' is a symbolic link; symbolic links inside the store are not followed",
+                    path.display()
+                )))
+            }
+            Ok(metadata) if !metadata.is_file() => Err(Self::operation_error(format!(
+                "file provider entry '{}' is not a regular file",
+                path.display()
+            ))),
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(Self::operation_error(format!(
+                "failed to inspect file provider entry '{}': {error}",
+                path.display()
+            ))),
+        }
+    }
+
+    #[cfg(unix)]
+    fn create_private_directories(path: &Path) -> std::io::Result<()> {
+        use std::os::unix::fs::DirBuilderExt;
+
+        let mut builder = fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700).create(path)
+    }
+
+    #[cfg(not(unix))]
+    fn create_private_directories(path: &Path) -> std::io::Result<()> {
+        fs::create_dir_all(path)
+    }
+
+    fn prepare_parent(&self, parent: &Path) -> Result<()> {
+        Self::create_private_directories(parent).map_err(|error| {
+            Self::operation_error(format!(
+                "failed to create file provider directory '{}': {error}",
+                parent.display()
+            ))
+        })?;
+        if !self.inspect_parent_chain(parent)? {
+            return Err(Self::operation_error(format!(
+                "file provider directory '{}' disappeared while preparing a write",
+                parent.display()
+            )));
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn restrict_temporary_file(path: &Path) -> std::io::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+    }
+
+    #[cfg(not(unix))]
+    fn restrict_temporary_file(_path: &Path) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Provider for FileProvider {
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        Self::validate_convention_component(project, "project")?;
+        Self::validate_convention_component(profile, "profile")?;
+        Self::validate_convention_component(key, "secret key")?;
+        Ok(NativeAddress {
+            item: format!("{project}/{profile}/{key}"),
+            ..Default::default()
+        })
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let path = self.entry_path(addr)?;
+        if !self.inspect_entry(&path)? {
+            return Ok(None);
+        }
+
+        let mut file = fs::File::open(&path).map_err(|error| {
+            Self::operation_error(format!(
+                "failed to open file provider entry '{}': {error}",
+                path.display()
+            ))
+        })?;
+        let mut value = String::new();
+        file.read_to_string(&mut value).map_err(|error| {
+            Self::operation_error(format!(
+                "failed to read UTF-8 from file provider entry '{}': {error}",
+                path.display()
+            ))
+        })?;
+        Ok(Some(SecretString::new(value.into())))
+    }
+
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        let path = self.entry_path(addr)?;
+        self.inspect_entry(&path).map(|_| ())
+    }
+
+    fn describe_write_target(&self, addr: Address<'_>) -> Result<String> {
+        Ok(self.entry_path(addr)?.display().to_string())
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let path = self.entry_path(addr)?;
+        let parent = path.parent().ok_or_else(|| {
+            Self::operation_error(format!(
+                "file provider entry '{}' has no parent directory",
+                path.display()
+            ))
+        })?;
+        self.prepare_parent(parent)?;
+        // Recheck after creating the directory tree so a pre-existing symlink
+        // or non-file target is rejected immediately before replacement.
+        self.inspect_entry(&path)?;
+
+        let mut temporary = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
+            Self::operation_error(format!(
+                "failed to create a temporary file next to file provider entry '{}': {error}",
+                path.display()
+            ))
+        })?;
+        Self::restrict_temporary_file(temporary.path()).map_err(|error| {
+            Self::operation_error(format!(
+                "failed to restrict permissions for file provider entry '{}': {error}",
+                path.display()
+            ))
+        })?;
+        temporary
+            .write_all(value.expose_secret().as_bytes())
+            .map_err(|error| {
+                Self::operation_error(format!(
+                    "failed to write file provider entry '{}': {error}",
+                    path.display()
+                ))
+            })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            Self::operation_error(format!(
+                "failed to flush file provider entry '{}': {error}",
+                path.display()
+            ))
+        })?;
+        temporary.persist(&path).map_err(|error| {
+            Self::operation_error(format!(
+                "failed to atomically replace file provider entry '{}': {}",
+                path.display(),
+                error.error
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn delete(&self, addr: Address<'_>) -> Result<bool> {
+        let path = self.entry_path(addr)?;
+        if !self.inspect_entry(&path)? {
+            return Ok(false);
+        }
+        fs::remove_file(&path).map_err(|error| {
+            Self::operation_error(format!(
+                "failed to delete file provider entry '{}': {error}",
+                path.display()
+            ))
+        })?;
+        Ok(true)
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        if self.config.directory.is_absolute() {
+            url::Url::from_file_path(&self.config.directory)
+                .map(|url| url.to_string())
+                .unwrap_or_else(|_| {
+                    let path = ProviderUrl::encode(&self.config.directory.display().to_string());
+                    format!("file://{path}")
+                })
+        } else {
+            let path = ProviderUrl::encode(&self.config.directory.display().to_string());
+            format!("file://./{path}")
+        }
+    }
+
+    fn physical_store_path(&self) -> Option<&Path> {
+        Some(&self.config.directory)
+    }
+
+    fn with_base_dir(&mut self, base_dir: &Path) {
+        if self.config.directory.is_relative() {
+            self.config.directory = base_dir.join(&self.config.directory);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use url::Url;
+
+    fn provider(directory: &Path) -> FileProvider {
+        FileProvider::new(FileConfig {
+            directory: directory.to_path_buf(),
+        })
+    }
+
+    #[test]
+    fn parses_explicit_relative_and_absolute_directories() {
+        let cases = [
+            ("file://.secrets", ".secrets"),
+            ("file://./local%20secrets", "local secrets"),
+            ("file://config/secrets", "config/secrets"),
+            ("file://~/.local/share", "~/.local/share"),
+            ("file:///run/secrets", "/run/secrets"),
+            ("file:///", "/"),
+        ];
+        for (uri, expected) in cases {
+            let url = ProviderUrl::new(Url::parse(uri).unwrap());
+            let config = FileConfig::try_from(&url).unwrap();
+            assert_eq!(config.directory, Path::new(expected), "{uri}");
+        }
+    }
+
+    #[test]
+    fn rejects_missing_directory() {
+        for spec in ["file", "file:", "file://"] {
+            let Err(error) = Box::<dyn Provider>::try_from(spec) else {
+                panic!("{spec} should require an explicit directory");
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains("requires an explicit relative or absolute directory path"),
+                "{spec}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_queries() {
+        let url = ProviderUrl::new(Url::parse("file://secrets?mode=flat").unwrap());
+        let error = FileConfig::try_from(&url).unwrap_err();
+        assert!(
+            error.to_string().contains("only a directory path"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn convention_round_trip_is_exact_and_profile_isolated() {
+        let directory = TempDir::new().unwrap();
+        let provider = provider(directory.path());
+        let value = SecretString::new(" leading\nline two\n".to_string().into());
+
+        provider
+            .set(Address::convention("app", "development", "TOKEN"), &value)
+            .unwrap();
+
+        let found = provider
+            .get(Address::convention("app", "development", "TOKEN"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.expose_secret(), value.expose_secret());
+        assert!(
+            provider
+                .get(Address::convention("app", "production", "TOKEN"))
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            fs::read_to_string(directory.path().join("app/development/TOKEN")).unwrap(),
+            value.expose_secret()
+        );
+    }
+
+    #[test]
+    fn native_item_can_address_a_nested_existing_file() {
+        let directory = TempDir::new().unwrap();
+        fs::create_dir_all(directory.path().join("mounted/database")).unwrap();
+        fs::write(
+            directory.path().join("mounted/database/password"),
+            "external-value\n",
+        )
+        .unwrap();
+        let provider = provider(directory.path());
+        let address = NativeAddress {
+            item: "mounted/database/password".to_string(),
+            ..Default::default()
+        };
+
+        let found = provider.get(Address::Native(&address)).unwrap().unwrap();
+        assert_eq!(found.expose_secret(), "external-value\n");
+    }
+
+    #[test]
+    fn missing_entry_and_directory_are_absent() {
+        let directory = TempDir::new().unwrap();
+        let missing_root = directory.path().join("not-created");
+        assert!(
+            provider(&missing_root)
+                .get(Address::convention("app", "default", "MISSING"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn traversal_absolute_and_empty_items_are_rejected() {
+        let directory = TempDir::new().unwrap();
+        let provider = provider(directory.path());
+        for item in [
+            "../outside",
+            "nested/../outside",
+            "nested//secret",
+            "nested\\secret",
+            "/absolute",
+            ".",
+            "",
+        ] {
+            let address = NativeAddress {
+                item: item.to_string(),
+                ..Default::default()
+            };
+            let error = provider.get(Address::Native(&address)).unwrap_err();
+            assert!(
+                error.to_string().contains("relative path"),
+                "{item:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn unsafe_convention_components_are_rejected() {
+        let provider = provider(Path::new("unused"));
+        for (project, profile) in [("../app", "default"), ("app", "../default")] {
+            let error = provider.convention_address(project, profile, "TOKEN");
+            assert!(
+                error
+                    .unwrap_err()
+                    .to_string()
+                    .contains("safe path component")
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_native_coordinate_is_rejected() {
+        let directory = TempDir::new().unwrap();
+        let address = NativeAddress {
+            item: "TOKEN".to_string(),
+            field: Some("password".to_string()),
+            ..Default::default()
+        };
+
+        let error = provider(directory.path())
+            .get(Address::Native(&address))
+            .unwrap_err();
+        assert!(error.to_string().contains("`field`"), "{error}");
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let directory = TempDir::new().unwrap();
+        let provider = provider(directory.path());
+        let address = Address::convention("app", "default", "TOKEN");
+        provider
+            .set(address, &SecretString::new("value".to_string().into()))
+            .unwrap();
+
+        assert!(provider.delete(address).unwrap());
+        assert!(!provider.delete(address).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_inside_the_store_are_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let directory = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        fs::write(outside.path().join("secret"), "must not be read").unwrap();
+        fs::create_dir_all(directory.path().join("app/default")).unwrap();
+        symlink(
+            outside.path().join("secret"),
+            directory.path().join("app/default/TOKEN"),
+        )
+        .unwrap();
+
+        let error = provider(directory.path())
+            .get(Address::convention("app", "default", "TOKEN"))
+            .unwrap_err();
+        assert!(error.to_string().contains("symbolic link"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn writes_owner_only_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = TempDir::new().unwrap();
+        let provider = provider(directory.path());
+        provider
+            .set(
+                Address::convention("app", "default", "TOKEN"),
+                &SecretString::new("value".to_string().into()),
+            )
+            .unwrap();
+
+        let mode = fs::metadata(directory.path().join("app/default/TOKEN"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn binary_entries_are_rejected_by_the_text_provider_api() {
+        let directory = TempDir::new().unwrap();
+        fs::create_dir_all(directory.path().join("app/default")).unwrap();
+        fs::write(directory.path().join("app/default/TOKEN"), [0xff, 0xfe]).unwrap();
+
+        let error = provider(directory.path())
+            .get(Address::convention("app", "default", "TOKEN"))
+            .unwrap_err();
+        assert!(error.to_string().contains("UTF-8"), "{error}");
+    }
+
+    #[test]
+    fn relative_directory_is_rebased_to_the_manifest() {
+        let mut provider = FileProvider::new(FileConfig {
+            directory: PathBuf::from("local/secrets"),
+        });
+        provider.with_base_dir(Path::new("/project"));
+        assert_eq!(
+            provider.config.directory,
+            Path::new("/project/local/secrets")
+        );
+    }
+
+    #[test]
+    fn write_target_description_is_exact_and_does_not_create_directories() {
+        let directory = TempDir::new().unwrap();
+        let root = directory.path().join("not-created");
+        let provider = provider(&root);
+
+        let target = provider
+            .describe_write_target(Address::convention("app", "development", "TOKEN"))
+            .unwrap();
+
+        assert_eq!(
+            target,
+            root.join("app/development/TOKEN").display().to_string()
+        );
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn uri_round_trips_a_directory_with_spaces() {
+        let provider = Box::<dyn Provider>::try_from("file:./local secrets").unwrap();
+        assert_eq!(provider.name(), "file");
+        assert_eq!(provider.uri(), "file://./local%20secrets");
+        let reparsed = Box::<dyn Provider>::try_from(provider.uri().as_str()).unwrap();
+        assert_eq!(reparsed.uri(), provider.uri());
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -21,6 +21,7 @@
 //! - [`dotenv::DotEnvProvider`]: `.env` file support
 //! - [`env::EnvProvider`]: Environment variables (read-only)
 //! - [`null::NullProvider`]: Defaults or ephemeral generation without storage (0.19+)
+//! - [`file::FileProvider`]: Plaintext file-per-secret storage (0.19+)
 //! - [`pass::PassProvider`]: Pass integration
 //! - [`gopass::GoPassProvider`]: Gopass integration
 //! - [`systemd_credential::SystemdCredentialProvider`]: systemd service credentials (0.17+)
@@ -47,6 +48,7 @@
 //! keyring://
 //! dotenv://.env.production
 //! null://  # Use defaults or ephemeral generation without storage, 0.19+
+//! file:./.secrets  # One plaintext file per secret, 0.19+
 //! onepassword://vault
 //! lastpass://folder
 //! keeper://SHARED_FOLDER_UID  # Keeper, 0.18+
@@ -296,6 +298,7 @@ pub mod bws;
 pub mod dashlane;
 pub mod dotenv;
 pub mod env;
+pub mod file;
 #[cfg(feature = "gcsm")]
 pub mod gcsm;
 pub mod gopass;
@@ -560,11 +563,20 @@ fn registration_for_scheme(scheme: &str) -> Option<&'static ProviderRegistration
 /// URI parser and alias resolution gate specs through here, so the correction
 /// fires in one place no matter which path first sees the spec.
 pub(crate) fn spec_names_known_provider(spec: &str) -> Result<bool> {
-    let (scheme, _) = split_spec(spec);
+    let (scheme, rest) = split_spec(spec);
     if scheme == "1password" {
         return Err(SecretSpecError::ProviderOperationFailed(
             "Invalid scheme '1password'. Use 'onepassword' instead (e.g., onepassword://vault)"
                 .to_string(),
+        ));
+    }
+    // The URL parser normalizes `file://` to `file:///`, making an omitted
+    // path indistinguishable from an explicitly selected filesystem root.
+    // Reject pathless spellings before parsing so only `file:/` or `file:///`
+    // can intentionally select the absolute root.
+    if scheme == "file" && (rest.is_empty() || rest == "//") {
+        return Err(SecretSpecError::ProviderOperationFailed(
+            file::MISSING_DIRECTORY_ERROR.to_string(),
         ));
     }
     Ok(registration_for_scheme(scheme).is_some())
@@ -1596,17 +1608,28 @@ pub(crate) fn provider_from_spec(
     //
     // Windows absolute paths (e.g. `dotenv://C:\path\.env`) need special care:
     // the drive-letter colon looks like a `host:port` separator and parsing
-    // fails with "invalid port number". Encode the whole path (drive colon and
-    // backslashes included) into an opaque host so it round-trips back out via
-    // `ProviderUrl::host()`. A Unix absolute path stays in the authority-less
-    // `scheme:///abs/path` form, which already parses cleanly.
+    // fails with "invalid port number". Custom schemes carry the encoded path
+    // in an opaque host so it round-trips through `ProviderUrl::host()`; the
+    // special `file` scheme uses its standard `file:///C:/...` form instead. A
+    // Unix absolute path already parses cleanly as `scheme:///abs/path`.
     let path_candidate = rest.trim_start_matches('/');
     let url_string = if is_windows_abs_path(path_candidate) {
-        format!(
-            "{}://{}",
-            scheme,
-            percent_encode(path_candidate.as_bytes(), WINDOWS_PATH_ENCODE_SET)
-        )
+        if scheme == "file" {
+            // `file` is a special URL scheme, so an encoded drive path cannot
+            // live in its host as it does for custom schemes. Use the standard
+            // authority-less file URL and normalize Windows separators.
+            let path = path_candidate.replace('\\', "/");
+            format!(
+                "file:///{}",
+                percent_encode(path.as_bytes(), URI_ENCODE_SET)
+            )
+        } else {
+            format!(
+                "{}://{}",
+                scheme,
+                percent_encode(path_candidate.as_bytes(), WINDOWS_PATH_ENCODE_SET)
+            )
+        }
     } else {
         let url_string = match rest {
             // Just scheme name (e.g., "keyring")
@@ -1778,6 +1801,13 @@ mod url_tests {
             "Windows dotenv path should parse, got {:?}",
             provider.err()
         );
+    }
+
+    #[test]
+    fn windows_file_path_uses_a_standard_file_url() {
+        let provider = Box::<dyn Provider>::try_from(r"file://C:\Users\foo\secrets").unwrap();
+        assert_eq!(provider.name(), "file");
+        assert_eq!(provider.uri(), "file:///C:/Users/foo/secrets");
     }
 
     #[test]

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -854,6 +854,15 @@ fn test_create_from_string_with_plain_names() {
     let provider = Box::<dyn Provider>::try_from("dotenv").unwrap();
     assert_eq!(provider.name(), "dotenv");
 
+    let Err(error) = Box::<dyn Provider>::try_from("file") else {
+        panic!("file should require an explicit directory");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("requires an explicit relative or absolute directory path")
+    );
+
     // Test onepassword separately to debug the issue
     match Box::<dyn Provider>::try_from("onepassword") {
         Ok(provider) => assert_eq!(provider.name(), "onepassword"),
@@ -957,6 +966,11 @@ fn test_documentation_examples() {
     // Test dotenv examples from provider list
     let provider = Box::<dyn Provider>::try_from("dotenv://path").unwrap();
     assert_eq!(provider.name(), "dotenv");
+
+    // File provider examples
+    let provider = Box::<dyn Provider>::try_from("file:./.secrets").unwrap();
+    assert_eq!(provider.name(), "file");
+    assert_eq!(provider.uri(), "file://./.secrets");
 
     // Test pass examples
     let provider = Box::<dyn Provider>::try_from("pass://").unwrap();
@@ -1094,6 +1108,13 @@ mod integration_tests {
                 let provider_spec = format!("dotenv:{}", dotenv_path.to_str().unwrap());
                 let provider = Box::<dyn Provider>::try_from(provider_spec.as_str())
                     .expect("Should create dotenv provider with path");
+                (provider, Some(temp_dir))
+            }
+            "file" => {
+                let temp_dir = TempDir::new().expect("Create temp directory");
+                let provider_spec = format!("file:{}", temp_dir.path().display());
+                let provider = Box::<dyn Provider>::try_from(provider_spec.as_str())
+                    .expect("Should create file provider with path");
                 (provider, Some(temp_dir))
             }
             "pass" => {
@@ -2159,6 +2180,17 @@ fn dotenv_write_read_symmetry() {
     let dir = TempDir::new().unwrap();
     let provider = DotEnvProvider::new(DotEnvConfig {
         path: dir.path().join(".env"),
+    });
+    assert_write_read_symmetry(&provider);
+}
+
+#[test]
+fn file_write_read_symmetry() {
+    use super::file::{FileConfig, FileProvider};
+
+    let dir = TempDir::new().unwrap();
+    let provider = FileProvider::new(FileConfig {
+        directory: dir.path().to_path_buf(),
     });
     assert_write_read_symmetry(&provider);
 }

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -3,8 +3,8 @@
 use crate::audit::{AuditAction, AuditContext, AuditLogger, AuditOutcome};
 use crate::cache::{self, CacheEntryStatus, CacheOwnership};
 use crate::config::{
-    Config, CredentialSource, GlobalConfig, NativeAddress, Profile, ProviderAlias, RequireReason,
-    Resolved, SecretEncoding,
+    Config, CredentialSource, ExtractFormat, GlobalConfig, NativeAddress, Profile, ProviderAlias,
+    RequireReason, Resolved, SecretEncoding, SecretExtract,
 };
 use crate::error::{Result, SecretSpecError};
 use crate::manifest::{CompiledManifest, MissingPolicy};
@@ -1571,8 +1571,47 @@ impl Secrets {
         Ok(())
     }
 
-    /// Decode a stored representation independently of its exposure shape, then
-    /// either return UTF-8 text or materialize the bytes to an owner-only file.
+    /// Select one logical value from a structured stored representation.
+    /// Diagnostics deliberately include only the secret name, format, pointer,
+    /// and parser location — never the stored document or selected value.
+    pub(crate) fn extract_stored_value(
+        extract: &SecretExtract,
+        diagnostic_name: &str,
+        value: &str,
+    ) -> Result<SecretString> {
+        match extract.format {
+            ExtractFormat::Json => {
+                let document: serde_json::Value =
+                    serde_json::from_str(value).map_err(|error| SecretSpecError::DecodeFailed {
+                        name: diagnostic_name.to_string(),
+                        encoding: extract.format.as_str(),
+                        reason: format!("stored value is not valid JSON: {error}"),
+                    })?;
+                let selected = document.pointer(&extract.pointer).ok_or_else(|| {
+                    SecretSpecError::DecodeFailed {
+                        name: diagnostic_name.to_string(),
+                        encoding: extract.format.as_str(),
+                        reason: format!(
+                            "JSON Pointer '{}' did not match the stored document",
+                            extract.pointer
+                        ),
+                    }
+                })?;
+                let selected = match selected {
+                    serde_json::Value::String(value) => value.clone(),
+                    value => {
+                        serde_json::to_string(value).expect("serializing JSON value cannot fail")
+                    }
+                };
+                Ok(SecretString::new(selected.into()))
+            }
+        }
+    }
+
+    /// Decode and extract a stored representation independently of its exposure
+    /// shape, then either return UTF-8 text or materialize the bytes to an
+    /// owner-only file. Extraction follows decoding and applies only across a
+    /// storage boundary; defaults and generated values are already logical.
     fn prepare_resolved(
         &self,
         planned: &PlannedSecret,
@@ -1588,13 +1627,38 @@ impl Secrets {
             _ => None,
         };
 
+        let extracted = match (representation, planned.extract()) {
+            (ResolvedRepresentation::Stored, Some(extract)) => {
+                let text = match &decoded {
+                    Some((encoding, decoded)) => {
+                        std::str::from_utf8(decoded.expose_secret()).map_err(|error| {
+                            SecretSpecError::DecodeFailed {
+                                name: diagnostic_name.to_string(),
+                                encoding: encoding.as_str(),
+                                reason: format!(
+                                    "decoded bytes are not valid UTF-8 and cannot be extracted as {} ({error})",
+                                    extract.format.as_str()
+                                ),
+                            }
+                        })?
+                    }
+                    None => value.expose_secret(),
+                };
+                Some(Self::extract_stored_value(extract, diagnostic_name, text)?)
+            }
+            _ => None,
+        };
+
         if planned.as_path() {
-            let bytes = decoded
+            let bytes = extracted
                 .as_ref()
-                .map(|(_, decoded)| decoded.expose_secret())
+                .map(|value| value.expose_secret().as_bytes())
+                .or_else(|| decoded.as_ref().map(|(_, decoded)| decoded.expose_secret()))
                 .unwrap_or_else(|| value.expose_secret().as_bytes());
             let (owner, path) = self.write_secret_to_temp_file(bytes)?;
             Ok(PreparedSecret::File { owner, path })
+        } else if let Some(extracted) = extracted {
+            Ok(PreparedSecret::Inline(extracted))
         } else if let Some((encoding, decoded)) = decoded {
             let text = std::str::from_utf8(decoded.expose_secret()).map_err(|error| {
                 SecretSpecError::DecodeFailed {
@@ -1613,11 +1677,11 @@ impl Secrets {
         }
     }
 
-    /// Inserts a resolved secret into the working set, decoding its optional
-    /// storage encoding when the value crossed a storage boundary, then
-    /// transparently materializing an `as_path` value to an owner-only temp
-    /// file whose lifetime is tied to `temp_files`. Shared by every resolution
-    /// branch so decoding and temp-file handling cannot drift.
+    /// Inserts a resolved secret into the working set, applying its optional
+    /// storage decoding and extraction when the value crossed a storage
+    /// boundary, then transparently materializing an `as_path` value to an
+    /// owner-only temp file whose lifetime is tied to `temp_files`. Shared by
+    /// every resolution branch so stored-value transforms cannot drift.
     fn insert_resolved(
         &self,
         secrets: &mut HashMap<String, SecretString>,
@@ -3017,6 +3081,19 @@ impl Secrets {
             return Err(err);
         };
 
+        if planned.extract().is_some() {
+            let err = SecretSpecError::ExtractedSecretReadOnly(name.to_string());
+            self.record_key_error(
+                AuditAction::Set,
+                &profile_name,
+                name,
+                route.primary().map(str::to_string),
+                planned.reference(),
+                &err,
+            );
+            return Err(err);
+        }
+
         let backend = match self.write_provider_for_route(route, Some(&profile_name)) {
             Ok(backend) => backend,
             Err(err) => {
@@ -3139,6 +3216,18 @@ impl Secrets {
             self.record_key_error(AuditAction::Delete, &profile_name, name, None, None, &error);
             return Err(error);
         };
+        if planned.extract().is_some() {
+            let error = SecretSpecError::ExtractedSecretReadOnly(name.to_string());
+            self.record_key_error(
+                AuditAction::Delete,
+                &profile_name,
+                name,
+                route.primary().map(str::to_string),
+                planned.reference(),
+                &error,
+            );
+            return Err(error);
+        }
         let backend = match self.write_provider_for_route(route, Some(&profile_name)) {
             Ok(backend) => backend,
             Err(error) => {
@@ -3450,6 +3539,15 @@ impl Secrets {
                         self.scoped_promptable_missing(&validation_errors, &profile_display)?;
                     if missing.is_empty() {
                         return Err(validation_failure(validation_errors));
+                    }
+                    // Extraction cannot be inverted into a containing document.
+                    // Reject the whole interactive write pass before prompting
+                    // for (and possibly storing) any earlier secret.
+                    if let Some(name) = missing.iter().find(|name| {
+                        self.resolve_secret_config(name, Some(&profile_display))
+                            .is_some_and(|secret| secret.extract.is_some())
+                    }) {
+                        return Err(SecretSpecError::ExtractedSecretReadOnly(name.clone()));
                     }
                     let total = missing.len();
                     // Name the provider without constructing it: this value is
@@ -3813,6 +3911,12 @@ impl Secrets {
                     continue;
                 };
 
+                if planned.extract().is_some() {
+                    return Err(SecretSpecError::ExtractedSecretReadOnly(
+                        planned.name.clone(),
+                    ));
+                }
+
                 read_names.push(name.clone());
                 let source_address = self.address_for_spec(
                     &planned,
@@ -3842,7 +3946,6 @@ impl Secrets {
                         from_provider_instance.uri()
                     )));
                 }
-
                 let source_value = from_provider_instance.get(source_address.as_address())?;
                 let target_value = target_provider.get(target_address.as_address())?;
 
@@ -4156,6 +4259,11 @@ impl Secrets {
             Some(config) if config.is_enabled() => config,
             _ => return Ok(None),
         };
+        if planned.extract().is_some() {
+            return Err(SecretSpecError::ExtractedSecretReadOnly(
+                planned.name.clone(),
+            ));
+        }
 
         let secret_type = match &planned.config().secret_type {
             Some(t) => t.as_str(),

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -5042,6 +5042,119 @@ BAD = { description = "invalid base64", encoding = "base64" }
 }
 
 #[test]
+fn test_json_extract_resolves_structured_values_after_decoding() {
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let store = temp_dir.path().join("store");
+    fs::create_dir(&store).unwrap();
+    let document_path = store.join("application.json");
+    let document = r#"{
+  "database": {
+    "password": "p@ss\nword",
+    "port": 5432,
+    "enabled": true,
+    "nullable": null,
+    "options": { "ssl": true },
+    "hosts": ["db-a", "db-b"]
+  },
+  "a/b": { "~key": "escaped" }
+}"#;
+    fs::write(&document_path, document).unwrap();
+    fs::write(
+        store.join("encoded.json"),
+        "eyJkYXRhIjp7InRva2VuIjoiYWJjIn19",
+    )
+    .unwrap();
+
+    let config_file = temp_dir.path().join("secretspec.toml");
+    let store_uri = toml::Value::String(format!("file:{}", store.display())).to_string();
+    fs::write(
+        &config_file,
+        format!(
+            r#"[project]
+name = "test-json-extract"
+revision = "1.0"
+require_reason = false
+
+[providers]
+documents = {store_uri}
+
+[profiles.default]
+PASSWORD = {{ description = "password", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/password" }} }}
+PORT = {{ description = "port", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/port" }} }}
+ENABLED = {{ description = "enabled", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/enabled" }} }}
+NULL_VALUE = {{ description = "null", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/nullable" }} }}
+OPTIONS = {{ description = "object", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/options" }} }}
+HOSTS = {{ description = "array", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/hosts" }} }}
+ESCAPED = {{ description = "escaped pointer", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/a~1b/~0key" }} }}
+OPTIONS_FILE = {{ description = "object as file", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/options" }}, as_path = true }}
+ENCODED = {{ description = "decoded document", providers = ["documents"], ref = {{ item = "encoded.json" }}, encoding = "base64", extract = {{ format = "json", pointer = "/data/token" }} }}
+FALLBACK = {{ description = "logical default", providers = ["documents"], ref = {{ item = "missing.json" }}, extract = {{ format = "json", pointer = "/ignored" }}, default = "already-logical" }}
+"#
+        ),
+    )
+    .unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    let spec = Secrets::new(config, None, None, None);
+    let validated = spec.validate().unwrap().unwrap();
+    let values = &validated.resolved.secrets;
+    assert_eq!(values["PASSWORD"].expose_secret(), "p@ss\nword");
+    assert_eq!(values["PORT"].expose_secret(), "5432");
+    assert_eq!(values["ENABLED"].expose_secret(), "true");
+    assert_eq!(values["NULL_VALUE"].expose_secret(), "null");
+    assert_eq!(values["OPTIONS"].expose_secret(), r#"{"ssl":true}"#);
+    assert_eq!(values["HOSTS"].expose_secret(), r#"["db-a","db-b"]"#);
+    assert_eq!(values["ESCAPED"].expose_secret(), "escaped");
+    assert_eq!(values["ENCODED"].expose_secret(), "abc");
+    assert_eq!(values["FALLBACK"].expose_secret(), "already-logical");
+    assert_eq!(
+        fs::read_to_string(values["OPTIONS_FILE"].expose_secret()).unwrap(),
+        r#"{"ssl":true}"#
+    );
+
+    let original = fs::read_to_string(&document_path).unwrap();
+    let set_error = spec.set("PASSWORD", Some("new".to_string())).unwrap_err();
+    assert!(matches!(
+        set_error,
+        SecretSpecError::ExtractedSecretReadOnly(ref name) if name == "PASSWORD"
+    ));
+    let delete_error = spec.delete("PASSWORD").unwrap_err();
+    assert!(matches!(
+        delete_error,
+        SecretSpecError::ExtractedSecretReadOnly(ref name) if name == "PASSWORD"
+    ));
+    let import_error = spec
+        .import(&format!("file:{}", store.display()))
+        .unwrap_err();
+    assert!(matches!(
+        import_error,
+        SecretSpecError::ExtractedSecretReadOnly(_)
+    ));
+    assert_eq!(fs::read_to_string(document_path).unwrap(), original);
+}
+
+#[test]
+fn test_json_extract_errors_do_not_expose_stored_documents() {
+    use crate::config::{ExtractFormat, SecretExtract};
+
+    let extract = SecretExtract {
+        format: ExtractFormat::Json,
+        pointer: "/database/password".to_string(),
+    };
+    for stored in [
+        r#"{"database":"sensitive-invalid-document""#,
+        r#"{"other":"sensitive-missing-pointer"}"#,
+    ] {
+        let error = Secrets::extract_stored_value(&extract, "PASSWORD", stored).unwrap_err();
+        assert_eq!(error.kind(), "decode_failed");
+        assert!(error.to_string().contains("using json"));
+        assert!(!error.to_string().contains("sensitive"));
+    }
+}
+
+#[test]
 fn test_binary_decoded_secret_requires_as_path() {
     use std::fs;
 
@@ -5712,6 +5825,7 @@ fn test_resolve_secret_config_merges_type_and_generate() {
             refs: None,
             as_path: None,
             encoding: None,
+            extract: None,
             secret_type: Some("password".to_string()),
             generate: Some(crate::config::GenerateConfig::Bool(true)),
         },


### PR DESCRIPTION
## Summary

- add a built-in `file` provider that stores each secret as a plaintext file under a configurable root
- support convention-based project/profile/key paths and explicit nested item references
- use atomic writes with restrictive Unix permissions and reject path traversal, symlinks, absolute item paths, binary data, and unsafe path forms
- add provider-independent `extract = { format = "json", pointer = "/…" }` support for selecting logical secrets from structured stored values
- apply JSON extraction after optional Base64/hex decoding and before `as_path`, including provider-native field composition
- keep extracted secrets read-only so writes, deletes, generation, prompting, and imports cannot replace a containing document and its sibling values
- add generic provider coverage, focused extraction tests, changelog entries, and all required 0.19+ documentation

## Why

The file provider gives local workflows and simple integrations a transparent filesystem-backed option while keeping SecretSpec's profile isolation and provider URI conventions.

Generic extraction lets any provider return a structured JSON document without making JSON parsing provider-specific. Multiple declarations can select nested values from the same document using RFC 6901 JSON Pointers.

## User impact

Users can configure `file:` or `file:<root>`; the default root is `.secretspec/secrets` relative to the manifest. Secret values are stored exactly as UTF-8 text at `<root>/<project>/<profile>/<key>`.

Declarations can add `extract = { format = "json", pointer = "/database/password" }`. JSON strings resolve to their unquoted contents; other JSON values use compact JSON rendering. Invalid JSON and missing pointers fail without exposing stored values. Defaults remain logical values and are not extracted.

Because the file provider stores plaintext secrets, its documentation calls out filesystem permissions, backup, and source-control risks.

## Validation

- `cargo test --all -j 2`
- `cargo test --package secretspec -j 2`
- focused file-provider and extraction tests
- `npm --prefix docs run check:provider-credentials`
- `npm --prefix docs run build`
- repository Clippy and Rustfmt hooks
- `git diff --check`
