### PR TITLE
Test Ruby gems with Bundler 4 Linux platforms

### DIFF
--- a/scripts/ci-sdks.sh
+++ b/scripts/ci-sdks.sh
@@ -74,6 +74,14 @@ echo "==> Ruby (pkg-config discovery)"
 bash secretspec-rb/scripts/build-ext.sh --enable-pkg-config
 ( cd secretspec-rb && ruby -e 'Dir["test/test_*.rb"].sort.each { |f| require File.expand_path(f) }' )
 
+echo "==> Ruby (Bundler 4 Linux platforms)"
+# Ruby in the pinned Nix environment may predate Ruby 4, so exercise the
+# published gem with pinned Ruby 4 glibc and musl containers. The integration
+# test includes a working glibc control and asserts both known packaging
+# failures: the generic Linux gem loading on musl, and the missing `ruby`
+# platform fallback.
+bash secretspec-rb/repro/bundler-4-platforms/run.sh
+
 echo "==> Node"
 # The Node SDK uses a napi-rs addon (not the cdylib), built via the @napi-rs/cli
 # devDependency. Install it and build the addon once up front: the test files

--- a/secretspec-rb/repro/bundler-4-platforms/Gemfile
+++ b/secretspec-rb/repro/bundler-4-platforms/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "secretspec", "= 0.19.0"

--- a/secretspec-rb/repro/bundler-4-platforms/README.md
+++ b/secretspec-rb/repro/bundler-4-platforms/README.md
@@ -1,0 +1,42 @@
+# Bundler 4 Linux platform reproduction
+
+This reproduces the Linux packaging behavior of the published
+`secretspec` 0.19.0 gems with Ruby and Bundler 4.
+
+## Run
+
+Docker is the only prerequisite:
+
+```console
+./run.sh
+```
+
+The repository's full SDK integration runner, `scripts/ci-sdks.sh`, invokes
+this script as part of its Ruby test section as well.
+
+The script uses Ruby 4.0.6 images and verifies that Bundler 4 is active. It
+runs three isolated cases:
+
+1. The Debian/glibc control installs the generic `${arch}-linux` gem and loads
+   it.
+2. Alpine/musl resolves and installs that same generic Linux gem, but loading
+   its extension fails because the bundled Rust archive was built for glibc.
+3. `BUNDLE_FORCE_RUBY_PLATFORM=true` fails resolution because 0.19.0 has no
+   `ruby` platform gem to use as a source-build fallback.
+
+The script treats the latter two failures as successful reproductions, so it
+exits zero only when all three behaviors are observed.
+
+## Why the generic Linux gem is selected
+
+The [RubyGems platform guide](https://guides.rubygems.org/platforms/#linux-and-musl)
+states that a bare platform such as `x86_64-linux` matches both glibc and musl.
+It is therefore not rejected by Bundler 4 as a deprecated platform. Instead,
+Bundler considers the current generic gem compatible with Alpine even though
+the native archive inside it is not.
+
+Publishing distinct `*-linux-gnu` and `*-linux-musl` gems prevents that unsafe
+match. Publishing a `ruby` variant would separately provide the fallback that
+`force_ruby_platform` requests, but such a gem would need enough source to
+build the Rust library locally; the current gem only builds its C glue locally
+and links a prebuilt Rust archive.

--- a/secretspec-rb/repro/bundler-4-platforms/require_secretspec.rb
+++ b/secretspec-rb/repro/bundler-4-platforms/require_secretspec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "secretspec"
+
+puts "loaded secretspec ABI #{Secretspec.abi_version}"

--- a/secretspec-rb/repro/bundler-4-platforms/run-case.sh
+++ b/secretspec-rb/repro/bundler-4-platforms/run-case.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -eu
+
+case "${REPRO_CASE:?set REPRO_CASE to gnu, musl, or force-ruby}" in
+  gnu)
+    # The slim Debian image also omits the extension toolchain. Keep this
+    # control on the small image while still testing the complete gem install.
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update >/dev/null
+    apt-get install --yes --no-install-recommends build-essential >/dev/null
+    ;;
+  musl)
+    # The Alpine Ruby image omits the compiler needed for SecretSpec's small C
+    # extension. Installing it ensures this case reaches the libc mismatch.
+    apk add --no-cache build-base >/dev/null
+    ;;
+  force-ruby)
+    ;;
+  *)
+    echo "unknown reproduction case: $REPRO_CASE" >&2
+    exit 2
+    ;;
+esac
+
+mkdir /work
+cp /repro/Gemfile /work/Gemfile
+cd /work
+
+ruby --version
+ruby -rbundler -e '
+  abort "expected Bundler 4, got #{Bundler::VERSION}" unless Bundler::VERSION.start_with?("4.")
+  puts "Bundler #{Bundler::VERSION}"
+'
+gem env platform
+
+show_resolution() {
+  sed -n '/^PLATFORMS$/,/^DEPENDENCIES$/p' Gemfile.lock
+  bundle exec ruby -e '
+    spec = Gem.loaded_specs.fetch("secretspec")
+    puts "selected gem platform: #{spec.platform}"
+  '
+}
+
+case "$REPRO_CASE" in
+  gnu)
+    bundle install
+    show_resolution
+    bundle exec ruby /repro/require_secretspec.rb
+    ;;
+  musl)
+    bundle install
+    show_resolution
+
+    set +e
+    bundle exec ruby /repro/require_secretspec.rb >load-error.log 2>&1
+    status=$?
+    set -e
+    cat load-error.log
+
+    if [ "$status" -eq 0 ]; then
+      echo "expected the generic Linux gem to fail when loaded on musl" >&2
+      exit 1
+    fi
+    if ! grep -F "Error relocating" load-error.log >/dev/null; then
+      echo "SecretSpec failed to load, but not with the expected libc relocation error" >&2
+      exit 1
+    fi
+    echo "reproduced: the generic Linux gem installs on musl but does not load"
+    ;;
+  force-ruby)
+    set +e
+    BUNDLE_FORCE_RUBY_PLATFORM=true bundle install >force-ruby-error.log 2>&1
+    status=$?
+    set -e
+    cat force-ruby-error.log
+
+    if [ "$status" -eq 0 ]; then
+      echo "expected force_ruby_platform resolution to fail" >&2
+      exit 1
+    fi
+    if ! grep -F "with platform 'ruby'" force-ruby-error.log >/dev/null; then
+      echo "Bundler failed, but not because the ruby platform gem is absent" >&2
+      exit 1
+    fi
+    echo "reproduced: force_ruby_platform has no source gem to select"
+    ;;
+esac

--- a/secretspec-rb/repro/bundler-4-platforms/run.sh
+++ b/secretspec-rb/repro/bundler-4-platforms/run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repro_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+run_case() {
+  local label="$1"
+  local image="$2"
+  local repro_case="$3"
+
+  echo
+  echo "==> $label"
+  docker run --rm \
+    --env "REPRO_CASE=$repro_case" \
+    --volume "$repro_dir:/repro:ro" \
+    "$image" \
+    sh /repro/run-case.sh
+}
+
+# Pin Ruby's patch version so the reproduction does not silently move to a
+# future Ruby/Bundler release. run-case.sh also verifies Bundler's major version.
+run_case "glibc control" "ruby:4.0.6-slim" "gnu"
+run_case "musl platform mismatch" "ruby:4.0.6-alpine" "musl"
+run_case "missing ruby-platform fallback" "ruby:4.0.6-slim" "force-ruby"


### PR DESCRIPTION
## What changed

- add a Docker-based Ruby 4.0.6 / Bundler 4 integration reproduction for `secretspec` 0.19.0
- cover a working glibc install, the generic Linux gem failing to load on musl, and the missing `ruby`-platform fallback
- run the reproduction from the Ruby section of `scripts/ci-sdks.sh`

## Why

The published Linux gems use the generic `${arch}-linux` platform. RubyGems matches that platform on both glibc and musl, so Bundler installs the glibc-built archive on Alpine and the extension later fails to load. `force_ruby_platform` cannot work around this because no `ruby` variant is published.

This is a characterization test: the two known packaging failures are expected and counted as successful reproductions. It verifies the diagnosis; it does not yet implement or assert the eventual packaging fix.

## Validation

- `bash -n scripts/ci-sdks.sh`
- `bash -n secretspec-rb/repro/bundler-4-platforms/run.sh`
- `sh -n secretspec-rb/repro/bundler-4-platforms/run-case.sh`
- `secretspec-rb/repro/bundler-4-platforms/run.sh`
- `git diff --cached --check`
