### PR TITLE
Prompt for missing secrets during run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Secrets can set `prompt = true` to request a hidden value from the controlling
+  terminal when `secretspec run` finds no stored value. Writable providers save
+  the answer for later runs; the `null` provider keeps it invocation-only.
 - Profiles can opt out of inheriting `[profiles.default]` by setting
   `inherit = false` in their profile defaults (0.19+), allowing standalone
   secret sets alongside profiles that still share the default declarations.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -127,7 +127,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). The null provider (0.19+) uses manifest defaults or ephemeral generation without storage.`,
+Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
         }),
       ],
       title: "SecretSpec",

--- a/docs/src/content/docs/concepts/declarative.md
+++ b/docs/src/content/docs/concepts/declarative.md
@@ -38,11 +38,15 @@ SECRET_NAME = {
 - `composed` (0.16+): Derive a read-only value from other declared secrets (see [Composed Secrets](/concepts/composed-secrets/) for the strict template and dependency semantics)
 - `type`: Secret type for auto-generation (`password`, `hex`, `base64`, `uuid`, `command`)
 - `generate`: Enable auto-generation when the secret is missing (`true` or a table with options)
+- `prompt` (0.19+): Securely ask for a missing value during `secretspec run` and
+  let the selected provider decide whether to save the answer
 
 ## Related Concepts
 
 - [Configuration Inheritance](/concepts/inheritance/) lets projects share common secret definitions via the `extends` field
 - [Secret Generation](/concepts/generation/) auto-creates passwords, tokens, and keys when secrets are missing
+- [Run prompts (0.19+)](/reference/configuration/#prompt-on-missing-during-run-019)
+  provision stored secrets on first use, or remain invocation-only with `null`
 - [Composed Secrets (0.16+)](/concepts/composed-secrets/) derive values from
   other declared secrets without dotenv or shell expansion
 

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -44,7 +44,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ | — |
 | [file](/providers/file/) (0.19+) | One plaintext UTF-8 file per secret | ✓ | ✓ | ✗ | — |
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ | — |
-| [null](/providers/null/) (0.19+) | No storage; uses a manifest default or ephemeral generation | ✗ | ✗ | N/A | — |
+| [null](/providers/null/) (0.19+) | No storage; uses a manifest default, ephemeral generation, or an ephemeral run prompt | ✗ | ✗ | N/A | — |
 | [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |
 | [pass](/providers/pass/) | Unix `pass` password store | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [gopass](/providers/gopass/) (0.15+) | `gopass` password store (git-synced, GPG-encrypted) | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |

--- a/docs/src/content/docs/development/adding-providers.md
+++ b/docs/src/content/docs/development/adding-providers.md
@@ -36,8 +36,14 @@ pub trait Provider: Send + Sync {
     /// SecretSpec 0.19+: optional, defaults to Persist. Return Ephemeral only
     /// when generated values should be returned for one resolution without
     /// calling `set`; ordinary writes remain governed by `check_writable`.
-    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
-        GeneratedValuePersistence::Persist
+    fn generated_value_persistence(&self) -> ProducedValuePersistence {
+        ProducedValuePersistence::Persist
+    }
+
+    /// SecretSpec 0.19+: optional, defaults to Persist. This is independent of
+    /// `prompt = true`, which selects operator input rather than storage policy.
+    fn prompted_value_persistence(&self) -> ProducedValuePersistence {
+        ProducedValuePersistence::Persist
     }
 
     /// SecretSpec 0.19+: optional pre-write description. The default renders
@@ -70,12 +76,15 @@ you declare the set, you never write the check. Have `set` call
 `self.check_writable(addr)?` first, so the pre-check and the write agree on
 one refusal message.
 
-SecretSpec 0.19+ also exposes `generated_value_persistence`. Leave its default
-of `Persist` for storage providers. `Ephemeral` is an explicit generation-only
-capability: after a healthy read miss, SecretSpec returns the generated logical
-value for the current materializing resolution without calling `set` or
-refreshing a cache. It does not make ordinary writes succeed and must be a pure,
-I/O-free capability check.
+SecretSpec 0.19+ also exposes `generated_value_persistence` and
+`prompted_value_persistence`. Leave their default of `Persist` for storage
+providers. `Ephemeral` is an explicit automatic-value capability: after a
+healthy read miss, SecretSpec returns the generated or prompted logical value
+for the current materializing resolution without calling `set` or refreshing a
+cache. It does not make ordinary writes succeed, and each method must be a pure,
+I/O-free capability check. In particular, `prompt = true` selects how a missing
+value is acquired; `prompted_value_persistence` decides what the provider does
+with the answer.
 
 In SecretSpec 0.19+, override `describe_write_target` when the provider URI and
 native coordinates do not identify the physical destination clearly. The

--- a/docs/src/content/docs/providers/null.md
+++ b/docs/src/content/docs/providers/null.md
@@ -1,16 +1,17 @@
 ---
 title: Null Provider
-description: Use committed defaults or ephemeral generation without a storage backend
+description: Use committed defaults, ephemeral generation, or run-time prompts without storage
 ---
 
 :::caution[Version compatibility]
 The `null` provider is added in SecretSpec 0.19.
 :::
 
-The null provider always reports that a value is missing. SecretSpec then uses
-the declaration's committed `default` or generates a fresh value when
-`generate` is enabled. This is useful for non-sensitive environment
-configuration and secrets that should exist for only one resolution.
+The null provider always reports that a value is missing. SecretSpec can then
+use the declaration's committed `default`, generate a fresh value, or—in
+SecretSpec 0.19+—ask the operator during `run` when `prompt = true`. This is
+useful for non-sensitive environment configuration and values that should exist
+for only one invocation or resolution.
 
 ## At a glance
 
@@ -19,7 +20,7 @@ configuration and secrets that should exist for only one resolution.
 | Provider | `null` (0.19+) |
 | URI | `null://` |
 | Access | Always returns missing; ordinary writes are rejected |
-| Best for | Team-shared defaults and ephemeral generated values |
+| Best for | Team-shared defaults, ephemeral generated values, and operator-supplied run values (0.19+) |
 | Storage | None |
 
 ## Quick start
@@ -61,6 +62,26 @@ and gives that value to the child process. A later `run`, `get`, `check`, or SDK
 value-carrying resolution generates a new value. Value-free reports mark the
 secret as generated without minting it.
 
+## Ephemeral operator input (0.19+)
+
+:::note[SecretSpec 0.19+]
+Run-time prompting through `null://` is available starting in SecretSpec 0.19.
+:::
+
+Combine `prompt = true` with `null` when the value must always come from the
+operator and must never be stored:
+
+```toml title="secretspec.toml"
+[profiles.default]
+DEPLOY_PASSWORD = { description = "One-time deployment password", required = true, prompt = true, providers = ["null"] }
+```
+
+`secretspec run -- ./deploy` reads the value through a hidden controlling
+terminal prompt, without consuming the child's stdin. The answer is present in
+the child environment for that invocation and is then discarded. It is never
+passed to `null.set()` or written to a cache. A noninteractive run fails before
+the child starts; other commands and SDK resolution do not prompt.
+
 ## How it works
 
 SecretSpec normally asks the selected provider before using a default or
@@ -69,8 +90,11 @@ report a missing value, and every ordinary write is rejected. The missing read
 lets SecretSpec use the committed default or generator without provider I/O.
 
 The provider has no options, credentials, feature flag, or persistent state.
-Use it on declarations with defaults or enabled generation. Required
-declarations with neither remain missing, and explicit writes are rejected.
+Use it on declarations with defaults, enabled generation, or `prompt = true`
+(0.19+). Here `prompt` chooses operator input while `null` chooses ephemeral
+handling; with a writable provider the same prompted answer would be saved.
+Required declarations with none of those remain missing, and explicit writes
+are rejected.
 
 :::danger[Defaults are public configuration]
 Manifest defaults are committed to version control in plaintext. Use `default`
@@ -79,7 +103,7 @@ exist in the resolving process and its configured delivery boundary.
 :::
 
 :::caution[Ephemeral means unstable]
-Generated values are shared only within one resolution. Do not use `null` for
-credentials that another process, machine, or later invocation must retrieve.
-Use a writable provider for those values.
+Generated and prompted values are shared only within one resolution or child
+invocation. Do not use `null` for credentials that another process, machine, or
+later invocation must retrieve. Use a writable provider for those values.
 :::

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -106,7 +106,7 @@ $ secretspec config global init  # 0.17+
   dotenv: Traditional .env files
   file: Plaintext files, one per secret (0.19+)
   env: Read-only environment variables
-  null: Use defaults or ephemeral generation without storage (0.19+)
+  null: Use defaults, generation, or run prompts without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -464,6 +464,28 @@ DATABASE_URL=postgresql://localhost/mydb
 $ secretspec run --scope api -- ./api-server
 ```
 
+SecretSpec 0.19+ can securely request a declared missing value before the child
+starts. The selected provider normally saves the answer; choose `null` when it
+must be ephemeral:
+
+```toml title="secretspec.toml"
+[profiles.default]
+DEPLOY_PASSWORD = { description = "One-time deployment password", required = true, prompt = true, providers = ["null"] }
+```
+
+```bash
+$ secretspec run -- ./deploy
+? Enter value for DEPLOY_PASSWORD (profile: default):
+```
+
+The hidden prompt reads from the controlling terminal, leaving the child's
+stdin unchanged even when it is piped or redirected. The answer is injected
+only for that invocation when the provider is `null`; writable providers save
+it and make the prompt a first-use provisioning step. If no controlling
+terminal exists, `run` fails before starting the child. Only declarations with
+`prompt = true` opt into this behavior; ordinary missing secrets still fail
+without a prompt.
+
 The `--provider` override applies to every secret, including those with a
 [`ref`](/reference/configuration/#secret-references) field: refs are redirected
 to the overriding provider just like convention secrets. This makes it easy to

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -167,6 +167,7 @@ Each secret variable is defined as a table with the following fields:
 | `extract` (0.19+) | table | No | Select one logical value from stored structured data, for example `extract = { format = "json", pointer = "/database/password" }` |
 | `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
 | `generate` | boolean or table | No | Enable auto-generation when secret is missing |
+| `prompt` (0.19+) | boolean | No | Securely prompt for a missing value during `secretspec run`; the selected provider controls persistence |
 
 Field notes:
 
@@ -180,6 +181,8 @@ Field notes:
   though the provider does not have to supply it.
 - `type` is required when `generate` is enabled.
 - `generate` and `default` cannot both be set.
+- `prompt = true` (0.19+) is for individually required secrets and cannot be
+  combined with `default`, enabled `generate`, `extract`, or `composed`.
 - `extract` (0.19+) is read-only and cannot be combined with enabled
   `generate`.
 
@@ -248,7 +251,7 @@ configuration and resolution behavior.
 Scopes name membership-only subsets of a profile's secrets, so a single service
 or task resolves only what it declares instead of the entire profile. They are
 **orthogonal to profiles**: a profile decides how each secret resolves
-(`required`, `default`, providers, references, generation, `as_path`,
+(`required`, `default`, providers, references, generation, prompts (0.19+), `as_path`,
 `encoding` (0.19+), `extract` (0.19+), and the storage namespace); a scope only
 decides *which* secrets take part in a given resolution.
 
@@ -897,6 +900,49 @@ vault, and item paths on provider URIs are errors.
 - [Audit log](/concepts/audit/) events carry a `ref` field with the coordinates.
 - `check --explain` and `check --json` attribute ref secrets to the store URI
   they resolved from.
+
+### Prompt on missing during run (0.19+)
+
+:::caution[Version compatibility]
+`prompt = true` declarations require SecretSpec 0.19 or newer.
+:::
+
+Use `prompt = true` when `secretspec run` should ask the operator after every
+configured provider has returned missing. Prompting is the value source;
+persistence remains a property of the selected provider.
+
+With a writable provider, the answer is saved and reused by later runs. The
+write destination and writability are checked before the hidden prompt opens,
+just as they are for `secretspec set`. Use the `null` provider when the answer
+must exist only for one child invocation:
+
+```toml
+[profiles.default]
+DEPLOY_PASSWORD = { description = "One-time deployment password", required = true, prompt = true, providers = ["null"] }
+```
+
+Here `null` makes the operator the only possible value source and explicitly
+declines persistence, so the answer is injected into the child environment and
+discarded after it exits. It is not written to a provider or cache. The prompt
+uses the controlling terminal rather than the command's stdin, so a pipe or
+redirected file remains available to the child:
+
+```bash
+$ printf 'deployment input\n' | secretspec run -- ./deploy
+? Enter value for DEPLOY_PASSWORD (profile: default):
+```
+
+Only `run` interprets `prompt = true` as a missing-value policy. `get`, `export`,
+SDK resolution, and value-free reports do not prompt. Interactive `check`
+retains its existing setup behavior instead: it offers to store any missing
+required secret, independently of `prompt`, and therefore cannot satisfy a
+`null`-backed declaration. A `run` without a controlling terminal fails before
+starting the child. Explicit `set` and import operations remain governed by the
+provider, not by `prompt`.
+
+`prompt = true` is limited to individually required secrets and cannot be
+combined with `default`, enabled `generate`, `extract`, or `composed`. Profile
+overrides may set `prompt = false` to return to ordinary missing-value behavior.
 
 ### Secret Generation
 

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -64,16 +64,19 @@ The `null` provider is added in SecretSpec 0.19.
 :::
 
 **URI**: `null://` - Always reports a missing value so the declaration's
-committed `default` or configured generator supplies the value
+committed `default`, configured generator, or `prompt = true` run input (0.19+)
+supplies the value
 
 ```text
 null://                      # No configuration or storage
 ```
 
 **Features**: No I/O, no authentication, no persistence, ordinary writes
-rejected; generated values are returned only for the current resolution
+rejected; generated and prompted values are returned only for the current
+resolution or child invocation
 **Use case**: Non-sensitive configuration from the version-controlled manifest,
-or ephemeral generated values that should be fresh for every resolution
+or ephemeral generated/operator-supplied values that should be fresh for every
+resolution or run
 
 ## systemd Credential Provider (0.17+)
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -65,7 +65,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },
   { slug: 'file', label: 'Plaintext files (0.19+)' },
   { slug: 'env', label: 'Environment variables' },
-  { slug: 'null', label: 'Defaults / ephemeral generation (null, 0.19+)' },
+  { slug: 'null', label: 'Defaults / ephemeral values (null, 0.19+)' },
   { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials (0.17+)' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden Secrets Manager' },
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
@@ -524,7 +524,7 @@ const reelScriptData = {
 <span class="landing-prompt">$</span> <span class="landing-cmd"><span class="tok-bin">secretspec</span> <span class="landing-arg">config global init</span></span>
 ? Select your preferred provider backend:
 <span class="landing-provider-cursor" aria-hidden="true">›</span><a class="landing-provider-line is-selected" style="--provider-line-color: var(--syntax-blue)" href="/providers/keyring/"><span class="provider-name">keyring</span>: Uses system keychain (Recommended)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/null/"><span class="provider-name">null</span>: Defaults or ephemeral generation, no storage (0.19+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/null/"><span class="provider-name">null</span>: Defaults, generation, or run prompts without storage (0.19+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/file/"><span class="provider-name">file</span>: Plaintext files, one per secret (0.19+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-red)" href="/providers/bw/"><span class="provider-name">bw</span>: Bitwarden Password Manager (0.18+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/kdbx/"><span class="provider-name">kdbx</span>: KeePass KDBX databases (0.17+)</a>

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -55,6 +55,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
 - **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
+- **Run prompts (0.19+)**: Set `prompt = true` to request a hidden missing value; writable providers save it, while `null` keeps it invocation-only
 - **Composed Secrets (0.16+)**: Derive read-only values such as DSNs from declared secrets with strict, order-independent `${UPPERCASE_NAME}` references
 - **[Configuration Inheritance](https://secretspec.dev/concepts/inheritance/)**: Extend and override shared configurations using the `extends` feature
 - **[Audit Logging](https://secretspec.dev/concepts/audit/)**: Every secret access recorded locally (who, when, why, outcome) — on by default, secret values never logged
@@ -82,7 +83,7 @@ $ secretspec config global init  # 0.17+
   dotenv: Traditional .env files
   file: Plaintext files, one per secret (0.19+)
   env: Read-only environment variables
-  null: Use defaults or ephemeral generation without storage (0.19+)
+  null: Use defaults, generation, or run prompts without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
@@ -200,7 +201,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[.env files](https://secretspec.dev/providers/dotenv)** - Traditional dotenv files
 - **[Plaintext files](https://secretspec.dev/providers/file)** (0.19+) - One UTF-8 file per secret in a local directory tree
 - **[Environment variables](https://secretspec.dev/providers/env)** - Read-only for CI/CD
-- **[Null](https://secretspec.dev/providers/null)** (0.19+) - Use committed defaults or ephemeral generation without secret storage
+- **[Null](https://secretspec.dev/providers/null)** (0.19+) - Use committed defaults, ephemeral generation, or ephemeral run prompts without secret storage
 - **[systemd credentials](https://secretspec.dev/providers/systemd-credential)** (0.17+) - Read-only credentials passed to the current service
 - **[Pass](https://secretspec.dev/providers/pass)** - Unix password manager with GPG encryption
 - **[Gopass](https://secretspec.dev/providers/gopass)** (0.15+) - GPG-based password manager with git-synced password store

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -1970,6 +1970,8 @@ struct SecretSerde {
     secret_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     generate: Option<GenerateConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt: Option<bool>,
 }
 
 /// Text encoding used for a secret's stored representation.
@@ -2144,6 +2146,10 @@ pub struct Secret {
     pub secret_type: Option<String>,
     /// Auto-generation configuration. Either `true` for defaults or a table with options.
     pub generate: Option<GenerateConfig>,
+    /// Prompt securely when the value is missing during `secretspec run`.
+    /// The selected provider decides whether the answer is persisted. Available
+    /// since SecretSpec 0.19.
+    pub prompt: Option<bool>,
 }
 
 impl TryFrom<SecretSerde> for Secret {
@@ -2179,6 +2185,7 @@ impl TryFrom<SecretSerde> for Secret {
             extract: value.extract,
             secret_type: value.secret_type,
             generate: value.generate,
+            prompt: value.prompt,
         })
     }
 }
@@ -2207,6 +2214,7 @@ impl From<Secret> for SecretSerde {
             extract: value.extract,
             secret_type: value.secret_type,
             generate: value.generate,
+            prompt: value.prompt,
         }
     }
 }
@@ -2312,9 +2320,28 @@ impl Secret {
                 || self.extract.is_some()
                 || self.secret_type.is_some()
                 || self.would_generate()
+                || self.prompt == Some(true)
             {
                 return Err(
-                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `refs`, `encoding`, `extract`, `type`, or enabled `generate`"
+                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `refs`, `encoding`, `extract`, `type`, enabled `generate`, or `prompt = true`"
+                        .into(),
+                );
+            }
+        }
+
+        if self.prompt == Some(true) {
+            if self.required == Some(false)
+                || self.at_least_one.is_some()
+                || self.exactly_one.is_some()
+            {
+                return Err(
+                    "`prompt = true` secrets must be individually required; omit `required` or set `required = true`"
+                        .into(),
+                );
+            }
+            if self.default.is_some() || self.would_generate() || self.extract.is_some() {
+                return Err(
+                    "`prompt = true` cannot be combined with `default`, enabled `generate`, or `extract`"
                         .into(),
                 );
             }
@@ -2504,6 +2531,7 @@ impl Secret {
             extract: inherit(current, default, |s| s.extract.clone()),
             secret_type: inherit(current, default, |s| s.secret_type.clone()),
             generate: inherit(current, default, |s| s.generate.clone()),
+            prompt: inherit(current, default, |s| s.prompt),
         })
     }
 }
@@ -3731,6 +3759,67 @@ default = "placeholder"
             ..Default::default()
         };
         assert!(s.validate().unwrap_err().contains("requires 'type'"));
+    }
+
+    #[test]
+    fn secret_prompt_parses_round_trips_and_inherits() {
+        let parsed: Secret =
+            toml::from_str("description = \"One-time deployment password\"\nprompt = true")
+                .unwrap();
+        assert_eq!(parsed.prompt, Some(true));
+        assert!(parsed.validate().is_ok());
+
+        let rendered = toml::to_string(&parsed).unwrap();
+        assert!(rendered.contains("prompt = true"), "{rendered}");
+
+        let inherited = Secret::resolved(None, Some(&parsed), None).unwrap();
+        assert_eq!(inherited.prompt, Some(true));
+        let disabled = Secret::resolved(
+            Some(&Secret {
+                prompt: Some(false),
+                ..Default::default()
+            }),
+            Some(&parsed),
+            None,
+        )
+        .unwrap();
+        assert_eq!(disabled.prompt, Some(false));
+    }
+
+    #[test]
+    fn secret_prompt_rejects_ambiguous_missing_value_policies() {
+        for secret in [
+            Secret {
+                description: Some("d".to_string()),
+                prompt: Some(true),
+                default: Some("fallback".to_string()),
+                ..Default::default()
+            },
+            Secret {
+                description: Some("d".to_string()),
+                prompt: Some(true),
+                required: Some(false),
+                ..Default::default()
+            },
+            Secret {
+                description: Some("d".to_string()),
+                prompt: Some(true),
+                secret_type: Some("password".to_string()),
+                generate: Some(GenerateConfig::Bool(true)),
+                ..Default::default()
+            },
+            Secret {
+                description: Some("d".to_string()),
+                prompt: Some(true),
+                extract: Some(SecretExtract {
+                    format: ExtractFormat::Json,
+                    pointer: "/password".to_string(),
+                }),
+                ..Default::default()
+            },
+        ] {
+            assert!(secret.validate().is_err());
+        }
     }
 
     #[test]

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -62,6 +62,12 @@ pub enum SecretSpecError {
     #[error("Secret '{0}' is required but not set")]
     RequiredSecretMissing(String),
     #[error(
+        "Secret '{0}' requires an interactive prompt, but no controlling terminal is available"
+    )]
+    PromptUnavailable(String),
+    #[error("Prompted value for secret '{0}' cannot be empty")]
+    PromptValueEmpty(String),
+    #[error(
         "Composed secret '{0}' is derived from other secrets and has no stored value to change"
     )]
     ComposedSecretReadOnly(String),
@@ -125,6 +131,8 @@ impl SecretSpecError {
             SecretSpecError::ProviderNotFound(_) => "provider_not_found",
             SecretSpecError::SecretNotFound(_) => "secret_not_found",
             SecretSpecError::RequiredSecretMissing(_) => "required_secret_missing",
+            SecretSpecError::PromptUnavailable(_) => "prompt_unavailable",
+            SecretSpecError::PromptValueEmpty(_) => "prompt_value_empty",
             SecretSpecError::ComposedSecretReadOnly(_) => "composed_secret_read_only",
             SecretSpecError::ExtractedSecretReadOnly(_) => "extracted_secret_read_only",
             SecretSpecError::CompositionFailed(_) => "composition_failed",
@@ -225,6 +233,14 @@ mod tests {
             (
                 SecretSpecError::RequiredSecretMissing("X".into()),
                 "required_secret_missing",
+            ),
+            (
+                SecretSpecError::PromptUnavailable("X".into()),
+                "prompt_unavailable",
+            ),
+            (
+                SecretSpecError::PromptValueEmpty("X".into()),
+                "prompt_value_empty",
             ),
             (
                 SecretSpecError::ComposedSecretReadOnly("X".into()),

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -78,7 +78,7 @@ pub use config::{
 
 // Public API exports
 pub use error::{Result, SecretSpecError};
-pub use provider::{DiscoveryContext, GeneratedValuePersistence, Provider};
+pub use provider::{DiscoveryContext, ProducedValuePersistence, Provider};
 pub use report::{
     RESOLUTION_REPORT_SCHEMA_VERSION, ResolutionReport, ResolutionStatus, SecretResolution,
 };

--- a/secretspec/src/manifest.rs
+++ b/secretspec/src/manifest.rs
@@ -20,6 +20,9 @@ pub(crate) enum MissingPolicy {
     UseDefault,
     /// The configured generator supplies the value.
     Generate,
+    /// `secretspec run` securely asks the operator; the selected provider
+    /// decides whether the answer is persisted.
+    Prompt,
 }
 
 impl MissingPolicy {
@@ -54,7 +57,9 @@ impl CompiledSecret {
         let declared_required = config
             .required
             .unwrap_or(config.default.is_none() && !conditionally_required);
-        let missing = if config.would_generate() {
+        let missing = if config.prompt == Some(true) {
+            MissingPolicy::Prompt
+        } else if config.would_generate() {
             MissingPolicy::Generate
         } else if config.default.is_some() {
             MissingPolicy::UseDefault
@@ -111,6 +116,17 @@ mod tests {
         let alternative = CompiledSecret::new(Secret::default(), true);
         assert_eq!(alternative.missing, MissingPolicy::Omit);
         assert!(!alternative.declared_required);
+
+        let prompted = CompiledSecret::new(
+            Secret {
+                prompt: Some(true),
+                ..Default::default()
+            },
+            false,
+        );
+        assert_eq!(prompted.missing, MissingPolicy::Prompt);
+        assert!(prompted.declared_required);
+        assert!(prompted.missing.guaranteed_on_success());
     }
 }
 

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -20,7 +20,7 @@
 //! - [`keeper::KeeperProvider`]: Keeper Secrets Manager integration (0.18+)
 //! - [`dotenv::DotEnvProvider`]: `.env` file support
 //! - [`env::EnvProvider`]: Environment variables (read-only)
-//! - [`null::NullProvider`]: Defaults or ephemeral generation without storage (0.19+)
+//! - [`null::NullProvider`]: Defaults, generation, or run prompts without storage (0.19+)
 //! - [`file::FileProvider`]: Plaintext file-per-secret storage (0.19+)
 //! - [`pass::PassProvider`]: Pass integration
 //! - [`gopass::GoPassProvider`]: Gopass integration
@@ -48,7 +48,7 @@
 //! ```text
 //! keyring://
 //! dotenv://.env.production
-//! null://  # Use defaults or ephemeral generation without storage, 0.19+
+//! null://  # Use defaults, generation, or run prompts without storage, 0.19+
 //! file:./.secrets  # One plaintext file per secret, 0.19+
 //! onepassword://vault
 //! lastpass://folder
@@ -642,19 +642,19 @@ impl<'a> DiscoveryContext<'a> {
     }
 }
 
-/// Whether a value minted by a secret's `generate` configuration is written
-/// back to its primary provider.
+/// Whether a value SecretSpec produces after a provider miss is written back
+/// to the primary provider.
 ///
 /// This capability is available since SecretSpec 0.19. It is deliberately
 /// separate from read and write support: a provider may reject ordinary writes
-/// while explicitly allowing SecretSpec to return a freshly generated value
-/// for the current resolution.
+/// while explicitly allowing SecretSpec to return a generated or prompted
+/// value for the current resolution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GeneratedValuePersistence {
-    /// Store the generated value through [`Provider::set`] and reuse it on
+pub enum ProducedValuePersistence {
+    /// Store the produced value through [`Provider::set`] and reuse it on
     /// subsequent resolutions. This is the default for storage providers.
     Persist,
-    /// Return the generated value only from the current materializing
+    /// Return the produced value only from the current materializing
     /// resolution. No provider write or cache refresh is performed.
     Ephemeral,
 }
@@ -861,13 +861,25 @@ pub trait Provider: Send + Sync {
     /// `generate` configuration after this provider's read route misses.
     /// Available since SecretSpec 0.19.
     ///
-    /// [`GeneratedValuePersistence::Ephemeral`] affects only automatic
+    /// [`ProducedValuePersistence::Ephemeral`] affects only automatic
     /// generation. Ordinary [`set`](Provider::set), deletion, imports, and
     /// provider reads keep their usual behavior. The capability must be pure:
     /// callers may inspect it without running authentication preflight or other
     /// provider I/O.
-    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
-        GeneratedValuePersistence::Persist
+    fn generated_value_persistence(&self) -> ProducedValuePersistence {
+        ProducedValuePersistence::Persist
+    }
+
+    /// Controls whether a value entered for a `prompt = true` declaration is
+    /// stored after the provider's read route misses. Available since
+    /// SecretSpec 0.19.
+    ///
+    /// The default persists the answer through [`Provider::set`], making the
+    /// prompt a first-use provisioning step. A provider that cannot or must not
+    /// retain values can return [`ProducedValuePersistence::Ephemeral`] so the
+    /// answer is used only by the current `run` resolution.
+    fn prompted_value_persistence(&self) -> ProducedValuePersistence {
+        ProducedValuePersistence::Persist
     }
 
     /// Describes the provider-native destination that a write to `addr` will
@@ -1260,8 +1272,11 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         (**self).check_writable(addr)
     }
-    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
+    fn generated_value_persistence(&self) -> ProducedValuePersistence {
         (**self).generated_value_persistence()
+    }
+    fn prompted_value_persistence(&self) -> ProducedValuePersistence {
+        (**self).prompted_value_persistence()
     }
     fn describe_write_target(&self, addr: Address<'_>) -> Result<String> {
         (**self).describe_write_target(addr)
@@ -1474,9 +1489,14 @@ impl Provider for PreflightGuard {
         self.inner.check_writable(addr)
     }
 
-    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
+    fn generated_value_persistence(&self) -> ProducedValuePersistence {
         // Capability inspection is pure and must not trigger authentication.
         self.inner.generated_value_persistence()
+    }
+
+    fn prompted_value_persistence(&self) -> ProducedValuePersistence {
+        // Capability inspection is pure and must not trigger authentication.
+        self.inner.prompted_value_persistence()
     }
 
     fn describe_write_target(&self, addr: Address<'_>) -> Result<String> {

--- a/secretspec/src/provider/null.rs
+++ b/secretspec/src/provider/null.rs
@@ -1,4 +1,4 @@
-use super::{Address, GeneratedValuePersistence, Provider, ProviderUrl};
+use super::{Address, ProducedValuePersistence, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the null provider.
 ///
 /// The provider takes no options because it never reads or stores values. It
-/// exists to let SecretSpec continue to a declaration's `default` or ephemeral
-/// generated value.
+/// exists to let SecretSpec continue to a declaration's `default`, ephemeral
+/// generated value, or ephemeral `prompt = true` input during `run`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NullConfig {}
 
@@ -41,16 +41,17 @@ impl TryFrom<&ProviderUrl> for NullConfig {
 /// A provider that never contains or stores a value.
 ///
 /// A miss lets normal resolution continue to the secret's committed `default`,
-/// or lets a configured generator mint a value for only the current resolution.
-/// This makes the provider useful for non-sensitive environment configuration
-/// committed to `secretspec.toml` and for ephemeral generated secrets.
+/// lets a configured generator mint a value for only the current resolution,
+/// or lets `run` ask for a `prompt = true` value without storing it. This makes
+/// the provider useful for non-sensitive environment configuration committed to
+/// `secretspec.toml` and for ephemeral generated or operator-supplied secrets.
 pub struct NullProvider;
 
 crate::register_provider! {
     struct: NullProvider,
     config: NullConfig,
     name: "null",
-    description: "Use defaults or ephemeral generation without storage (0.19+)",
+    description: "Use defaults, generation, or run prompts without storage (0.19+)",
     schemes: ["null"],
     examples: ["null://"],
 }
@@ -99,8 +100,12 @@ impl Provider for NullProvider {
         ))
     }
 
-    fn generated_value_persistence(&self) -> GeneratedValuePersistence {
-        GeneratedValuePersistence::Ephemeral
+    fn generated_value_persistence(&self) -> ProducedValuePersistence {
+        ProducedValuePersistence::Ephemeral
+    }
+
+    fn prompted_value_persistence(&self) -> ProducedValuePersistence {
+        ProducedValuePersistence::Ephemeral
     }
 
     fn name(&self) -> &'static str {
@@ -130,7 +135,11 @@ mod tests {
         assert!(provider.get(addr).unwrap().is_none());
         assert_eq!(
             provider.generated_value_persistence(),
-            GeneratedValuePersistence::Ephemeral
+            ProducedValuePersistence::Ephemeral
+        );
+        assert_eq!(
+            provider.prompted_value_persistence(),
+            ProducedValuePersistence::Ephemeral
         );
         let error = provider
             .set(addr, &SecretString::new("8090".into()))
@@ -223,7 +232,11 @@ mod tests {
         let provider = Box::<dyn Provider>::try_from("null://").unwrap();
         assert_eq!(
             provider.generated_value_persistence(),
-            GeneratedValuePersistence::Ephemeral
+            ProducedValuePersistence::Ephemeral
+        );
+        assert_eq!(
+            provider.prompted_value_persistence(),
+            ProducedValuePersistence::Ephemeral
         );
     }
 

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -10,7 +10,7 @@ use crate::error::{Result, SecretSpecError};
 use crate::manifest::{CompiledManifest, MissingPolicy};
 use crate::plan::{PlannedSecret, ResolutionPlan, ResolvedCache, Route};
 use crate::provider::{
-    Address, GeneratedValuePersistence, OwnedAddress, Provider as ProviderTrait,
+    Address, OwnedAddress, ProducedValuePersistence, Provider as ProviderTrait,
     ProviderCredentials, same_storage_container,
 };
 use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
@@ -416,11 +416,24 @@ enum Materialize {
     /// Full pass: mint-and-store a missing generatable secret and write each
     /// `as_path` secret to a temp file. Backs `validate()`/`resolve()`/`check`.
     Values,
+    /// Full pass for `run`: the same materialization as `Values`, plus secure
+    /// controlling-terminal input for declarations with `prompt = true`.
+    Run,
     /// Value-free pass: never write a generated secret back to a provider and
     /// never persist a secret to disk. A generatable-but-absent secret is still
     /// reported as it *would* resolve, without minting it. Backs `report()` and
     /// `resolve_without_values()`.
     None,
+}
+
+impl Materialize {
+    fn values(self) -> bool {
+        self != Self::None
+    }
+
+    fn prompts(self) -> bool {
+        self == Self::Run
+    }
 }
 
 /// A logical value in the shape exposed to callers. Inline values remain
@@ -528,6 +541,9 @@ pub struct Secrets {
     /// consume a value. Library and SDK instances leave this unset, so planning
     /// a write never produces unsolicited output outside the CLI.
     write_target_reporter: Option<WriteTargetReporter>,
+    /// Test seam for deterministic run-prompt coverage. Production CLI
+    /// instances leave this unset and use the controlling terminal.
+    prompt_reader: Option<PromptReader>,
 }
 
 /// Credential-free description of one provider write, computed after routing
@@ -541,6 +557,7 @@ pub(crate) struct WriteTarget {
 }
 
 type WriteTargetReporter = Arc<dyn Fn(&WriteTarget) + Send + Sync>;
+type PromptReader = Arc<dyn Fn(&str, &str) -> Result<SecretString> + Send + Sync>;
 
 /// secretspec's own opt-in for marking the current process as an agent. Lets any
 /// harness that the `detect-coding-agent` crate does not recognize identify itself.
@@ -724,6 +741,7 @@ impl Secrets {
             audit: None,
             provider_credentials_cache: ProviderCredentialsCache::default(),
             write_target_reporter: None,
+            prompt_reader: None,
         }
     }
 
@@ -806,6 +824,7 @@ impl Secrets {
             audit,
             provider_credentials_cache: ProviderCredentialsCache::default(),
             write_target_reporter: None,
+            prompt_reader: None,
         })
     }
 
@@ -818,6 +837,14 @@ impl Secrets {
         reporter: impl Fn(&WriteTarget) + Send + Sync + 'static,
     ) {
         self.write_target_reporter = Some(Arc::new(reporter));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_prompt_reader(
+        &mut self,
+        reader: impl Fn(&str, &str) -> Result<SecretString> + Send + Sync + 'static,
+    ) {
+        self.prompt_reader = Some(Arc::new(reader));
     }
 
     /// Sets the provider to use for secret operations
@@ -4443,7 +4470,7 @@ impl Secrets {
         let addr = address.as_address();
         let backend = self.write_provider_for_route(route, Some(profile_name))?;
 
-        if backend.generated_value_persistence() == GeneratedValuePersistence::Ephemeral {
+        if backend.generated_value_persistence() == ProducedValuePersistence::Ephemeral {
             eprintln!(
                 "{} {} - generated for this resolution without provider storage (profile: {})",
                 "✓".green(),
@@ -4489,6 +4516,100 @@ impl Secrets {
         );
 
         Ok(Some(value))
+    }
+
+    /// Reads one missing value from the controlling terminal during `run`.
+    /// Inquire's crossterm backend opens `/dev/tty` on Unix (and the console
+    /// input handle on Windows) when stdin is redirected, so the child retains
+    /// its original stdin stream. Persistence is deliberately handled by
+    /// [`Self::try_prompt_secret`], after this input-only step succeeds.
+    fn prompt_run_secret(&self, name: &str, profile: &str) -> Result<SecretString> {
+        let value = if let Some(reader) = &self.prompt_reader {
+            reader(name, profile)?
+        } else {
+            let message = format!("Enter value for {name} (profile: {profile}):");
+            let entered = inquire::Password::new(&message)
+                .without_confirmation()
+                .prompt()
+                .map_err(|error| match error {
+                    inquire::InquireError::NotTTY | inquire::InquireError::IO(_) => {
+                        SecretSpecError::PromptUnavailable(name.to_string())
+                    }
+                    other => SecretSpecError::InquireError(other),
+                })?;
+            SecretString::new(entered.into())
+        };
+
+        if value.expose_secret().is_empty() {
+            return Err(SecretSpecError::PromptValueEmpty(name.to_string()));
+        }
+        Ok(value)
+    }
+
+    /// Acquires a missing value for `prompt = true` and applies the primary
+    /// provider's persistence policy. Storage providers persist by default,
+    /// making the prompt a first-use provisioning step; explicitly ephemeral
+    /// providers such as `null` return the answer only to this `run`.
+    fn try_prompt_secret(
+        &self,
+        planned: &PlannedSecret,
+        profile_name: &str,
+    ) -> Result<SecretString> {
+        let name = planned.name.as_str();
+        let route = planned
+            .route
+            .as_ref()
+            .expect("a prompted secret is provider-backed");
+        let address = self.address_for_spec(
+            planned,
+            route.group_key(),
+            &self.config.project.name,
+            profile_name,
+        )?;
+        let addr = address.as_address();
+        let backend = self.write_provider_for_route(route, Some(profile_name))?;
+        let persistence = backend.prompted_value_persistence();
+
+        // A durable answer is a write. Resolve and preview the exact target,
+        // and reject a read-only destination, before asking the operator for a
+        // value. Ephemeral providers explicitly bypass the write path.
+        if persistence == ProducedValuePersistence::Persist {
+            self.preflight_write(planned, profile_name, backend.as_ref())?;
+        }
+
+        let value = self.prompt_run_secret(name, profile_name)?;
+        if persistence == ProducedValuePersistence::Ephemeral {
+            eprintln!(
+                "{} {} - entered for this run without provider storage (profile: {})",
+                "✓".green(),
+                name,
+                profile_name
+            );
+            return Ok(value);
+        }
+
+        let encoded_value = Self::encoded_for_storage(planned, &value);
+        let stored_value = encoded_value.as_ref().unwrap_or(&value);
+        let set_result = backend.set(addr, stored_value);
+        self.audit_write_result(
+            &set_result,
+            name,
+            profile_name,
+            Some(backend.uri()),
+            address.native(),
+            None,
+        );
+        set_result?;
+        self.sync_cache_after_write(planned, route, profile_name, stored_value);
+
+        eprintln!(
+            "{} {} - entered and saved to {} (profile: {})",
+            "✓".green(),
+            name,
+            backend.name(),
+            profile_name
+        );
+        Ok(value)
     }
 
     /// Writes secret bytes to a temporary file and returns the file handle and path
@@ -4745,18 +4866,16 @@ impl Secrets {
     /// `Check` audit event.
     ///
     /// Top-level reads ([`Self::validate`], `check`) pass `true`. Internal
-    /// re-validations inside [`Self::ensure_secrets`] pass `false`, so a single
-    /// user action emits one `Check` (not several), and `secretspec run` — which
-    /// resolves via `ensure_secrets` and then records its own `Run` event — is
-    /// not also recorded as a `Check`. The trade-off: a direct
+    /// re-validations inside [`Self::ensure_secrets`] and the `run` resolver pass
+    /// `false`, so one user action does not also emit a `Check`. The trade-off:
+    /// a direct
     /// `ensure_secrets` call (rare; not the path `secretspec-derive` uses) does
     /// not emit a `Check` read event, though any writes it performs are audited.
     ///
-    /// `materialize` gates the pass's two side effects (minting+storing a
-    /// generated secret, and writing `as_path` temp files). [`Materialize::None`]
-    /// runs the identical resolution but skips both, so the value-free entry
-    /// points reach the same per-secret status without mutating a provider or
-    /// touching disk; see [`Materialize`].
+    /// `materialize` gates value production, generated-secret persistence,
+    /// `as_path` files, and run-only prompting for missing values.
+    /// [`Materialize::None`] runs the same provider resolution without those
+    /// effects; see [`Materialize`].
     fn validate_audited(
         &self,
         emit_check: bool,
@@ -5016,15 +5135,15 @@ impl Secrets {
     /// derives nothing itself. It builds a provider per primary-store group,
     /// fetches the groups concurrently, then walks each secret: a primary hit is
     /// recorded; a miss falls through the secret's resolved fallback chain, then
-    /// generation, then the committed default, before being reported missing. A
+    /// its compiled missing-value policy (prompt, generation, default, or
+    /// absence). A
     /// primary that *errored* (rather than merely lacked the secret) with no
     /// fallback to try surfaces that error instead of a spurious "missing", so a
     /// machine consumer can tell an outage from an unprovisioned secret.
     ///
-    /// `materialize` gates the two side effects (minting+storing a generated
-    /// secret and writing `as_path` temp files); [`Materialize::None`] runs the
-    /// identical resolution but skips both, reaching the same per-secret status
-    /// without mutating a provider or touching disk.
+    /// `materialize` gates values and their effects. [`Materialize::Run`] also
+    /// enables explicit missing-value prompts; [`Materialize::None`] skips all value
+    /// production, provider/cache writes, and temp files.
     fn execute_plan(
         &self,
         plan: &ResolutionPlan,
@@ -5251,13 +5370,13 @@ impl Secrets {
                     source_provider = cached_uris
                         .remove(name)
                         .or_else(|| group_uris.get(&primary_uri).cloned());
-                    if !was_cached && materialize == Materialize::Values {
+                    if !was_cached && materialize.values() {
                         self.write_cached_secret(planned, route, profile, &value);
                     }
                     // Copy the value into the response only on a full pass; a
                     // value-free pass has the status it needs and never
                     // materializes a value or writes a temp file.
-                    if materialize == Materialize::Values {
+                    if materialize.values() {
                         self.insert_resolved(
                             &mut secrets,
                             &mut temp_files,
@@ -5306,7 +5425,7 @@ impl Secrets {
 
                     if let Some(value) = fallback_value {
                         source_provider = fallback_uri;
-                        if materialize == Materialize::Values {
+                        if materialize.values() {
                             self.write_cached_secret(planned, route, profile, &value);
                             self.insert_resolved(
                                 &mut secrets,
@@ -5320,12 +5439,38 @@ impl Secrets {
                         status = ResolutionStatus::Resolved;
                     } else {
                         match planned.secret.missing {
+                            MissingPolicy::Prompt => {
+                                // Prompt only for names the active scope exposes.
+                                // A hidden composition dependency must never be
+                                // disclosed merely because a visible derived
+                                // secret depends on it.
+                                if materialize.prompts()
+                                    && output_filter.is_none_or(|filter| filter.contains(name))
+                                {
+                                    let prompted = self.try_prompt_secret(planned, profile)?;
+                                    self.insert_resolved(
+                                        &mut secrets,
+                                        &mut temp_files,
+                                        planned,
+                                        diagnostic_name,
+                                        prompted,
+                                        ResolvedRepresentation::Logical,
+                                    )?;
+                                    status = ResolutionStatus::Resolved;
+                                } else if required {
+                                    missing_required.push(name.clone());
+                                    status = ResolutionStatus::MissingRequired;
+                                } else {
+                                    missing_optional.push(name.clone());
+                                    status = ResolutionStatus::MissingOptional;
+                                }
+                            }
                             MissingPolicy::Generate => {
                                 // A full pass mints and stores; a value-free pass
                                 // reports that generation would resolve without
                                 // performing that side effect.
                                 generated = true;
-                                if materialize == Materialize::Values {
+                                if materialize.values() {
                                     let generated_value = self
                                         .try_generate_secret(planned, profile)?
                                         .expect("compiled Generate policy has a generator");
@@ -5347,7 +5492,7 @@ impl Secrets {
                                     .as_ref()
                                     .expect("compiled UseDefault policy has a default");
                                 default_applied = true;
-                                if materialize == Materialize::Values {
+                                if materialize.values() {
                                     self.insert_resolved(
                                         &mut secrets,
                                         &mut temp_files,
@@ -5437,7 +5582,7 @@ impl Secrets {
                     statuses.get(dependency) == Some(&ResolutionStatus::Resolved)
                 });
                 let status = if dependencies_resolved {
-                    if materialize == Materialize::Values {
+                    if materialize.values() {
                         let rendered = template
                             .render(|dependency| {
                                 secrets.get(dependency).map(|value| value.expose_secret())
@@ -5463,7 +5608,9 @@ impl Secrets {
                             missing_optional.push(planned.name.clone());
                             ResolutionStatus::MissingOptional
                         }
-                        MissingPolicy::Generate | MissingPolicy::UseDefault => {
+                        MissingPolicy::Generate
+                        | MissingPolicy::UseDefault
+                        | MissingPolicy::Prompt => {
                             unreachable!("composed source conflicts are rejected at load time")
                         }
                     }
@@ -5662,10 +5809,16 @@ impl Secrets {
             )));
         }
 
-        // Ensure all secrets are available (will error out if missing).
+        // Resolve all secrets for this invocation. `Materialize::Run` is the
+        // only mode allowed to ask for an explicitly `prompt = true` value;
+        // the prompt backend uses the controlling terminal and leaves the
+        // child's inherited stdin untouched.
         // `validation_result` owns the temp files for `as_path` secrets and
         // must stay alive until the child process has terminated.
-        let validation_result = match self.ensure_secrets(None, None, false) {
+        let resolution = self
+            .validate_audited(false, Materialize::Run)
+            .and_then(|result| result.map_err(validation_failure));
+        let validation_result = match resolution {
             Ok(v) => v,
             Err(e) => {
                 // Record the attempt even when validation fails and the command
@@ -6703,6 +6856,141 @@ mod report_provider_tests {
             .unwrap();
         assert_eq!(got, "vault://host");
         assert!(!got.contains("zzz"));
+    }
+}
+
+#[cfg(test)]
+mod run_prompt_tests {
+    use super::*;
+    use crate::config::Secret;
+    use secrecy::ExposeSecret;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn prompted_spec() -> Secrets {
+        let config = crate::tests::resolve_test_config(HashMap::from([(
+            "DEPLOY_PASSWORD".to_string(),
+            Secret {
+                description: Some("One-time deployment password".to_string()),
+                required: Some(true),
+                providers: Some(vec!["null".to_string()]),
+                prompt: Some(true),
+                ..Default::default()
+            },
+        )]));
+        Secrets::new(config, None, None, None)
+    }
+
+    fn prompted_dotenv_spec(path: &std::path::Path) -> Secrets {
+        let config = crate::tests::resolve_test_config(HashMap::from([(
+            "DEPLOY_PASSWORD".to_string(),
+            Secret {
+                description: Some("Deployment password".to_string()),
+                required: Some(true),
+                providers: Some(vec![format!("dotenv://{}", path.display())]),
+                prompt: Some(true),
+                ..Default::default()
+            },
+        )]));
+        Secrets::new(config, None, None, None)
+    }
+
+    #[test]
+    fn run_prompts_again_for_each_resolution_without_storing() {
+        let _env = crate::tests::scrub_resolution_env();
+        let prompts = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&prompts);
+        let mut spec = prompted_spec();
+        spec.set_prompt_reader(move |name, profile| {
+            assert_eq!(name, "DEPLOY_PASSWORD");
+            assert_eq!(profile, "default");
+            observed.fetch_add(1, Ordering::SeqCst);
+            Ok(SecretString::new("entered-once".into()))
+        });
+
+        for expected_prompts in 1..=2 {
+            let validated = spec
+                .validate_audited(false, Materialize::Run)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                validated.resolved.secrets["DEPLOY_PASSWORD"].expose_secret(),
+                "entered-once"
+            );
+            assert_eq!(prompts.load(Ordering::SeqCst), expected_prompts);
+        }
+
+        // Ordinary library/SDK resolution never opens an interactive prompt.
+        assert!(
+            spec.validate_audited(false, Materialize::Values)
+                .unwrap()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn writable_provider_persists_the_prompted_value() {
+        let _env = crate::tests::scrub_resolution_env();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let dotenv_path = temp_dir.path().join("prompt.env");
+        let prompts = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&prompts);
+        let mut spec = prompted_dotenv_spec(&dotenv_path);
+        spec.set_prompt_reader(move |name, profile| {
+            assert_eq!(name, "DEPLOY_PASSWORD");
+            assert_eq!(profile, "default");
+            observed.fetch_add(1, Ordering::SeqCst);
+            Ok(SecretString::new("persisted-answer".into()))
+        });
+
+        for _ in 0..2 {
+            let validated = spec
+                .validate_audited(false, Materialize::Run)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                validated.resolved.secrets["DEPLOY_PASSWORD"].expose_secret(),
+                "persisted-answer"
+            );
+        }
+
+        assert_eq!(prompts.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            std::fs::read_to_string(dotenv_path).unwrap(),
+            "DEPLOY_PASSWORD=\"persisted-answer\"\n"
+        );
+    }
+
+    #[test]
+    fn run_surfaces_an_unavailable_controlling_terminal() {
+        let _env = crate::tests::scrub_resolution_env();
+        let mut spec = prompted_spec();
+        spec.set_prompt_reader(|name, _| Err(SecretSpecError::PromptUnavailable(name.to_string())));
+
+        let error = match spec.validate_audited(false, Materialize::Run) {
+            Err(error) => error,
+            Ok(_) => panic!("run resolution should fail without a controlling terminal"),
+        };
+        assert!(matches!(
+            error,
+            SecretSpecError::PromptUnavailable(name) if name == "DEPLOY_PASSWORD"
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_injects_the_prompted_value_into_the_child() {
+        let _env = crate::tests::scrub_resolution_env();
+        let mut spec = prompted_spec();
+        spec.set_prompt_reader(|_, _| Ok(SecretString::new("entered-once".into())));
+
+        let exit = spec
+            .run_command(vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "test \"$DEPLOY_PASSWORD\" = entered-once".to_string(),
+            ])
+            .unwrap();
+        assert_eq!(exit, 0);
     }
 }
 

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -5828,6 +5828,7 @@ fn test_resolve_secret_config_merges_type_and_generate() {
             extract: None,
             secret_type: Some("password".to_string()),
             generate: Some(crate::config::GenerateConfig::Bool(true)),
+            prompt: None,
         },
     );
     profiles.insert(


### PR DESCRIPTION
## Summary

- add a SecretSpec 0.19+ `prompt = true` missing-value policy for `secretspec run`
- read hidden input from the controlling terminal so the child retains its original stdin
- keep acquisition and persistence separate: writable providers save prompted values, while `null` keeps them invocation-only without provider or cache writes
- validate incompatible declaration combinations and document the behavior across the CLI, configuration reference, provider listings, README, and changelog

## Why

SecretSpec already prompted for every missing required secret during interactive `check`, but that flow always stored the answer. `run` explicitly disabled prompting, and the `null` provider only supported defaults and generated values. This left no declarative path for the operator-supplied flow requested in #218.

With this change, `prompt = true` selects secure operator input after the configured provider route misses. Persistence remains the provider's decision, so `prompt = true` with `providers = ["null"]` provides the one-invocation flow without redefining prompting itself as non-persistent.

## User impact

```toml
[profiles.default]
DEPLOY_PASSWORD = {
  description = "One-time deployment password"
  required = true
  prompt = true
  providers = ["null"]
}
```

`secretspec run -- ./deploy` prompts securely, injects the answer into the child, preserves the child's stdin, and discards the answer when the child exits. Selecting a writable provider instead saves the answer for subsequent runs.

## Validation

- `cargo test --all`
- `npm --prefix docs run build`
- commit hooks: `clippy`, `rustfmt`
- `git diff --check`

Addresses #218.
