### PR TITLE
fix(providers): offer a per-provider address when a coordinate is unsupported

### DIFF
--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -470,6 +470,12 @@ impl<'a> Address<'a> {
 /// it came from, and how to fix it, so a `ref` written for one store fails
 /// loudly when routing points it at a store that cannot honor those
 /// coordinates, instead of silently resolving something else.
+///
+/// Both remedies are offered because dropping the coordinate is only right when
+/// every endpoint should share one address. When the coordinate is meaningful to
+/// the store the ref was written for — a Bitwarden or 1Password item field, say —
+/// and this store simply organizes the secret differently, the fix is a
+/// per-provider address (0.19+), not a lossy edit to the ref.
 fn reject_unsupported_coords(
     provider: &str,
     addr: &NativeAddress,
@@ -483,7 +489,9 @@ fn reject_unsupported_coords(
         if !supported.contains(&name) {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
                 "the {provider} provider does not support the `{name}` coordinate. \
-                 Drop `{name}` from the ref for `{item}`.",
+                 Drop `{name}` from the ref for `{item}`, or give this provider its \
+                 own address with `refs.<alias>` or an alias `ref` template (0.19+): \
+                 https://secretspec.dev/concepts/references/#different-coordinates-per-provider-019",
                 item = addr.item
             )));
         }

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -6212,6 +6212,19 @@ fn test_single_store_ref_rejects_unsupported_coordinate_up_front() {
                 msg.contains("dotenv"),
                 "message should name the store: {msg}"
             );
+            // Dropping the coordinate is only one of the two remedies, and it is
+            // the wrong one when the coordinate is meaningful to the store the
+            // ref was written for. The message must also point at a
+            // per-provider address, or a user whose ref legitimately needs
+            // `field` is left with no way forward.
+            assert!(
+                msg.contains("refs.<alias>"),
+                "message should offer a per-provider address: {msg}"
+            );
+            assert!(
+                msg.contains("concepts/references"),
+                "message should link the reference docs: {msg}"
+            );
         }
         other => panic!("expected ProviderOperationFailed, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

- name `refs.<alias>` / an alias `ref` template in the unsupported-coordinate error, alongside the existing "drop the coordinate" advice
- link the 0.19 reference docs from that message
- assert both remedies in the existing rejection test

## Why

The message currently offers one remedy:

```
the dotenv provider does not support the `field` coordinate.
Drop `field` from the ref for `shared-prod`.
```

Dropping the coordinate is correct when every endpoint should share one address.
It is the wrong advice when the coordinate is meaningful to the store the ref was
written for and another store simply organizes the secret differently — dropping
`field` would change which secret is addressed in Bitwarden, so the user cannot
follow the only instruction they are given.

That is the shape reported in #266. Since #292 there is a real answer —
per-provider addresses — but nothing in the failure path mentions it. After this
change:

```
the dotenv provider does not support the `field` coordinate. Drop `field` from
the ref for `shared-prod`, or give this provider its own address with
`refs.<alias>` or an alias `ref` template (0.19+):
https://secretspec.dev/concepts/references/#different-coordinates-per-provider-019
```

The wording stays generic because `reject_unsupported_coords` sees only the
provider, the coordinate, and the item — it cannot tell a route-wide `ref` from a
scoped one, and naming the alias would mean threading resolution context into the
provider layer for a diagnostic.

## Validation

- `cargo test -p secretspec` — 1172 passed; the 21 failures are `sops` tests on a
  machine without the `sops` CLI, identical before and after this change
- `cargo fmt --check` clean; `cargo clippy -p secretspec --all-targets` reports
  the same 20 pre-existing warnings before and after
- verified end to end against the #266 reproduction: a `kdbx` source with
  `ref = { item, field }` importing into a `dotenv` destination