### PR TITLE
Publish SecretSpec through WinGet

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,43 @@
+name: Publish to WinGet
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Published GitHub release tag to submit (for example, v0.19.0)"
+        required: true
+        type: string
+  # cargo-dist creates the GitHub Release with GITHUB_TOKEN, which does not
+  # emit another `release` workflow event. Wait for the Release workflow
+  # instead so WinGet Releaser sees the published Windows ZIP.
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: winget-${{ inputs.release_tag || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v') &&
+        !contains(github.event.workflow_run.head_branch, '-')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit WinGet manifest
+        uses: vedantmgoyal9/winget-releaser@b3a5dae0047c6180023acba3f548c55fdf6b7193 # main
+        with:
+          identifier: Cachix.SecretSpec
+          installers-regex: '^secretspec-x86_64-pc-windows-msvc\.zip$'
+          release-tag: ${{ inputs.release_tag || github.event.workflow_run.head_branch }}
+          fork-user: domenkozar
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -148,6 +148,24 @@ intentionally leaves the checksum alone, making a missing checksum refresh
 visible during release review. There is no Swift registry credential or
 separate repository.
 
+### WinGet — bootstrap submission pending
+
+[`winget-releaser`](https://github.com/vedantmgoyal9/winget-releaser)
+requires one package version in the WinGet Community Repository before it can
+derive future manifests. `Cachix.SecretSpec` 0.18.0 is the manual bootstrap:
+
+1. Merge the initial manifest submission in
+   [microsoft/winget-pkgs#413776](https://github.com/microsoft/winget-pkgs/pull/413776).
+2. Create a classic GitHub personal access token for `domenkozar` with only the
+   `public_repo` scope. The action does not support fine-grained tokens.
+3. Store it as the `WINGET_TOKEN` repository secret. The action uses the
+   `domenkozar/winget-pkgs` fork created for the bootstrap submission.
+
+After this one-time setup, `winget.yml` runs after each successful stable
+`Release` workflow and submits the matching
+`secretspec-x86_64-pc-windows-msvc.zip`. Manual dispatch accepts an existing
+published release tag for recovery or retry. Prerelease tags are skipped.
+
 ## Python (PyPI) — `python-wheels.yml`
 
 - **Build:** the Rust resolver is statically linked into a pyo3 extension

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -27,6 +27,13 @@ If you installed SecretSpec through Nix or another package manager, update it
 through that package manager instead.
 
 </TabItem>
+<TabItem label="WinGet">
+
+```powershell
+winget install --exact --id Cachix.SecretSpec
+```
+
+</TabItem>
 <TabItem label="Devenv.sh">
 
 Add to your `devenv.nix`:


### PR DESCRIPTION
## Summary

- add WinGet to the Quick Start installation tabs
- automate future stable WinGet submissions with `winget-releaser`
- document the one-time bootstrap and token setup for maintainers

## Why

Windows users should be able to install SecretSpec from the primary guide,
and new SecretSpec releases should update WinGet alongside the other release
channels instead of relying on manual manifest maintenance.

## Publication dependency

- Initial `Cachix.SecretSpec` 0.18.0 manifest:
  https://github.com/microsoft/winget-pkgs/pull/413776
- That bootstrap must merge before the documented install command works and
  before `winget-releaser` can derive later versions.
- The `WINGET_TOKEN` repository secret still needs a classic PAT with
  `public_repo` scope for the `domenkozar/winget-pkgs` fork.

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/winget.yml`
- `devenv shell npm --prefix docs run astro -- check` (0 errors)
- official WinGet 1.12 JSON schemas for all bootstrap manifest files
- release ZIP checksum verified against the published SHA-256
- `git diff --check`
