### PR TITLE
ci(workflows): stop persisting checkout credentials

### DIFF
--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -78,6 +78,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         shell: bash
         run: bash scripts/sync-sdk-versions.sh
@@ -172,6 +174,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
       - name: Build dynamically loadable musl resolver
@@ -237,6 +241,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
       - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
@@ -314,6 +320,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dotnet-nuget

--- a/.github/workflows/ffi-build.yml
+++ b/.github/workflows/ffi-build.yml
@@ -59,6 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install rustup (the manylinux container ships none)
         if: matrix.container

--- a/.github/workflows/go-embed.yml
+++ b/.github/workflows/go-embed.yml
@@ -60,6 +60,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install rustup (the manylinux container ships none)
         if: matrix.container

--- a/.github/workflows/go-static.yml
+++ b/.github/workflows/go-static.yml
@@ -46,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # The musl rebuild of the full provider stack plus the Nix store overflows
       # the ~14GB free on a hosted runner.
       - name: Free up disk space

--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -43,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
       # The cdylib + CLI debug build (AWS/GCP/Bitwarden providers) plus the
@@ -98,6 +100,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
       - name: Install Rust (pinned by rust-toolchain.toml)

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -68,6 +68,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
 

--- a/.github/workflows/php-ext.yml
+++ b/.github/workflows/php-ext.yml
@@ -70,6 +70,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -49,6 +49,8 @@ jobs:
           - { arch: aarch64, target: aarch64-unknown-linux-gnu, runner: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
       - name: Build wheel (manylinux)
@@ -78,6 +80,8 @@ jobs:
           - { target: windows-x86_64, runner: windows-latest }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
       - name: Install Rust (pinned by rust-toolchain.toml)

--- a/.github/workflows/ruby-gems.yml
+++ b/.github/workflows/ruby-gems.yml
@@ -55,6 +55,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
 

--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # The full workspace debug build (AWS/GCP/Bitwarden providers) plus the
       # Nix store overflows the ~14GB free on a hosted runner.
       # /usr/share/dotnet is safe to purge: the C# suite uses devenv's dotnet.
@@ -43,6 +45,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
       - name: Build the native resolver

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: |
           rustup toolchain install
@@ -78,6 +80,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Verify the committed Swift binary version
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     # The full devenv shell includes every SDK toolchain plus the musl static
     # dependencies. It no longer fits alongside the preinstalled software on
     # GitHub's Ubuntu image, so reclaim that space before populating /nix.
@@ -73,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Install Rust
       run: rustup toolchain install stable --profile minimal
     - name: Cache Rust builds
@@ -90,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Install Rust
       run: rustup toolchain install stable --profile minimal
     - name: Verify the published crate contains its schema fixture
@@ -109,6 +115,8 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Download SOPS 3.13.2
       uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
       with:


### PR DESCRIPTION
## Summary

- Set `persist-credentials: false` on 22 checkout steps used by build and test jobs.
- Leave the eight tag-moving and publication checkouts unchanged for separate review.
- Preserve the workflows that intentionally use authenticated Git operations.

## Rationale

`actions/checkout` persists its authentication token in the local Git configuration by default. These build and test jobs do not perform authenticated Git operations, so retaining those credentials gives subsequent steps and uploaded workspace content unnecessary access to the token.

This change limits credential availability without changing the upcoming release paths. In particular, it leaves `auto-tag-latest` and the Go embedded release job unchanged because they update Git refs.

The remaining publication jobs can be reviewed independently against their tag-only behavior.

## Validation

- `devenv shell -- actionlint -shellcheck=`
- `devenv shell -- pre-commit run -a`
- Zizmor regular-persona `artipacked` findings reduced from 30 to 8