### PR TITLE
Docs copyable examples

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import starlightLlmsTxt from "starlight-llms-txt";
 import starlightBlog from "starlight-blog";
+import { terminalCopyPlugin } from "./src/lib/terminal-copy.mjs";
 
 const rustSdkBasicExample = readFileSync(
   new URL("../secretspec-derive/examples/basic.rs", import.meta.url),
@@ -57,6 +58,9 @@ export default defineConfig({
   },
   integrations: [
     starlight({
+      expressiveCode: {
+        plugins: [terminalCopyPlugin()],
+      },
       plugins: [
         starlightBlog({
           title: "Blog",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "npm run check:provider-credentials && astro check && astro build",
+    "build": "npm run check:provider-credentials && npm run check:terminal-copy && astro check && astro build",
     "check:provider-credentials": "node --test scripts/provider-credentials.test.mjs && node scripts/check-provider-credentials.mjs",
+    "check:terminal-copy": "node --test scripts/terminal-copy.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/docs/scripts/terminal-copy.test.mjs
+++ b/docs/scripts/terminal-copy.test.mjs
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  extractTerminalCommands,
+  terminalCopyPlugin,
+} from "../src/lib/terminal-copy.mjs";
+
+test("copies prompted commands without prompts, comments, or output", () => {
+  const session = `# Set a secret
+$ secretspec set DATABASE_URL --provider pass
+Enter value for DATABASE_URL: ********
+✓ Secret 'DATABASE_URL' saved to pass (profile: default)
+
+# Run with secrets
+$ secretspec run --provider pass -- npm start`;
+
+  assert.equal(
+    extractTerminalCommands(session),
+    `secretspec set DATABASE_URL --provider pass
+secretspec run --provider pass -- npm start`,
+  );
+});
+
+test("joins Bash continuation lines without copying backslashes", () => {
+  const session = `$ secretspec init \\
+    --from 'awsps://us-east-1?template=/{profile}/{project}/{key}' \\
+    --project payments \\
+    --profile production
+✓ Created secretspec.toml with 12 secrets`;
+
+  assert.equal(
+    extractTerminalCommands(session, "bash"),
+    "secretspec init --from 'awsps://us-east-1?template=/{profile}/{project}/{key}' --project payments --profile production",
+  );
+  assert.equal(
+    extractTerminalCommands(session, "console"),
+    "secretspec init --from 'awsps://us-east-1?template=/{profile}/{project}/{key}' --project payments --profile production",
+  );
+});
+
+test("preserves quoted hashes across Bash continuation lines", () => {
+  const session = `$ printf "%s\\n" "hello \\
+    # world"`;
+
+  assert.equal(
+    extractTerminalCommands(session, "bash"),
+    'printf "%s\\n" "hello # world"',
+  );
+});
+
+test("does not absorb continuation lines outside shell blocks", () => {
+  assert.equal(
+    extractTerminalCommands("$ command \\\n    --flag\noutput", "text"),
+    "command \\",
+  );
+});
+
+test("omits inline annotations from copied commands", () => {
+  assert.equal(
+    extractTerminalCommands(
+      '$ secretspec add API_KEY --description "API access token" # 0.18+',
+    ),
+    'secretspec add API_KEY --description "API access token"',
+  );
+  assert.equal(
+    extractTerminalCommands('$ command "value # stays" https://example.test/#id'),
+    'command "value # stays" https://example.test/#id',
+  );
+});
+
+test("leaves command-only blocks unchanged", () => {
+  assert.equal(
+    extractTerminalCommands("npm install\nnpm test"),
+    "npm install\nnpm test",
+  );
+});
+
+function terminalBlockAst(lineCount, isTerminal = true) {
+  const button = {
+    type: "element",
+    tagName: "button",
+    properties: { dataCode: "$ secretspec check\u007f✓ All secrets are set" },
+    children: [{ type: "element", tagName: "div", properties: {}, children: [] }],
+  };
+  const blockAst = {
+    type: "element",
+    tagName: "figure",
+    properties: {
+      className: isTerminal ? ["frame", "is-terminal"] : ["frame"],
+    },
+    children: [
+      {
+        type: "element",
+        tagName: "pre",
+        properties: {},
+        children: [
+          {
+            type: "element",
+            tagName: "code",
+            properties: {},
+            children: Array.from({ length: lineCount }, () => ({
+              type: "element",
+              tagName: "div",
+              properties: { className: ["ec-line"] },
+              children: [],
+            })),
+          },
+        ],
+      },
+      {
+        type: "element",
+        tagName: "div",
+        properties: { className: ["copy"] },
+        children: [button],
+      },
+    ],
+  };
+
+  return { blockAst, button };
+}
+
+test("renders one copy button beside each prompted command", () => {
+  const { blockAst } = terminalBlockAst(5);
+
+  terminalCopyPlugin().hooks.postprocessRenderedBlock({
+    codeBlock: {
+      language: "console",
+      code: `# Check secrets
+$ secretspec check
+✓ All secrets are set
+
+$ secretspec run -- npm start`,
+    },
+    renderData: { blockAst },
+  });
+
+  const lines = blockAst.children[0].children[0].children;
+  assert.deepEqual(
+    lines.map((line) => line.properties.className),
+    [
+      ["ec-line"],
+      ["ec-line", "terminal-command-start"],
+      ["ec-line"],
+      ["ec-line"],
+      ["ec-line", "terminal-command-start"],
+    ],
+  );
+  assert.equal(lines[1].children[0].properties.className[0], "copy");
+  assert.equal(
+    lines[1].children[0].children[0].properties.dataCode,
+    "secretspec check",
+  );
+  assert.equal(
+    lines[4].children[0].children[0].properties.dataCode,
+    "secretspec run -- npm start",
+  );
+  assert.equal(
+    blockAst.children.some((child) => child === lines[1].children[0]),
+    false,
+  );
+  assert.equal(
+    blockAst.children.some((child) =>
+      child.properties?.className?.includes("copy"),
+    ),
+    false,
+  );
+});
+
+test("renders one copy button for a multiline prompted command", () => {
+  const { blockAst } = terminalBlockAst(4);
+
+  terminalCopyPlugin().hooks.postprocessRenderedBlock({
+    codeBlock: {
+      language: "bash",
+      code: `$ secretspec init \\
+    --project payments \\
+    --profile production
+✓ Created secretspec.toml`,
+    },
+    renderData: { blockAst },
+  });
+
+  const lines = blockAst.children[0].children[0].children;
+  assert.equal(lines[0].children.length, 1);
+  assert.equal(lines[1].children.length, 0);
+  assert.equal(lines[2].children.length, 0);
+  assert.equal(
+    lines[0].children[0].children[0].properties.dataCode,
+    "secretspec init --project payments --profile production",
+  );
+});
+
+test("leaves command-only shell blocks on the default copy button", () => {
+  const { blockAst } = terminalBlockAst(1);
+
+  terminalCopyPlugin().hooks.postprocessRenderedBlock({
+    codeBlock: { language: "bash", code: "secretspec-update" },
+    renderData: { blockAst },
+  });
+
+  const line = blockAst.children[0].children[0].children[0];
+  assert.deepEqual(line.properties.className, ["ec-line"]);
+  assert.equal(line.children.length, 0);
+  assert.equal(blockAst.children[1].properties.className[0], "copy");
+});
+
+test("uses the rendered terminal frame instead of a language allowlist", () => {
+  const { blockAst } = terminalBlockAst(2);
+
+  terminalCopyPlugin().hooks.postprocessRenderedBlock({
+    codeBlock: { language: "zsh", code: "$ secretspec check\noutput" },
+    renderData: { blockAst },
+  });
+
+  const line = blockAst.children[0].children[0].children[0];
+  assert.equal(line.children[0].properties.className[1], "terminal-line-copy");
+  assert.equal(line.children[0].children[0].properties.dataCode, "secretspec check");
+});
+
+test("leaves explicitly nonterminal Bash frames unchanged", () => {
+  const { blockAst } = terminalBlockAst(1, false);
+
+  terminalCopyPlugin().hooks.postprocessRenderedBlock({
+    codeBlock: { language: "bash", code: "$ secretspec check" },
+    renderData: { blockAst },
+  });
+
+  const line = blockAst.children[0].children[0].children[0];
+  assert.equal(line.children.length, 0);
+  assert.equal(blockAst.children[1].properties.className[0], "copy");
+});
+
+test("does not add a copy button for an empty prompted annotation", () => {
+  const { blockAst } = terminalBlockAst(1);
+
+  terminalCopyPlugin().hooks.postprocessRenderedBlock({
+    codeBlock: { language: "bash", code: "$ # 0.18+" },
+    renderData: { blockAst },
+  });
+
+  const line = blockAst.children[0].children[0].children[0];
+  assert.equal(line.children.length, 0);
+  assert.equal(blockAst.children[1].properties.className[0], "copy");
+});

--- a/docs/scripts/terminal-copy.test.mjs
+++ b/docs/scripts/terminal-copy.test.mjs
@@ -39,6 +39,21 @@ test("joins Bash continuation lines without copying backslashes", () => {
   );
 });
 
+test("preserves token boundaries across Bash continuations", () => {
+  assert.equal(
+    extractTerminalCommands("$ printf foo\\\nbar", "bash"),
+    "printf foobar",
+  );
+  assert.equal(
+    extractTerminalCommands("$ printf foo \\\nbar", "bash"),
+    "printf foo bar",
+  );
+  assert.equal(
+    extractTerminalCommands("$ printf foo\\\n    bar", "bash"),
+    "printf foo bar",
+  );
+});
+
 test("preserves quoted hashes across Bash continuation lines", () => {
   const session = `$ printf "%s\\n" "hello \\
     # world"`;
@@ -66,6 +81,14 @@ test("omits inline annotations from copied commands", () => {
   assert.equal(
     extractTerminalCommands('$ command "value # stays" https://example.test/#id'),
     'command "value # stays" https://example.test/#id',
+  );
+  assert.equal(
+    extractTerminalCommands("$ command;# annotation"),
+    "command;",
+  );
+  assert.equal(
+    extractTerminalCommands("$ printf foo\\ #bar"),
+    "printf foo\\ #bar",
   );
 });
 
@@ -205,7 +228,7 @@ test("leaves command-only shell blocks on the default copy button", () => {
   assert.equal(blockAst.children[1].properties.className[0], "copy");
 });
 
-test("uses the rendered terminal frame instead of a language allowlist", () => {
+test("supports prompted terminal languages outside the continuation allowlist", () => {
   const { blockAst } = terminalBlockAst(2);
 
   terminalCopyPlugin().hooks.postprocessRenderedBlock({
@@ -218,7 +241,7 @@ test("uses the rendered terminal frame instead of a language allowlist", () => {
   assert.equal(line.children[0].children[0].properties.dataCode, "secretspec check");
 });
 
-test("leaves explicitly nonterminal Bash frames unchanged", () => {
+test("cleans prompted blocks even when their frame is nonterminal", () => {
   const { blockAst } = terminalBlockAst(1, false);
 
   terminalCopyPlugin().hooks.postprocessRenderedBlock({
@@ -227,8 +250,9 @@ test("leaves explicitly nonterminal Bash frames unchanged", () => {
   });
 
   const line = blockAst.children[0].children[0].children[0];
-  assert.equal(line.children.length, 0);
-  assert.equal(blockAst.children[1].properties.className[0], "copy");
+  assert.equal(line.children[0].properties.className[1], "terminal-line-copy");
+  assert.equal(line.children[0].children[0].properties.dataCode, "secretspec check");
+  assert.equal(blockAst.children.length, 1);
 });
 
 test("does not add a copy button for an empty prompted annotation", () => {
@@ -241,5 +265,18 @@ test("does not add a copy button for an empty prompted annotation", () => {
 
   const line = blockAst.children[0].children[0].children[0];
   assert.equal(line.children.length, 0);
+  assert.equal(blockAst.children.length, 1);
+});
+
+test("keeps the default button when replacement AST validation fails", () => {
+  const { blockAst } = terminalBlockAst(1);
+  blockAst.children[1].children = [];
+
+  terminalCopyPlugin().hooks.postprocessRenderedBlock({
+    codeBlock: { language: "bash", code: "$ secretspec check" },
+    renderData: { blockAst },
+  });
+
+  assert.equal(blockAst.children.length, 2);
   assert.equal(blockAst.children[1].properties.className[0], "copy");
 });

--- a/docs/src/lib/terminal-copy.mjs
+++ b/docs/src/lib/terminal-copy.mjs
@@ -1,0 +1,172 @@
+function scanShellLine(line, initialQuote) {
+  let quote = initialQuote;
+  let escaped = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if ((character === "'" || character === '"') && !quote) {
+      quote = character;
+      continue;
+    }
+    if (character === quote) {
+      quote = undefined;
+      continue;
+    }
+    if (
+      character === "#" &&
+      !quote &&
+      (index === 0 || /\s/.test(line[index - 1]))
+    ) {
+      return {
+        text: line.slice(0, index).trimEnd(),
+        quote,
+        escaped: false,
+      };
+    }
+  }
+
+  return { text: line, quote, escaped };
+}
+
+function withoutLineContinuation(line) {
+  return line.trimEnd().slice(0, -1).trimEnd();
+}
+
+export function extractTerminalCommandGroups(code, language = "bash") {
+  const lines = code.split("\n");
+  const commands = [];
+  let current;
+  const supportsContinuation = ["bash", "console", "sh", "shell"].includes(
+    language,
+  );
+
+  for (const [lineIndex, line] of lines.entries()) {
+    const prompted = line.match(/^\s*\$\s(.*)$/);
+    if (prompted) {
+      const scanned = scanShellLine(prompted[1]);
+      const continues = supportsContinuation && scanned.escaped;
+      current = {
+        lineIndex,
+        lines: [
+          continues ? withoutLineContinuation(scanned.text) : scanned.text,
+        ],
+        quote: scanned.quote,
+      };
+      commands.push(current);
+      if (!continues) current = undefined;
+      continue;
+    }
+
+    if (current) {
+      const scanned = scanShellLine(line, current.quote);
+      const continues = scanned.escaped;
+      current.lines.push(
+        (continues
+          ? withoutLineContinuation(scanned.text)
+          : scanned.text
+        ).trim(),
+      );
+      current.quote = scanned.quote;
+      if (!continues) current = undefined;
+    }
+  }
+
+  return commands
+    .map(({ lineIndex, lines: commandLines }) => ({
+      lineIndex,
+      command: commandLines.join(" ").trim(),
+    }))
+    .filter(({ command }) => command.length > 0);
+}
+
+export function extractTerminalCommands(code, language = "bash") {
+  const commands = extractTerminalCommandGroups(code, language);
+  return commands.length
+    ? commands.map(({ command }) => command).join("\n")
+    : code;
+}
+
+function findElement(node, predicate, parent) {
+  if (!node || node.type !== "element") return undefined;
+  if (predicate(node)) return { node, parent };
+
+  for (const child of node.children ?? []) {
+    const result = findElement(child, predicate, node);
+    if (result) return result;
+  }
+
+  return undefined;
+}
+
+function hasClass(node, className) {
+  return node.properties?.className?.includes(className);
+}
+
+function cloneNode(node) {
+  return {
+    ...node,
+    properties: { ...node.properties },
+    children: node.children?.map(cloneNode) ?? [],
+  };
+}
+
+export function terminalCopyPlugin() {
+  return {
+    name: "SecretSpec terminal copy",
+    hooks: {
+      postprocessRenderedBlock: ({ codeBlock, renderData }) => {
+        if (!hasClass(renderData.blockAst, "is-terminal")) return;
+        const commands = extractTerminalCommandGroups(
+          codeBlock.code,
+          codeBlock.language,
+        );
+        if (!commands.length) return;
+
+        const copy = findElement(renderData.blockAst, (node) =>
+          hasClass(node, "copy"),
+        );
+        const code = findElement(
+          renderData.blockAst,
+          (node) => node.tagName === "code",
+        );
+        if (!copy?.parent || !code) return;
+
+        const copyIndex = copy.parent.children.indexOf(copy.node);
+        copy.parent.children.splice(copyIndex, 1);
+
+        for (const { lineIndex, command } of commands) {
+          const line = code.node.children[lineIndex];
+          if (!line) continue;
+
+          const lineCopy = cloneNode(copy.node);
+          lineCopy.properties.className = ["copy", "terminal-line-copy"];
+          const button = findElement(
+            lineCopy,
+            (node) => node.tagName === "button",
+          )?.node;
+          if (!button) continue;
+
+          if ("dataCode" in button.properties) {
+            button.properties.dataCode = command;
+          } else {
+            button.properties["data-code"] = command;
+          }
+
+          line.properties.className = [
+            ...(line.properties.className ?? []),
+            "terminal-command-start",
+          ];
+          line.children.push(lineCopy);
+        }
+      },
+    },
+  };
+}

--- a/docs/src/lib/terminal-copy.mjs
+++ b/docs/src/lib/terminal-copy.mjs
@@ -1,11 +1,15 @@
-function scanShellLine(line, initialQuote) {
-  let quote = initialQuote;
+const promptPattern = /^\s*\$\s(.*)$/;
+
+function scanShellLine(line, initialState = {}) {
+  let quote = initialState.quote;
+  let atTokenStart = initialState.atTokenStart ?? true;
   let escaped = false;
 
   for (let index = 0; index < line.length; index += 1) {
     const character = line[index];
     if (escaped) {
       escaped = false;
+      atTokenStart = false;
       continue;
     }
     if (character === "\\" && quote !== "'") {
@@ -14,30 +18,42 @@ function scanShellLine(line, initialQuote) {
     }
     if ((character === "'" || character === '"') && !quote) {
       quote = character;
+      atTokenStart = false;
       continue;
     }
     if (character === quote) {
       quote = undefined;
+      atTokenStart = false;
       continue;
     }
-    if (
-      character === "#" &&
-      !quote &&
-      (index === 0 || /\s/.test(line[index - 1]))
-    ) {
+    if (character === "#" && !quote && atTokenStart) {
       return {
         text: line.slice(0, index).trimEnd(),
         quote,
         escaped: false,
+        atTokenStart,
       };
     }
+    if (!quote && /\s/.test(character)) {
+      atTokenStart = true;
+      continue;
+    }
+    if (!quote && /[;|&()<>]/.test(character)) {
+      atTokenStart = true;
+      continue;
+    }
+    atTokenStart = false;
   }
 
-  return { text: line, quote, escaped };
+  return { text: line, quote, escaped, atTokenStart };
 }
 
 function withoutLineContinuation(line) {
-  return line.trimEnd().slice(0, -1).trimEnd();
+  const withoutBackslash = line.trimEnd().slice(0, -1);
+  return {
+    text: withoutBackslash.trimEnd(),
+    separator: /\s$/.test(withoutBackslash) ? " " : "",
+  };
 }
 
 export function extractTerminalCommandGroups(code, language = "bash") {
@@ -49,16 +65,19 @@ export function extractTerminalCommandGroups(code, language = "bash") {
   );
 
   for (const [lineIndex, line] of lines.entries()) {
-    const prompted = line.match(/^\s*\$\s(.*)$/);
+    const prompted = line.match(promptPattern);
     if (prompted) {
       const scanned = scanShellLine(prompted[1]);
       const continues = supportsContinuation && scanned.escaped;
+      const continuation = continues
+        ? withoutLineContinuation(scanned.text)
+        : undefined;
       current = {
         lineIndex,
-        lines: [
-          continues ? withoutLineContinuation(scanned.text) : scanned.text,
-        ],
+        lines: [continuation?.text ?? scanned.text],
+        separators: continuation ? [continuation.separator] : [],
         quote: scanned.quote,
+        atTokenStart: scanned.atTokenStart,
       };
       commands.push(current);
       if (!continues) current = undefined;
@@ -66,24 +85,37 @@ export function extractTerminalCommandGroups(code, language = "bash") {
     }
 
     if (current) {
-      const scanned = scanShellLine(line, current.quote);
+      const scanned = scanShellLine(line, current);
       const continues = scanned.escaped;
-      current.lines.push(
-        (continues
-          ? withoutLineContinuation(scanned.text)
-          : scanned.text
-        ).trim(),
-      );
+      const continuation = continues
+        ? withoutLineContinuation(scanned.text)
+        : undefined;
+      if (
+        current.separators.at(-1) === "" &&
+        /^\s/.test(continuation?.text ?? scanned.text)
+      ) {
+        current.separators[current.separators.length - 1] = " ";
+      }
+      current.lines.push((continuation?.text ?? scanned.text).trim());
+      if (continuation) current.separators.push(continuation.separator);
       current.quote = scanned.quote;
+      current.atTokenStart = scanned.atTokenStart;
       if (!continues) current = undefined;
     }
   }
 
   return commands
-    .map(({ lineIndex, lines: commandLines }) => ({
-      lineIndex,
-      command: commandLines.join(" ").trim(),
-    }))
+    .map(({ lineIndex, lines: commandLines, separators }) => {
+      const command = commandLines
+        .slice(1)
+        .reduce(
+          (joined, segment, index) =>
+            `${joined}${separators[index] ?? " "}${segment}`,
+          commandLines[0],
+        )
+        .trim();
+      return { lineIndex, command };
+    })
     .filter(({ command }) => command.length > 0);
 }
 
@@ -123,28 +155,38 @@ export function terminalCopyPlugin() {
     name: "SecretSpec terminal copy",
     hooks: {
       postprocessRenderedBlock: ({ codeBlock, renderData }) => {
-        if (!hasClass(renderData.blockAst, "is-terminal")) return;
+        const hasPrompt = codeBlock.code
+          .split("\n")
+          .some((line) => promptPattern.test(line));
+        if (!hasPrompt) return;
+
         const commands = extractTerminalCommandGroups(
           codeBlock.code,
           codeBlock.language,
         );
-        if (!commands.length) return;
 
         const copy = findElement(renderData.blockAst, (node) =>
           hasClass(node, "copy"),
         );
+        if (!copy?.parent) return;
+
+        const copyIndex = copy.parent.children.indexOf(copy.node);
+        if (copyIndex < 0) return;
+
+        if (!commands.length) {
+          copy.parent.children.splice(copyIndex, 1);
+          return;
+        }
+
         const code = findElement(
           renderData.blockAst,
           (node) => node.tagName === "code",
         );
-        if (!copy?.parent || !code) return;
+        if (!code) return;
 
-        const copyIndex = copy.parent.children.indexOf(copy.node);
-        copy.parent.children.splice(copyIndex, 1);
-
-        for (const { lineIndex, command } of commands) {
+        const replacements = commands.map(({ lineIndex, command }) => {
           const line = code.node.children[lineIndex];
-          if (!line) continue;
+          if (!line?.children) return undefined;
 
           const lineCopy = cloneNode(copy.node);
           lineCopy.properties.className = ["copy", "terminal-line-copy"];
@@ -152,7 +194,7 @@ export function terminalCopyPlugin() {
             lineCopy,
             (node) => node.tagName === "button",
           )?.node;
-          if (!button) continue;
+          if (!button) return undefined;
 
           if ("dataCode" in button.properties) {
             button.properties.dataCode = command;
@@ -160,6 +202,13 @@ export function terminalCopyPlugin() {
             button.properties["data-code"] = command;
           }
 
+          return { line, lineCopy };
+        });
+        if (replacements.some((replacement) => !replacement)) return;
+
+        copy.parent.children.splice(copyIndex, 1);
+
+        for (const { line, lineCopy } of replacements) {
           line.properties.className = [
             ...(line.properties.className ?? []),
             "terminal-command-start",

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -61,7 +61,15 @@
 /* Each prompted command gets a copy button aligned with its first line. */
 .sl-markdown-content
   .expressive-code
-  figure.is-terminal
+  figure
+  .terminal-command-start {
+  align-items: center;
+  min-block-size: 2.5rem;
+}
+
+.sl-markdown-content
+  .expressive-code
+  figure
   .terminal-command-start
   > .code {
   padding-inline-end: 3rem;
@@ -69,11 +77,20 @@
 
 .sl-markdown-content
   .expressive-code
-  figure.is-terminal
+  figure
   .terminal-line-copy {
   inset-block-start: 50%;
   inset-inline-end: 0.5rem;
   transform: translateY(-50%);
+}
+
+@media (hover: hover) {
+  .sl-markdown-content
+    .expressive-code
+    figure
+    .terminal-command-start {
+    min-block-size: 2rem;
+  }
 }
 
 /* Swap the release-post logo artwork with the active documentation theme. */

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -58,6 +58,24 @@
   color: var(--sl-color-accent-high);
 }
 
+/* Each prompted command gets a copy button aligned with its first line. */
+.sl-markdown-content
+  .expressive-code
+  figure.is-terminal
+  .terminal-command-start
+  > .code {
+  padding-inline-end: 3rem;
+}
+
+.sl-markdown-content
+  .expressive-code
+  figure.is-terminal
+  .terminal-line-copy {
+  inset-block-start: 50%;
+  inset-inline-end: 0.5rem;
+  transform: translateY(-50%);
+}
+
 /* Swap the release-post logo artwork with the active documentation theme. */
 :root[data-theme="dark"]
   img[alt="The new SecretSpec document-and-keyhole logo"] {


### PR DESCRIPTION
Improve terminal code examples with one copy button per command. Copied commands exclude prompts, output, comments, and continuation backslashes.
Each example with several commands now has several buttons.

<img width="410" height="244" alt="image" src="https://github.com/user-attachments/assets/798d59e5-9b6a-4e3f-99c9-30febc57cdf9" />

Previously big examples with large outputs were hard to copy.