### PR TITLE
ci(workflows): restrict token permissions

### DIFF
--- a/.github/workflows/auto-tag-latest.yml
+++ b/.github/workflows/auto-tag-latest.yml
@@ -3,9 +3,14 @@ on:
   push:
     tags:
       - v**
+
+permissions: {}
+
 jobs:
   latest-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Update 'latest' git tag

--- a/.github/workflows/go-embed.yml
+++ b/.github/workflows/go-embed.yml
@@ -37,6 +37,9 @@ on:
       - ".github/workflows/go-embed.yml"
       - "scripts/check-linux-portability.sh"
 
+permissions:
+  contents: read
+
 jobs:
   embed:
     name: ${{ matrix.target }}

--- a/.github/workflows/go-static.yml
+++ b/.github/workflows/go-static.yml
@@ -37,6 +37,9 @@ on:
       - "secretspec-ffi/**"
       - ".github/workflows/go-static.yml"
 
+permissions:
+  contents: read
+
 jobs:
   static:
     name: x86_64-linux-musl (fully static)

--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -35,6 +35,9 @@ on:
     tags:
       - v**
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -40,6 +40,9 @@ on:
       - ".github/workflows/node-addon.yml"
       - "scripts/sync-sdk-versions.sh"
 
+permissions:
+  contents: read
+
 jobs:
   addon:
     name: ${{ matrix.target }}

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -34,6 +34,9 @@ on:
       - ".github/workflows/python-wheels.yml"
       - "scripts/sync-sdk-versions.sh"
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: wheel ${{ matrix.arch }} (manylinux)

--- a/.github/workflows/ruby-gems.yml
+++ b/.github/workflows/ruby-gems.yml
@@ -37,6 +37,9 @@ on:
       - "scripts/sync-sdk-versions.sh"
       - "scripts/copy-mingw-import-libs.sh"
 
+permissions:
+  contents: read
+
 jobs:
   gems:
     name: ${{ matrix.target }}

--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -11,6 +11,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   sdks:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 # Do not let superseded revisions occupy the limited macOS runner pool.
 concurrency:
   group: ${{ github.workflow }}-test-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

- Set explicit `contents: read` permissions for build and test workflows.
- Use deny-by-default permissions for the latest-tag workflow and grant `contents: write` only to its tag-moving job.
- Preserve the existing job-local write and OIDC permissions required for publication.

## Rationale

Several workflows currently rely on the repository's default `GITHUB_TOKEN` permissions. This can give ordinary build jobs broader access than they need, particularly when reusable release workflows are called with a `contents: write` permission ceiling.

The reusable workflow callers retain their existing write ceilings because GitHub validates the permissions requested by all declared jobs before evaluating job conditions. The new workflow-level `contents: read` defaults ensure that non-publishing build jobs remain read-only, while existing release jobs can still request their explicitly declared publication permissions.

## Validation

- `devenv shell -- actionlint -shellcheck=`
- `devenv shell -- pre-commit run -a`
- Zizmor regular-persona scan: maintained-workflow `excessive-permissions` findings reduced from 24 to 0