### PR TITLE
cli: add shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `secretspec completions <shell>` generates completion scripts for Bash,
   Elvish, Fish, Nushell, PowerShell, and Zsh directly from the CLI definition,
-  including command, option, and possible-value descriptions.
+  including descriptions and contextual suggestions for profiles, scopes,
+  secret names, providers, aliases, paths, and commands. Completion reads
+  configuration metadata only; it never queries providers or reads secret
+  values.
 
 ## [0.19.1] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `secretspec completions <shell>` generates completion scripts for Bash,
+  Elvish, Fish, Nushell, PowerShell, and Zsh directly from the CLI definition,
+  including command, option, and possible-value descriptions.
+
 ## [0.19.1] - 2026-08-11
 
 Republishes 0.19.0's command-line artifacts. The library and CLI behave exactly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1339,15 +1339,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.6.0"
+name = "clap_complete"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb66bc82eb9c92b1727310ae2c5868df22ae7cf46185bc5c544a4fa71955e49"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4381,7 +4400,7 @@ dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5215,6 +5234,8 @@ dependencies = [
  "azure_security_keyvault_secrets",
  "base64",
  "clap",
+ "clap_complete",
+ "clap_complete_nushell",
  "colored",
  "data-encoding",
  "detect-coding-agent",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -1345,6 +1345,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -2039,7 +2042,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -3281,6 +3284,15 @@ name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_executable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -5243,6 +5255,7 @@ dependencies = [
  "etcetera",
  "google-cloud-secretmanager-v1",
  "inquire",
+ "is_executable",
  "jiff",
  "jsonschema",
  "keepass",
@@ -5527,6 +5540,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ edition = "2024"
 
 [workspace.dependencies]
 clap = { version = "4.0", features = ["derive", "env"] }
-clap_complete = "4.6"
+clap_complete = { version = "4.6", features = ["unstable-dynamic"] }
 clap_complete_nushell = "4.6"
+is_executable = "1.0"
 keyring = "4.1.6"
 keepass = { version = "0.13.17", features = ["save_kdbx4"] }
 keeper-secrets-manager-core = { version = "17.3.0", default-features = false, features = ["blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2024"
 
 [workspace.dependencies]
 clap = { version = "4.0", features = ["derive", "env"] }
+clap_complete = "4.6"
+clap_complete_nushell = "4.6"
 keyring = "4.1.6"
 keepass = { version = "0.13.17", features = ["save_kdbx4"] }
 keeper-secrets-manager-core = { version = "17.3.0", default-features = false, features = ["blocking"] }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -677,6 +677,43 @@ $ secretspec audit --action run -n 5
 $ secretspec audit --json | jq 'select(.outcome == "missing")'
 ```
 
+### completions (0.20+)
+
+:::caution[Version compatibility]
+`completions` is available starting with SecretSpec 0.20.
+:::
+
+Generate a completion script from the same command definition used by
+`secretspec --help`. The output includes every command, option, possible value,
+and description supported by the target shell.
+
+```bash
+$ secretspec completions <SHELL>
+```
+
+Supported shells are `bash`, `elvish`, `fish`, `nushell`, `powershell`, and
+`zsh`. Load completions for the current session with the command for your
+shell:
+
+- Bash: `source <(secretspec completions bash)`
+- Elvish: `eval (secretspec completions elvish | slurp)`
+- Fish: `secretspec completions fish | source`
+- PowerShell: `secretspec completions powershell | Out-String | Invoke-Expression`
+- Zsh: `autoload -U compinit && compinit && source <(secretspec completions zsh)`
+
+For persistent Bash, Elvish, Fish, PowerShell, or Zsh completions, put the
+corresponding command in your shell's startup file. Generating the script at
+startup keeps it synchronized after a SecretSpec upgrade.
+
+Nushell loads completion modules from a file:
+
+```nu
+secretspec completions nushell | save -f ~/.config/nushell/completions-secretspec.nu
+use ~/.config/nushell/completions-secretspec.nu *
+```
+
+Regenerate that file after upgrading SecretSpec.
+
 ## Environment Variables
 
 | Variable | Description |

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -683,9 +683,18 @@ $ secretspec audit --json | jq 'select(.outcome == "missing")'
 `completions` is available starting with SecretSpec 0.20.
 :::
 
-Generate a completion script from the same command definition used by
-`secretspec --help`. The output includes every command, option, possible value,
-and description supported by the target shell.
+Generate a completion script that asks the same command definition used by
+`secretspec --help` for suggestions. Completion results include every command,
+option, possible value, and description supported by the target shell. They
+also provide contextual suggestions for profile, scope, secret, provider, and
+provider-alias names. File arguments complete paths, while `secretspec run`
+completes executables and command-argument paths.
+
+When you press Tab, the completion script invokes `secretspec` to calculate the
+current suggestions. SecretSpec reads the nearest `secretspec.toml` (or the
+manifest selected by `--file` or `SECRETSPEC_FILE`) and user configuration to
+discover names and descriptions. It does not contact providers or read secret
+values.
 
 ```bash
 $ secretspec completions <SHELL>

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -17,6 +17,8 @@ required-features = ["cli"]
 
 [dependencies]
 clap.workspace = true
+clap_complete = { workspace = true, optional = true }
+clap_complete_nushell = { workspace = true, optional = true }
 keyring = { workspace = true, optional = true }
 keepass = { workspace = true, optional = true }
 keeper-secrets-manager-core = { workspace = true, optional = true }
@@ -57,7 +59,7 @@ age = { workspace = true, optional = true }
 
 [features]
 default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "infisical", "bw", "age", "scaleway", "sops"]
-cli = ["dep:toml_edit"]
+cli = ["dep:toml_edit", "dep:clap_complete", "dep:clap_complete_nushell"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
 keeper = ["dep:keeper-secrets-manager-core"]

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -19,6 +19,7 @@ required-features = ["cli"]
 clap.workspace = true
 clap_complete = { workspace = true, optional = true }
 clap_complete_nushell = { workspace = true, optional = true }
+is_executable = { workspace = true, optional = true }
 keyring = { workspace = true, optional = true }
 keepass = { workspace = true, optional = true }
 keeper-secrets-manager-core = { workspace = true, optional = true }
@@ -59,7 +60,7 @@ age = { workspace = true, optional = true }
 
 [features]
 default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "infisical", "bw", "age", "scaleway", "sops"]
-cli = ["dep:toml_edit", "dep:clap_complete", "dep:clap_complete_nushell"]
+cli = ["dep:toml_edit", "dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
 keeper = ["dep:keeper-secrets-manager-core"]

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -310,7 +310,7 @@ secretspec run -- command        # Run command with secrets as env vars
 # Inspect access
 secretspec audit                 # Show the local audit log of secret access
 
-# Enable Fish completions for this session (0.20+)
+# Enable contextual Fish completions for this session (0.20+)
 secretspec completions fish | source
 ```
 

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -309,6 +309,9 @@ secretspec run -- command        # Run command with secrets as env vars
 
 # Inspect access
 secretspec audit                 # Show the local audit log of secret access
+
+# Enable Fish completions for this session (0.20+)
+secretspec completions fish | source
 ```
 
 See the [full CLI reference](https://secretspec.dev/reference/cli) for all commands and options.

--- a/secretspec/src/cli/completion.rs
+++ b/secretspec/src/cli/completion.rs
@@ -1,8 +1,9 @@
 use super::{Cli, CompletionShell};
+use crate::manifest::CompiledManifest;
 use crate::provider::providers as registered_providers;
 use crate::{Config, GlobalConfig};
-use clap::CommandFactory;
 use clap::builder::StyledStr;
+use clap::{ArgMatches, CommandFactory};
 use clap_complete::engine::{CompletionCandidate, PathCompleter, ValueCompleter};
 use clap_complete::env::{Bash, Elvish, EnvCompleter, Fish, Powershell, Shells, Zsh};
 use is_executable::IsExecutable;
@@ -17,6 +18,7 @@ static CONTEXT: OnceLock<CompletionContext> = OnceLock::new();
 
 struct CompletionContext {
     config: Option<Config>,
+    manifest: Option<CompiledManifest>,
     global: Option<GlobalConfig>,
     profile: String,
 }
@@ -24,12 +26,20 @@ struct CompletionContext {
 impl CompletionContext {
     fn load(args: &[OsString], current_dir: &Path) -> Self {
         let words = completion_words(args);
-        let explicit_file = argument_value(words, "--file", "-f").map(PathBuf::from);
-        let env_file = std::env::var_os("SECRETSPEC_FILE")
-            .filter(|value| !value.is_empty())
-            .map(PathBuf::from);
-        let path = explicit_file
-            .or(env_file)
+        let matches = Cli::command()
+            .ignore_errors(true)
+            .try_get_matches_from(words)
+            .ok();
+        let path = matches
+            .as_ref()
+            .and_then(|matches| {
+                matches
+                    .try_get_one::<PathBuf>("file")
+                    .ok()
+                    .flatten()
+                    .cloned()
+            })
+            .filter(|path| !path.as_os_str().is_empty())
             .map(|path| {
                 if path.is_relative() {
                     current_dir.join(path)
@@ -38,19 +48,21 @@ impl CompletionContext {
                 }
             })
             .or_else(|| find_manifest(current_dir));
-        let config = path
+        let loaded = path
             .as_deref()
             .and_then(|path| Config::try_from(path).ok())
-            .filter(|config| config.validate().is_ok());
-        let global = GlobalConfig::load().ok().flatten();
-        let profile = argument_value(words, "--profile", "-P")
-            .and_then(|value| value.into_string().ok())
-            .filter(|value| !value.trim().is_empty())
-            .or_else(|| {
-                std::env::var("SECRETSPEC_PROFILE")
+            .and_then(|config| {
+                config
+                    .validate_and_compile()
                     .ok()
-                    .filter(|value| !value.trim().is_empty())
-            })
+                    .map(|manifest| (config, manifest))
+            });
+        let (config, manifest) = loaded.unzip();
+        let global = load_global_config();
+        let profile = matches
+            .as_ref()
+            .and_then(profile_value)
+            .filter(|value| !value.trim().is_empty())
             .or_else(|| {
                 global
                     .as_ref()
@@ -60,6 +72,7 @@ impl CompletionContext {
 
         Self {
             config,
+            manifest,
             global,
             profile,
         }
@@ -72,28 +85,23 @@ fn completion_words(args: &[OsString]) -> &[OsString] {
         .map_or(args, |index| &args[index + 1..])
 }
 
-fn argument_value(args: &[OsString], long: &str, short: &str) -> Option<OsString> {
-    let mut value = None;
-    let mut words = args.iter().skip(1);
-    while let Some(word) = words.next() {
-        if word == "--" {
-            break;
-        }
-        if word == long || word == short {
-            value = words.next().cloned();
-            continue;
-        }
-        if let Some(word) = word.to_str() {
-            if let Some(attached) = word.strip_prefix(&format!("{long}=")) {
-                value = Some(attached.into());
-            } else if let Some(attached) = word.strip_prefix(short)
-                && !attached.is_empty()
-            {
-                value = Some(attached.into());
-            }
-        }
-    }
-    value
+fn profile_value(matches: &ArgMatches) -> Option<String> {
+    matches
+        .try_get_one::<String>("profile")
+        .ok()
+        .flatten()
+        .cloned()
+        .or_else(|| {
+            matches
+                .subcommand()
+                .and_then(|(_, matches)| profile_value(matches))
+        })
+}
+
+fn load_global_config() -> Option<GlobalConfig> {
+    let path = GlobalConfig::path().ok()?;
+    let content = std::fs::read_to_string(path).ok()?;
+    toml::from_str(&content).ok()
 }
 
 fn find_manifest(start: &Path) -> Option<PathBuf> {
@@ -170,9 +178,10 @@ fn command_candidates(current: &OsStr, path: Option<&OsStr>) -> Vec<CompletionCa
     }
     matching(
         current,
-        commands
-            .into_iter()
-            .map(|(name, path)| candidate(name, path)),
+        commands.into_iter().map(|(name, path)| {
+            let hidden = name.as_os_str().as_encoded_bytes().starts_with(b".");
+            candidate(name, path).hide(hidden)
+        }),
     )
 }
 
@@ -204,8 +213,11 @@ fn profile_candidates(
 }
 
 pub(super) fn scopes(current: &OsStr) -> Vec<CompletionCandidate> {
-    let mut candidates: Vec<_> = CONTEXT
-        .get()
+    matching(current, scope_candidates(CONTEXT.get()))
+}
+
+fn scope_candidates(context: Option<&CompletionContext>) -> Vec<CompletionCandidate> {
+    let mut candidates: Vec<_> = context
         .and_then(|context| context.config.as_ref())
         .and_then(|config| config.scopes.as_ref())
         .into_iter()
@@ -213,7 +225,7 @@ pub(super) fn scopes(current: &OsStr) -> Vec<CompletionCandidate> {
         .map(|name| candidate(name, "Manifest scope"))
         .collect();
     candidates.sort();
-    matching(current, candidates)
+    candidates
 }
 
 pub(super) fn secrets(current: &OsStr) -> Vec<CompletionCandidate> {
@@ -224,45 +236,64 @@ fn secret_candidates(context: Option<&CompletionContext>) -> Vec<CompletionCandi
     let Some(context) = context else {
         return Vec::new();
     };
-    let Some(config) = &context.config else {
+    let Some(manifest) = &context.manifest else {
         return Vec::new();
     };
-    let Some(profile) = config.profiles.get(&context.profile) else {
+    let Some(profile) = manifest.profiles.get(&context.profile) else {
         return Vec::new();
     };
 
-    let mut secrets = BTreeMap::new();
-    if context.profile != "default"
-        && profile.inherits_default()
-        && let Some(default) = config.profiles.get("default")
-    {
-        secrets.extend(&default.secrets);
-    }
-    secrets.extend(&profile.secrets);
-    secrets
-        .into_iter()
-        .map(|(name, config)| candidate(name, config.description.as_deref().unwrap_or("Secret")))
+    profile
+        .secrets
+        .iter()
+        .map(|(name, secret)| {
+            candidate(
+                name,
+                secret.config.description.as_deref().unwrap_or("Secret"),
+            )
+        })
         .collect()
 }
 
 pub(super) fn providers(current: &OsStr) -> Vec<CompletionCandidate> {
-    matching(current, provider_candidates(CONTEXT.get(), true))
+    matching(current, provider_candidates(CONTEXT.get()))
 }
 
 pub(super) fn provider_aliases(current: &OsStr) -> Vec<CompletionCandidate> {
-    matching(current, provider_candidates(CONTEXT.get(), false))
+    matching(current, provider_alias_candidates(CONTEXT.get(), true))
 }
 
-fn provider_candidates(
-    context: Option<&CompletionContext>,
-    include_registered: bool,
-) -> Vec<CompletionCandidate> {
+pub(super) fn global_provider_aliases(current: &OsStr) -> Vec<CompletionCandidate> {
+    matching(current, provider_alias_candidates(CONTEXT.get(), false))
+}
+
+fn provider_candidates(context: Option<&CompletionContext>) -> Vec<CompletionCandidate> {
     let mut candidates = BTreeMap::new();
-    if include_registered {
-        for provider in registered_providers() {
-            candidates.insert(provider.name.to_string(), provider.description.to_string());
-        }
+    for provider in registered_providers() {
+        candidates.insert(provider.name.to_string(), provider.description.to_string());
     }
+    candidates.extend(provider_alias_map(context, true));
+    candidates
+        .into_iter()
+        .map(|(name, help)| candidate(name, help))
+        .collect()
+}
+
+fn provider_alias_candidates(
+    context: Option<&CompletionContext>,
+    include_project: bool,
+) -> Vec<CompletionCandidate> {
+    provider_alias_map(context, include_project)
+        .into_iter()
+        .map(|(name, help)| candidate(name, help))
+        .collect()
+}
+
+fn provider_alias_map(
+    context: Option<&CompletionContext>,
+    include_project: bool,
+) -> BTreeMap<String, String> {
+    let mut candidates = BTreeMap::new();
     if let Some(context) = context {
         if let Some(aliases) = context
             .global
@@ -273,10 +304,11 @@ fn provider_candidates(
                 candidates.insert(name.clone(), "User provider alias".to_string());
             }
         }
-        if let Some(aliases) = context
-            .config
-            .as_ref()
-            .and_then(|config| config.providers.as_ref())
+        if include_project
+            && let Some(aliases) = context
+                .config
+                .as_ref()
+                .and_then(|config| config.providers.as_ref())
         {
             for name in aliases.keys() {
                 candidates.insert(name.clone(), "Project provider alias".to_string());
@@ -284,9 +316,6 @@ fn provider_candidates(
         }
     }
     candidates
-        .into_iter()
-        .map(|(name, help)| candidate(name, help))
-        .collect()
 }
 
 pub(super) fn complete() {
@@ -424,10 +453,14 @@ team = "keyring://"
 [scopes.api]
 secrets = ["API_KEY"]
 
+[scopes.worker]
+secrets = ["API_KEY"]
+
 [profiles.default]
 API_KEY = { description = "API token" }
 
 [profiles.production]
+API_KEY = { required = false }
 DATABASE_URL = { description = "Production database" }
 "#,
         )
@@ -449,18 +482,70 @@ DATABASE_URL = { description = "Production database" }
             .collect()
     }
 
+    fn help(candidates: &[CompletionCandidate], value: &str) -> Option<String> {
+        candidates
+            .iter()
+            .find(|candidate| candidate.get_value() == value)
+            .and_then(CompletionCandidate::get_help)
+            .map(ToString::to_string)
+    }
+
     #[test]
     fn context_reads_the_nearest_manifest_and_explicit_profile() {
         let (_directory, context) = fixture();
         assert_eq!(context.profile, "production");
         assert!(context.config.is_some());
+        assert!(context.manifest.is_some());
+    }
+
+    #[test]
+    fn context_resolves_an_explicit_manifest_from_the_current_directory() {
+        let (directory, _) = fixture();
+        let nested = directory.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        let selected = fs::read_to_string(directory.path().join("secretspec.toml"))
+            .unwrap()
+            .replace("completion-test", "selected-manifest");
+        fs::write(directory.path().join("selected.toml"), selected).unwrap();
+        let args = [
+            OsString::from("secretspec"),
+            OsString::from("--file"),
+            OsString::from("../selected.toml"),
+            OsString::from("get"),
+            OsString::from("API_KEY"),
+        ];
+        let context = CompletionContext::load(&args, &nested);
+        assert_eq!(
+            context
+                .config
+                .as_ref()
+                .map(|config| config.project.name.as_str()),
+            Some("selected-manifest")
+        );
     }
 
     #[test]
     fn secret_candidates_include_inherited_declarations_and_descriptions() {
         let (_directory, context) = fixture();
         let candidates = secret_candidates(Some(&context));
+        assert_eq!(help(&candidates, "API_KEY").as_deref(), Some("API token"));
         assert_eq!(values(candidates), ["API_KEY", "DATABASE_URL"]);
+    }
+
+    #[test]
+    fn context_does_not_parse_child_command_options() {
+        let (directory, _) = fixture();
+        let args = [
+            OsString::from("secretspec"),
+            OsString::from("run"),
+            OsString::from("--profile"),
+            OsString::from("production"),
+            OsString::from("deploy"),
+            OsString::from("--profile"),
+            OsString::from("child-profile"),
+        ];
+        let context = CompletionContext::load(&args, directory.path());
+        assert_eq!(context.profile, "production");
     }
 
     #[test]
@@ -473,19 +558,54 @@ DATABASE_URL = { description = "Production database" }
     }
 
     #[test]
-    fn provider_candidates_combine_registered_and_project_aliases() {
-        let (_directory, context) = fixture();
-        let candidates = values(provider_candidates(Some(&context), true));
+    fn provider_candidates_combine_registered_and_both_alias_scopes() {
+        let (_directory, mut context) = fixture();
+        context.global = Some(
+            toml::from_str(
+                r#"
+[defaults.providers]
+personal = "keyring://"
+"#,
+            )
+            .unwrap(),
+        );
+        let candidates = values(provider_candidates(Some(&context)));
         assert!(candidates.contains(&"keyring".to_string()));
+        assert!(candidates.contains(&"personal".to_string()));
         assert!(candidates.contains(&"team".to_string()));
+
+        assert_eq!(
+            values(provider_alias_candidates(Some(&context), false)),
+            ["personal"]
+        );
+        assert_eq!(
+            values(provider_alias_candidates(Some(&context), true)),
+            ["personal", "team"]
+        );
     }
 
     #[test]
     fn malformed_or_missing_manifests_produce_no_project_candidates() {
         let directory = tempfile::tempdir().unwrap();
-        let context = CompletionContext::load(&[OsString::from("secretspec")], directory.path());
-        assert!(context.config.is_none());
-        assert!(secret_candidates(Some(&context)).is_empty());
+        let args = [OsString::from("secretspec")];
+        let missing = CompletionContext::load(&args, directory.path());
+        assert!(missing.config.is_none());
+        assert!(secret_candidates(Some(&missing)).is_empty());
+
+        fs::write(directory.path().join("secretspec.toml"), "not = [valid").unwrap();
+        let malformed = CompletionContext::load(&args, directory.path());
+        assert!(malformed.config.is_none());
+        assert!(secret_candidates(Some(&malformed)).is_empty());
+    }
+
+    #[test]
+    fn scope_candidates_are_sorted_and_prefix_filtered() {
+        let (_directory, context) = fixture();
+        assert_eq!(values(scope_candidates(Some(&context))), ["api", "worker"]);
+        assert_eq!(
+            values(matching(OsStr::new("w"), scope_candidates(Some(&context)))),
+            ["worker"]
+        );
     }
 
     #[test]
@@ -496,6 +616,28 @@ DATABASE_URL = { description = "Production database" }
         assert!(output.contains("SECRETSPEC_COMPLETE: nushell"));
         assert!(output.contains("@complete 'nu-complete secretspec'"));
         assert!(output.contains("export extern secretspec"));
+    }
+
+    #[test]
+    fn nushell_dynamic_output_preserves_values_and_descriptions() {
+        let mut command = Cli::command();
+        let mut output = Vec::new();
+        Nushell
+            .write_complete(
+                &mut command,
+                vec![OsString::from("secretspec"), OsString::from("c")],
+                None,
+                &mut output,
+            )
+            .unwrap();
+        let candidates: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        let config = candidates
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|candidate| candidate["value"] == "config")
+            .unwrap();
+        assert_eq!(config["description"], "Manage SecretSpec configuration");
     }
 
     #[test]
@@ -525,10 +667,13 @@ DATABASE_URL = { description = "Production database" }
 
         let directory = tempfile::tempdir().unwrap();
         let executable = directory.path().join("deploy-tool");
+        let hidden = directory.path().join(".deploy-wrapper");
         let regular_file = directory.path().join("deploy-notes");
         fs::write(&executable, "").unwrap();
+        fs::write(&hidden, "").unwrap();
         fs::write(&regular_file, "").unwrap();
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::set_permissions(&hidden, fs::Permissions::from_mode(0o755)).unwrap();
 
         assert_eq!(
             values(command_candidates(
@@ -537,5 +682,8 @@ DATABASE_URL = { description = "Production database" }
             )),
             ["deploy-tool"]
         );
+        let hidden = command_candidates(OsStr::new(".deploy-"), Some(directory.path().as_os_str()));
+        assert_eq!(hidden.len(), 1);
+        assert!(hidden[0].is_hide_set());
     }
 }

--- a/secretspec/src/cli/completion.rs
+++ b/secretspec/src/cli/completion.rs
@@ -1,0 +1,541 @@
+use super::{Cli, CompletionShell};
+use crate::provider::providers as registered_providers;
+use crate::{Config, GlobalConfig};
+use clap::CommandFactory;
+use clap::builder::StyledStr;
+use clap_complete::engine::{CompletionCandidate, PathCompleter, ValueCompleter};
+use clap_complete::env::{Bash, Elvish, EnvCompleter, Fish, Powershell, Shells, Zsh};
+use is_executable::IsExecutable;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+const COMPLETE_VAR: &str = "SECRETSPEC_COMPLETE";
+static CONTEXT: OnceLock<CompletionContext> = OnceLock::new();
+
+struct CompletionContext {
+    config: Option<Config>,
+    global: Option<GlobalConfig>,
+    profile: String,
+}
+
+impl CompletionContext {
+    fn load(args: &[OsString], current_dir: &Path) -> Self {
+        let words = completion_words(args);
+        let explicit_file = argument_value(words, "--file", "-f").map(PathBuf::from);
+        let env_file = std::env::var_os("SECRETSPEC_FILE")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from);
+        let path = explicit_file
+            .or(env_file)
+            .map(|path| {
+                if path.is_relative() {
+                    current_dir.join(path)
+                } else {
+                    path
+                }
+            })
+            .or_else(|| find_manifest(current_dir));
+        let config = path
+            .as_deref()
+            .and_then(|path| Config::try_from(path).ok())
+            .filter(|config| config.validate().is_ok());
+        let global = GlobalConfig::load().ok().flatten();
+        let profile = argument_value(words, "--profile", "-P")
+            .and_then(|value| value.into_string().ok())
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                std::env::var("SECRETSPEC_PROFILE")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            })
+            .or_else(|| {
+                global
+                    .as_ref()
+                    .and_then(|config| config.defaults.profile.clone())
+            })
+            .unwrap_or_else(|| "default".to_string());
+
+        Self {
+            config,
+            global,
+            profile,
+        }
+    }
+}
+
+fn completion_words(args: &[OsString]) -> &[OsString] {
+    args.iter()
+        .position(|word| word == "--")
+        .map_or(args, |index| &args[index + 1..])
+}
+
+fn argument_value(args: &[OsString], long: &str, short: &str) -> Option<OsString> {
+    let mut value = None;
+    let mut words = args.iter().skip(1);
+    while let Some(word) = words.next() {
+        if word == "--" {
+            break;
+        }
+        if word == long || word == short {
+            value = words.next().cloned();
+            continue;
+        }
+        if let Some(word) = word.to_str() {
+            if let Some(attached) = word.strip_prefix(&format!("{long}=")) {
+                value = Some(attached.into());
+            } else if let Some(attached) = word.strip_prefix(short)
+                && !attached.is_empty()
+            {
+                value = Some(attached.into());
+            }
+        }
+    }
+    value
+}
+
+fn find_manifest(start: &Path) -> Option<PathBuf> {
+    let mut directory = start.to_path_buf();
+    loop {
+        let candidate = directory.join("secretspec.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !directory.pop() {
+            return None;
+        }
+    }
+}
+
+fn candidate(value: impl Into<OsString>, help: impl Into<String>) -> CompletionCandidate {
+    let help = help.into().split_whitespace().collect::<Vec<_>>().join(" ");
+    CompletionCandidate::new(value).help((!help.is_empty()).then(|| StyledStr::from(help)))
+}
+
+fn matching(
+    current: &OsStr,
+    candidates: impl IntoIterator<Item = CompletionCandidate>,
+) -> Vec<CompletionCandidate> {
+    let Some(current) = current.to_str() else {
+        return Vec::new();
+    };
+    candidates
+        .into_iter()
+        .filter(|candidate| candidate.get_value().to_string_lossy().starts_with(current))
+        .collect()
+}
+
+pub(super) struct RunCompleter;
+
+impl ValueCompleter for RunCompleter {
+    fn complete(&self, current: &OsStr) -> Vec<CompletionCandidate> {
+        self.complete_at(0, current)
+    }
+
+    fn complete_at(&self, arg_index: usize, current: &OsStr) -> Vec<CompletionCandidate> {
+        if arg_index == 0 {
+            command_candidates(current, std::env::var_os("PATH").as_deref())
+        } else {
+            PathCompleter::any().complete(current)
+        }
+    }
+}
+
+fn command_candidates(current: &OsStr, path: Option<&OsStr>) -> Vec<CompletionCandidate> {
+    let current_path = Path::new(current);
+    if current_path
+        .parent()
+        .is_some_and(|parent| !parent.as_os_str().is_empty())
+    {
+        return PathCompleter::any()
+            .filter(|path| path.is_executable())
+            .complete(current);
+    }
+
+    let mut commands = BTreeMap::new();
+    for directory in path.into_iter().flat_map(std::env::split_paths) {
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_executable() {
+                commands
+                    .entry(entry.file_name())
+                    .or_insert_with(|| path.display().to_string());
+            }
+        }
+    }
+    matching(
+        current,
+        commands
+            .into_iter()
+            .map(|(name, path)| candidate(name, path)),
+    )
+}
+
+pub(super) fn profiles(current: &OsStr) -> Vec<CompletionCandidate> {
+    matching(current, profile_candidates(CONTEXT.get(), false))
+}
+
+pub(super) fn profiles_or_none(current: &OsStr) -> Vec<CompletionCandidate> {
+    matching(current, profile_candidates(CONTEXT.get(), true))
+}
+
+fn profile_candidates(
+    context: Option<&CompletionContext>,
+    include_none: bool,
+) -> Vec<CompletionCandidate> {
+    let mut candidates = BTreeMap::new();
+    if include_none {
+        candidates.insert("none", "Clear the configured default profile");
+    }
+    if let Some(config) = context.and_then(|context| context.config.as_ref()) {
+        for name in config.profiles.keys() {
+            candidates.insert(name, "Manifest profile");
+        }
+    }
+    candidates
+        .into_iter()
+        .map(|(name, help)| candidate(name, help))
+        .collect()
+}
+
+pub(super) fn scopes(current: &OsStr) -> Vec<CompletionCandidate> {
+    let mut candidates: Vec<_> = CONTEXT
+        .get()
+        .and_then(|context| context.config.as_ref())
+        .and_then(|config| config.scopes.as_ref())
+        .into_iter()
+        .flat_map(|scopes| scopes.keys())
+        .map(|name| candidate(name, "Manifest scope"))
+        .collect();
+    candidates.sort();
+    matching(current, candidates)
+}
+
+pub(super) fn secrets(current: &OsStr) -> Vec<CompletionCandidate> {
+    matching(current, secret_candidates(CONTEXT.get()))
+}
+
+fn secret_candidates(context: Option<&CompletionContext>) -> Vec<CompletionCandidate> {
+    let Some(context) = context else {
+        return Vec::new();
+    };
+    let Some(config) = &context.config else {
+        return Vec::new();
+    };
+    let Some(profile) = config.profiles.get(&context.profile) else {
+        return Vec::new();
+    };
+
+    let mut secrets = BTreeMap::new();
+    if context.profile != "default"
+        && profile.inherits_default()
+        && let Some(default) = config.profiles.get("default")
+    {
+        secrets.extend(&default.secrets);
+    }
+    secrets.extend(&profile.secrets);
+    secrets
+        .into_iter()
+        .map(|(name, config)| candidate(name, config.description.as_deref().unwrap_or("Secret")))
+        .collect()
+}
+
+pub(super) fn providers(current: &OsStr) -> Vec<CompletionCandidate> {
+    matching(current, provider_candidates(CONTEXT.get(), true))
+}
+
+pub(super) fn provider_aliases(current: &OsStr) -> Vec<CompletionCandidate> {
+    matching(current, provider_candidates(CONTEXT.get(), false))
+}
+
+fn provider_candidates(
+    context: Option<&CompletionContext>,
+    include_registered: bool,
+) -> Vec<CompletionCandidate> {
+    let mut candidates = BTreeMap::new();
+    if include_registered {
+        for provider in registered_providers() {
+            candidates.insert(provider.name.to_string(), provider.description.to_string());
+        }
+    }
+    if let Some(context) = context {
+        if let Some(aliases) = context
+            .global
+            .as_ref()
+            .and_then(|global| global.defaults.providers.as_ref())
+        {
+            for name in aliases.keys() {
+                candidates.insert(name.clone(), "User provider alias".to_string());
+            }
+        }
+        if let Some(aliases) = context
+            .config
+            .as_ref()
+            .and_then(|config| config.providers.as_ref())
+        {
+            for name in aliases.keys() {
+                candidates.insert(name.clone(), "Project provider alias".to_string());
+            }
+        }
+    }
+    candidates
+        .into_iter()
+        .map(|(name, help)| candidate(name, help))
+        .collect()
+}
+
+pub(super) fn complete() {
+    let Some(shell) = std::env::var_os(COMPLETE_VAR) else {
+        return;
+    };
+    if shell.is_empty() || shell == "0" {
+        return;
+    }
+    let args: Vec<OsString> = std::env::args_os().collect();
+    let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let _ = CONTEXT.set(CompletionContext::load(&args, &current_dir));
+    let nushell = Nushell;
+    let shells: [&dyn EnvCompleter; 6] = [&Bash, &Elvish, &Fish, &nushell, &Powershell, &Zsh];
+    clap_complete::CompleteEnv::with_factory(Cli::command)
+        .var(COMPLETE_VAR)
+        .shells(Shells(&shells))
+        .complete();
+}
+
+pub(super) fn generate(shell: CompletionShell, output: &mut dyn io::Write) -> io::Result<()> {
+    match shell {
+        CompletionShell::Bash => registration(&Bash, output),
+        CompletionShell::Elvish => registration(&Elvish, output),
+        CompletionShell::Fish => registration(&Fish, output),
+        CompletionShell::Nushell => generate_nushell(output),
+        CompletionShell::PowerShell => registration(&Powershell, output),
+        CompletionShell::Zsh => registration(&Zsh, output),
+    }
+}
+
+fn registration(shell: &dyn EnvCompleter, output: &mut dyn io::Write) -> io::Result<()> {
+    shell.write_registration(
+        COMPLETE_VAR,
+        "secretspec",
+        "secretspec",
+        "secretspec",
+        output,
+    )
+}
+
+fn generate_nushell(output: &mut dyn io::Write) -> io::Result<()> {
+    let mut command = Cli::command();
+    let mut generated = Vec::new();
+    clap_complete::generate(
+        clap_complete_nushell::Nushell,
+        &mut command,
+        "secretspec",
+        &mut generated,
+    );
+    let generated = String::from_utf8(generated).map_err(io::Error::other)?;
+    let completer = r#"module completions {
+
+  def "nu-complete secretspec" [spans: list<string>] {
+    with-env { SECRETSPEC_COMPLETE: nushell } {
+      ^secretspec -- ...$spans
+    } | from json
+  }
+"#;
+    let generated = generated
+        .replacen("module completions {\n", completer, 1)
+        .replace(
+            "  export extern ",
+            "  @complete 'nu-complete secretspec'\n  export extern ",
+        );
+    output.write_all(generated.as_bytes())
+}
+
+struct Nushell;
+
+impl EnvCompleter for Nushell {
+    fn name(&self) -> &'static str {
+        "nushell"
+    }
+
+    fn is(&self, name: &str) -> bool {
+        matches!(name, "nu" | "nushell")
+    }
+
+    fn write_registration(
+        &self,
+        _var: &str,
+        _name: &str,
+        _bin: &str,
+        _completer: &str,
+        _buf: &mut dyn io::Write,
+    ) -> io::Result<()> {
+        Err(io::Error::other(
+            "Nushell registration is generated as a module",
+        ))
+    }
+
+    fn write_complete(
+        &self,
+        command: &mut clap::Command,
+        mut args: Vec<OsString>,
+        current_dir: Option<&Path>,
+        output: &mut dyn io::Write,
+    ) -> io::Result<()> {
+        if args.is_empty() {
+            args.push(OsString::new());
+        }
+        let index = args.len() - 1;
+        let completions = clap_complete::engine::complete(command, args, index, current_dir)?;
+        let completions: Vec<_> = completions
+            .into_iter()
+            .map(|candidate| {
+                serde_json::json!({
+                    "value": candidate.get_value().to_string_lossy(),
+                    "description": candidate.get_help().map(ToString::to_string).unwrap_or_default(),
+                })
+            })
+            .collect();
+        serde_json::to_writer(output, &completions).map_err(io::Error::other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn fixture() -> (tempfile::TempDir, CompletionContext) {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(
+            directory.path().join("secretspec.toml"),
+            r#"
+[project]
+name = "completion-test"
+revision = "1.0"
+
+[providers]
+team = "keyring://"
+
+[scopes.api]
+secrets = ["API_KEY"]
+
+[profiles.default]
+API_KEY = { description = "API token" }
+
+[profiles.production]
+DATABASE_URL = { description = "Production database" }
+"#,
+        )
+        .unwrap();
+        let args = [
+            OsString::from("secretspec"),
+            OsString::from("get"),
+            OsString::from("--profile"),
+            OsString::from("production"),
+        ];
+        let context = CompletionContext::load(&args, directory.path());
+        (directory, context)
+    }
+
+    fn values(candidates: Vec<CompletionCandidate>) -> Vec<String> {
+        candidates
+            .into_iter()
+            .map(|candidate| candidate.get_value().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn context_reads_the_nearest_manifest_and_explicit_profile() {
+        let (_directory, context) = fixture();
+        assert_eq!(context.profile, "production");
+        assert!(context.config.is_some());
+    }
+
+    #[test]
+    fn secret_candidates_include_inherited_declarations_and_descriptions() {
+        let (_directory, context) = fixture();
+        let candidates = secret_candidates(Some(&context));
+        assert_eq!(values(candidates), ["API_KEY", "DATABASE_URL"]);
+    }
+
+    #[test]
+    fn profile_candidates_are_sorted_and_can_include_the_clear_value() {
+        let (_directory, context) = fixture();
+        assert_eq!(
+            values(profile_candidates(Some(&context), true)),
+            ["default", "none", "production"]
+        );
+    }
+
+    #[test]
+    fn provider_candidates_combine_registered_and_project_aliases() {
+        let (_directory, context) = fixture();
+        let candidates = values(provider_candidates(Some(&context), true));
+        assert!(candidates.contains(&"keyring".to_string()));
+        assert!(candidates.contains(&"team".to_string()));
+    }
+
+    #[test]
+    fn malformed_or_missing_manifests_produce_no_project_candidates() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = CompletionContext::load(&[OsString::from("secretspec")], directory.path());
+        assert!(context.config.is_none());
+        assert!(secret_candidates(Some(&context)).is_empty());
+    }
+
+    #[test]
+    fn generated_nushell_module_delegates_to_the_dynamic_engine() {
+        let mut output = Vec::new();
+        generate_nushell(&mut output).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("SECRETSPEC_COMPLETE: nushell"));
+        assert!(output.contains("@complete 'nu-complete secretspec'"));
+        assert!(output.contains("export extern secretspec"));
+    }
+
+    #[test]
+    fn dynamic_engine_keeps_command_descriptions() {
+        let mut command = Cli::command();
+        let candidates = clap_complete::engine::complete(
+            &mut command,
+            vec![OsString::from("secretspec"), OsString::from("c")],
+            1,
+            None,
+        )
+        .unwrap();
+        let config = candidates
+            .iter()
+            .find(|candidate| candidate.get_value() == "config")
+            .unwrap();
+        assert_eq!(
+            config.get_help().map(ToString::to_string).as_deref(),
+            Some("Manage SecretSpec configuration")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_completer_finds_executables_on_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("deploy-tool");
+        let regular_file = directory.path().join("deploy-notes");
+        fs::write(&executable, "").unwrap();
+        fs::write(&regular_file, "").unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert_eq!(
+            values(command_candidates(
+                OsStr::new("deploy-"),
+                Some(directory.path().as_os_str())
+            )),
+            ["deploy-tool"]
+        );
+    }
+}

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -240,8 +240,8 @@ enum Commands {
     },
 }
 
-fn generate_completions(shell: CompletionShell, output: &mut dyn Write) {
-    completion::generate(shell, output).expect("failed to generate shell completions");
+fn generate_completions(shell: CompletionShell, output: &mut dyn Write) -> std::io::Result<()> {
+    completion::generate(shell, output)
 }
 
 /// Cached provider maintenance commands (0.17+).
@@ -325,7 +325,7 @@ enum GlobalProviderAction {
     /// Remove a provider alias
     Remove {
         /// Name of the provider alias to remove
-        #[arg(add = clap_complete::ArgValueCompleter::new(completion::provider_aliases))]
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::global_provider_aliases))]
         name: String,
     },
     /// List all configured provider aliases
@@ -356,7 +356,7 @@ enum ProviderAction {
     #[command(hide = true)]
     Remove {
         /// Name of the provider alias to remove
-        #[arg(add = clap_complete::ArgValueCompleter::new(completion::provider_aliases))]
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::global_provider_aliases))]
         name: String,
     },
     /// List all configured provider aliases
@@ -1454,7 +1454,7 @@ pub fn main() -> Result<()> {
             Ok(())
         }
         Commands::Completions { shell } => {
-            generate_completions(shell, &mut std::io::stdout().lock());
+            generate_completions(shell, &mut std::io::stdout().lock()).into_diagnostic()?;
             Ok(())
         }
         // Import secrets from one provider to another
@@ -2096,7 +2096,7 @@ mod tests {
 
         for shell in shells {
             let mut output = Vec::new();
-            generate_completions(shell, &mut output);
+            generate_completions(shell, &mut output).unwrap();
             let output = String::from_utf8(output).unwrap();
             assert!(
                 output.contains("secretspec"),
@@ -2107,15 +2107,6 @@ mod tests {
                 "missing dynamic completion protocol for {shell:?}"
             );
         }
-    }
-
-    #[test]
-    fn fish_completions_do_not_evaluate_value_descriptions() {
-        let mut output = Vec::new();
-        generate_completions(CompletionShell::Fish, &mut output);
-        let output = String::from_utf8(output).unwrap();
-        assert!(!output.contains("$("));
-        assert!(!output.contains("$GITHUB_ENV"));
     }
 
     #[test]

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1,6 +1,6 @@
 use crate::provider::{Provider, providers, spec_names_known_provider};
 use crate::{Config, ExportFormat, GlobalConfig, GlobalDefaults, Profile, Project, Secrets};
-use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -8,6 +8,8 @@ use std::io::{IsTerminal, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+
+mod completion;
 
 /// Main CLI structure for the secretspec application.
 ///
@@ -19,7 +21,7 @@ use std::path::{Path, PathBuf};
 #[command(version)]
 struct Cli {
     /// Path to secretspec.toml (default: auto-detect by walking up from current directory)
-    #[arg(short = 'f', long, global = true, env = "SECRETSPEC_FILE")]
+    #[arg(short = 'f', long, global = true, env = "SECRETSPEC_FILE", value_hint = ValueHint::FilePath)]
     file: Option<PathBuf>,
 
     /// Reason for accessing secrets, recorded by providers that support audit
@@ -61,13 +63,13 @@ enum Commands {
         /// Discover declarations from a provider (additional providers in 0.18+)
         ///
         /// Note: no short flag here — `-f` is the global `--file` option.
-        #[arg(long, default_value = "dotenv://.env")]
+        #[arg(long, default_value = "dotenv://.env", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         from: String,
         /// Project used to select the provider namespace (0.18+; defaults to directory name)
         #[arg(long)]
         project: Option<String>,
         /// Profile used to select the provider namespace (0.18+)
-        #[arg(short = 'P', long, default_value = "default")]
+        #[arg(short = 'P', long, default_value = "default", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: String,
     },
     /// Add a secret declaration to secretspec.toml (0.18+)
@@ -78,37 +80,39 @@ enum Commands {
         #[arg(short, long)]
         description: Option<String>,
         /// Profile to add the secret to
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
     },
     /// Set a secret value
     Set {
         /// Name of the secret
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::secrets))]
         name: String,
         /// Value of the secret (will prompt if not provided)
         value: Option<String>,
         /// Provider backend to use
-        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         provider: Option<String>,
         /// Profile to use
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
     },
     /// Get a secret value
     Get {
         /// Name of the secret
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::secrets))]
         name: String,
         /// Provider backend to use
-        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         provider: Option<String>,
         /// Profile to use
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
     },
     /// Delete stored secret values from a provider (0.18+)
     Delete {
         /// Names of the secrets to delete
-        #[arg(required_unless_present = "all", conflicts_with = "all")]
+        #[arg(required_unless_present = "all", conflicts_with = "all", add = clap_complete::ArgValueCompleter::new(completion::secrets))]
         names: Vec<String>,
         /// Delete every provider-backed secret declared in the active profile
         #[arg(long)]
@@ -117,38 +121,38 @@ enum Commands {
         #[arg(short, long, requires = "all", conflicts_with = "names")]
         yes: bool,
         /// Provider backend to delete from
-        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         provider: Option<String>,
         /// Profile to use
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
     },
     /// Run a command with secrets injected
     Run {
         /// Provider backend to use
-        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         provider: Option<String>,
         /// Profile to use
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
         /// Scope to resolve (a `[scopes]` subset of the profile). Excluded
         /// secrets are removed from the child environment even if inherited.
-        #[arg(short = 'S', long, env = "SECRETSPEC_SCOPE")]
+        #[arg(short = 'S', long, env = "SECRETSPEC_SCOPE", add = clap_complete::ArgValueCompleter::new(completion::scopes))]
         scope: Option<String>,
         /// Command and arguments to run
-        #[arg(trailing_var_arg = true)]
+        #[arg(trailing_var_arg = true, value_hint = ValueHint::CommandWithArguments, add = clap_complete::ArgValueCompleter::new(completion::RunCompleter))]
         command: Vec<String>,
     },
     /// Resolve secrets and print them for another tool to consume
     Export {
         /// Provider backend to use
-        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         provider: Option<String>,
         /// Profile to use
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
         /// Scope to resolve (a `[scopes]` subset of the profile)
-        #[arg(short = 'S', long, env = "SECRETSPEC_SCOPE")]
+        #[arg(short = 'S', long, env = "SECRETSPEC_SCOPE", add = clap_complete::ArgValueCompleter::new(completion::scopes))]
         scope: Option<String>,
         /// Output format
         #[arg(long, value_enum, default_value = "shell")]
@@ -157,13 +161,13 @@ enum Commands {
     /// Check if all required secrets are in the provider, if not set them
     Check {
         /// Provider backend to use
-        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         provider: Option<String>,
         /// Profile to use
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
         /// Scope to check (a `[scopes]` subset of the profile)
-        #[arg(short = 'S', long, env = "SECRETSPEC_SCOPE")]
+        #[arg(short = 'S', long, env = "SECRETSPEC_SCOPE", add = clap_complete::ArgValueCompleter::new(completion::scopes))]
         scope: Option<String>,
         /// Don't prompt for missing secrets (exit with error if any are missing)
         #[arg(short = 'n', long)]
@@ -188,10 +192,10 @@ enum Commands {
     /// Example: `secretspec schema | quicktype -s schema --top-level SecretSpec --lang typescript`
     Schema {
         /// Emit the schema for this profile's fields instead of the union
-        #[arg(short = 'P', long)]
+        #[arg(short = 'P', long, add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
         /// Write to this file instead of stdout
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = ValueHint::FilePath)]
         output: Option<PathBuf>,
     },
     /// Generate shell completion scripts (0.20+)
@@ -208,6 +212,7 @@ enum Commands {
     /// Import secrets from a provider to another provider
     Import {
         /// Provider backend to import from (secrets will be imported to the default provider)
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::providers))]
         from_provider: String,
         /// Delete a source value only after the destination contains the same value (0.18+)
         #[arg(long)]
@@ -236,45 +241,7 @@ enum Commands {
 }
 
 fn generate_completions(shell: CompletionShell, output: &mut dyn Write) {
-    let mut command = Cli::command();
-    match shell {
-        CompletionShell::Bash => clap_complete::generate(
-            clap_complete::Shell::Bash,
-            &mut command,
-            "secretspec",
-            output,
-        ),
-        CompletionShell::Elvish => clap_complete::generate(
-            clap_complete::Shell::Elvish,
-            &mut command,
-            "secretspec",
-            output,
-        ),
-        CompletionShell::Fish => clap_complete::generate(
-            clap_complete::Shell::Fish,
-            &mut command,
-            "secretspec",
-            output,
-        ),
-        CompletionShell::Nushell => clap_complete::generate(
-            clap_complete_nushell::Nushell,
-            &mut command,
-            "secretspec",
-            output,
-        ),
-        CompletionShell::PowerShell => clap_complete::generate(
-            clap_complete::Shell::PowerShell,
-            &mut command,
-            "secretspec",
-            output,
-        ),
-        CompletionShell::Zsh => clap_complete::generate(
-            clap_complete::Shell::Zsh,
-            &mut command,
-            "secretspec",
-            output,
-        ),
-    }
+    completion::generate(shell, output).expect("failed to generate shell completions");
 }
 
 /// Cached provider maintenance commands (0.17+).
@@ -283,9 +250,10 @@ enum CacheAction {
     /// Delete cached values for one secret, or all cached secrets (0.17+)
     Clear {
         /// Secret to clear; omit to clear every cached secret in the profile
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::secrets))]
         name: Option<String>,
         /// Profile whose cache entries should be cleared
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
     },
 }
@@ -305,10 +273,10 @@ enum ConfigAction {
     #[command(hide = true)]
     Init {
         /// Provider backend to save without prompting (0.17+)
-        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         provider: Option<String>,
         /// Default profile to save without prompting; use "none" to clear it (0.17+)
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles_or_none))]
         profile: Option<String>,
     },
     /// Show current configuration
@@ -325,10 +293,10 @@ enum GlobalConfigAction {
     /// Initialize user-global defaults
     Init {
         /// Provider backend to save without prompting
-        #[arg(short, long, env = "SECRETSPEC_PROVIDER")]
+        #[arg(short, long, env = "SECRETSPEC_PROVIDER", add = clap_complete::ArgValueCompleter::new(completion::providers))]
         provider: Option<String>,
         /// Default profile to save without prompting; use "none" to clear it
-        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE")]
+        #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles_or_none))]
         profile: Option<String>,
     },
     /// Show user-global configuration
@@ -357,6 +325,7 @@ enum GlobalProviderAction {
     /// Remove a provider alias
     Remove {
         /// Name of the provider alias to remove
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::provider_aliases))]
         name: String,
     },
     /// List all configured provider aliases
@@ -387,6 +356,7 @@ enum ProviderAction {
     #[command(hide = true)]
     Remove {
         /// Name of the provider alias to remove
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::provider_aliases))]
         name: String,
     },
     /// List all configured provider aliases
@@ -395,6 +365,7 @@ enum ProviderAction {
     /// Store the credentials declared by a provider alias
     Login {
         /// Name of the provider alias to store credentials for
+        #[arg(add = clap_complete::ArgValueCompleter::new(completion::provider_aliases))]
         name: String,
     },
 }
@@ -881,6 +852,7 @@ fn select_config_init_profile(profile: Option<String>) -> Result<Option<String>>
 /// * `Err` - If any error occurred during execution
 #[doc(hidden)]
 pub fn main() -> Result<()> {
+    completion::complete();
     let cli = Cli::parse();
 
     match cli.command {
@@ -2082,6 +2054,7 @@ mod tests {
 
     #[test]
     fn cli_command_definition_is_valid() {
+        use clap::CommandFactory;
         Cli::command().debug_assert();
     }
 
@@ -2111,7 +2084,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_scripts_cover_the_full_cli() {
+    fn completion_scripts_register_the_dynamic_engine() {
         let shells = [
             CompletionShell::Bash,
             CompletionShell::Elvish,
@@ -2130,12 +2103,8 @@ mod tests {
                 "missing binary for {shell:?}"
             );
             assert!(
-                output.contains("config"),
-                "missing subcommands for {shell:?}"
-            );
-            assert!(
-                output.contains("provider"),
-                "missing nested commands for {shell:?}"
+                output.contains("SECRETSPEC_COMPLETE"),
+                "missing dynamic completion protocol for {shell:?}"
             );
         }
     }
@@ -2147,27 +2116,6 @@ mod tests {
         let output = String::from_utf8(output).unwrap();
         assert!(!output.contains("$("));
         assert!(!output.contains("$GITHUB_ENV"));
-    }
-
-    #[test]
-    fn completion_scripts_include_descriptions_where_supported() {
-        let shells = [
-            CompletionShell::Elvish,
-            CompletionShell::Fish,
-            CompletionShell::Nushell,
-            CompletionShell::PowerShell,
-            CompletionShell::Zsh,
-        ];
-
-        for shell in shells {
-            let mut output = Vec::new();
-            generate_completions(shell, &mut output);
-            let output = String::from_utf8(output).unwrap();
-            assert!(
-                output.contains("Initialize a new secretspec.toml"),
-                "missing descriptions for {shell:?}"
-            );
-        }
     }
 
     #[test]

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1,6 +1,6 @@
 use crate::provider::{Provider, providers, spec_names_known_provider};
 use crate::{Config, ExportFormat, GlobalConfig, GlobalDefaults, Profile, Project, Secrets};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -31,6 +31,23 @@ struct Cli {
     /// The subcommand to execute
     #[command(subcommand)]
     command: Commands,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum CompletionShell {
+    /// Bourne Again Shell
+    Bash,
+    /// Elvish shell
+    Elvish,
+    /// Friendly Interactive Shell
+    Fish,
+    /// Nushell
+    Nushell,
+    /// PowerShell
+    #[value(name = "powershell")]
+    PowerShell,
+    /// Z shell
+    Zsh,
 }
 
 /// Available commands for the secretspec CLI.
@@ -177,6 +194,12 @@ enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
+    /// Generate shell completion scripts (0.20+)
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: CompletionShell,
+    },
     /// Manage SecretSpec configuration
     Config {
         #[command(subcommand)]
@@ -210,6 +233,48 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+}
+
+fn generate_completions(shell: CompletionShell, output: &mut dyn Write) {
+    let mut command = Cli::command();
+    match shell {
+        CompletionShell::Bash => clap_complete::generate(
+            clap_complete::Shell::Bash,
+            &mut command,
+            "secretspec",
+            output,
+        ),
+        CompletionShell::Elvish => clap_complete::generate(
+            clap_complete::Shell::Elvish,
+            &mut command,
+            "secretspec",
+            output,
+        ),
+        CompletionShell::Fish => clap_complete::generate(
+            clap_complete::Shell::Fish,
+            &mut command,
+            "secretspec",
+            output,
+        ),
+        CompletionShell::Nushell => clap_complete::generate(
+            clap_complete_nushell::Nushell,
+            &mut command,
+            "secretspec",
+            output,
+        ),
+        CompletionShell::PowerShell => clap_complete::generate(
+            clap_complete::Shell::PowerShell,
+            &mut command,
+            "secretspec",
+            output,
+        ),
+        CompletionShell::Zsh => clap_complete::generate(
+            clap_complete::Shell::Zsh,
+            &mut command,
+            "secretspec",
+            output,
+        ),
+    }
 }
 
 /// Cached provider maintenance commands (0.17+).
@@ -1416,6 +1481,10 @@ pub fn main() -> Result<()> {
             }
             Ok(())
         }
+        Commands::Completions { shell } => {
+            generate_completions(shell, &mut std::io::stdout().lock());
+            Ok(())
+        }
         // Import secrets from one provider to another
         Commands::Import {
             from_provider,
@@ -2013,8 +2082,92 @@ mod tests {
 
     #[test]
     fn cli_command_definition_is_valid() {
-        use clap::CommandFactory;
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn completions_accept_every_supported_shell() {
+        let cases = [
+            ("bash", CompletionShell::Bash),
+            ("elvish", CompletionShell::Elvish),
+            ("fish", CompletionShell::Fish),
+            ("nushell", CompletionShell::Nushell),
+            ("powershell", CompletionShell::PowerShell),
+            ("zsh", CompletionShell::Zsh),
+        ];
+
+        for (name, expected) in cases {
+            let cli = Cli::try_parse_from(["secretspec", "completions", name]).unwrap();
+            match cli.command {
+                Commands::Completions { shell } => assert_eq!(shell, expected),
+                _ => panic!("expected completions command"),
+            }
+        }
+    }
+
+    #[test]
+    fn completions_reject_an_unknown_shell() {
+        assert!(Cli::try_parse_from(["secretspec", "completions", "tcsh"]).is_err());
+    }
+
+    #[test]
+    fn completion_scripts_cover_the_full_cli() {
+        let shells = [
+            CompletionShell::Bash,
+            CompletionShell::Elvish,
+            CompletionShell::Fish,
+            CompletionShell::Nushell,
+            CompletionShell::PowerShell,
+            CompletionShell::Zsh,
+        ];
+
+        for shell in shells {
+            let mut output = Vec::new();
+            generate_completions(shell, &mut output);
+            let output = String::from_utf8(output).unwrap();
+            assert!(
+                output.contains("secretspec"),
+                "missing binary for {shell:?}"
+            );
+            assert!(
+                output.contains("config"),
+                "missing subcommands for {shell:?}"
+            );
+            assert!(
+                output.contains("provider"),
+                "missing nested commands for {shell:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fish_completions_do_not_evaluate_value_descriptions() {
+        let mut output = Vec::new();
+        generate_completions(CompletionShell::Fish, &mut output);
+        let output = String::from_utf8(output).unwrap();
+        assert!(!output.contains("$("));
+        assert!(!output.contains("$GITHUB_ENV"));
+    }
+
+    #[test]
+    fn completion_scripts_include_descriptions_where_supported() {
+        let shells = [
+            CompletionShell::Elvish,
+            CompletionShell::Fish,
+            CompletionShell::Nushell,
+            CompletionShell::PowerShell,
+            CompletionShell::Zsh,
+        ];
+
+        for shell in shells {
+            let mut output = Vec::new();
+            generate_completions(shell, &mut output);
+            let output = String::from_utf8(output).unwrap();
+            assert!(
+                output.contains("Initialize a new secretspec.toml"),
+                "missing descriptions for {shell:?}"
+            );
+        }
     }
 
     #[test]

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -6090,14 +6090,14 @@ impl Secrets {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum ExportFormat {
-    /// POSIX `export KEY='value'` statements
+    /// `export KEY='value'` lines for `eval "$(secretspec export)"`
     #[default]
     Shell,
     /// `KEY=value` lines in dotenv syntax
     Dotenv,
     /// A single JSON object mapping each secret name to its value
     Json,
-    /// GitHub/Forgejo Actions environment file plus `::add-mask::` on stdout
+    /// GitHub/Forgejo Actions `$GITHUB_ENV` file plus `::add-mask::` on stdout
     Gha,
 }
 

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -6090,14 +6090,14 @@ impl Secrets {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum ExportFormat {
-    /// `export KEY='value'` lines for `eval "$(secretspec export)"`
+    /// POSIX `export KEY='value'` statements
     #[default]
     Shell,
     /// `KEY=value` lines in dotenv syntax
     Dotenv,
     /// A single JSON object mapping each secret name to its value
     Json,
-    /// GitHub/Forgejo Actions `$GITHUB_ENV` file plus `::add-mask::` on stdout
+    /// GitHub/Forgejo Actions environment file plus `::add-mask::` on stdout
     Gha,
 }
 


### PR DESCRIPTION
<img width="1174" height="497" alt="image" src="https://github.com/user-attachments/assets/f76336a4-c989-46da-afa6-b79c0a32acbd" />

Adds secretspec completions for Bash, Elvish, Fish, Nushell, PowerShell, and Zsh.

Completions are generated directly from the Clap command definition and include nested commands, options, possible values, and descriptions where supported. Includes tests and setup documentation.