### PR TITLE
Release 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 - A provider URI may no longer carry a credential. A URI with a password
-  (`scheme://user:secret@host`) is rejected, and `onepassword+token://` no
+  (`scheme://user:PASSWORD@host`) is rejected, and `onepassword+token://` no
   longer accepts the service account token in its userinfo
   (`onepassword+token://token@vault`). A URI is committed to `secretspec.toml`,
   echoed into shell history, and printed by CI, so a credential written there is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.19.1] - 2026-08-11
+
+Republishes 0.19.0's command-line artifacts. The library and CLI behave exactly
+as in 0.19.0.
 
 ### Added
 
@@ -14,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checksum. The static installer keeps selecting the x86_64 build on Windows
   ARM64, which runs under emulation, so download the archive directly for a
   native binary.
+
+### Fixed
+
+- The 0.19.0 GitHub Release shipped without its CLI archives, its installer,
+  and the Swift XCFramework, so `curl https://install.secretspec.dev | sh` and
+  `swift package` resolution of 0.19.0 both failed. Every language registry
+  (crates.io, PyPI, npm, RubyGems, Hackage, NuGet) published 0.19.0 normally and
+  is unaffected. Install 0.19.1 instead; SwiftPM version ranges resolve to it
+  automatically.
 
 ## [0.19.0] - 2026-08-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "age",
  "aws-config",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-derive"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "http 1.4.0",
  "insta",
@@ -5268,7 +5268,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-ffi"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "secretspec",
  "serde_json",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-node-native"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-php-native"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "ext-php-rs",
  "secretspec",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "secretspec-py-native"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "pyo3",
  "secretspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2024"
 
 [workspace.dependencies]
@@ -53,8 +53,8 @@ azure_identity = "1.0.0"
 azure_security_keyvault_secrets = "1.0.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
-secretspec-derive = { version = "0.19.0", path = "./secretspec-derive" }
-secretspec = { version = "0.19.0", path = "./secretspec" }
+secretspec-derive = { version = "0.19.1", path = "./secretspec-derive" }
+secretspec = { version = "0.19.1", path = "./secretspec" }
 rand = "0.9"
 rsa = { version = "0.9", features = ["pem"] }
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 // scripts/sync-sdk-versions.sh. Release preparation replaces the checksum
 // after building the versioned XCFramework; see RELEASE.md.
 let secretSpecBinaryVersion = "0.19.0"
-let secretSpecBinaryChecksum = "c7992602db6999ddc1df40a34d67f59cef3b5e1e06b4b7d417e814c2ff83f305"
+let secretSpecBinaryChecksum = "f4e97fd9d97cea3c9881103f810b1e569cf269ab2a50a896ea7e3ba6926e4baf"
 
 let localBinaryPath = "secretspec-swift/Artifacts/CSecretSpec.xcframework"
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 // scripts/sync-sdk-versions.sh. Release preparation replaces the checksum
 // after building the versioned XCFramework; see RELEASE.md.
 let secretSpecBinaryVersion = "0.19.1"
-let secretSpecBinaryChecksum = "f4e97fd9d97cea3c9881103f810b1e569cf269ab2a50a896ea7e3ba6926e4baf"
+let secretSpecBinaryChecksum = "50b6a9007990d22c24b0659bf7ae195cb1b624c328ae694c4218703508d90bf9"
 
 let localBinaryPath = "secretspec-swift/Artifacts/CSecretSpec.xcframework"
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 // Keep this in sync with the Cargo workspace version via
 // scripts/sync-sdk-versions.sh. Release preparation replaces the checksum
 // after building the versioned XCFramework; see RELEASE.md.
-let secretSpecBinaryVersion = "0.19.0"
+let secretSpecBinaryVersion = "0.19.1"
 let secretSpecBinaryChecksum = "f4e97fd9d97cea3c9881103f810b1e569cf269ab2a50a896ea7e3ba6926e4baf"
 
 let localBinaryPath = "secretspec-swift/Artifacts/CSecretSpec.xcframework"

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -304,7 +304,7 @@ Provider credentials follow these rules:
 - **Names are provider-specific.** The catalog above is exhaustive. Unsupported
   names are rejected before any source is read.
 - **A URI may not carry a credential (0.19+).** A provider URI with a password
-  (`scheme://user:secret@host`) is rejected, as is a service account token in
+  (`scheme://user:PASSWORD@host`) is rejected, as is a service account token in
   the `onepassword+token://` userinfo. A URI is committed to `secretspec.toml`,
   echoed into shell history, and printed by CI, so a credential written there is
   already disclosed. Use a provider credential or the provider's environment

--- a/secretspec-derive/Cargo.toml
+++ b/secretspec-derive/Cargo.toml
@@ -15,7 +15,7 @@ quote.workspace = true
 proc-macro2.workspace = true
 toml.workspace = true
 serde.workspace = true
-secretspec = { version = "0.19.0", path = "../secretspec", default-features = false }
+secretspec = { version = "0.19.1", path = "../secretspec", default-features = false }
 
 [dev-dependencies]
 trybuild.workspace = true

--- a/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpec.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>Cachix.SecretSpec</PackageId>
-    <Version>0.19.0</Version>
+    <Version>0.19.1</Version>
     <Authors>Cachix</Authors>
     <Description>C# SDK for SecretSpec, the declarative secrets manager.</Description>
     <PackageTags>secrets;configuration;security;dotnet</PackageTags>

--- a/secretspec-dotnet/tests/SecretSpec.PackageSmoke/SecretSpec.PackageSmoke.csproj
+++ b/secretspec-dotnet/tests/SecretSpec.PackageSmoke/SecretSpec.PackageSmoke.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>0.19.0</Version>
+    <Version>0.19.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/secretspec-hs/secretspec.cabal
+++ b/secretspec-hs/secretspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               secretspec
-version:            0.19.0
+version:            0.19.1
 synopsis:           Haskell SDK for SecretSpec, a declarative secrets manager
 description:
   A thin client over the @secretspec-ffi@ C ABI (linked at build time).

--- a/secretspec-node/package.json
+++ b/secretspec-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretspec",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "A declarative interface for every secret provider. Node.js SDK.",
   "license": "Apache-2.0",
   "homepage": "https://secretspec.dev/",

--- a/secretspec-py/pyproject.toml
+++ b/secretspec-py/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "secretspec"
-version = "0.19.0"
+version = "0.19.1"
 description = "A declarative interface for every secret provider. Python SDK."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/secretspec-rb/secretspec.gemspec
+++ b/secretspec-rb/secretspec.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "secretspec"
-  spec.version     = "0.19.0"
+  spec.version     = "0.19.1"
   spec.summary     = "A declarative interface for every secret provider. Ruby SDK."
   spec.description = "Ruby bindings for SecretSpec: a native extension that " \
                      "statically links the secretspec-ffi C ABI."


### PR DESCRIPTION
Republishes 0.19.0's command-line artifacts. The library and CLI behave exactly
as in 0.19.0.

## Why 0.19.1 exists

v0.19.0 published to every language registry — crates.io, PyPI, npm, RubyGems,
Hackage, NuGet — but its GitHub Release carried **no CLI archives, no installer,
and no XCFramework**. `curl https://install.secretspec.dev | sh` returns 404 and
SwiftPM cannot resolve 0.19.0.

Two independent causes, both fixed in `29d3123`:

**1. The changelog emptied cargo-dist's job output.** The 0.19.0 entry
illustrated the newly rejected URI form as `scheme://user:secret@host`. The
runner masks credential-shaped URLs, cargo-dist embeds the changelog in its
manifest, and GitHub then refused to pass the manifest between jobs:

```
##[warning]Skip output 'val' since it may contain secret.
```

Every job gated on `fromJson(needs.plan.outputs.val)` skipped, so `plan`
succeeded, both build stages skipped, and `host`/`announce` published the
release anyway. The example is now an unmistakable placeholder
(`scheme://user:PASSWORD@host`), in the changelog and the matching docs
sentence.

**2. The SwiftPM checksum was stale.** It was computed before #315 and the
merges from main landed. The XCFramework embeds the compiled FFI, so the tag
build produced a different hash and the publish job correctly refused rather
than shipping a mismatched binary.

## Ordering

The Swift checksum is committed **last**, immediately before the tag, computed
from the final 0.19.1 tree. Computing it early and letting code land on top is
what broke 0.19.0. A verification run (`publish: false`) confirms the pin
against a fresh build before tagging.

## Also in this release

Windows ARM64 CLI artifacts, which landed on main after 0.19.0 was cut, ship
here. Its changelog entry moved out of `Unreleased` into 0.19.1.

## What is not affected

The language registries already have 0.19.0 and are untouched; their publish
jobs skip duplicates and publish 0.19.1 alongside. Nothing published is
rewritten and no tag is moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — see https://github.com/cli/cli/issues/13904