### PR TITLE
Add Windows ARM64 CLI release artifacts

### DIFF
--- a/.github/workflows/cli-artifacts.yml
+++ b/.github/workflows/cli-artifacts.yml
@@ -21,10 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install dist
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.28.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -59,6 +60,7 @@ jobs:
         run: git config --global core.longpaths true
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install Rust in the build container
         if: ${{ matrix.container }}
@@ -109,6 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install cached dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -58,12 +58,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.28.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -117,6 +118,7 @@ jobs:
           git config --global core.longpaths true
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install Rust non-interactively if not already installed
         if: ${{ matrix.container }}
@@ -175,6 +177,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install cached dist
         uses: actions/download-artifact@v4
@@ -224,6 +227,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Install cached dist
         uses: actions/download-artifact@v4
@@ -288,4 +292,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: recursive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Windows ARM64 CLI release artifacts (`aarch64-pc-windows-msvc`).
 - Secrets can store values as standard Base64, URL-safe Base64, or hexadecimal
   using `encoding`; writes encode logical text and reads decode stored values,
   while `as_path = true` materializes arbitrary decoded bytes.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.28.2"
+cargo-dist-version = "0.29.0"
 # CI backends to support
 ci = "github"
 # Only root release tags (vX.Y.Z) should invoke cargo-dist. Language SDKs in
@@ -18,7 +18,7 @@ installers = ["shell"]
 # so a whole-workspace release build fails; precise builds skip them.
 precise-builds = true
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-pc-windows-msvc", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
@@ -29,3 +29,7 @@ install-updater = true
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
 aarch64-apple-darwin = "macos-latest"
 x86_64-apple-darwin = "macos-15"
+
+# Build Windows ARM64 on the same x64 Windows runners as MSVC x64 (cargo-dist 0.29+).
+[dist.github-custom-runners.aarch64-pc-windows-msvc]
+runner = "windows-2022"


### PR DESCRIPTION
## Summary
GitHub Releases (e.g. v0.18.0) only shipped `secretspec-x86_64-pc-windows-msvc.zip` because `dist-workspace.toml` did not list Windows ARM64.

This adds `aarch64-pc-windows-msvc` and builds it on the existing `windows-2022` x64 runners via cargo-dist 0.29.0 (Windows→Windows cross-compile support).

## Changes
- `dist-workspace.toml`: cargo-dist `0.28.2` → `0.29.0`, add `aarch64-pc-windows-msvc`, pin runner to `windows-2022`
- `.github/workflows/v-release.yml`: installer pin to v0.29.0 + `persist-credentials: false` (from `dist generate`)
- `.github/workflows/cli-artifacts.yml`: same pin / checkout tweak for the non-publishing artifact workflow
- `CHANGELOG.md`: Unreleased note for Windows ARM64 CLI artifacts

`dist plan` (cargo-dist 0.29.0) includes:
- runner `windows-2022`, target `aarch64-pc-windows-msvc` (no container)
- artifacts `secretspec-aarch64-pc-windows-msvc.zip` (+ update/sha256)

## Out of scope
Language SDK native matrices (Node/FFI/.NET/etc.) remain Windows x64-only; this only covers the CLI release path.

## Test plan
- [x] `dist plan` shows `windows-2022` / `aarch64-pc-windows-msvc` and the ARM64 zip
- [ ] After merge, next `vX.Y.Z` release includes `secretspec-aarch64-pc-windows-msvc.zip`