### PR TITLE
ci(workflows): verify rustup bootstrap

### DIFF
--- a/.github/workflows/dotnet-package.yml
+++ b/.github/workflows/dotnet-package.yml
@@ -27,6 +27,7 @@ on:
       - "secretspec-dotnet/**"
       - "secretspec-ffi/**"
       - ".github/workflows/dotnet-package.yml"
+      - "scripts/install-rustup.sh"
       - "scripts/sync-sdk-versions.sh"
 
 permissions:
@@ -89,12 +90,11 @@ jobs:
         shell: bash
         run: yum install -y libicu
 
-      - name: Install rustup in manylinux
+      - name: Install verified rustup in manylinux
         if: matrix.container
         shell: bash
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
-            sh -s -- -y --default-toolchain none
+          bash scripts/install-rustup.sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust
@@ -189,8 +189,7 @@ jobs:
             "${{ matrix.image }}" \
             bash -c '
               set -euo pipefail
-              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs |
-                sh -s -- -y --default-toolchain none
+              bash scripts/install-rustup.sh
               export PATH="$HOME/.cargo/bin:$PATH"
               rustup toolchain install
               cargo build -p secretspec-ffi --release \

--- a/.github/workflows/ffi-build.yml
+++ b/.github/workflows/ffi-build.yml
@@ -30,6 +30,7 @@ on:
       - "secretspec-ffi/**"
       - ".github/workflows/ffi-build.yml"
       - "scripts/check-linux-portability.sh"
+      - "scripts/install-rustup.sh"
 
 jobs:
   build:
@@ -62,11 +63,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install rustup (the manylinux container ships none)
+      - name: Install verified rustup (the manylinux container ships none)
         if: matrix.container
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
-            sh -s -- -y --default-toolchain none
+          bash scripts/install-rustup.sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust (pinned by rust-toolchain.toml)

--- a/.github/workflows/go-embed.yml
+++ b/.github/workflows/go-embed.yml
@@ -36,6 +36,7 @@ on:
       - "secretspec-ffi/**"
       - ".github/workflows/go-embed.yml"
       - "scripts/check-linux-portability.sh"
+      - "scripts/install-rustup.sh"
 
 permissions:
   contents: read
@@ -63,11 +64,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install rustup (the manylinux container ships none)
+      - name: Install verified rustup (the manylinux container ships none)
         if: matrix.container
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
-            sh -s -- -y --default-toolchain none
+          bash scripts/install-rustup.sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust (pinned by rust-toolchain.toml)

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -38,6 +38,7 @@ on:
     paths:
       - "secretspec-node/**"
       - ".github/workflows/node-addon.yml"
+      - "scripts/install-rustup.sh"
       - "scripts/sync-sdk-versions.sh"
 
 permissions:
@@ -73,10 +74,10 @@ jobs:
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
 
-      - name: Install rustup (the manylinux container ships none)
+      - name: Install verified rustup (the manylinux container ships none)
         if: matrix.container
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+          bash scripts/install-rustup.sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Install Rust (pinned by rust-toolchain.toml)

--- a/scripts/install-rustup.sh
+++ b/scripts/install-rustup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Install a pinned rustup bootstrap in Linux build containers that do not ship
+# Rust. The compiler toolchain remains pinned separately by rust-toolchain.toml.
+set -euo pipefail
+
+# When updating, verify each digest against the matching rustup-init.sha256 at
+# https://static.rust-lang.org/rustup/archive/<version>/<target>/.
+rustup_version="1.29.0"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "install-rustup.sh only supports Linux build containers" >&2
+  exit 2
+fi
+
+case "$(uname -m)" in
+  x86_64 | amd64)
+    rustup_arch="x86_64"
+    ;;
+  aarch64 | arm64)
+    rustup_arch="aarch64"
+    ;;
+  *)
+    echo "unsupported rustup architecture: $(uname -m)" >&2
+    exit 2
+    ;;
+esac
+
+rustup_libc="gnu"
+ldd_version="$(ldd --version 2>&1 || true)"
+if [[ "$ldd_version" == *musl* ]]; then
+  rustup_libc="musl"
+fi
+rustup_target="${rustup_arch}-unknown-linux-${rustup_libc}"
+
+case "$rustup_target" in
+  x86_64-unknown-linux-gnu)
+    expected_sha256="4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10"
+    ;;
+  aarch64-unknown-linux-gnu)
+    expected_sha256="9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792"
+    ;;
+  x86_64-unknown-linux-musl)
+    expected_sha256="9cd3fda5fd293890e36ab271af6a786ee22084b5f6c2b83fd8323cec6f0992c1"
+    ;;
+  aarch64-unknown-linux-musl)
+    expected_sha256="88761caacddb92cd79b0b1f939f3990ba1997d701a38b3e8dd6746a562f2a759"
+    ;;
+esac
+
+rustup_init="$(mktemp "${TMPDIR:-/tmp}/rustup-init.XXXXXX")"
+trap 'rm -f "$rustup_init"' EXIT
+rustup_url="https://static.rust-lang.org/rustup/archive/${rustup_version}/${rustup_target}/rustup-init"
+
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+  "$rustup_url" --output "$rustup_init"
+
+if command -v sha256sum >/dev/null; then
+  actual_sha256="$(sha256sum "$rustup_init" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null; then
+  actual_sha256="$(shasum -a 256 "$rustup_init" | awk '{ print $1 }')"
+else
+  echo "sha256sum or shasum is required to verify rustup-init" >&2
+  exit 1
+fi
+
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+  echo "rustup-init checksum mismatch for $rustup_target" >&2
+  echo "expected: $expected_sha256" >&2
+  echo "actual:   $actual_sha256" >&2
+  exit 1
+fi
+
+chmod +x "$rustup_init"
+"$rustup_init" -y --default-toolchain none


### PR DESCRIPTION
## Summary

- add a shared Linux rustup bootstrap helper pinned to rustup 1.29.0
- verify the downloaded `rustup-init` binary against an in-repository SHA-256 digest for  GNU/musl on x86_64/aarch64
- replace five direct `sh.rustup.rs | sh` pipelines across the .NET, FFI, Go embed, and Node workflows
- run the affected workflows when the shared helper changes

## Rationale

The affected container jobs currently execute the response from the mutable `sh.rustup.rs` endpoint directly. Downloading a versioned `rustup-init` artifact and checking it against a pinned digest establishes the exact bytes before execution.

This only pins the rustup bootstrap itself. The Rust compiler toolchain remains managed separately through `rust-toolchain.toml`, so the resulting build toolchain and release behavior are unchanged.

The remaining installer pipelines in `cli-artifacts.yml` and the generated `v-release.yml` are intentionally left for a cargo-dist-native follow-up.

## Maintenance

Updating rustup requires changing the version and the four platform-specific digests together, using the corresponding official `rustup-init.sha256` files. This is manual maintenance outside Dependabot's GitHub Actions update flow.

## Validation

  - Bash syntax validation
  - ShellCheck
  - `actionlint`
  - runtime tests for GNU and musl on both x86_64 and aarch64
  - confirmed all pinned digests against the official rustup 1.29.0 checksum files