### PR TITLE
Resolve a single secret by name, and reject credentials in provider URIs (0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- The Rust SDK can resolve a single secret with `Secrets::resolve_named`, which
+  reads only that secret and the inputs it composes from. An unrelated missing
+  required secret no longer fails the call, and the result distinguishes an
+  undeclared name (including one the active scope hides) from a declared secret
+  with no value, reporting whether that value was required.
+- `Secrets::with_default_reason` sets a session reason only when none is already
+  in effect, so an embedding application can describe itself without discarding
+  the reason its own caller supplied through `with_reason` or
+  `SECRETSPEC_REASON`.
+
+### Changed
+
+- `secretspec get` resolves through the same path as the SDK's `resolve_named`,
+  so a single-secret read makes exactly the decisions batch resolution makes. It
+  continues to read the whole profile regardless of an active scope, and audits
+  the coordinates it actually reached.
+
 ## [0.19.0] - 2026-08-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- The Rust SDK can resolve a single secret with `Secrets::resolve_named`, which
-  reads only that secret and the inputs it composes from. An unrelated missing
-  required secret no longer fails the call, and the result distinguishes an
-  undeclared name (including one the active scope hides) from a declared secret
-  with no value, reporting whether that value was required.
-- `Secrets::with_default_reason` sets a session reason only when none is already
-  in effect, so an embedding application can describe itself without discarding
-  the reason its own caller supplied through `with_reason` or
-  `SECRETSPEC_REASON`.
+## [0.19.0] - 2026-08-09
 
 ### Changed
 
@@ -35,16 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so a single-secret read makes exactly the decisions batch resolution makes. It
   continues to read the whole profile regardless of an active scope, and audits
   the coordinates it actually reached.
-
-## [0.19.0] - 2026-08-09
-
-### Changed
 - The Rust SDK's `ProviderAlias` now provides `leaf`, `credentials`, and
   `credentials_mut` helpers so callers can construct and inspect leaf or
   inline-cached aliases without depending on their storage representation.
 
 ### Added
 
+- The Rust SDK can resolve a single secret with `Secrets::resolve_named`, which
+  reads only that secret and the inputs it composes from. An unrelated missing
+  required secret no longer fails the call, and the result distinguishes an
+  undeclared name (including one the active scope hides) from a declared secret
+  with no value, reporting whether that value was required.
+- `Secrets::with_default_reason` sets a session reason only when none is already
+  in effect, so an embedding application can describe itself without discarding
+  the reason its own caller supplied through `with_reason` or
+  `SECRETSPEC_REASON`.
 - Profiles can opt out of inheriting `[profiles.default]` by setting
   `inherit = false` in their profile defaults (0.19+), allowing standalone
   secret sets alongside profiles that still share the default declarations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- A provider URI may no longer carry a credential. A URI with a password
+  (`scheme://user:secret@host`) is rejected, and `onepassword+token://` no
+  longer accepts the service account token in its userinfo
+  (`onepassword+token://token@vault`). A URI is committed to `secretspec.toml`,
+  echoed into shell history, and printed by CI, so a credential written there is
+  already disclosed and redacting it at the terminal cannot retract it. Keep the
+  scheme and supply the credential through a provider credential
+  (`secretspec config provider login <alias>`, or `credentials = { ... }` on the
+  alias) or the provider's environment variable; the errors name both. An
+  unparseable provider specification is now also redacted before it is reported.
 - `secretspec get` resolves through the same path as the SDK's `resolve_named`,
   so a single-secret read makes exactly the decisions batch resolution makes. It
   continues to read the whole profile regardless of an active scope, and audits

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -299,7 +299,7 @@ Provider credentials follow these rules:
   profiles should share one provider credential.
 - **Names are provider-specific.** The catalog above is exhaustive. Unsupported
   names are rejected before any source is read.
-- **A URI may not carry a credential (0.20+).** A provider URI with a password
+- **A URI may not carry a credential (0.19+).** A provider URI with a password
   (`scheme://user:secret@host`) is rejected, as is a service account token in
   the `onepassword+token://` userinfo. A URI is committed to `secretspec.toml`,
   echoed into shell history, and printed by CI, so a credential written there is

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -299,6 +299,12 @@ Provider credentials follow these rules:
   profiles should share one provider credential.
 - **Names are provider-specific.** The catalog above is exhaustive. Unsupported
   names are rejected before any source is read.
+- **A URI may not carry a credential (0.20+).** A provider URI with a password
+  (`scheme://user:secret@host`) is rejected, as is a service account token in
+  the `onepassword+token://` userinfo. A URI is committed to `secretspec.toml`,
+  echoed into shell history, and printed by CI, so a credential written there is
+  already disclosed. Use a provider credential or the provider's environment
+  variable instead.
 
 ## Next steps
 

--- a/docs/src/content/docs/providers/onepassword.mdx
+++ b/docs/src/content/docs/providers/onepassword.mdx
@@ -79,8 +79,16 @@ op = { uri = "onepassword://Production", credentials = { service_account_token =
 ```
 
 When no explicit `service_account_token` is supplied, the provider falls back
-to `OP_SERVICE_ACCOUNT_TOKEN` or the `onepassword+token://` URI scheme. These
-fallbacks also work in SecretSpec 0.14.
+to `OP_SERVICE_ACCOUNT_TOKEN`. The `onepassword+token://` scheme selects service
+account authentication and takes the token from one of those two sources.
+
+:::caution
+From SecretSpec 0.20 on, the token may not be written into the URI itself
+(`onepassword+token://token@vault` and `onepassword+token://account:token@vault`
+are rejected). A URI reaches committed manifests, shell history, and CI logs, so
+the token belongs in a provider credential or the environment. Keep the scheme
+and drop the token: `onepassword+token://Production`.
+:::
 
 ### Manual signin (legacy)
 
@@ -98,12 +106,15 @@ expire after 30 minutes of inactivity; if they expire mid-session,
 
 ```
 onepassword://[account@]vault
-onepassword+token://[token@]vault
+onepassword+token://vault
 ```
 
 - `account`: Optional account shorthand
 - `vault`: Target vault name (defaults to "Private")
-- `token`: Service account token
+
+The `onepassword+token://` form selects service account authentication; supply
+the token as the `service_account_token` provider credential or through
+`OP_SERVICE_ACCOUNT_TOKEN`.
 
 The URI names a vault only; item paths (e.g. `onepassword://Vault/item/field`)
 are rejected. To name a specific item, see [Use existing secrets](#use-existing-secrets).
@@ -113,7 +124,7 @@ are rejected. To name a specific item, see [Use existing secrets](#use-existing-
 ```text
 onepassword://Production
 onepassword://work@DevVault
-onepassword+token://ops_token123@Production
+onepassword+token://Production
 onepassword://
 ```
 

--- a/docs/src/content/docs/providers/onepassword.mdx
+++ b/docs/src/content/docs/providers/onepassword.mdx
@@ -83,7 +83,7 @@ to `OP_SERVICE_ACCOUNT_TOKEN`. The `onepassword+token://` scheme selects service
 account authentication and takes the token from one of those two sources.
 
 :::caution
-From SecretSpec 0.20 on, the token may not be written into the URI itself
+From SecretSpec 0.19 on, the token may not be written into the URI itself
 (`onepassword+token://token@vault` and `onepassword+token://account:token@vault`
 are rejected). A URI reaches committed manifests, shell history, and CI logs, so
 the token belongs in a provider credential or the environment. Keep the scheme

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -205,7 +205,7 @@ onepassword+token://SecureVault    # Service account
 The `onepassword+token://` scheme selects service account authentication; the
 token comes from the `service_account_token` provider credential or
 `OP_SERVICE_ACCOUNT_TOKEN`. Putting the token in the URI
-(`onepassword+token://token@vault`) is rejected from 0.20 on, since a URI ends
+(`onepassword+token://token@vault`) is rejected from 0.19 on, since a URI ends
 up in committed manifests, shell history, and CI logs.
 
 **Features**: Read/write, cloud sync, profiles via vaults, service accounts

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -194,13 +194,19 @@ apply to it and those reads sync hourly.
 
 ## OnePassword Provider
 
-**URI**: `onepassword://[account@]vault` or `onepassword+token://user:token@vault`
+**URI**: `onepassword://[account@]vault` or `onepassword+token://vault`
 
 ```bash
-onepassword://MyVault                           # Default account
-onepassword://work@CompanyVault                 # Specific account
-onepassword+token://user:op_token@SecureVault   # Service account
+onepassword://MyVault              # Default account
+onepassword://work@CompanyVault    # Specific account
+onepassword+token://SecureVault    # Service account
 ```
+
+The `onepassword+token://` scheme selects service account authentication; the
+token comes from the `service_account_token` provider credential or
+`OP_SERVICE_ACCOUNT_TOKEN`. Putting the token in the URI
+(`onepassword+token://token@vault`) is rejected from 0.20 on, since a URI ends
+up in committed manifests, shell history, and CI logs.
 
 **Features**: Read/write, cloud sync, profiles via vaults, service accounts
 **Prerequisites**: `op` CLI, authenticated through desktop app integration, a

--- a/docs/src/content/docs/sdk/rust.mdx
+++ b/docs/src/content/docs/sdk/rust.mdx
@@ -69,7 +69,7 @@ would leave that field unfillable. `SecretSpec::builder()` therefore has no
 profile. Use a separate manifest or the untyped API when a component needs a
 narrowed set.
 
-## Resolving one secret (0.20+)
+## Resolving one secret (0.19+)
 
 `resolve()` answers whether the whole profile can be satisfied, so a single
 missing required secret fails it and returns nothing. When a component needs one
@@ -84,7 +84,7 @@ surface this session resolves. Provider and configuration failures stay `Err`
 rather than turning into a missing value, and whole-profile presence constraints
 (`at_least_one`, `exactly_one`) are not evaluated for a single-secret read.
 
-`with_default_reason()` (also 0.20+) supplies a reason only when the caller has
+`with_default_reason()` (also 0.19+) supplies a reason only when the caller has
 not already set one through `with_reason()` or `SECRETSPEC_REASON`, so a wrapper
 can describe itself without overwriting the more specific reason it was given.
 

--- a/docs/src/content/docs/sdk/rust.mdx
+++ b/docs/src/content/docs/sdk/rust.mdx
@@ -8,6 +8,7 @@ import basicExample from '../../../../../secretspec-derive/examples/basic.rs?raw
 import profilesExample from '../../../../../secretspec-derive/examples/profiles.rs?raw';
 import scopesExample from '../../../../../secretspec-derive/examples/scopes.rs?raw';
 import asPathExample from '../../../../../secretspec-derive/examples/as_path.rs?raw';
+import namedExample from '../../../../../secretspec-derive/examples/named.rs?raw';
 import exampleManifest from '../../../../../secretspec-derive/secretspec.toml?raw';
 
 SecretSpec provides a Rust library with type-safe access to secrets through a
@@ -67,6 +68,25 @@ would leave that field unfillable. `SecretSpec::builder()` therefore has no
 `with_scope`, and typed `load()` and `load_profile()` always resolve the full
 profile. Use a separate manifest or the untyped API when a component needs a
 narrowed set.
+
+## Resolving one secret (0.20+)
+
+`resolve()` answers whether the whole profile can be satisfied, so a single
+missing required secret fails it and returns nothing. When a component needs one
+secret, `resolve_named()` reads only that secret and the inputs it composes
+from, and reports the outcomes separately:
+
+<Code code={namedExample} lang="rust" meta='title="named.rs"' />
+
+`NamedResolution::Undeclared` covers both a name the profile does not declare
+and one the active [scope](/concepts/scopes/) hides, since neither is on the
+surface this session resolves. Provider and configuration failures stay `Err`
+rather than turning into a missing value, and whole-profile presence constraints
+(`at_least_one`, `exactly_one`) are not evaluated for a single-secret read.
+
+`with_default_reason()` (also 0.20+) supplies a reason only when the caller has
+not already set one through `with_reason()` or `SECRETSPEC_REASON`, so a wrapper
+can describe itself without overwriting the more specific reason it was given.
 
 ## Secrets as file paths
 

--- a/secretspec-derive/examples/named.rs
+++ b/secretspec-derive/examples/named.rs
@@ -1,0 +1,23 @@
+use secretspec::{NamedResolution, Secrets};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Resolving one secret reads only that secret and its composition inputs,
+    // so an unrelated missing required secret cannot fail the call.
+    let spec = Secrets::load()?.with_default_reason("cache warmup");
+
+    match spec.resolve_named("REDIS_URL")? {
+        NamedResolution::Resolved(secret) => {
+            // Exactly one of `value` and `path` is set; `path` for `as_path`.
+            println!("resolved from {:?}", secret.source);
+        }
+        // Declared, but nothing provided it. `required` says whether a
+        // whole-profile resolve would treat that as an error.
+        NamedResolution::Missing { required } => {
+            println!("no value (required: {required})");
+        }
+        // Not declared in this profile, or hidden by the active scope.
+        NamedResolution::Undeclared => println!("not on this profile's surface"),
+    }
+
+    Ok(())
+}

--- a/secretspec/src/audit.rs
+++ b/secretspec/src/audit.rs
@@ -482,6 +482,10 @@ fn redact_uri(uri: &str) -> String {
 /// `vault://host?token=...` — is not echoed to the terminal. Unlike [`redact_uri`]
 /// it sacrifices attribution detail (account/profile/prefix) for safety, which is
 /// acceptable for a transient warning that also names the affected secret.
+///
+/// Credential-bearing URIs are rejected outright (see
+/// [`crate::provider::reject_uri_credential`]); this stays the safety net for
+/// diagnostics that echo a URI before or while it is being validated.
 pub(crate) fn redact_uri_strict(uri: &str) -> String {
     let without_userinfo = match userinfo_span(uri) {
         // Drop `userinfo@`, keeping the scheme prefix and everything from the host.

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -83,7 +83,8 @@ pub use report::{
     RESOLUTION_REPORT_SCHEMA_VERSION, ResolutionReport, ResolutionStatus, SecretResolution,
 };
 pub use resolve::{
-    RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource, resolve_json,
+    NamedResolution, RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource,
+    resolve_json,
 };
 pub use secrets::ExportFormat;
 pub use secrets::Secrets;

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -1272,10 +1272,14 @@ mod tests {
         assert!(message.contains("mirror"), "{message}");
     }
 
+    /// A password-bearing URI is refused outright now, so what a diagnostic can
+    /// still echo is the userinfo the URI legitimately carries (here a Vault
+    /// namespace). Strict redaction drops it anyway: the same-store message
+    /// names the store, not who authenticates to it.
     #[test]
-    fn same_store_error_redacts_inline_authoritative_credentials() {
+    fn same_store_error_redacts_inline_authoritative_userinfo() {
         let _env = scrub_resolution_env();
-        let source = "vault://team-user:super-sensitive-password@127.0.0.1:8200/secret?tls=false";
+        let source = "vault://team-user@127.0.0.1:8200/secret?tls=false";
         let inline = ProviderAlias::from(source)
             .with_cache(ProviderCache::new(source, "8h").expect("valid cache policy"));
         let spec = cached_spec_with(vec!["route"], &[("route", inline)]);
@@ -1287,6 +1291,28 @@ mod tests {
             "{message}"
         );
         assert!(!message.contains("team-user"), "{message}");
+        assert!(!message.contains("tls=false"), "{message}");
+    }
+
+    /// Planning a cached route reconstructs its canonical provider URI, so a
+    /// password-bearing alias is refused here, before any store is contacted.
+    /// The refusal has to quote the URI to be actionable, which is why strict
+    /// redaction outlives the credential-bearing URIs it was written for: the
+    /// message that tells you not to embed a credential must not repeat it.
+    #[test]
+    fn planning_refuses_an_inline_credential_without_echoing_it() {
+        let _env = scrub_resolution_env();
+        let source = "vault://team-user:super-sensitive-password@127.0.0.1:8200/secret?tls=false";
+        let inline = ProviderAlias::from(source)
+            .with_cache(ProviderCache::new(source, "8h").expect("valid cache policy"));
+        let spec = cached_spec_with(vec!["route"], &[("route", inline)]);
+
+        let message = spec.build_plan(None).unwrap_err().to_string();
+        assert!(message.contains("carries a password"), "{message}");
+        assert!(
+            message.contains("secretspec config provider login"),
+            "{message}"
+        );
         assert!(!message.contains("super-sensitive-password"), "{message}");
     }
 

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -105,6 +105,11 @@ impl Route {
     /// the raw fallback — or `None` for the default provider. Each entry is
     /// resolved (and credential-backed) only when the read reaches it, so the chain
     /// is genuinely tried in order.
+    ///
+    /// Test-only: resolution walks the chain inside the plan executor, which
+    /// owns the ordering. This exposes the same order for tests that assert how
+    /// a route was resolved.
+    #[cfg(test)]
     pub(crate) fn specs(&self) -> Option<Vec<String>> {
         self.primary.as_ref().map(|primary| {
             let mut specs = Vec::with_capacity(1 + self.fallback.len());

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -1666,9 +1666,13 @@ pub(crate) fn provider_from_spec(
     };
 
     let proper_url = Url::parse(&url_string).map_err(|e| {
+        // Redacted: a spec that fails to parse can still carry a credential in
+        // its userinfo, and this message is printed. The rejection in
+        // `reject_uri_credential` only runs once parsing succeeds.
         SecretSpecError::ProviderOperationFailed(format!(
             "Invalid provider specification '{}': {}",
-            s, e
+            crate::audit::redact_uri_strict(s),
+            e
         ))
     })?;
 
@@ -1683,10 +1687,67 @@ impl TryFrom<&Url> for Box<dyn Provider> {
     }
 }
 
+/// Refuses a provider URI that carries a credential in its password position.
+///
+/// A URI is the wrong place for a secret: it is committed to `secretspec.toml`,
+/// echoed into shell history, and printed by CI. Redacting it at the terminal
+/// does not unpublish it from any of those. Provider credentials exist for this
+/// (`credentials = { … }` on the alias, `secretspec config provider login`, or
+/// the provider's environment fallback), so the password position is rejected
+/// outright rather than read, ignored, or scrubbed.
+///
+/// Only the password position is universal. Every provider that reads the
+/// username reads a non-secret from it (a Vault namespace, an AWS profile, a
+/// Bitwarden organization, a 1Password account), so a scheme whose username
+/// carries a credential rejects it itself.
+///
+/// Since SecretSpec 0.20.
+fn reject_uri_credential(url: &ProviderUrl) -> Result<()> {
+    if url.password().is_none() {
+        return Ok(());
+    }
+    let scheme = url.scheme();
+    let registration = registration_for_scheme(scheme);
+    // Name the credentials this provider actually accepts, straight from its
+    // registration, so the remedy is concrete rather than a pointer to the
+    // general mechanism. A provider that accepts none never had a use for the
+    // password either, so say that instead of suggesting a credential.
+    let remedy = match registration {
+        Some(reg) if !reg.credential_names.is_empty() => {
+            let names = reg
+                .credential_names
+                .iter()
+                .map(|name| format!("`{name}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "Supply it as the {names} provider credential instead \
+                 (`secretspec config provider login <alias>`, or `credentials = \
+                 {{ ... }}` on the alias), or use the provider's environment \
+                 variable. See https://secretspec.dev/providers/{}/",
+                reg.info.name
+            )
+        }
+        Some(reg) => format!(
+            "The {} provider takes no credentials, so remove the userinfo from \
+             the URI. See https://secretspec.dev/providers/{}/",
+            reg.info.name, reg.info.name
+        ),
+        None => "See https://secretspec.dev/reference/provider-credentials/".to_string(),
+    };
+    Err(SecretSpecError::ProviderOperationFailed(format!(
+        "provider URI '{}' carries a password. SecretSpec does not accept \
+         credentials in URIs: a URI reaches committed manifests, shell history, \
+         and CI logs, so a credential written there is already disclosed. {remedy}",
+        crate::audit::redact_uri_strict(url.0.as_str()),
+    )))
+}
+
 pub(crate) fn provider_from_url(
     url: &ProviderUrl,
     credentials: ProviderCredentials,
 ) -> Result<Box<dyn Provider>> {
+    reject_uri_credential(url)?;
     let scheme = url.scheme();
 
     let registration = registration_for_scheme(scheme)

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -1701,7 +1701,7 @@ impl TryFrom<&Url> for Box<dyn Provider> {
 /// Bitwarden organization, a 1Password account), so a scheme whose username
 /// carries a credential rejects it itself.
 ///
-/// Since SecretSpec 0.20.
+/// Since SecretSpec 0.19.
 fn reject_uri_credential(url: &ProviderUrl) -> Result<()> {
     if url.password().is_none() {
         return Ok(());

--- a/secretspec/src/provider/onepassword.rs
+++ b/secretspec/src/provider/onepassword.rs
@@ -156,6 +156,29 @@ impl TryFrom<&ProviderUrl> for OnePasswordConfig {
             }
         }
 
+        // The `onepassword+token://token@vault` form carried a service account
+        // token in the URI, which then travelled into committed manifests,
+        // shell history, and CI logs. The token now comes from a provider
+        // credential or the environment; the scheme itself
+        // (`onepassword+token://vault`) still selects service account auth.
+        // Checked for both userinfo positions, since the token was accepted in
+        // either, and independently of the host so it cannot be reached only
+        // through a vault-bearing URI.
+        if scheme == "onepassword+token" && (!url.username().is_empty() || url.password().is_some())
+        {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "onepassword+token:// no longer accepts the service account token in the \
+                 URI, because a URI reaches committed manifests, shell history, and CI \
+                 logs. Keep the scheme without the token \
+                 (`onepassword+token://<vault>`) and supply the token as the \
+                 `service_account_token` provider credential (`secretspec config provider \
+                 login <alias>`, or `credentials = { service_account_token = \"keyring\" }` \
+                 on the alias), or set OP_SERVICE_ACCOUNT_TOKEN. See \
+                 https://secretspec.dev/providers/onepassword/#provider-credentials"
+                    .to_string(),
+            ));
+        }
+
         let mut config = Self::default();
 
         // Parse URL components for account@vault format, ignoring dummy localhost
@@ -166,16 +189,7 @@ impl TryFrom<&ProviderUrl> for OnePasswordConfig {
 
             // Check if we have username (account) information
             if !username.is_empty() {
-                // Handle user:token format for service account tokens
-                if scheme == "onepassword+token" {
-                    if let Some(password) = url.password() {
-                        config.service_account_token = Some(password);
-                    } else {
-                        config.service_account_token = Some(username);
-                    }
-                } else {
-                    config.account = Some(username);
-                }
+                config.account = Some(username);
                 config.default_vault = Some(host);
             } else {
                 // No username, so the host is the vault
@@ -888,7 +902,7 @@ impl Provider for OnePasswordProvider {
 
     fn uri(&self) -> String {
         // Reconstruct the URI from the config
-        // Format: onepassword://[account@]vault or onepassword+token://[token@]vault
+        // Format: onepassword://[account@]vault or onepassword+token://vault
 
         let scheme = if self.config.service_account_token.is_some() {
             "onepassword+token"
@@ -898,8 +912,8 @@ impl Provider for OnePasswordProvider {
 
         let mut uri = format!("{}://", scheme);
 
-        // For service account token, the token itself might be in the URI
-        // but we don't want to expose the actual token value, just indicate it's configured
+        // A configured service account token (from a provider credential or the
+        // environment) selects the scheme but is never written into the URI.
         if self.config.service_account_token.is_some() {
             // Just indicate token auth is being used without exposing the token
             if let Some(ref vault) = self.config.default_vault {
@@ -1227,18 +1241,45 @@ mod tests {
         );
     }
 
+    /// Both userinfo spellings the token scheme used to accept are now refused,
+    /// through the real construction path, in an error that says where the token
+    /// belongs instead and never repeats the token back.
+    ///
+    /// The two spellings are refused by different checks — the password position
+    /// by the shared URI gate, the username position by this provider — so both
+    /// are exercised end to end rather than against this module's `try_from`.
     #[test]
-    fn try_from_token_scheme_captures_token_from_username() {
-        let c = config("onepassword+token://ops_tok@Private");
-        assert_eq!(c.service_account_token.as_deref(), Some("ops_tok"));
-        assert_eq!(c.default_vault.as_deref(), Some("Private"));
-        assert_eq!(c.account, None);
+    fn try_from_token_scheme_rejects_a_token_in_the_uri() {
+        for source in [
+            "onepassword+token://ops_tok@Private",
+            "onepassword+token://acct:ops_tok@Private",
+        ] {
+            let Err(error) = Box::<dyn crate::provider::Provider>::try_from(source) else {
+                panic!("{source} was accepted");
+            };
+            let message = error.to_string();
+            assert!(
+                message.contains("service_account_token"),
+                "{source}: {message}"
+            );
+            assert!(!message.contains("ops_tok"), "{source}: {message}");
+        }
+
+        // The documented single-token form additionally names the environment
+        // fallback and how to keep the scheme.
+        let message = config_err("onepassword+token://ops_tok@Private").to_string();
+        assert!(message.contains("OP_SERVICE_ACCOUNT_TOKEN"), "{message}");
+        assert!(message.contains("onepassword+token://<vault>"), "{message}");
     }
 
+    /// The scheme itself still selects service account authentication; only the
+    /// embedded token is gone.
     #[test]
-    fn try_from_token_scheme_captures_token_from_password() {
-        let c = config("onepassword+token://acct:ops_tok@Private");
-        assert_eq!(c.service_account_token.as_deref(), Some("ops_tok"));
+    fn try_from_token_scheme_without_a_token_selects_the_vault() {
+        let c = config("onepassword+token://Private");
+        assert_eq!(c.default_vault.as_deref(), Some("Private"));
+        assert_eq!(c.service_account_token, None);
+        assert_eq!(c.account, None);
     }
 
     #[test]
@@ -1292,8 +1333,12 @@ mod tests {
 
     #[test]
     fn uri_for_token_does_not_leak_secret() {
-        let provider =
-            OnePasswordProvider::new(config("onepassword+token://ops_secret_tok@Private"));
+        // The token now reaches the config from a provider credential or the
+        // environment rather than the URI, and still must not resurface in the
+        // `uri()` the audit log persists.
+        let mut config = config("onepassword+token://Private");
+        config.service_account_token = Some("ops_secret_tok".to_string());
+        let provider = OnePasswordProvider::new(config);
         let uri = provider.uri();
         assert_eq!(uri, "onepassword+token://Private");
         assert!(!uri.contains("ops_secret_tok"));

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -803,38 +803,47 @@ fn test_create_from_string_with_full_uris() {
     let provider = Box::<dyn Provider>::try_from("onepassword://work@Production").unwrap();
     assert_eq!(provider.name(), "onepassword");
 
-    // Test onepassword with token
-    let provider =
-        Box::<dyn Provider>::try_from("onepassword+token://:ops_abc123@Private").unwrap();
+    // Test onepassword with the service account scheme; the token comes from a
+    // credential or the environment, never from the URI.
+    let provider = Box::<dyn Provider>::try_from("onepassword+token://Private").unwrap();
     assert_eq!(provider.name(), "onepassword");
 }
 
-/// The audit log and the fallback-chain warnings persist a provider's `uri()`
-/// and rely on it never echoing a credential the user embedded in the source
-/// URI (see `Provider::uri`). Enforce that contract for every registered scheme:
-/// build the provider from a URI carrying a recognizable secret in the
-/// *password* position and assert the reconstructed `uri()` does not contain it.
+/// A URL password is always a credential, and a URI is the one place a
+/// credential must never live: it reaches committed manifests, shell history,
+/// and CI logs, where no amount of terminal redaction can retract it. Enforce
+/// for *every* registered scheme that such a URI builds nothing and that the
+/// refusal does not repeat the secret back.
 ///
-/// The username/host/path positions hold non-secret attribution (1Password
-/// accounts, AWS profiles, Vault namespaces) and are intentionally preserved; a
-/// URL *password* is always a credential and must never resurface. A scheme that
-/// rejects this URI shape simply builds nothing, which leaks nothing.
+/// The username, host, and path positions are intentionally untouched: they
+/// hold non-secret attribution (1Password accounts, AWS profiles, Vault
+/// namespaces). A scheme whose username *was* a credential rejects it itself,
+/// which `try_from_token_scheme_rejects_a_token_in_the_uri` covers.
 #[test]
-fn uri_never_echoes_a_userinfo_password() {
+fn every_scheme_rejects_a_userinfo_password() {
     const SECRET: &str = "leaked_pw_DO_NOT_ECHO";
 
     for reg in super::PROVIDER_REGISTRY {
         for &scheme in reg.schemes {
             let source = format!("{scheme}://attribution:{SECRET}@host/path");
-            // Only assert on schemes that build; a parse failure echoes nothing.
-            let Ok(provider) = Box::<dyn Provider>::try_from(source.as_str()) else {
-                continue;
+            let Err(error) = Box::<dyn Provider>::try_from(source.as_str()) else {
+                panic!("provider scheme {scheme:?} accepted a URL password");
             };
-            let uri = provider.uri();
+            let message = error.to_string();
             assert!(
-                !uri.contains(SECRET),
-                "provider scheme {scheme:?} echoed a URL password into uri(): {uri:?}"
+                !message.contains(SECRET),
+                "provider scheme {scheme:?} echoed a URL password into its error: {message:?}"
             );
+            // The refusal has to be actionable, so it names the credentials this
+            // provider accepts instead. Driven by the registration, so a new
+            // provider gets the same quality without touching this test.
+            for credential in reg.credential_names {
+                assert!(
+                    message.contains(credential),
+                    "provider scheme {scheme:?} refused a URL password without naming its \
+                     {credential:?} credential: {message:?}"
+                );
+            }
         }
     }
 }

--- a/secretspec/src/resolve.rs
+++ b/secretspec/src/resolve.rs
@@ -115,7 +115,7 @@ impl ResolveResponse {
 /// and whether its absence is an error. A genuine provider or configuration
 /// failure is never one of these variants; it surfaces as `Err` from the call.
 ///
-/// Available since SecretSpec 0.20.
+/// Available since SecretSpec 0.19.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NamedResolution {
     /// The name is not declared on the active resolution surface: either absent

--- a/secretspec/src/resolve.rs
+++ b/secretspec/src/resolve.rs
@@ -107,6 +107,34 @@ impl ResolveResponse {
     }
 }
 
+/// The outcome of resolving one secret by name with
+/// [`crate::Secrets::resolve_named`].
+///
+/// The three variants separate the questions a batch resolve conflates: whether
+/// the name exists on the active surface at all, whether it produced a value,
+/// and whether its absence is an error. A genuine provider or configuration
+/// failure is never one of these variants; it surfaces as `Err` from the call.
+///
+/// Available since SecretSpec 0.20.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamedResolution {
+    /// The name is not declared on the active resolution surface: either absent
+    /// from the merged profile, or declared but hidden by the active scope. The
+    /// caller asked about a secret this configuration does not offer, which is
+    /// usually a bug in the caller rather than a missing value.
+    Undeclared,
+    /// The secret is declared but produced no value.
+    Missing {
+        /// Whether the profile declares this secret required, which is what
+        /// makes the absence an error for a whole-profile resolve. Reported here
+        /// rather than decided: a named resolve returns this variant either way
+        /// and leaves the policy to the caller.
+        required: bool,
+    },
+    /// The secret produced a value.
+    Resolved(ResolvedSecret),
+}
+
 /// Which resolution shape a request asks for.
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -14,7 +14,9 @@ use crate::provider::{
     ProviderCredentials, same_storage_container,
 };
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
-use crate::resolve::{RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource};
+use crate::resolve::{
+    NamedResolution, RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource,
+};
 use crate::validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
 use colored::Colorize;
 use data_encoding::{
@@ -57,6 +59,51 @@ fn validation_failure(errors: ValidationErrors) -> SecretSpecError {
     }
 }
 
+/// Which declared secrets a single-secret resolution can see.
+///
+/// A scope narrows what a session resolves, but it is a `check`/`run`/`export`
+/// concept: `secretspec get NAME` names one secret and has no `--scope`, so it
+/// reads the whole profile. The SDK's [`Secrets::resolve_named`] resolves the
+/// session's surface instead, scope included.
+#[derive(Clone, Copy)]
+enum Surface {
+    /// The scope intersection, or the whole profile when no scope is active.
+    Scoped,
+    /// Every secret the profile declares, whatever the active scope.
+    WholeProfile,
+}
+
+impl Surface {
+    fn names(self, secrets: &Secrets, profile: &str) -> Result<Vec<String>> {
+        match self {
+            Self::Scoped => secrets.resolve_profile_secret_names(Some(profile)),
+            Self::WholeProfile => secrets.profile_secret_names_unscoped(Some(profile)),
+        }
+    }
+}
+
+/// Translates a resolution entry's provenance flags into the value-carrying
+/// response's [`ResolvedSource`]. Shared so a batch resolve and a named one
+/// cannot disagree about where a value came from.
+fn resolved_source(entry: &SecretResolution) -> ResolvedSource {
+    if entry.generated {
+        ResolvedSource::Generated
+    } else if entry.default_applied {
+        ResolvedSource::Default
+    } else if entry.composed {
+        ResolvedSource::Composed
+    } else {
+        ResolvedSource::Provider
+    }
+}
+
+/// Stands in for a secret's name in diagnostics when the active scope hides it.
+///
+/// Every accessed-but-not-visible secret is by construction a dependency of a
+/// visible composed secret, so this describes what it is without disclosing
+/// which secret it is.
+pub(crate) const HIDDEN_SECRET_LABEL: &str = "a hidden composition input";
+
 /// Emits a warning when a provider in a fallback chain fails so the user
 /// can see why a particular link was skipped, without aborting the chain.
 ///
@@ -67,13 +114,6 @@ fn validation_failure(errors: ValidationErrors) -> SecretSpecError {
 /// `awssm://…?prefix=…`) from a provider's own `uri()`.
 ///
 /// [`redact_uri_strict`]: crate::audit::redact_uri_strict
-/// Stands in for a secret's name in diagnostics when the active scope hides it.
-///
-/// Every accessed-but-not-visible secret is by construction a dependency of a
-/// visible composed secret, so this describes what it is without disclosing
-/// which secret it is.
-pub(crate) const HIDDEN_SECRET_LABEL: &str = "a hidden composition input";
-
 fn warn_provider_failure(display_uri: &str, secret_name: &str, err: &SecretSpecError) {
     eprintln!(
         "{} provider {} failed for {}: {}; trying next provider in chain",
@@ -934,6 +974,38 @@ impl Secrets {
     pub fn with_reason(mut self, reason: impl Into<String>) -> Self {
         if let Some(reason) = normalize_reason(&reason.into()) {
             self.reason = Some(reason);
+        }
+        self
+    }
+
+    /// Sets a session reason only when none is already in effect.
+    ///
+    /// This is the "supply a fallback" form of [`Secrets::with_reason`]: an
+    /// embedding application can describe *itself* ("nightly export job") without
+    /// overwriting the more specific reason its own caller passed through
+    /// `SECRETSPEC_REASON`. Calling `with_reason` for that purpose would silently
+    /// discard the user's reason and put the wrapper's boilerplate in every audit
+    /// log entry instead.
+    ///
+    /// The reason is normalized like every other source, so a blank or
+    /// whitespace-only argument still leaves the session without a reason rather
+    /// than storing an empty one. Precedence is therefore: an explicit
+    /// [`Secrets::with_reason`], then `SECRETSPEC_REASON`, then this default.
+    ///
+    /// Available since SecretSpec 0.20.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use secretspec::Secrets;
+    ///
+    /// // Uses SECRETSPEC_REASON when the caller set one, "nightly export" otherwise.
+    /// let spec = Secrets::load().unwrap().with_default_reason("nightly export");
+    /// spec.check(false).unwrap();
+    /// ```
+    pub fn with_default_reason(mut self, reason: impl Into<String>) -> Self {
+        if self.reason.is_none() {
+            self.reason = normalize_reason(&reason.into());
         }
         self
     }
@@ -2173,43 +2245,6 @@ impl Secrets {
         provider.get_many(&requests)
     }
 
-    /// Read and validate one cached envelope. Every cache failure is fail-open:
-    /// the authoritative route remains usable and gets a chance to refresh the
-    /// cache after a successful read.
-    fn read_cached_secret(
-        &self,
-        planned: &PlannedSecret,
-        route: &Route,
-        profile: &str,
-    ) -> Option<(SecretString, String)> {
-        let cache = route.cache()?;
-        let provider = match self.build_provider(cache.spec.clone(), Some(profile)) {
-            Ok(provider) => provider,
-            Err(error) => {
-                cache_read_warning(&planned.name, error);
-                return None;
-            }
-        };
-        let stored = match provider.get(self.cache_address(profile, &planned.name)) {
-            Ok(Some(value)) => value,
-            Ok(None) => return None,
-            Err(error) => {
-                cache_read_warning(&planned.name, error);
-                return None;
-            }
-        };
-        match cached_entry(planned, cache, &stored, &self.config.project.name, profile) {
-            CachedEntry::Fresh(value) => Some((value, provider.uri())),
-            CachedEntry::Stale => {
-                self.evict_cache_entry(provider.as_ref(), &planned.name, profile);
-                None
-            }
-            // Someone else's value: fall through to the authoritative route and
-            // leave it alone.
-            CachedEntry::Foreign => None,
-        }
-    }
-
     /// Cache-first read for a whole plan: one provider per distinct cache store,
     /// one batched read each.
     ///
@@ -3271,232 +3306,44 @@ impl Secrets {
         Ok(deleted)
     }
 
-    /// Retrieves and prints a secret value
+    /// Resolves one secret and prints it to stdout: the CLI's `secretspec get`.
     ///
-    /// This method retrieves a secret from the storage backend and prints it
-    /// to stdout. If the secret is not found but has a default value, the
-    /// default is printed.
+    /// A secret declared `as_path` prints the path to its materialized file,
+    /// which outlives this process; every other secret prints its value. A
+    /// value from the manifest's `default`, a `generate` config, or a
+    /// composition prints like any other.
     ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the secret to retrieve
-    /// * `provider_arg` - Optional provider to use
-    /// * `profile` - Optional profile to use
-    ///
-    /// # Returns
-    ///
-    /// `Ok(())` if the secret was found and printed
+    /// Library callers want [`Self::resolve_named`], which returns the value
+    /// instead of printing it and distinguishes an undeclared name from a
+    /// declared secret with no value.
     ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - The secret is not defined in the specification
-    /// - The secret is not found and has no default value
+    /// [`SecretSpecError::SecretNotFound`] when the name is not declared on the
+    /// active profile and scope, or is declared but produced no value. Provider
+    /// and configuration failures surface as their own errors.
     pub fn get(&self, name: &str) -> Result<()> {
-        self.ensure_reason_for(AuditAction::Get, Some(name))?;
-        let profile_name = self.resolve_profile_name(None);
-        // Plan the secret exactly as batch resolution would, so the read route,
-        // address, and effective config are the same decisions `check`/`run`
-        // make. `None` means it is not declared in this profile.
-        let planned = match self.plan_secret(name, &profile_name, None) {
-            Ok(Some(planned)) => planned,
-            // Planning failed (e.g. an undefined provider alias). Still an
-            // attempted read, so audit it like the batch path audits every
-            // planning failure; no provider can be attributed yet.
-            Err(err) => {
-                self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
-                return Err(err);
+        // A printer over the library API, so the CLI's single-secret read makes
+        // exactly the resolution decisions `resolve_named` makes (and audits
+        // them once, there) rather than maintaining a second single-secret path.
+        match self.resolve_named_within(name, Surface::WholeProfile)? {
+            NamedResolution::Resolved(secret) => {
+                // `as_path` secrets are materialized and their temp file
+                // persisted during resolution, so a printed path is still valid
+                // after this process exits.
+                let rendered = secret
+                    .value
+                    .or(secret.path)
+                    .expect("a resolved secret carries either a value or a path");
+                println!("{rendered}");
+                Ok(())
             }
-            Ok(None) => {
-                // The secret is not defined, so no provider can be attributed.
-                // Audit the failed read for parity with `set`'s undefined path.
-                let err = SecretSpecError::SecretNotFound(name.to_string());
-                self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
-                return Err(err);
-            }
-        };
-        // Composed values and generated-on-miss values need the batch executor:
-        // it renders dependency closures and owns the generation policy,
-        // including providers that return a value without storing it.
-        if planned.is_composed() || planned.secret.missing == MissingPolicy::Generate {
-            let names = if planned.is_composed() {
-                self.composed_dependency_names(name, &profile_name)
-            } else {
-                vec![name.to_string()]
-            };
-            let plan = self.build_plan_from_names(profile_name.clone(), names)?;
-            // No output filter: the closure resolves the target's dependencies
-            // and this caller reads only the target from the result.
-            return match self.execute_plan(&plan, Materialize::Values, None)? {
-                Ok(mut validated) => {
-                    if !validated.resolved.secrets.contains_key(name) {
-                        let err = SecretSpecError::SecretNotFound(name.to_string());
-                        self.record_key_error(
-                            AuditAction::Get,
-                            &profile_name,
-                            name,
-                            None,
-                            None,
-                            &err,
-                        );
-                        return Err(err);
-                    }
-                    validated.keep_temp_files()?;
-                    let value = &validated.resolved.secrets[name];
-                    let source_provider = validated
-                        .resolution
-                        .iter()
-                        .find(|entry| entry.name == name)
-                        .and_then(|entry| entry.source_provider.clone());
-                    self.record(
-                        AuditAction::Get,
-                        &profile_name,
-                        AuditOutcome::Found,
-                        AuditFields {
-                            key: Some(name),
-                            provider_uri: source_provider.clone(),
-                            reference: source_provider
-                                .is_some()
-                                .then(|| planned.reference())
-                                .flatten(),
-                            ..Default::default()
-                        },
-                    );
-                    println!("{}", value.expose_secret());
-                    Ok(())
-                }
-                Err(errors) => {
-                    let err = validation_failure(errors);
-                    self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
-                    Err(err)
-                }
-            };
-        }
-        let route = planned
-            .route
-            .as_ref()
-            .expect("non-composed secrets have a provider route");
-        let default = planned.config().default.clone();
-        // A fresh cache hit completes the read without constructing or
-        // contacting any authoritative provider. Misses and invalid entries
-        // fall through to the ordinary ordered provider route.
-        let (result, cache_hit) =
-            if let Some((value, uri)) = self.read_cached_secret(&planned, route, &profile_name) {
-                (Ok((Some(value), Some(uri), None)), true)
-            } else {
-                // Walk the route's chain in order; each entry is resolved lazily and a
-                // broken link is skipped with a warning, so an undefined alias never
-                // blocks a provider elsewhere in the chain from answering.
-                let read_specs = route.specs();
-                let provider_cache = ProviderCache::default();
-                let result = self.get_secret_from_providers(
-                    &provider_cache,
-                    &planned,
-                    name,
-                    read_specs.as_deref(),
-                    &self.config.project.name,
-                    &profile_name,
-                    route.primary(),
-                );
-                if let Ok((Some(value), _, _)) = &result {
-                    self.write_cached_secret(&planned, route, &profile_name, value);
-                }
-                (result, false)
-            };
-
-        // Audit the access at the provider boundary, before defaults are applied.
-        // The provider URI consulted is reported back so the chain miss/error
-        // attributes to the last provider tried rather than guessing. The native
-        // coordinates (if any) are recorded alongside, since the provider URI
-        // names only the store.
-        let attempted_address = if !cache_hit && result.is_err() {
-            let read_specs = route.specs();
-            let provider_spec = read_specs
-                .as_deref()
-                .and_then(|specs| specs.last().map(String::as_str));
-            self.address_for_spec(
-                &planned,
-                provider_spec,
-                &self.config.project.name,
-                &profile_name,
-            )
-            .ok()
-        } else {
-            None
-        };
-        let reference = if cache_hit {
-            None
-        } else {
-            result
-                .as_ref()
-                .ok()
-                .and_then(|(_, _, reference)| reference.as_ref())
-                .or_else(|| attempted_address.as_ref().and_then(OwnedAddress::native))
-                .or_else(|| planned.reference())
-        };
-        match &result {
-            Ok((Some(_), uri, _)) => self.record(
-                AuditAction::Get,
-                &profile_name,
-                AuditOutcome::Found,
-                AuditFields {
-                    key: Some(name),
-                    provider_uri: uri.clone(),
-                    reference,
-                    ..Default::default()
-                },
-            ),
-            Ok((None, uri, _)) if default.is_some() => self.record(
-                AuditAction::Get,
-                &profile_name,
-                AuditOutcome::Default,
-                AuditFields {
-                    key: Some(name),
-                    provider_uri: uri.clone(),
-                    reference,
-                    ..Default::default()
-                },
-            ),
-            Ok((None, uri, _)) => self.record(
-                AuditAction::Get,
-                &profile_name,
-                AuditOutcome::Missing,
-                AuditFields {
-                    key: Some(name),
-                    provider_uri: uri.clone(),
-                    reference,
-                    ..Default::default()
-                },
-            ),
-            Err(e) => {
-                self.record_key_error(AuditAction::Get, &profile_name, name, None, reference, e)
+            // Undeclared and missing are one error for the CLI: either way there
+            // is nothing to print. Both are already audited by `resolve_named`.
+            NamedResolution::Missing { .. } | NamedResolution::Undeclared => {
+                Err(SecretSpecError::SecretNotFound(name.to_string()))
             }
         }
-
-        let (value, representation) = match result?.0 {
-            Some(value) => (value, ResolvedRepresentation::Stored),
-            None => (
-                default
-                    .map(|value| SecretString::new(value.into()))
-                    .ok_or_else(|| SecretSpecError::SecretNotFound(name.to_string()))?,
-                ResolvedRepresentation::Logical,
-            ),
-        };
-        match self.prepare_resolved(&planned, name, value, representation)? {
-            PreparedSecret::Inline(value) => println!("{}", value.expose_secret()),
-            PreparedSecret::File { owner, .. } => {
-                // `get` prints a path for use after this process exits, so unlike
-                // SDK resolution it deliberately persists the backing file.
-                let temp_path = owner.into_temp_path();
-                let persisted_path = temp_path.keep().map_err(|error| {
-                    SecretSpecError::Io(io::Error::other(format!(
-                        "Failed to persist temporary file: {error}"
-                    )))
-                })?;
-                println!("{}", persisted_path.display());
-            }
-        }
-        Ok(())
     }
 
     /// Ensures all required secrets are present, optionally prompting for missing ones
@@ -4618,6 +4465,218 @@ impl Secrets {
         self.resolve_impl(false)
     }
 
+    /// Resolve one declared secret by name.
+    ///
+    /// [`Self::resolve`] answers "can this whole profile be satisfied", which is
+    /// the wrong question for a consumer that needs a single secret: an
+    /// unrelated missing required secret fails the call and yields nothing, even
+    /// though the requested secret is sitting there. This resolves only `name`
+    /// and the composition inputs it derives from, so no other declaration can
+    /// fail it, and it separates the outcomes a batch resolve conflates — see
+    /// [`NamedResolution`].
+    ///
+    /// The active profile and scope both apply. A secret the scope hides is
+    /// reported as [`NamedResolution::Undeclared`]: it is not on the surface
+    /// this session resolves, and reporting it as merely missing would leak that
+    /// the scope hides it. Genuine provider and configuration failures (an
+    /// undefined alias, an unreachable vault) stay errors instead of collapsing
+    /// into a missing value.
+    ///
+    /// Whole-profile presence constraints (`at_least_one`, `exactly_one`) are
+    /// not evaluated, matching the CLI's single-secret `get`: whether a group is
+    /// satisfied is a property of the profile, and this read deliberately never
+    /// looks at the rest of it.
+    ///
+    /// Like [`Self::resolve`], this carries the value, mints a generatable
+    /// secret, and persists an `as_path` temp file so the returned path outlives
+    /// the call. Treat the payload as sensitive.
+    ///
+    /// Available since SecretSpec 0.20.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use secretspec::{NamedResolution, Secrets};
+    ///
+    /// let spec = Secrets::load().unwrap();
+    /// match spec.resolve_named("DATABASE_URL").unwrap() {
+    ///     NamedResolution::Resolved(secret) => println!("got {:?}", secret.source),
+    ///     NamedResolution::Missing { required } => println!("missing (required: {required})"),
+    ///     NamedResolution::Undeclared => println!("not declared in this profile"),
+    /// }
+    /// ```
+    pub fn resolve_named(&self, name: &str) -> Result<NamedResolution> {
+        self.resolve_named_within(name, Surface::Scoped)
+    }
+
+    /// Shared core of [`Self::resolve_named`] and [`Self::get`].
+    ///
+    /// They differ only in which surface decides that a name exists: the SDK
+    /// resolves what the session exposes (a scope narrows it), while the CLI's
+    /// `get` names one secret and has no `--scope`, so an ambient or configured
+    /// scope must not hide a secret from it.
+    fn resolve_named_within(&self, name: &str, surface: Surface) -> Result<NamedResolution> {
+        self.ensure_reason_for(AuditAction::Get, Some(name))?;
+        let profile_name = self.resolve_profile_name(None);
+
+        // Decide whether this surface offers the name at all, before any
+        // provider is contacted.
+        let visible = match surface.names(self, &profile_name) {
+            Ok(visible) => visible,
+            Err(err) => {
+                self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
+                return Err(err);
+            }
+        };
+        if !visible.iter().any(|declared| declared == name) {
+            // An attempted read of a name this surface does not offer is still
+            // an attempted read, and is audited as one (matching how `set`
+            // records an undefined secret). No provider can be attributed.
+            let err = SecretSpecError::SecretNotFound(name.to_string());
+            self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
+            return Ok(NamedResolution::Undeclared);
+        }
+
+        // The target plus its transitive composition inputs: the same
+        // least-access plan `get` builds, so an unrelated required secret is
+        // never read and can never fail this call.
+        let names = self.composed_dependency_names(name, &profile_name);
+        let plan = match self.build_plan_from_names(profile_name.clone(), names) {
+            Ok(plan) => plan,
+            Err(err) => {
+                self.record_key_error(AuditAction::Get, &profile_name, name, None, None, &err);
+                return Err(err);
+            }
+        };
+        // No output filter: the dependency closure has to resolve, and a filter
+        // would additionally enable the whole-profile constraint checks that a
+        // single-secret read does not own.
+        let mut read_addresses = HashMap::new();
+        let outcome =
+            match self.execute_plan(&plan, Materialize::Values, None, Some(&mut read_addresses)) {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    let reference = read_addresses.get(name);
+                    self.record_key_error(
+                        AuditAction::Get,
+                        &profile_name,
+                        name,
+                        None,
+                        reference,
+                        &err,
+                    );
+                    return Err(err);
+                }
+            };
+        // Exactly the coordinates the read reached, never the declared ones: an
+        // alias `ref` template resolves to a different address per provider, and
+        // a read served from cache addressed no authoritative store at all.
+        let reference = read_addresses.get(name);
+
+        match outcome {
+            Ok(mut validated) => {
+                // Cloned so the entry outlives the `&mut` borrow that persisting
+                // the temp files needs.
+                let entry = validated
+                    .resolution
+                    .iter()
+                    .find(|entry| entry.name == name)
+                    .expect("the planned target always has a resolution entry")
+                    .clone();
+                if entry.status != ResolutionStatus::Resolved {
+                    self.record(
+                        AuditAction::Get,
+                        &profile_name,
+                        AuditOutcome::Missing,
+                        AuditFields {
+                            key: Some(name),
+                            reference,
+                            ..Default::default()
+                        },
+                    );
+                    return Ok(NamedResolution::Missing {
+                        required: entry.required,
+                    });
+                }
+
+                // Persist as_path temp files so the returned path stays valid
+                // for the caller, exactly as `resolve` does.
+                validated.keep_temp_files()?;
+                let raw = validated
+                    .resolved
+                    .secrets
+                    .get(name)
+                    .expect("a Resolved entry always has a value")
+                    .expose_secret()
+                    .to_string();
+                let (value, path) = if entry.as_path {
+                    (None, Some(raw))
+                } else {
+                    (Some(raw), None)
+                };
+
+                self.record(
+                    AuditAction::Get,
+                    &profile_name,
+                    if entry.default_applied {
+                        AuditOutcome::Default
+                    } else {
+                        AuditOutcome::Found
+                    },
+                    AuditFields {
+                        key: Some(name),
+                        provider_uri: entry.source_provider.clone(),
+                        reference,
+                        ..Default::default()
+                    },
+                );
+                Ok(NamedResolution::Resolved(ResolvedSecret {
+                    value,
+                    path,
+                    as_path: entry.as_path,
+                    source: resolved_source(&entry),
+                    source_provider: entry.source_provider,
+                }))
+            }
+            Err(errors) => {
+                // Constraints are skipped for this partial plan, so a violation
+                // here would mean the resolver changed its mind about that;
+                // surface it rather than reporting a missing value.
+                if !errors.constraint_violations.is_empty() {
+                    let err = SecretSpecError::ValidationFailed(Box::new(errors));
+                    self.record_key_error(
+                        AuditAction::Get,
+                        &profile_name,
+                        name,
+                        None,
+                        reference,
+                        &err,
+                    );
+                    return Err(err);
+                }
+                // The target is missing; a composed target whose input is
+                // missing reports against the target, which is what the caller
+                // asked about.
+                let required = errors
+                    .resolution
+                    .iter()
+                    .find(|entry| entry.name == name)
+                    .is_none_or(|entry| entry.required);
+                self.record(
+                    AuditAction::Get,
+                    &profile_name,
+                    AuditOutcome::Missing,
+                    AuditFields {
+                        key: Some(name),
+                        reference,
+                        ..Default::default()
+                    },
+                );
+                Ok(NamedResolution::Missing { required })
+            }
+        }
+    }
+
     /// Shared core of [`Self::resolve`]/[`Self::resolve_without_values`].
     /// `include_values` gates whether resolved secret values are copied into the
     /// response and, in turn, whether the underlying pass mints generated
@@ -4643,15 +4702,7 @@ impl Secrets {
                     if entry.status != ResolutionStatus::Resolved {
                         continue;
                     }
-                    let source = if entry.generated {
-                        ResolvedSource::Generated
-                    } else if entry.default_applied {
-                        ResolvedSource::Default
-                    } else if entry.composed {
-                        ResolvedSource::Composed
-                    } else {
-                        ResolvedSource::Provider
-                    };
+                    let source = resolved_source(entry);
                     // Only copy the secret value out when the caller wants it;
                     // otherwise the bytes never enter the response.
                     let (value, path) = if !include_values {
@@ -4819,7 +4870,9 @@ impl Secrets {
         let result: Result<std::result::Result<ValidatedSecrets, ValidationErrors>> =
             visible_result
                 .and_then(|_| self.build_plan_from_names(profile_name.clone(), worklist))
-                .and_then(|plan| self.execute_plan(&plan, materialize, output_filter.as_ref()));
+                .and_then(|plan| {
+                    self.execute_plan(&plan, materialize, output_filter.as_ref(), None)
+                });
 
         // Record exactly one `Check` event for the whole batch when this is a
         // top-level read, regardless of how the resolution exited — so a failed
@@ -5025,11 +5078,16 @@ impl Secrets {
     /// secret and writing `as_path` temp files); [`Materialize::None`] runs the
     /// identical resolution but skips both, reaching the same per-secret status
     /// without mutating a provider or touching disk.
+    /// `read_addresses` collects the native coordinates each secret was actually
+    /// read from, for the callers that audit a single secret. A cache hit
+    /// contributes nothing: the authoritative coordinates were not consulted, so
+    /// recording them would overstate what the read touched.
     fn execute_plan(
         &self,
         plan: &ResolutionPlan,
         materialize: Materialize,
         output_filter: Option<&HashSet<String>>,
+        mut read_addresses: Option<&mut HashMap<String, NativeAddress>>,
     ) -> Result<std::result::Result<ValidatedSecrets, ValidationErrors>> {
         let project = self.config.project.name.as_str();
         let profile = plan.profile.as_str();
@@ -5251,6 +5309,16 @@ impl Secrets {
                     source_provider = cached_uris
                         .remove(name)
                         .or_else(|| group_uris.get(&primary_uri).cloned());
+                    if !was_cached && let Some(addresses) = read_addresses.as_deref_mut() {
+                        // The primary answered, so it was addressed with the
+                        // coordinates the group fetch computed for this spec.
+                        if let Ok(address) =
+                            self.address_for_spec(planned, primary_uri, project, profile)
+                            && let Some(native) = address.native()
+                        {
+                            addresses.insert(name.clone(), native.clone());
+                        }
+                    }
                     if !was_cached && materialize == Materialize::Values {
                         self.write_cached_secret(planned, route, profile, &value);
                     }
@@ -5272,38 +5340,59 @@ impl Secrets {
                 None => {
                     let primary_failed = failed_primary_uris.contains_key(&primary_uri);
 
+                    // The primary was addressed even though it did not answer.
+                    // An audited failed read has to name the coordinates it
+                    // attempted, so record them before the error paths below
+                    // return. A fallback that answers overwrites this with the
+                    // address that did.
+                    if let Some(addresses) = read_addresses.as_deref_mut()
+                        && let Ok(address) =
+                            self.address_for_spec(planned, primary_uri, project, profile)
+                        && let Some(native) = address.native()
+                    {
+                        addresses.insert(name.clone(), native.clone());
+                    }
+
                     // The primary missed, so consume the fallback result fetched
                     // concurrently above. Each chain was still tried in order
                     // and received the diagnostic label rather than a hidden
                     // composition input's raw name.
-                    let (fallback_value, fallback_uri, _) = match route.fallback_specs() {
-                        Some(_) => {
-                            let resolved = fallback_results
-                                .remove(name)
-                                .expect("primary miss with fallback was prefetched")?;
-                            // A primary that errored plus an exhausted fallback
-                            // chain is not "missing": the authoritative provider
-                            // is unreachable and might hold the value. Surface the
-                            // primary error, exactly as the no-fallback arm below.
-                            if resolved.0.is_none() && primary_failed {
+                    let (fallback_value, fallback_uri, fallback_reference) =
+                        match route.fallback_specs() {
+                            Some(_) => {
+                                let resolved = fallback_results
+                                    .remove(name)
+                                    .expect("primary miss with fallback was prefetched")?;
+                                // A primary that errored plus an exhausted fallback
+                                // chain is not "missing": the authoritative provider
+                                // is unreachable and might hold the value. Surface the
+                                // primary error, exactly as the no-fallback arm below.
+                                if resolved.0.is_none() && primary_failed {
+                                    let err = failed_primary_uris
+                                        .remove(&primary_uri)
+                                        .expect("primary_failed implies entry present");
+                                    return Err(err);
+                                }
+                                resolved
+                            }
+                            // No alternative chain and the primary failed: surface the
+                            // original error rather than reporting a spurious missing.
+                            None if primary_failed => {
                                 let err = failed_primary_uris
                                     .remove(&primary_uri)
                                     .expect("primary_failed implies entry present");
                                 return Err(err);
                             }
-                            resolved
-                        }
-                        // No alternative chain and the primary failed: surface the
-                        // original error rather than reporting a spurious missing.
-                        None if primary_failed => {
-                            let err = failed_primary_uris
-                                .remove(&primary_uri)
-                                .expect("primary_failed implies entry present");
-                            return Err(err);
-                        }
-                        None => (None, None, None),
-                    };
+                            None => (None, None, None),
+                        };
 
+                    if let Some(addresses) = read_addresses.as_deref_mut()
+                        && let Some(reference) = fallback_reference
+                    {
+                        // Recorded for a miss too: the attempted coordinates are
+                        // what an audited failed read has to name.
+                        addresses.insert(name.clone(), reference);
+                    }
                     if let Some(value) = fallback_value {
                         source_provider = fallback_uri;
                         if materialize == Materialize::Values {
@@ -6204,6 +6293,45 @@ mod policy_tests {
         assert_eq!(normalize_reason(""), None);
         assert_eq!(normalize_reason("   "), None);
         assert_eq!(normalize_reason("\t\n"), None);
+    }
+
+    /// A default reason fills the gap but never overwrites one the caller
+    /// already supplied: a wrapper describing itself must not replace the more
+    /// specific reason its own caller passed in.
+    #[test]
+    fn with_default_reason_only_fills_an_absent_reason() {
+        let spec = || {
+            Secrets::new(
+                crate::tests::resolve_test_config(HashMap::new()),
+                None,
+                None,
+                None,
+            )
+        };
+
+        // No reason yet: the default is adopted, normalized like any other.
+        assert_eq!(
+            spec().with_default_reason("  nightly export  ").reason,
+            Some("nightly export".to_string())
+        );
+
+        // A reason already in effect wins, whichever order the calls come in.
+        assert_eq!(
+            spec()
+                .with_reason("running migrations")
+                .with_default_reason("nightly export")
+                .reason,
+            Some("running migrations".to_string())
+        );
+
+        // A blank default is no reason at all, so the session stays unreasoned
+        // rather than storing an empty string that would satisfy nothing.
+        assert_eq!(spec().with_default_reason("   ").reason, None);
+        // ...and a blank default cannot clear a real reason either.
+        assert_eq!(
+            spec().with_reason("deploy").with_default_reason("").reason,
+            Some("deploy".to_string())
+        );
     }
 
     #[test]

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -992,7 +992,7 @@ impl Secrets {
     /// than storing an empty one. Precedence is therefore: an explicit
     /// [`Secrets::with_reason`], then `SECRETSPEC_REASON`, then this default.
     ///
-    /// Available since SecretSpec 0.20.
+    /// Available since SecretSpec 0.19.
     ///
     /// # Example
     ///
@@ -4491,7 +4491,7 @@ impl Secrets {
     /// secret, and persists an `as_path` temp file so the returned path outlives
     /// the call. Treat the payload as sensitive.
     ///
-    /// Available since SecretSpec 0.20.
+    /// Available since SecretSpec 0.19.
     ///
     /// # Example
     ///

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -722,6 +722,183 @@ fn test_resolve_carries_values_and_provenance() {
     );
 }
 
+/// A declared secret carrying the description the manifest requires.
+fn described(description: &str) -> Secret {
+    Secret {
+        description: Some(description.to_string()),
+        ..Default::default()
+    }
+}
+
+/// A profile holding one stored secret, one optional-missing secret, one
+/// required-missing secret, and a composition over the stored one, all served by
+/// a dotenv store. Enough surface to tell the named-resolution outcomes apart.
+fn named_resolution_spec(env_path: &Path) -> Secrets {
+    fs::write(env_path, "DB_USER=alice\n").unwrap();
+    let secrets = HashMap::from([
+        ("DB_USER".to_string(), described("user")),
+        (
+            "SENTRY_DSN".to_string(),
+            Secret {
+                required: Some(false),
+                ..described("dsn")
+            },
+        ),
+        ("MISSING_TOKEN".to_string(), described("token")),
+        (
+            "DSN".to_string(),
+            Secret {
+                composed: Some("postgres://${DB_USER}@db/app".to_string()),
+                ..described("database url")
+            },
+        ),
+    ]);
+    let config = resolve_test_config(secrets);
+    config.validate().unwrap();
+    let provider = format!("dotenv://{}", env_path.display());
+    Secrets::new(config, None, Some(provider), None)
+}
+
+/// The reason this API exists: `resolve()` fails wholesale when any required
+/// secret is missing, so a consumer that needs one secret cannot get it. A named
+/// resolution reads only its target, so an unrelated missing required secret is
+/// none of its business.
+#[test]
+fn resolve_named_ignores_an_unrelated_missing_required_secret() {
+    use crate::resolve::{NamedResolution, ResolvedSource};
+
+    let temp_dir = TempDir::new().unwrap();
+    let spec = named_resolution_spec(&temp_dir.path().join(".env"));
+
+    // The batch API cannot serve this profile at all: MISSING_TOKEN sinks it.
+    let batch = spec.resolve().unwrap();
+    assert!(!batch.is_ok());
+    assert!(batch.secrets.is_empty());
+
+    // The named API still returns the secret that is actually present.
+    let resolved = match spec.resolve_named("DB_USER").unwrap() {
+        NamedResolution::Resolved(secret) => secret,
+        other => panic!("DB_USER is stored and must resolve, got {other:?}"),
+    };
+    assert_eq!(resolved.value.as_deref(), Some("alice"));
+    assert_eq!(resolved.source, ResolvedSource::Provider);
+    assert!(resolved.source_provider.is_some());
+}
+
+/// A composed target pulls in exactly its own inputs, so it resolves even though
+/// an unrelated required secret elsewhere in the profile is missing.
+#[test]
+fn resolve_named_resolves_a_composition_from_its_own_inputs() {
+    use crate::resolve::{NamedResolution, ResolvedSource};
+
+    let temp_dir = TempDir::new().unwrap();
+    let spec = named_resolution_spec(&temp_dir.path().join(".env"));
+
+    let resolved = match spec.resolve_named("DSN").unwrap() {
+        NamedResolution::Resolved(secret) => secret,
+        other => panic!("DSN composes over a stored secret, got {other:?}"),
+    };
+    assert_eq!(resolved.value.as_deref(), Some("postgres://alice@db/app"));
+    assert_eq!(resolved.source, ResolvedSource::Composed);
+}
+
+/// Missing declared secrets report their declared requirement rather than
+/// failing, leaving the policy call to the caller.
+#[test]
+fn resolve_named_reports_missing_declared_secrets_with_their_requirement() {
+    use crate::resolve::NamedResolution;
+
+    let temp_dir = TempDir::new().unwrap();
+    let spec = named_resolution_spec(&temp_dir.path().join(".env"));
+
+    assert_eq!(
+        spec.resolve_named("MISSING_TOKEN").unwrap(),
+        NamedResolution::Missing { required: true }
+    );
+    assert_eq!(
+        spec.resolve_named("SENTRY_DSN").unwrap(),
+        NamedResolution::Missing { required: false }
+    );
+}
+
+/// An undeclared name is a distinct outcome from a declared secret with no
+/// value: the caller asked about something this configuration does not offer.
+#[test]
+fn resolve_named_reports_an_undeclared_name() {
+    use crate::resolve::NamedResolution;
+
+    let temp_dir = TempDir::new().unwrap();
+    let spec = named_resolution_spec(&temp_dir.path().join(".env"));
+
+    assert_eq!(
+        spec.resolve_named("NOT_IN_THE_MANIFEST").unwrap(),
+        NamedResolution::Undeclared
+    );
+}
+
+/// A scope narrows the surface a session resolves, so a secret it hides is not
+/// on offer here. Reporting it as merely missing would disclose that the scope
+/// hides it, and would invite the caller to treat it as settable.
+#[test]
+fn resolve_named_treats_a_scope_hidden_secret_as_undeclared() {
+    use crate::config::Scope;
+    use crate::resolve::NamedResolution;
+
+    let temp_dir = TempDir::new().unwrap();
+    let env_path = temp_dir.path().join(".env");
+    fs::write(&env_path, "DB_USER=alice\nAPI_KEY=k\n").unwrap();
+
+    let mut config = resolve_test_config(HashMap::from([
+        ("DB_USER".to_string(), described("user")),
+        ("API_KEY".to_string(), described("api key")),
+    ]));
+    config.scopes = Some(HashMap::from([(
+        "db".to_string(),
+        Scope {
+            secrets: vec!["DB_USER".to_string()],
+        },
+    )]));
+    config.validate().unwrap();
+
+    let provider = format!("dotenv://{}", env_path.display());
+    let mut spec = Secrets::new(config, None, Some(provider), None);
+    spec.set_scope("db");
+
+    assert!(matches!(
+        spec.resolve_named("DB_USER").unwrap(),
+        NamedResolution::Resolved(_)
+    ));
+    // Stored in the same file and declared in the profile, but out of scope.
+    assert_eq!(
+        spec.resolve_named("API_KEY").unwrap(),
+        NamedResolution::Undeclared
+    );
+}
+
+/// A broken configuration is an error, not an absent value: collapsing the two
+/// would let a typo in a provider alias read as "this secret is unset".
+#[test]
+fn resolve_named_surfaces_configuration_errors() {
+    let temp_dir = TempDir::new().unwrap();
+    let env_path = temp_dir.path().join(".env");
+    fs::write(&env_path, "DB_USER=alice\n").unwrap();
+
+    let secrets = HashMap::from([(
+        "DB_USER".to_string(),
+        Secret {
+            providers: Some(vec!["no_such_alias".to_string()]),
+            ..described("user")
+        },
+    )]);
+    let config = resolve_test_config(secrets);
+    let spec = Secrets::new(config, None, None, None);
+
+    assert!(
+        spec.resolve_named("DB_USER").is_err(),
+        "an undefined provider alias must not read as a missing value"
+    );
+}
+
 #[test]
 fn composed_secrets_resolve_in_dependency_order_without_reparsing_values() {
     use crate::resolve::ResolvedSource;


### PR DESCRIPTION
Two independent units, each shippable on its own. **Part of 0.19.0**: this
targets `release-0.19.0` and should merge before #314, so the release carries
both.

## Resolve a single secret by name (`47e87cd`)

`resolve()` answers "can this whole profile be satisfied", which is the wrong
question for a consumer that needs one secret: an unrelated missing required
secret fails the call and returns nothing. `Secrets::resolve_named` resolves
only the requested secret and the inputs it composes from, and separates the
outcomes the batch shape conflates:

```rust
pub enum NamedResolution {
    Undeclared,                  // not on this profile/scope surface
    Missing { required: bool },  // declared, no value
    Resolved(ResolvedSecret),
}
```

`Secrets::with_default_reason` sets a session reason only when none is in
effect, so a wrapper can describe itself without discarding the reason its
caller supplied through `with_reason` or `SECRETSPEC_REASON`.

`secretspec get` becomes a printer over the same path instead of a second
single-secret implementation. Their surfaces differ, and that is now explicit
rather than implied by which code path you took: `get` names one secret and has
no `--scope`, so it reads the whole profile, while the SDK resolves the
session's scoped surface. To keep `get`'s audit trail, the plan executor now
reports the coordinates each read actually reached, so an event still names the
alias-expanded `ref` and still records none for a cache hit.

Removing the duplicate path left the singular cache read and the route's spec
walk unused. The executor consults caches before constructing any provider and
skips a fully-cached group, so `get`'s "a cache hit contacts nothing" property
is intact.

## Reject credentials in provider URIs (`71c6fc9`) — breaking

A provider URI is committed to `secretspec.toml`, echoed into shell history, and
printed by CI, so a credential written there is already disclosed and terminal
redaction cannot retract it. Provider credentials (0.15+) cover every case the
URI form did, so the URI form is now refused rather than read:

- any `scheme://user:password@host`, for every registered scheme
- `onepassword+token://token@vault` and `onepassword+token://account:token@vault`

The refusal reads the accepted credential names off the provider's registration,
so each provider points at its own credential and docs page:

> provider URI 'vault://host' carries a password. ... Supply it as the `role_id`,
> `secret_id`, `token` provider credential instead (`secretspec config provider
> login <alias>`, or `credentials = { ... }` on the alias), or use the provider's
> environment variable. See https://secretspec.dev/providers/vault/

A provider that accepts no credentials says to drop the userinfo instead. The
`onepassword+token://` scheme still selects service account authentication; only
the embedded token is gone.

Rejecting the shape surfaced a leak beside it: a specification that fails to
parse as a URL never reaches this gate, and its error echoed the credential
verbatim. That message is redacted now. `redact_uri_strict` stays crate-internal
for exactly that reason — the message refusing a credential must not repeat it.

## Notes for review

- 1201 tests green. Unit 1 was also tested in isolation (1200 green) before
  being committed, so it is shippable independently rather than merely ordered
  first.
- The registry-driven `every_scheme_rejects_a_userinfo_password` replaces a test
  that had become vacuous: its `let Ok(..) else { continue }` would have skipped
  every scheme under the new rule and still passed.
- Docs carry `(0.19+)` at each point of use: the 1Password page, the provider
  reference, the providers concept page, and the Rust SDK page (with a compiled
  example). Changelog entries are folded into the 0.19.0 section.
- Not done deliberately: `resolve_named` is Rust-only. Exposing it over the C
  ABI means committing `NamedResolution` to a wire format, which is its own call.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — see https://github.com/cli/cli/issues/13904