### PR TITLE
Add Rust-first Spec API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The Rust SDK can describe secrets without TOML through the public `Spec`,
+  `SpecBuilder`, `Profile`, and `Secret` API. TOML parsing and code generation
+  use the same validated model, so Rust-first and file-backed projects share
+  inheritance, generation, and provider behavior, including profile-level
+  requiredness defaults and explicit opt-outs from inherited path, prompt, and
+  generation settings. Existing specs can be copied or consumed back into a
+  builder to add, replace, or remove declarations before rebuilding a validated
+  spec.
 - Structured caller context lets CLI and SDK integrations identify the invoking
   software, version, operation, and non-secret resource independently of the
   user-supplied access reason. Audit records and providers receive the context,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requiredness defaults and explicit opt-outs from inherited path, prompt, and
   generation settings. Existing specs can be copied or consumed back into a
   builder to add, replace, or remove declarations before rebuilding a validated
-  spec.
+  spec. This validated declaration API replaces the previously exposed raw
+  configuration and code-generation implementation types. Custom provider
+  implementations should now return declarations such as
+  `Secret::required(...)` from `Provider::reflect` instead of constructing raw
+  configuration secrets.
 - Structured caller context lets CLI and SDK integrations identify the invoking
   software, version, operation, and non-secret resource independently of the
   user-supplied access reason. Audit records and providers receive the context,

--- a/docs/src/content/docs/sdk/rust.mdx
+++ b/docs/src/content/docs/sdk/rust.mdx
@@ -9,6 +9,7 @@ import profilesExample from '../../../../../secretspec-derive/examples/profiles.
 import scopesExample from '../../../../../secretspec-derive/examples/scopes.rs?raw';
 import asPathExample from '../../../../../secretspec-derive/examples/as_path.rs?raw';
 import namedExample from '../../../../../secretspec-derive/examples/named.rs?raw';
+import rustFirstExample from '../../../../../secretspec/examples/rust_first.rs?raw';
 import exampleManifest from '../../../../../secretspec-derive/secretspec.toml?raw';
 
 SecretSpec provides a Rust library with type-safe access to secrets through a
@@ -42,6 +43,49 @@ use with any declared profile:
 Required and defaulted secrets are generated as `String`; secrets that may be
 absent are `Option<String>`. Field names use Rust snake case, so `DATABASE_URL`
 becomes `database_url`.
+
+## Describing secrets in Rust (0.20+)
+
+Starting with SecretSpec 0.20, `Spec` is the format-independent declaration
+API. Build one directly in Rust when an application owns its secret contract
+in code, then pass the validated specification to `Secrets::from_spec`:
+
+<Code code={rustFirstExample} lang="rust" meta='title="rust_first.rs"' />
+
+`Spec::from_toml` and `Spec::try_from(path)` produce the same type through the
+same validation and compilation path. Convert from a path for manifests with
+`extends`, because a TOML string has no directory from which to resolve relative
+paths.
+A spec loaded from a file retains that file's directory for relative provider
+paths. A Rust-built declaration resolves them from the current working directory
+by default; `Secrets::from_spec_at` selects another logical base directory.
+
+`Spec` is immutable so its declarations and compiled view cannot drift apart.
+Use `to_builder()` to edit a copy, or `into_builder()` to consume the original,
+then rebuild to validate the result:
+
+```rust
+let edited = spec
+    .to_builder()
+    .remove_secret("default", "LEGACY_TOKEN")
+    .add_secret(
+        "production",
+        "DEPLOY_TOKEN",
+        Secret::required("Production deployment token"),
+    )
+    .build()?;
+```
+
+`remove_secret` removes the declaration from that profile. Removing an override
+can reveal the declaration inherited from `default`; removing it from `default`
+also removes it from profiles that only inherited it. `build()` rejects dangling
+scope membership, invalid compositions, empty profiles, and other semantic
+errors introduced by an edit. These operations edit the in-memory specification;
+they do not rewrite or preserve the formatting of a TOML document.
+
+The Rust-first API complements `declare_secrets!`: `Spec` describes and
+resolves names dynamically, while the macro continues to generate statically
+typed fields from a manifest at compile time.
 
 ## Profile-specific types
 

--- a/secretspec-derive/src/lib.rs
+++ b/secretspec-derive/src/lib.rs
@@ -21,7 +21,7 @@
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use secretspec::codegen::{CodegenIr, IrField, build_ir, capitalize};
+use secretspec::__private::codegen::{CodegenIr, IrField, build_ir, capitalize};
 use std::collections::{BTreeMap, HashSet};
 use syn::{LitStr, parse_macro_input};
 
@@ -496,7 +496,7 @@ fn field_name_ident(name: &str) -> proc_macro2::Ident {
 /// Map a shared-IR field's optionality and path-ness to its Rust type.
 ///
 /// This is the only typing decision the derive macro still makes locally; the
-/// underlying optional/as_path facts come from [`secretspec::codegen`].
+/// underlying optional/as_path facts come from SecretSpec's shared codegen IR.
 fn ir_field_type(field: &IrField) -> proc_macro2::TokenStream {
     match (field.optional, field.as_path) {
         (true, true) => quote! { Option<std::path::PathBuf> },

--- a/secretspec-derive/src/lib.rs
+++ b/secretspec-derive/src/lib.rs
@@ -21,7 +21,6 @@
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use secretspec::Config;
 use secretspec::codegen::{CodegenIr, IrField, build_ir, capitalize};
 use std::collections::{BTreeMap, HashSet};
 use syn::{LitStr, parse_macro_input};
@@ -280,16 +279,18 @@ pub fn declare_secrets(input: TokenStream) -> TokenStream {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     let full_path = std::path::Path::new(&manifest_dir).join(&path);
 
-    let config: Config = match Config::try_from(full_path.as_path()) {
-        Ok(config) => config,
+    let spec = match secretspec::__private::load_for_codegen(full_path.as_path()) {
+        Ok(spec) => spec,
         Err(e) => {
             let error = format!("Failed to parse TOML: {}", e);
             return quote! { compile_error!(#error); }.into();
         }
     };
 
+    let ir = build_ir(&spec);
+
     // Validate the configuration at compile time
-    if let Err(validation_errors) = validate_config_for_codegen(&config) {
+    if let Err(validation_errors) = validate_config_for_codegen(&ir) {
         let error_message = format!(
             "Invalid secretspec configuration:\n{}",
             validation_errors.join("\n")
@@ -298,7 +299,7 @@ pub fn declare_secrets(input: TokenStream) -> TokenStream {
     }
 
     // Generate all the code
-    let output = generate_secret_spec_code(config);
+    let output = generate_secret_spec_code(ir);
     output.into()
 }
 
@@ -325,14 +326,14 @@ pub fn declare_secrets(input: TokenStream) -> TokenStream {
 ///
 /// - `Ok(())` if validation passes
 /// - `Err(Vec<String>)` containing all validation errors if any are found
-fn validate_config_for_codegen(config: &Config) -> Result<(), Vec<String>> {
+fn validate_config_for_codegen(ir: &CodegenIr) -> Result<(), Vec<String>> {
     let mut errors = Vec::new();
 
     // Validate secret names produce valid Rust identifiers
-    validate_rust_identifiers(config, &mut errors);
+    validate_rust_identifiers(ir, &mut errors);
 
     // Validate profile names produce valid Rust enum variants
-    validate_profile_identifiers(config, &mut errors);
+    validate_profile_identifiers(ir, &mut errors);
 
     if errors.is_empty() {
         Ok(())
@@ -358,7 +359,7 @@ fn validate_config_for_codegen(config: &Config) -> Result<(), Vec<String>> {
 /// - Secret names with invalid characters (e.g., "my-secret" with hyphen)
 /// - Secret names that are Rust keywords (e.g., "TYPE", "IMPL")
 /// - Multiple secrets producing the same field name (e.g., "API_KEY" and "api_key")
-fn validate_rust_identifiers(config: &Config, errors: &mut Vec<String>) {
+fn validate_rust_identifiers(ir: &CodegenIr, errors: &mut Vec<String>) {
     let rust_keywords = [
         "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else", "enum",
         "extern", "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move",
@@ -367,10 +368,12 @@ fn validate_rust_identifiers(config: &Config, errors: &mut Vec<String>) {
         "final", "macro", "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
     ];
 
-    for (profile_name, profile_config) in &config.profiles {
+    for profile in &ir.profile_fields {
+        let profile_name = &profile.name;
         let mut profile_field_names = HashSet::new();
 
-        for secret_name in profile_config.secrets.keys() {
+        for field in &profile.fields {
+            let secret_name = &field.name;
             let field_name = secret_name.to_lowercase();
 
             // Check if it produces a valid Rust identifier
@@ -454,8 +457,8 @@ fn is_valid_rust_identifier(s: &str) -> bool {
 ///
 /// - Profile names that start with numbers (e.g., "1production")
 /// - Profile names with invalid characters (e.g., "prod-env")
-fn validate_profile_identifiers(config: &Config, errors: &mut Vec<String>) {
-    for profile_name in config.profiles.keys() {
+fn validate_profile_identifiers(ir: &CodegenIr, errors: &mut Vec<String>) {
+    for profile_name in &ir.profiles {
         let variant_name = capitalize(profile_name);
         if !is_valid_rust_identifier(&variant_name) {
             errors.push(format!(
@@ -1389,12 +1392,7 @@ mod builder_generation {
 /// 4. Generate SecretSpecProfile enum (profile-specific types)
 /// 5. Generate builder pattern implementation
 /// 6. Combine all components with necessary imports
-fn generate_secret_spec_code(config: Config) -> proc_macro2::TokenStream {
-    // Reduce the manifest to the shared codegen IR once. Every typing decision
-    // (union vs per-profile fields, optionality, as_path, profile list) comes
-    // from here, so this macro and the other-language emitters cannot drift.
-    let ir = build_ir(&config);
-
+fn generate_secret_spec_code(ir: CodegenIr) -> proc_macro2::TokenStream {
     let profile_variants = profile_variants_from_ir(&ir);
 
     // Union struct fields.

--- a/secretspec-derive/src/tests.rs
+++ b/secretspec-derive/src/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use secretspec::__private::Config;
-    use secretspec::codegen::{CodegenIr, IrField, IrProfile, capitalize};
+    use secretspec::__private::codegen::{CodegenIr, IrField, IrProfile, capitalize};
 
     fn codegen_ir(config: &Config) -> CodegenIr {
         let mut profile_fields: Vec<IrProfile> = config
@@ -182,7 +182,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
 "#;
 
         let spec = secretspec::Spec::from_toml(toml_str).unwrap();
-        let ir = secretspec::codegen::build_ir(&spec);
+        let ir = secretspec::__private::codegen::build_ir(&spec);
         assert!(!ir.union[0].optional, "a default always supplies a value");
     }
 

--- a/secretspec-derive/src/tests.rs
+++ b/secretspec-derive/src/tests.rs
@@ -1,7 +1,38 @@
 #[cfg(test)]
 mod tests {
-    use secretspec::Config;
-    use secretspec::codegen::capitalize;
+    use secretspec::__private::Config;
+    use secretspec::codegen::{CodegenIr, IrField, IrProfile, capitalize};
+
+    fn codegen_ir(config: &Config) -> CodegenIr {
+        let mut profile_fields: Vec<IrProfile> = config
+            .profiles
+            .iter()
+            .map(|(name, profile)| {
+                let mut fields: Vec<IrField> = profile
+                    .secrets
+                    .keys()
+                    .map(|name| IrField {
+                        name: name.clone(),
+                        optional: false,
+                        as_path: false,
+                        description: None,
+                    })
+                    .collect();
+                fields.sort_by(|a, b| a.name.cmp(&b.name));
+                IrProfile {
+                    name: name.clone(),
+                    fields,
+                }
+            })
+            .collect();
+        profile_fields.sort_by(|a, b| a.name.cmp(&b.name));
+        CodegenIr {
+            project: config.project.name.clone(),
+            profiles: profile_fields.iter().map(|p| p.name.clone()).collect(),
+            union: Vec::new(),
+            profile_fields,
+        }
+    }
 
     #[test]
     fn test_capitalize() {
@@ -150,8 +181,8 @@ revision = "1.0"
 HAS_DEFAULT = { description = "Secret with default", required = false, default = "some-default" }
 "#;
 
-        let config: Config = toml::from_str(toml_str).unwrap();
-        let ir = secretspec::codegen::build_ir(&config);
+        let spec = secretspec::Spec::from_toml(toml_str).unwrap();
+        let ir = secretspec::codegen::build_ir(&spec);
         assert!(!ir.union[0].optional, "a default always supplies a value");
     }
 
@@ -182,7 +213,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
     #[test]
     fn test_validate_rust_identifiers() {
         use crate::validate_rust_identifiers;
-        use secretspec::{Profile, Project, Secret};
+        use secretspec::__private::{Profile, Project, Secret};
         use std::collections::HashMap;
 
         let mut errors = Vec::new();
@@ -229,7 +260,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
             scopes: None,
         };
 
-        validate_rust_identifiers(&valid_config, &mut errors);
+        validate_rust_identifiers(&codegen_ir(&valid_config), &mut errors);
         assert!(
             errors.is_empty(),
             "Valid identifiers should not produce errors"
@@ -278,7 +309,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         };
 
         errors.clear();
-        validate_rust_identifiers(&invalid_config, &mut errors);
+        validate_rust_identifiers(&codegen_ir(&invalid_config), &mut errors);
         assert_eq!(
             errors.len(),
             2,
@@ -301,7 +332,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
     #[test]
     fn test_validate_rust_keywords() {
         use crate::validate_rust_identifiers;
-        use secretspec::{Profile, Project, Secret};
+        use secretspec::__private::{Profile, Project, Secret};
         use std::collections::HashMap;
 
         let mut errors = Vec::new();
@@ -358,7 +389,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
             scopes: None,
         };
 
-        validate_rust_identifiers(&keyword_config, &mut errors);
+        validate_rust_identifiers(&codegen_ir(&keyword_config), &mut errors);
         assert_eq!(errors.len(), 3, "Should have errors for all Rust keywords");
         let error_text = errors.join(" ");
         assert!(
@@ -381,7 +412,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
     #[test]
     fn test_validate_duplicate_field_names() {
         use crate::validate_rust_identifiers;
-        use secretspec::{Profile, Project, Secret};
+        use secretspec::__private::{Profile, Project, Secret};
         use std::collections::HashMap;
 
         let mut errors = Vec::new();
@@ -438,7 +469,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
             scopes: None,
         };
 
-        validate_rust_identifiers(&duplicate_config, &mut errors);
+        validate_rust_identifiers(&codegen_ir(&duplicate_config), &mut errors);
         // Should have 2 duplicate errors (3 secrets, 2 duplicates)
         let duplicate_errors: Vec<_> = errors
             .iter()
@@ -454,7 +485,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
     #[test]
     fn test_validate_profile_identifiers() {
         use crate::validate_profile_identifiers;
-        use secretspec::{Profile, Project};
+        use secretspec::__private::{Profile, Project};
         use std::collections::HashMap;
 
         let mut errors = Vec::new();
@@ -493,7 +524,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
             scopes: None,
         };
 
-        validate_profile_identifiers(&valid_config, &mut errors);
+        validate_profile_identifiers(&codegen_ir(&valid_config), &mut errors);
         assert!(
             errors.is_empty(),
             "Valid profile names should not produce errors"
@@ -527,7 +558,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         };
 
         errors.clear();
-        validate_profile_identifiers(&invalid_config, &mut errors);
+        validate_profile_identifiers(&codegen_ir(&invalid_config), &mut errors);
         assert_eq!(
             errors.len(),
             2,
@@ -605,7 +636,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
     #[test]
     fn test_validate_config_for_codegen() {
         use crate::validate_config_for_codegen;
-        use secretspec::{Profile, Project, Secret};
+        use secretspec::__private::{Profile, Project, Secret};
         use std::collections::HashMap;
 
         // Test valid config
@@ -657,7 +688,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
             scopes: None,
         };
 
-        let result = validate_config_for_codegen(&valid_config);
+        let result = validate_config_for_codegen(&codegen_ir(&valid_config));
         assert!(result.is_ok(), "Valid config should pass validation");
 
         // Test invalid config
@@ -702,7 +733,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
             scopes: None,
         };
 
-        let result = validate_config_for_codegen(&invalid_config);
+        let result = validate_config_for_codegen(&codegen_ir(&invalid_config));
         assert!(result.is_err(), "Invalid config should fail validation");
         let errors = result.unwrap_err();
         assert!(!errors.is_empty(), "Should have validation errors");

--- a/secretspec-derive/tests/integration_test.rs
+++ b/secretspec-derive/tests/integration_test.rs
@@ -102,23 +102,6 @@ mod complex_generation {
     }
 }
 
-mod empty_generation {
-    use super::*;
-
-    declare_secrets!("tests/fixtures/empty.toml");
-
-    #[test]
-    fn test_empty_struct() {
-        // Verify the struct is generated even with no secrets
-        let _size = std::mem::size_of::<SecretSpec>();
-
-        // The struct should have no fields
-        fn _test_no_fields(_s: SecretSpec) {
-            // Empty struct
-        }
-    }
-}
-
 mod as_path_lifetime {
     use super::*;
     use std::fs;

--- a/secretspec-derive/tests/test_macro.rs
+++ b/secretspec-derive/tests/test_macro.rs
@@ -28,11 +28,3 @@ fn test_profile_specific_secrets() {
     // - enum Profile with Development, Staging, Production variants
     // - enum SecretSpecProfile with profile-specific field types
 }
-
-#[test]
-fn test_empty_secrets() {
-    // This should compile without errors
-    declare_secrets!("tests/fixtures/empty.toml");
-
-    // The macro should generate empty structs
-}

--- a/secretspec/examples/rust_first.rs
+++ b/secretspec/examples/rust_first.rs
@@ -1,0 +1,28 @@
+use secretspec::{Profile, Secret, Secrets, Spec};
+
+fn main() -> secretspec::Result<()> {
+    let spec = Spec::builder("checkout")
+        .provider("env", "env://")
+        .secret(
+            "DATABASE_URL",
+            Secret::required("PostgreSQL connection URL").providers(["env"]),
+        )
+        .secret(
+            "SENTRY_DSN",
+            Secret::optional("Sentry error-reporting endpoint"),
+        )
+        .profile(
+            "production",
+            Profile::new().secret("SENTRY_DSN", Secret::required("Production Sentry endpoint")),
+        )
+        .scope("web", ["DATABASE_URL", "SENTRY_DSN"])
+        .build()?;
+
+    let mut secrets = Secrets::from_spec(spec)?;
+    secrets.set_profile("production");
+    secrets.set_scope("web");
+
+    let resolved = secrets.resolve()?;
+    println!("resolved profile: {}", resolved.profile);
+    Ok(())
+}

--- a/secretspec/src/cli/completion.rs
+++ b/secretspec/src/cli/completion.rs
@@ -1,7 +1,7 @@
 use super::{Cli, CompletionShell};
-use crate::manifest::CompiledManifest;
+use crate::config::{Config, GlobalConfig};
+use crate::manifest::CompiledSpec;
 use crate::provider::providers as registered_providers;
-use crate::{Config, GlobalConfig};
 use clap::builder::StyledStr;
 use clap::{ArgMatches, CommandFactory};
 use clap_complete::engine::{CompletionCandidate, PathCompleter, ValueCompleter};
@@ -18,7 +18,7 @@ static CONTEXT: OnceLock<CompletionContext> = OnceLock::new();
 
 struct CompletionContext {
     config: Option<Config>,
-    manifest: Option<CompiledManifest>,
+    manifest: Option<CompiledSpec>,
     global: Option<GlobalConfig>,
     profile: String,
 }

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1,7 +1,6 @@
+use crate::config::{Config, GlobalConfig, GlobalDefaults, Profile as ConfigProfile, Project};
 use crate::provider::{Provider, providers, spec_names_known_provider};
-use crate::{
-    CallerContext, Config, ExportFormat, GlobalConfig, GlobalDefaults, Profile, Project, Secrets,
-};
+use crate::{CallerContext, ExportFormat, Secrets};
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
 use std::collections::{HashMap, HashSet};
@@ -567,7 +566,7 @@ fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
     Ok(doc.to_string())
 }
 
-/// Rejects names that cannot occupy a flattened secret key in [`Profile`].
+/// Rejects names that cannot occupy a flattened secret key in [`ConfigProfile`].
 fn validate_add_secret_name(name: &str) -> Result<()> {
     if !crate::config::is_valid_identifier(name) {
         return Err(miette!(
@@ -958,13 +957,16 @@ pub fn main() -> Result<()> {
             // Discover declarations in the namespace the new manifest will use.
             let secrets = provider
                 .reflect(crate::DiscoveryContext::new(&project_name, &profile))
-                .into_diagnostic()?;
+                .into_diagnostic()?
+                .into_iter()
+                .map(|(name, secret)| (name, secret.into_config()))
+                .collect();
 
             // Create a new project config
             let mut profiles = HashMap::new();
             profiles.insert(
                 profile.clone(),
-                Profile {
+                ConfigProfile {
                     defaults: None,
                     secrets,
                 },
@@ -1527,7 +1529,7 @@ pub fn main() -> Result<()> {
         // Generate typed accessors for another language (value-free)
         Commands::Schema { profile, output } => {
             let app = load_secrets(&cli.file, &cli.reason, &caller)?;
-            let ir = crate::codegen::build_ir(app.config());
+            let ir = crate::codegen::build_ir_from_manifest(&app.manifest);
             let schema = crate::codegen::schema::emit(&ir, profile.as_deref())
                 .map_err(|e| miette!("{e}"))?;
             match output {
@@ -1786,7 +1788,7 @@ mod tests {
             },
             profiles: HashMap::from([(
                 "default".to_string(),
-                Profile {
+                ConfigProfile {
                     defaults: None,
                     secrets,
                 },
@@ -2024,7 +2026,7 @@ mod tests {
             },
             profiles: HashMap::from([(
                 "default".to_string(),
-                Profile {
+                ConfigProfile {
                     defaults: None,
                     secrets: HashMap::from([(
                         "DATABASE_URL".to_string(),

--- a/secretspec/src/codegen.rs
+++ b/secretspec/src/codegen.rs
@@ -184,7 +184,8 @@ pub(crate) fn build_ir_from_manifest(manifest: &CompiledSpec) -> CodegenIr {
 /// drop the converter or rename the type). By default it describes the union
 /// `SecretSpec` (safe for any profile); with a profile it describes that
 /// profile's exact fields. Pair it with `quicktype --top-level <Name>`.
-pub mod schema {
+#[cfg(any(feature = "cli", test))]
+pub(crate) mod schema {
     use super::{CodegenIr, IrField, capitalize};
     use serde_json::{Map, Value, json};
 

--- a/secretspec/src/codegen.rs
+++ b/secretspec/src/codegen.rs
@@ -19,8 +19,8 @@
 //! optional secret is nullable, while required, defaulted, and generated secrets
 //! are guaranteed to have a value when resolution succeeds.
 
-use crate::config::Config;
-use crate::manifest::{CompiledManifest, CompiledSecret};
+use crate::manifest::{CompiledSecret, CompiledSpec};
+use crate::spec::Spec;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -71,7 +71,7 @@ pub struct CodegenIr {
 /// - a path if *any* profile declares it `as_path`;
 /// - described by the first profile, in sorted name order, that declares a
 ///   description.
-fn build_union(manifest: &CompiledManifest) -> Vec<IrField> {
+fn build_union(manifest: &CompiledSpec) -> Vec<IrField> {
     let total_profiles = manifest.profiles.len();
     struct Acc {
         /// Profiles where successful resolution guarantees the secret.
@@ -136,9 +136,12 @@ fn build_profile_fields(secrets: &BTreeMap<String, CompiledSecret>) -> Vec<IrFie
 
 /// Reduce a manifest to the language-neutral [`CodegenIr`] every emitter
 /// consumes. This is the only place manifest typing decisions are made.
-pub fn build_ir(config: &Config) -> CodegenIr {
-    let manifest = CompiledManifest::compile(config);
-    let union = build_union(&manifest);
+pub fn build_ir(spec: &Spec) -> CodegenIr {
+    build_ir_from_manifest(&spec.compiled)
+}
+
+pub(crate) fn build_ir_from_manifest(manifest: &CompiledSpec) -> CodegenIr {
+    let union = build_union(manifest);
 
     let profile_fields = if manifest.profiles.is_empty() {
         // No declared profiles: a single `default` profile carrying every field,
@@ -161,7 +164,7 @@ pub fn build_ir(config: &Config) -> CodegenIr {
     let profiles = profile_fields.iter().map(|p| p.name.clone()).collect();
 
     CodegenIr {
-        project: manifest.project,
+        project: manifest.project.clone(),
         profiles,
         union,
         profile_fields,
@@ -261,7 +264,7 @@ pub mod schema {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Profile, ProfileDefaults, Project, Secret};
+    use crate::config::{Config, Profile, ProfileDefaults, Project, Secret};
     use std::collections::HashMap;
 
     fn secret(required: Option<bool>, as_path: Option<bool>, desc: Option<&str>) -> Secret {
@@ -299,13 +302,17 @@ mod tests {
         }
     }
 
+    fn build_ir_from_config(config: &Config) -> CodegenIr {
+        build_ir_from_manifest(&CompiledSpec::compile(config))
+    }
+
     fn union_field<'a>(ir: &'a CodegenIr, name: &str) -> &'a IrField {
         ir.union.iter().find(|f| f.name == name).unwrap()
     }
 
     #[test]
     fn union_optional_if_optional_or_missing_in_any_profile() {
-        let ir = build_ir(&config_with(vec![
+        let ir = build_ir_from_config(&config_with(vec![
             (
                 "development",
                 vec![
@@ -337,7 +344,7 @@ mod tests {
 
     #[test]
     fn union_as_path_if_any_profile_marks_it() {
-        let ir = build_ir(&config_with(vec![
+        let ir = build_ir_from_config(&config_with(vec![
             (
                 "development",
                 vec![("CERT", secret(Some(true), None, None))],
@@ -352,7 +359,7 @@ mod tests {
 
     #[test]
     fn per_profile_fields_are_sorted_and_exact() {
-        let ir = build_ir(&config_with(vec![
+        let ir = build_ir_from_config(&config_with(vec![
             (
                 "development",
                 vec![
@@ -391,7 +398,7 @@ mod tests {
 
     #[test]
     fn unspecified_required_is_non_optional_matching_runtime() {
-        let ir = build_ir(&config_with(vec![(
+        let ir = build_ir_from_config(&config_with(vec![(
             "default",
             vec![("TOKEN", secret(None, None, None))],
         )]));
@@ -421,7 +428,7 @@ mod tests {
             ],
         )]);
 
-        let ir = build_ir(&config);
+        let ir = build_ir_from_config(&config);
         assert!(union_field(&ir, "PASSWORD").optional);
         assert!(union_field(&ir, "TOKEN").optional);
     }
@@ -431,14 +438,14 @@ mod tests {
         let mut token = secret(None, None, None);
         token.default = Some("fallback".to_string());
 
-        let ir = build_ir(&config_with(vec![("default", vec![("TOKEN", token)])]));
+        let ir = build_ir_from_config(&config_with(vec![("default", vec![("TOKEN", token)])]));
 
         assert!(!union_field(&ir, "TOKEN").optional);
     }
 
     #[test]
     fn profile_fields_include_secrets_inherited_from_default() {
-        let ir = build_ir(&config_with(vec![
+        let ir = build_ir_from_config(&config_with(vec![
             (
                 "default",
                 vec![("SHARED_TOKEN", secret(Some(true), None, None))],
@@ -486,7 +493,7 @@ mod tests {
             providers: None,
         });
 
-        let ir = build_ir(&config);
+        let ir = build_ir_from_config(&config);
         let deployment = ir
             .profile_fields
             .iter()
@@ -507,7 +514,7 @@ mod tests {
 
     #[test]
     fn schema_emits_types_and_nullability_for_quicktype() {
-        let ir = build_ir(&config_with(vec![
+        let ir = build_ir_from_config(&config_with(vec![
             (
                 "development",
                 vec![
@@ -563,7 +570,7 @@ mod tests {
         // quicktype turns a JSON Schema "description" into a native docstring
         // in every target language, so a declared description should reach the
         // generated schema even though it plays no role in the type itself.
-        let ir = build_ir(&config_with(vec![(
+        let ir = build_ir_from_config(&config_with(vec![(
             "default",
             vec![
                 (
@@ -589,7 +596,7 @@ mod tests {
     fn empty_profiles_yield_single_default_with_union_fields() {
         let mut config = config_with(vec![]);
         config.profiles.clear();
-        let ir = build_ir(&config);
+        let ir = build_ir_from_config(&config);
         assert_eq!(ir.profiles, vec!["default"]);
         assert_eq!(ir.profile_fields.len(), 1);
         assert_eq!(ir.profile_fields[0].name, "default");

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -1106,6 +1106,7 @@ impl TryFrom<&Path> for Config {
 /// Parsed from `[project].require_reason`, which accepts a boolean or the string
 /// `"agents"`. Defaults to [`RequireReason::Agents`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum RequireReason {
     /// Never require a reason.
     Never,

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -34,7 +34,7 @@
 //! ```
 
 use crate::composition::Template;
-use crate::manifest::CompiledManifest;
+use crate::manifest::CompiledSpec;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet, hash_map};
 use std::fs;
@@ -693,7 +693,7 @@ impl Config {
     /// Validate and return the compiled manifest, so callers that also need the
     /// effective view (e.g. [`crate::Secrets::load_from`]) reuse the single
     /// compile validation already performed instead of recompiling.
-    pub(crate) fn validate_and_compile(&self) -> Result<CompiledManifest, ParseError> {
+    pub(crate) fn validate_and_compile(&self) -> Result<CompiledSpec, ParseError> {
         if self.project.name.is_empty() {
             return Err(ParseError::Validation(
                 "Project name cannot be empty".into(),
@@ -710,7 +710,7 @@ impl Config {
         // checks consume the same compiled manifest as runtime and codegen.
         // Validate `default` first, then remaining profiles in name order so
         // error attribution is deterministic.
-        let compiled = CompiledManifest::compile(self);
+        let compiled = CompiledSpec::compile(self);
         let default_profile = self.profiles.get("default");
         if let Some(default_profile) = default_profile {
             default_profile
@@ -755,7 +755,7 @@ impl Config {
     /// launches the command with every manifest secret scrubbed and none
     /// injected — a green result that guarantees nothing. A blank or repeated
     /// entry is likewise a typo with no meaning, not a subset worth resolving.
-    fn validate_scopes(&self, compiled: &CompiledManifest) -> Result<(), ParseError> {
+    fn validate_scopes(&self, compiled: &CompiledSpec) -> Result<(), ParseError> {
         let Some(scopes) = &self.scopes else {
             return Ok(());
         };
@@ -867,7 +867,7 @@ impl Config {
 }
 
 fn validate_compiled_profile(
-    manifest: &CompiledManifest,
+    manifest: &CompiledSpec,
     profile_name: &str,
 ) -> Result<(), ParseError> {
     let profile = manifest
@@ -2646,6 +2646,7 @@ impl GlobalConfig {
     /// - The config directory cannot be created
     /// - The file cannot be written
     /// - The configuration cannot be serialized
+    #[cfg(feature = "cli")]
     pub fn save(&self) -> Result<(), io::Error> {
         let config_path = Self::path()?;
 
@@ -3300,7 +3301,7 @@ ACCESS_TOKEN = { description = "Access token", required = { at_least_one = ["aut
         .unwrap();
 
         config.validate().unwrap();
-        let compiled = CompiledManifest::compile(&config);
+        let compiled = CompiledSpec::compile(&config);
         let production = compiled.profile("production").unwrap();
         assert_eq!(production.constraints.at_least_one[0].name, "auth");
         assert_eq!(
@@ -3406,7 +3407,7 @@ ACCESS_TOKEN = { required = { at_least_one = "auth" } }
         .unwrap();
 
         config.validate().unwrap();
-        let compiled = CompiledManifest::compile(&config);
+        let compiled = CompiledSpec::compile(&config);
         let password = &compiled.profile("production").unwrap().secrets["PASSWORD"];
         assert!(!password.declared_required);
         assert_eq!(password.config.required, None);

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -35,6 +35,7 @@ pub(crate) fn display_error_chain(error: &(dyn std::error::Error + 'static)) -> 
 /// This enum represents all possible errors that can occur when working with
 /// the secretspec library.
 #[derive(Error, Debug, Diagnostic)]
+#[non_exhaustive]
 pub enum SecretSpecError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -95,6 +95,9 @@ pub enum SecretSpecError {
     InvalidProfile(String),
     #[error("Invalid scope: {0}")]
     InvalidScope(String),
+    /// A parsed or Rust-built declaration failed semantic validation (0.20+).
+    #[error("Invalid SecretSpec declaration: {0}")]
+    InvalidSpec(String),
     #[error("Validation failed: {0}")]
     ValidationFailed(Box<ValidationErrors>),
     #[error("Secret generation failed: {0}")]
@@ -146,6 +149,7 @@ impl SecretSpecError {
             SecretSpecError::Json(_) => "json",
             SecretSpecError::InvalidProfile(_) => "invalid_profile",
             SecretSpecError::InvalidScope(_) => "invalid_scope",
+            SecretSpecError::InvalidSpec(_) => "invalid_spec",
             SecretSpecError::ValidationFailed(_) => "validation_failed",
             SecretSpecError::GenerationFailed(_) => "generation_failed",
             SecretSpecError::DecodeFailed { .. } => "decode_failed",
@@ -175,9 +179,7 @@ impl From<ParseError> for SecretSpecError {
             ParseError::CircularDependency(msg) => {
                 SecretSpecError::Io(io::Error::new(io::ErrorKind::InvalidData, msg))
             }
-            ParseError::Validation(msg) => {
-                SecretSpecError::Io(io::Error::new(io::ErrorKind::InvalidData, msg))
-            }
+            ParseError::Validation(msg) => SecretSpecError::InvalidSpec(msg),
             ParseError::ExtendedConfigNotFound(path) => {
                 SecretSpecError::ExtendedConfigNotFound(path)
             }
@@ -269,6 +271,10 @@ mod tests {
             (
                 SecretSpecError::InvalidProfile("ghost".into()),
                 "invalid_profile",
+            ),
+            (
+                SecretSpecError::InvalidSpec("bad declaration".into()),
+                "invalid_spec",
             ),
             (
                 SecretSpecError::GenerationFailed("rng".into()),

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -45,7 +45,7 @@
 mod audit;
 mod cache;
 mod caller;
-pub mod codegen;
+mod codegen;
 mod composition;
 mod config;
 mod error;
@@ -75,6 +75,10 @@ pub use config::Resolved;
 /// and its builder API instead.
 #[doc(hidden)]
 pub mod __private {
+    pub mod codegen {
+        pub use crate::codegen::{CodegenIr, IrField, IrProfile, build_ir, capitalize};
+    }
+
     pub use crate::config::{
         Config, GenerateConfig, GenerateOptions, Profile, ProfileDefaults, Project, Secret,
     };

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -6,6 +6,7 @@
 //! # Features
 //!
 //! - **Declarative Configuration**: Define secrets in `secretspec.toml`
+//! - **Rust-first Declarations**: Build a [`Spec`] directly in Rust (0.20+)
 //! - **Multiple Providers**: Keyring, dotenv, environment variables, Keeper Secrets Manager (0.18+)
 //! - **Profile Support**: Different configurations for development, staging, production
 //! - **Type Safety**: Optional compile-time code generation for strongly-typed access
@@ -55,6 +56,7 @@ mod plan;
 mod report;
 mod resolve;
 mod secrets;
+mod spec;
 mod validation;
 
 pub(crate) mod provider;
@@ -67,19 +69,23 @@ pub mod cli;
 pub use caller::CallerContext;
 pub use config::Resolved;
 
-// Re-export config types for CLI usage only - these are marked #[doc(hidden)]
+/// Implementation details shared with `secretspec-derive`.
+///
+/// These document types are not part of the supported Rust SDK. Use [`Spec`]
+/// and its builder API instead.
 #[doc(hidden)]
-pub use config::{
-    AuditConfig, Config, GlobalConfig, GlobalDefaults, Profile, ProfileDefaults, Project,
-};
-
-// Re-export Secret and generation types for secretspec-derive
-#[doc(hidden)]
-pub use config::{
-    ExtractFormat, GenerateConfig, GenerateOptions, Secret, SecretEncoding, SecretExtract,
-};
+pub mod __private {
+    pub use crate::config::{
+        Config, GenerateConfig, GenerateOptions, Profile, ProfileDefaults, Project, Secret,
+    };
+    pub use crate::spec::load_for_codegen;
+}
 
 // Public API exports
+pub use config::{
+    CredentialSource, ExtractFormat, NativeAddress, NativeAddressTemplate, ProviderAlias,
+    ProviderCache, RequireReason, SecretEncoding, SecretExtract,
+};
 pub use error::{Result, SecretSpecError};
 pub use provider::{DiscoveryContext, ProducedValuePersistence, Provider};
 pub use report::{
@@ -91,6 +97,7 @@ pub use resolve::{
 };
 pub use secrets::ExportFormat;
 pub use secrets::Secrets;
+pub use spec::{Generation, PasswordCharset, Profile, Secret, Spec, SpecBuilder};
 pub use validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
 
 #[cfg(test)]

--- a/secretspec/src/manifest.rs
+++ b/secretspec/src/manifest.rs
@@ -153,12 +153,12 @@ pub(crate) struct CompiledConstraints {
 
 /// A parsed manifest reduced to the semantics shared by runtime and codegen.
 #[derive(Debug, Clone)]
-pub(crate) struct CompiledManifest {
+pub(crate) struct CompiledSpec {
     pub(crate) project: String,
     pub(crate) profiles: BTreeMap<String, CompiledProfile>,
 }
 
-impl CompiledManifest {
+impl CompiledSpec {
     pub(crate) fn compile(config: &Config) -> Self {
         let default_profile = config.profiles.get("default");
         let mut profiles = BTreeMap::new();

--- a/secretspec/src/provider/age.rs
+++ b/secretspec/src/provider/age.rs
@@ -27,8 +27,8 @@ use super::{
     Address, DiscoveryContext, Provider, ProviderCredentials, ProviderUrl, credential_or_env,
     flat_item,
 };
-use crate::config::{NativeAddress, Secret};
-use crate::{Result, SecretSpecError};
+use crate::config::NativeAddress;
+use crate::{Result, Secret, SecretSpecError};
 use age::armor::{ArmoredReader, ArmoredWriter, Format};
 use age::{Decryptor, Encryptor, Identity, IdentityFile, NoCallbacks, Recipient};
 use secrecy::{ExposeSecret, SecretString};
@@ -474,11 +474,7 @@ impl Provider for AgeProvider {
             .load()?
             .into_keys()
             .map(|key| {
-                let secret = Secret {
-                    description: Some(format!("{} secret", key)),
-                    required: Some(true),
-                    ..Default::default()
-                };
+                let secret = Secret::required(format!("{} secret", key));
                 (key, secret)
             })
             .collect())

--- a/secretspec/src/provider/awsps.rs
+++ b/secretspec/src/provider/awsps.rs
@@ -345,11 +345,7 @@ impl AwspsProvider {
 
         Ok(Some((
             key.to_string(),
-            crate::Secret {
-                description: Some(format!("{key} secret")),
-                required: Some(true),
-                ..Default::default()
-            },
+            crate::Secret::required(format!("{key} secret")),
         )))
     }
 
@@ -829,7 +825,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
         assert_eq!(key, "DATABASE_URL");
-        assert_eq!(declaration.required, Some(true));
+        assert_eq!(declaration.required_setting(), Some(true));
         assert!(
             AwspsProvider::declaration_from_parameter(path, "/production/payments/nested/TOKEN")
                 .unwrap()

--- a/secretspec/src/provider/bw.rs
+++ b/secretspec/src/provider/bw.rs
@@ -1125,11 +1125,7 @@ fn declarations_from_items(
 
         declarations.insert(
             item.name.clone(),
-            Secret {
-                description: Some(format!("{} Bitwarden secret", item.name)),
-                required: Some(true),
-                ..Default::default()
-            },
+            Secret::required(format!("{} Bitwarden secret", item.name)),
         );
     }
 
@@ -4109,10 +4105,10 @@ mod tests {
 
         assert_eq!(declarations.len(), 2);
         assert_eq!(
-            declarations["API_KEY"].description.as_deref(),
-            Some("API_KEY Bitwarden secret")
+            declarations["API_KEY"].description(),
+            "API_KEY Bitwarden secret"
         );
-        assert_eq!(declarations["API_KEY"].required, Some(true));
+        assert_eq!(declarations["API_KEY"].required_setting(), Some(true));
         assert!(declarations.contains_key("CARD_TOKEN"));
     }
 
@@ -4985,8 +4981,8 @@ mod tests {
 
             assert_eq!(declarations.len(), 1);
             assert_eq!(
-                declarations["API_KEY"].description.as_deref(),
-                Some("API_KEY Bitwarden secret")
+                declarations["API_KEY"].description(),
+                "API_KEY Bitwarden secret"
             );
             assert!(!format!("{:?}", declarations["API_KEY"]).contains("must-not-appear"));
 

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -349,12 +349,7 @@ impl Provider for DotEnvProvider {
         self.check_writable(addr)
     }
 
-    fn reflect(
-        &self,
-        _context: DiscoveryContext<'_>,
-    ) -> Result<HashMap<String, crate::config::Secret>> {
-        use crate::config::Secret;
-
+    fn reflect(&self, _context: DiscoveryContext<'_>) -> Result<HashMap<String, crate::Secret>> {
         if !self.config.path.exists() {
             return Ok(HashMap::new());
         }
@@ -374,11 +369,7 @@ impl Provider for DotEnvProvider {
         for (key, _value) in load_dotenv(&self.config.path)? {
             secrets.insert(
                 key.clone(),
-                Secret {
-                    description: Some(format!("{} secret", key)),
-                    required: Some(true),
-                    ..Default::default()
-                },
+                crate::Secret::required(format!("{} secret", key)),
             );
         }
 
@@ -525,12 +516,8 @@ mod tests {
         assert!(secrets.contains_key("DATABASE_URL"));
 
         let api_key_config = &secrets["API_KEY"];
-        assert_eq!(
-            api_key_config.description,
-            Some("API_KEY secret".to_string())
-        );
-        assert_eq!(api_key_config.required, Some(true));
-        assert!(api_key_config.default.is_none());
+        assert_eq!(api_key_config.description(), "API_KEY secret");
+        assert_eq!(api_key_config.required_setting(), Some(true));
     }
 
     #[test]

--- a/secretspec/src/provider/fly.rs
+++ b/secretspec/src/provider/fly.rs
@@ -6,8 +6,8 @@
 //! than placed in process arguments.
 
 use super::{Address, DiscoveryContext, Provider, ProviderCredentials, ProviderUrl};
-use crate::config::{NativeAddress, Secret};
-use crate::{Result, SecretSpecError};
+use crate::config::NativeAddress;
+use crate::{Result, Secret, SecretSpecError};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -381,11 +381,7 @@ impl Provider for FlyProvider {
             .into_iter()
             .map(|listed| {
                 let name = listed.name;
-                let secret = Secret {
-                    description: Some(format!("{name} Fly.io app secret")),
-                    required: Some(true),
-                    ..Default::default()
-                };
+                let secret = Secret::required(format!("{name} Fly.io app secret"));
                 (name, secret)
             })
             .collect())

--- a/secretspec/src/provider/passbolt.rs
+++ b/secretspec/src/provider/passbolt.rs
@@ -697,14 +697,7 @@ impl Provider for PassboltProvider {
                 continue;
             };
             if declarations
-                .insert(
-                    key.to_string(),
-                    Secret {
-                        description: Some(format!("{key} secret")),
-                        required: Some(true),
-                        ..Default::default()
-                    },
-                )
+                .insert(key.to_string(), Secret::required(format!("{key} secret")))
                 .is_some()
             {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(

--- a/secretspec/src/provider/preflight.rs
+++ b/secretspec/src/provider/preflight.rs
@@ -246,10 +246,7 @@ impl Provider for PreflightGuard {
         self.inner.with_credentials(credentials);
     }
 
-    fn reflect(
-        &self,
-        context: DiscoveryContext<'_>,
-    ) -> Result<HashMap<String, crate::config::Secret>> {
+    fn reflect(&self, context: DiscoveryContext<'_>) -> Result<HashMap<String, crate::Secret>> {
         self.check()?;
         self.inner.reflect(context)
     }

--- a/secretspec/src/provider/traits.rs
+++ b/secretspec/src/provider/traits.rs
@@ -502,15 +502,20 @@ pub trait Provider: Send + Sync {
     /// it. Hierarchical providers should use it so discovery stays inside the
     /// same namespace as [`convention_address`](Provider::convention_address).
     /// The default implementation returns an unsupported-operation error.
+    /// Implementations return the public declaration [`Secret`](crate::Secret),
+    /// built with constructors such as [`Secret::required`](crate::Secret::required),
+    /// rather than the raw configuration document type used before 0.20.
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let context = DiscoveryContext::new("payments", "production");
-    /// let secrets = provider.reflect(context)?;
-    /// for (name, secret) in secrets {
-    ///     println!("Found secret: {} = {:?}", name, secret);
-    /// }
+    /// let mut secrets = HashMap::new();
+    /// secrets.insert(
+    ///     "DATABASE_URL".to_string(),
+    ///     Secret::required("Database connection URL"),
+    /// );
+    /// # let _ = context;
     /// ```
     fn reflect(&self, _context: DiscoveryContext<'_>) -> Result<HashMap<String, crate::Secret>> {
         Err(SecretSpecError::ProviderOperationFailed(format!(

--- a/secretspec/src/provider/traits.rs
+++ b/secretspec/src/provider/traits.rs
@@ -512,10 +512,7 @@ pub trait Provider: Send + Sync {
     ///     println!("Found secret: {} = {:?}", name, secret);
     /// }
     /// ```
-    fn reflect(
-        &self,
-        _context: DiscoveryContext<'_>,
-    ) -> Result<HashMap<String, crate::config::Secret>> {
+    fn reflect(&self, _context: DiscoveryContext<'_>) -> Result<HashMap<String, crate::Secret>> {
         Err(SecretSpecError::ProviderOperationFailed(format!(
             "Provider '{}' does not support reflection",
             self.name()
@@ -773,10 +770,7 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     fn set_profile(&self, profile: &str) {
         (**self).set_profile(profile);
     }
-    fn reflect(
-        &self,
-        context: DiscoveryContext<'_>,
-    ) -> Result<HashMap<String, crate::config::Secret>> {
+    fn reflect(&self, context: DiscoveryContext<'_>) -> Result<HashMap<String, crate::Secret>> {
         (**self).reflect(context)
     }
     fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -8,7 +8,7 @@ use crate::config::{
     RequireReason, Resolved, SecretEncoding, SecretExtract,
 };
 use crate::error::{Result, SecretSpecError};
-use crate::manifest::{CompiledManifest, MissingPolicy};
+use crate::manifest::{CompiledSpec, MissingPolicy};
 use crate::plan::{PlannedSecret, ResolutionPlan, ResolvedCache, Route};
 use crate::provider::{
     Address, OwnedAddress, ProducedValuePersistence, Provider as ProviderTrait,
@@ -18,6 +18,7 @@ use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{
     NamedResolution, RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource,
 };
+use crate::spec::Spec;
 use crate::validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
 use colored::Colorize;
 use data_encoding::{
@@ -25,7 +26,6 @@ use data_encoding::{
 };
 use secrecy::{ExposeSecret, SecretSlice, SecretString};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::convert::TryFrom;
 use std::env;
 use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
@@ -537,7 +537,7 @@ pub struct Secrets {
     config: Config,
     /// Effective profile semantics compiled once from `config` and shared by
     /// planning, runtime resolution, and inventory surfaces.
-    pub(crate) manifest: CompiledManifest,
+    pub(crate) manifest: CompiledSpec,
     /// Directory containing the loaded `secretspec.toml`. Relative filesystem
     /// paths held by file-backed providers (e.g. `dotenv`) are resolved against
     /// this rather than the process's current working directory, so running
@@ -770,7 +770,7 @@ impl Secrets {
         provider: Option<String>,
         profile: Option<String>,
     ) -> Self {
-        let manifest = CompiledManifest::compile(&config);
+        let manifest = CompiledSpec::compile(&config);
         Self {
             config,
             manifest,
@@ -828,13 +828,35 @@ impl Secrets {
     ///
     /// * `path` - Path to the `secretspec.toml` file
     pub fn load_from(path: &Path) -> Result<Self> {
-        let project_config = Config::try_from(path)?;
-        // Semantic validation (required vs default, ref coordinate rules,
-        // generate consistency) runs here so every CLI and SDK entry point
-        // enforces the same rules the config documents. The compiled manifest it
-        // produces is the one stored below, so the effective view is compiled
-        // exactly once per load.
-        let manifest = project_config.validate_and_compile()?;
+        let spec = Spec::try_from(path)?;
+        Self::from_spec(spec)
+    }
+
+    /// Creates a resolver from a Rust-built or parsed [`Spec`].
+    ///
+    /// A spec loaded from a path with [`Spec::try_from`] retains the manifest's
+    /// directory for relative provider paths. Rust-built specs and TOML strings
+    /// use the process's current working directory. [`Self::from_spec_at`]
+    /// explicitly overrides either behavior.
+    ///
+    /// Available starting with SecretSpec 0.20.
+    pub fn from_spec(spec: Spec) -> Result<Self> {
+        let base_dir = spec.base_dir.clone().unwrap_or_else(|| PathBuf::from("."));
+        Self::from_spec_at(spec, base_dir)
+    }
+
+    /// Creates a resolver from a [`Spec`] with an explicit logical base directory.
+    ///
+    /// `base_dir` resolves relative paths held by providers, just as
+    /// [`Self::load_from`] uses the directory containing `secretspec.toml`. The
+    /// path is not canonicalized and does not need to exist at construction
+    /// time.
+    ///
+    /// Available starting with SecretSpec 0.20.
+    pub fn from_spec_at(spec: Spec, base_dir: impl Into<PathBuf>) -> Result<Self> {
+        // A Spec already owns the exact compiled view produced by validation,
+        // so file and Rust frontends both arrive here without recompiling.
+        let (config, manifest) = spec.into_parts();
         let global_config = GlobalConfig::load()?;
         // Auditing is a per-machine concern configured in the user-global config
         // (`[audit]` in ~/.config/secretspec/config.toml), not the project. It is
@@ -845,21 +867,11 @@ impl Secrets {
                 .and_then(|g| g.audit.clone())
                 .unwrap_or_default(),
         );
-        // Directory the config lives in, used to resolve relative provider
-        // paths (e.g. `dotenv:.config/.env`) against the project root instead
-        // of the current working directory. Kept logical (not canonicalized) so
-        // a relative `--file` stays relative to the CWD and Windows extended
-        // (`\\?\`) prefixes are never introduced.
-        let config_dir = path
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| PathBuf::from("."));
-
         Ok(Self {
-            require_reason: project_config.project.require_reason.unwrap_or_default(),
-            config: project_config,
+            require_reason: config.project.require_reason.unwrap_or_default(),
+            config,
             manifest,
-            config_dir,
+            config_dir: base_dir.into(),
             global_config,
             provider: None,
             profile: None,
@@ -6319,6 +6331,32 @@ fn gha_heredoc_delimiter(value: &str) -> String {
         if !value.lines().any(|line| line == delimiter) {
             return delimiter;
         }
+    }
+}
+
+#[cfg(test)]
+mod construction_tests {
+    use super::*;
+
+    #[test]
+    fn from_spec_uses_explicit_logical_base_directory() {
+        let spec = Spec::from_toml(
+            r#"
+            [project]
+            name = "embedded"
+            revision = "1.0"
+            require_reason = false
+
+            [profiles.default]
+            TOKEN = { description = "Embedded token", required = false }
+        "#,
+        )
+        .unwrap();
+        let base_dir = PathBuf::from("a-base-directory-that-does-not-exist");
+
+        let secrets = Secrets::from_spec_at(spec, &base_dir).unwrap();
+
+        assert_eq!(secrets.config_dir, base_dir);
     }
 }
 

--- a/secretspec/src/spec.rs
+++ b/secretspec/src/spec.rs
@@ -701,6 +701,7 @@ impl Generation {
 ///
 /// Available starting with SecretSpec 0.20.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PasswordCharset {
     /// ASCII letters and decimal digits.
     Alphanumeric,

--- a/secretspec/src/spec.rs
+++ b/secretspec/src/spec.rs
@@ -1,0 +1,1026 @@
+//! Format-independent SecretSpec declarations.
+//!
+//! [`Spec`] is the semantic boundary shared by file-based configuration and
+//! declarations assembled directly in Rust. The TOML representation remains
+//! an implementation detail in `config`; callers construct the same model with
+//! [`SpecBuilder`], [`Profile`], and [`Secret`].
+
+use crate::config::{
+    Config, GenerateConfig, GenerateOptions, NativeAddress, Profile as ConfigProfile,
+    ProfileDefaults, Project, ProviderAlias, RequireReason, Scope, Secret as ConfigSecret,
+    SecretEncoding, SecretExtract,
+};
+use crate::error::{Result, SecretSpecError};
+use crate::manifest::CompiledSpec;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+/// A validated, format-independent description of a SecretSpec project.
+///
+/// A `Spec` may be loaded from `secretspec.toml` with [`Spec::try_from`] or
+/// assembled directly in Rust with [`Spec::builder`]. Both paths perform the
+/// same semantic validation and produce the same compiled representation.
+///
+/// Available starting with SecretSpec 0.20.
+#[derive(Debug, Clone)]
+pub struct Spec {
+    pub(crate) config: Config,
+    pub(crate) compiled: CompiledSpec,
+    pub(crate) base_dir: Option<PathBuf>,
+}
+
+impl Spec {
+    /// Begin describing a project directly in Rust.
+    pub fn builder(project: impl Into<String>) -> SpecBuilder {
+        SpecBuilder::new(project)
+    }
+
+    /// Parse and validate one complete TOML document.
+    ///
+    /// A string has no location against which `extends` paths can be resolved,
+    /// so use [`Spec::try_from`] with a path when the document uses inheritance.
+    pub fn from_toml(source: &str) -> Result<Self> {
+        let config = Config::from_str(source)?;
+        if config
+            .project
+            .extends
+            .as_ref()
+            .is_some_and(|extends| !extends.is_empty())
+        {
+            return Err(SecretSpecError::InvalidSpec(
+                "a TOML string cannot resolve `project.extends`; load it from a path with Spec::try_from"
+                    .to_string(),
+            ));
+        }
+        Self::from_config_document(config)
+    }
+
+    /// The project name used for provider namespacing.
+    pub fn project(&self) -> &str {
+        &self.compiled.project
+    }
+
+    /// Declared profile names in deterministic order.
+    pub fn profiles(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.compiled.profiles.keys().map(String::as_str)
+    }
+
+    /// Effective secret names for `profile`, including inherited declarations.
+    pub fn secrets(&self, profile: &str) -> Option<impl ExactSizeIterator<Item = &str>> {
+        self.compiled
+            .profile(profile)
+            .map(|profile| profile.secrets.keys().map(String::as_str))
+    }
+
+    /// Consume this validated specification and reopen its declarations for editing.
+    ///
+    /// [`SpecBuilder::build`] validates and compiles the edited declarations into a
+    /// new `Spec`. The original `Spec` is consumed so its declarations and compiled
+    /// view can never drift apart. Use [`Self::to_builder`] to retain it.
+    pub fn into_builder(self) -> SpecBuilder {
+        self.into()
+    }
+
+    /// Copy this validated specification into a builder for editing.
+    ///
+    /// The original `Spec` remains unchanged. Prefer [`Self::into_builder`] when it
+    /// is no longer needed.
+    pub fn to_builder(&self) -> SpecBuilder {
+        self.into()
+    }
+
+    pub(crate) fn from_config_document(config: Config) -> Result<Self> {
+        if config.project.revision != "1.0" {
+            return Err(SecretSpecError::UnsupportedRevision(
+                config.project.revision,
+            ));
+        }
+        let compiled = config.validate_and_compile()?;
+        Ok(Self {
+            config,
+            compiled,
+            base_dir: None,
+        })
+    }
+
+    pub(crate) fn into_parts(self) -> (Config, CompiledSpec) {
+        (self.config, self.compiled)
+    }
+}
+
+/// Derive-crate bridge that preserves configuration-loader diagnostics while
+/// still returning the same validated [`Spec`] every other frontend consumes.
+#[doc(hidden)]
+pub fn load_for_codegen(path: &Path) -> std::result::Result<Spec, String> {
+    let config = Config::try_from(path).map_err(|error| error.to_string())?;
+    Spec::from_config_document(config).map_err(|error| error.to_string())
+}
+
+impl FromStr for Spec {
+    type Err = SecretSpecError;
+
+    fn from_str(source: &str) -> Result<Self> {
+        Self::from_toml(source)
+    }
+}
+
+impl TryFrom<&Path> for Spec {
+    type Error = SecretSpecError;
+
+    /// Load, merge, and validate a `secretspec.toml` file.
+    ///
+    /// Relative `extends` paths are resolved from the file that declares them.
+    fn try_from(path: &Path) -> Result<Self> {
+        let mut spec = Self::from_config_document(Config::try_from(path)?)?;
+        spec.base_dir = Some(
+            path.parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from(".")),
+        );
+        Ok(spec)
+    }
+}
+
+/// Rust-first construction of a [`Spec`].
+///
+/// Available starting with SecretSpec 0.20.
+#[derive(Debug)]
+pub struct SpecBuilder {
+    config: Config,
+    base_dir: Option<PathBuf>,
+    errors: Vec<String>,
+}
+
+impl SpecBuilder {
+    fn new(project: impl Into<String>) -> Self {
+        Self {
+            config: Config {
+                project: Project {
+                    name: project.into(),
+                    ..Project::default()
+                },
+                profiles: HashMap::new(),
+                providers: None,
+                scopes: None,
+            },
+            base_dir: None,
+            errors: Vec::new(),
+        }
+    }
+
+    /// Set the policy for requiring an access reason.
+    pub fn require_reason(mut self, policy: RequireReason) -> Self {
+        self.config.project.require_reason = Some(policy);
+        self
+    }
+
+    /// Add a secret to the `default` profile.
+    pub fn secret(mut self, name: impl Into<String>, secret: Secret) -> Self {
+        let profile = self
+            .config
+            .profiles
+            .entry("default".to_string())
+            .or_default();
+        insert_secret(profile, name.into(), secret, &mut self.errors, "default");
+        self
+    }
+
+    /// Add a declaration to an existing profile.
+    ///
+    /// This is the edit-oriented counterpart to [`Self::secret`], which creates
+    /// the `default` profile when needed. A missing profile or an existing
+    /// declaration is reported by [`Self::build`] rather than silently creating
+    /// or replacing it.
+    pub fn add_secret(
+        mut self,
+        profile: impl Into<String>,
+        name: impl Into<String>,
+        secret: Secret,
+    ) -> Self {
+        let profile = profile.into();
+        let name = name.into();
+        let Some(declarations) = self.config.profiles.get_mut(&profile) else {
+            self.errors.push(format!(
+                "cannot add secret '{name}': profile '{profile}' does not exist"
+            ));
+            return self;
+        };
+        if declarations.secrets.contains_key(&name) {
+            self.errors.push(format!(
+                "cannot add secret '{name}': profile '{profile}' already contains that declaration"
+            ));
+            return self;
+        }
+        declarations.secrets.insert(name, secret.config);
+        self
+    }
+
+    /// Replace an existing declaration in one profile.
+    ///
+    /// The replacement is not applied when either the profile or declaration is
+    /// absent; [`Self::build`] reports the collected edit error.
+    pub fn replace_secret(
+        mut self,
+        profile: impl Into<String>,
+        name: impl Into<String>,
+        secret: Secret,
+    ) -> Self {
+        let profile = profile.into();
+        let name = name.into();
+        let Some(declarations) = self.config.profiles.get_mut(&profile) else {
+            self.errors.push(format!(
+                "cannot replace secret '{name}': profile '{profile}' does not exist"
+            ));
+            return self;
+        };
+        let Some(existing) = declarations.secrets.get_mut(&name) else {
+            self.errors.push(format!(
+                "cannot replace secret '{name}': profile '{profile}' does not contain that declaration"
+            ));
+            return self;
+        };
+        *existing = secret.config;
+        self
+    }
+
+    /// Remove a declaration from one profile.
+    ///
+    /// This removes the profile-local declaration, not necessarily the secret
+    /// from the profile's effective view. Removing an override can reveal a
+    /// declaration inherited from `default`; removing a `default` declaration
+    /// also removes it from profiles that only inherited it. References from
+    /// scopes, compositions, or constraints are checked again by [`Self::build`].
+    pub fn remove_secret(mut self, profile: impl Into<String>, name: impl Into<String>) -> Self {
+        let profile = profile.into();
+        let name = name.into();
+        let Some(declarations) = self.config.profiles.get_mut(&profile) else {
+            self.errors.push(format!(
+                "cannot remove secret '{name}': profile '{profile}' does not exist"
+            ));
+            return self;
+        };
+        if declarations.secrets.remove(&name).is_none() {
+            self.errors.push(format!(
+                "cannot remove secret '{name}': profile '{profile}' does not contain that declaration"
+            ));
+        }
+        self
+    }
+
+    /// Add a named profile.
+    pub fn profile(mut self, name: impl Into<String>, profile: Profile) -> Self {
+        let name = name.into();
+        self.errors.extend(
+            profile
+                .errors
+                .into_iter()
+                .map(|error| format!("profile '{name}': {error}")),
+        );
+        if self
+            .config
+            .profiles
+            .insert(name.clone(), profile.config)
+            .is_some()
+        {
+            self.errors.push(format!("duplicate profile '{name}'"));
+        }
+        self
+    }
+
+    /// Define a project-local provider alias.
+    pub fn provider(mut self, name: impl Into<String>, provider: impl Into<ProviderAlias>) -> Self {
+        let name = name.into();
+        let providers = self.config.providers.get_or_insert_with(HashMap::new);
+        if providers.insert(name.clone(), provider.into()).is_some() {
+            self.errors
+                .push(format!("duplicate provider alias '{name}'"));
+        }
+        self
+    }
+
+    /// Define a named, membership-only subset of secrets.
+    pub fn scope<I, S>(mut self, name: impl Into<String>, secrets: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let name = name.into();
+        let scopes = self.config.scopes.get_or_insert_with(HashMap::new);
+        let scope = Scope {
+            secrets: secrets.into_iter().map(Into::into).collect(),
+        };
+        if scopes.insert(name.clone(), scope).is_some() {
+            self.errors.push(format!("duplicate scope '{name}'"));
+        }
+        self
+    }
+
+    /// Validate and compile this declaration.
+    pub fn build(self) -> Result<Spec> {
+        if !self.errors.is_empty() {
+            return Err(SecretSpecError::InvalidSpec(self.errors.join("; ")));
+        }
+        let mut spec = Spec::from_config_document(self.config)?;
+        spec.base_dir = self.base_dir;
+        Ok(spec)
+    }
+}
+
+impl From<Spec> for SpecBuilder {
+    fn from(spec: Spec) -> Self {
+        Self {
+            config: spec.config,
+            base_dir: spec.base_dir,
+            errors: Vec::new(),
+        }
+    }
+}
+
+impl From<&Spec> for SpecBuilder {
+    fn from(spec: &Spec) -> Self {
+        Self {
+            config: spec.config.clone(),
+            base_dir: spec.base_dir.clone(),
+            errors: Vec::new(),
+        }
+    }
+}
+
+/// One profile in a Rust-built [`Spec`].
+///
+/// Available starting with SecretSpec 0.20.
+#[derive(Debug, Default)]
+pub struct Profile {
+    config: ConfigProfile,
+    errors: Vec<String>,
+}
+
+impl Profile {
+    /// Create an empty profile.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a secret to this profile.
+    pub fn secret(mut self, name: impl Into<String>, secret: Secret) -> Self {
+        insert_secret(
+            &mut self.config,
+            name.into(),
+            secret,
+            &mut self.errors,
+            "this profile",
+        );
+        self
+    }
+
+    /// Choose whether this profile inherits declarations from `default`.
+    pub fn inherit_default(mut self, inherit: bool) -> Self {
+        self.defaults().inherit = Some(inherit);
+        self
+    }
+
+    /// Set the requiredness inherited by secrets that omit it.
+    pub fn required_by_default(mut self, required: bool) -> Self {
+        self.defaults().required = Some(required);
+        self
+    }
+
+    /// Set the value inherited by secrets that do not declare their own default.
+    pub fn default_value(mut self, value: impl Into<String>) -> Self {
+        self.defaults().default = Some(value.into());
+        self
+    }
+
+    /// Set the provider chain inherited by secrets that omit one.
+    pub fn providers<I, S>(mut self, providers: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.defaults().providers = Some(providers.into_iter().map(Into::into).collect());
+        self
+    }
+
+    fn defaults(&mut self) -> &mut ProfileDefaults {
+        self.config.defaults.get_or_insert(ProfileDefaults {
+            inherit: None,
+            required: None,
+            default: None,
+            providers: None,
+        })
+    }
+}
+
+fn insert_secret(
+    profile: &mut ConfigProfile,
+    name: String,
+    secret: Secret,
+    errors: &mut Vec<String>,
+    profile_name: &str,
+) {
+    if profile
+        .secrets
+        .insert(name.clone(), secret.config)
+        .is_some()
+    {
+        errors.push(format!("duplicate secret '{name}' in {profile_name}"));
+    }
+}
+
+/// One secret declaration in a Rust-built [`Spec`].
+///
+/// Descriptions are required at construction time. [`Secret::new`] inherits
+/// its requiredness from the profile, while [`Secret::required`],
+/// [`Secret::optional`], and [`Secret::defaulted`] declare it explicitly.
+///
+/// Available starting with SecretSpec 0.20.
+#[derive(Debug, Clone)]
+pub struct Secret {
+    config: ConfigSecret,
+}
+
+impl Secret {
+    /// Declare a secret whose requiredness comes from its profile defaults.
+    ///
+    /// Without a profile-level requiredness default, the secret is required.
+    pub fn new(description: impl Into<String>) -> Self {
+        Self {
+            config: ConfigSecret {
+                description: Some(description.into()),
+                ..ConfigSecret::default()
+            },
+        }
+    }
+
+    /// Declare a required secret.
+    pub fn required(description: impl Into<String>) -> Self {
+        let mut secret = Self::new(description);
+        secret.config.required = Some(true);
+        secret
+    }
+
+    /// The human-readable purpose of this declaration.
+    pub fn description(&self) -> &str {
+        self.config
+            .description
+            .as_deref()
+            .expect("Rust-built secrets always carry a description")
+    }
+
+    /// The explicitly declared requiredness, if this secret uses an individual
+    /// required policy rather than a presence group.
+    pub fn required_setting(&self) -> Option<bool> {
+        self.config.required
+    }
+
+    /// Declare a secret that may be absent.
+    pub fn optional(description: impl Into<String>) -> Self {
+        let mut secret = Self::new(description);
+        secret.config.required = Some(false);
+        secret
+    }
+
+    /// Declare a secret with a committed fallback value.
+    pub fn defaulted(description: impl Into<String>, value: impl Into<String>) -> Self {
+        let mut secret = Self::optional(description);
+        secret.config.default = Some(value.into());
+        secret
+    }
+
+    /// Add this secret to one or more `at_least_one` presence groups.
+    pub fn at_least_one<I, S>(mut self, groups: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.config.required = None;
+        self.config.at_least_one = Some(groups.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Add this secret to one or more `exactly_one` presence groups.
+    pub fn exactly_one<I, S>(mut self, groups: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.config.required = None;
+        self.config.exactly_one = Some(groups.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Derive this value from a `${NAME}` template over other secrets.
+    pub fn composed(mut self, template: impl Into<String>) -> Self {
+        self.config.composed = Some(template.into());
+        self
+    }
+
+    /// Select an ordered provider fallback chain.
+    pub fn providers<I, S>(mut self, providers: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.config.providers = Some(providers.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Address an externally managed value using provider-native coordinates.
+    pub fn reference(mut self, address: NativeAddress) -> Self {
+        self.config.reference = Some(address);
+        self
+    }
+
+    /// Override provider-native coordinates for one provider alias.
+    pub fn reference_for(mut self, provider: impl Into<String>, address: NativeAddress) -> Self {
+        self.config
+            .refs
+            .get_or_insert_with(HashMap::new)
+            .insert(provider.into(), address);
+        self
+    }
+
+    /// Choose whether to materialize the resolved value in a temporary file.
+    pub fn as_path(mut self, as_path: bool) -> Self {
+        self.config.as_path = Some(as_path);
+        self
+    }
+
+    /// Set the provider-side storage encoding.
+    pub fn encoding(mut self, encoding: SecretEncoding) -> Self {
+        self.config.encoding = Some(encoding);
+        self
+    }
+
+    /// Extract a value from a structured provider result.
+    pub fn extract(mut self, extract: SecretExtract) -> Self {
+        self.config.extract = Some(extract);
+        self
+    }
+
+    /// Generate the value when it is absent.
+    pub fn generate(mut self, generation: Generation) -> Self {
+        let (secret_type, config) = generation.into_config();
+        self.config.secret_type = Some(secret_type.to_string());
+        self.config.generate = Some(config);
+        self
+    }
+
+    /// Disable generation inherited from the `default` profile.
+    pub fn disable_generation(mut self) -> Self {
+        self.config.generate = Some(GenerateConfig::Bool(false));
+        self
+    }
+
+    /// Choose whether to prompt securely when `secretspec run` cannot resolve
+    /// the value.
+    pub fn prompt(mut self, prompt: bool) -> Self {
+        self.config.prompt = Some(prompt);
+        self
+    }
+
+    #[cfg(feature = "cli")]
+    pub(crate) fn into_config(self) -> ConfigSecret {
+        self.config
+    }
+}
+
+/// A typed secret-generation strategy.
+///
+/// Available starting with SecretSpec 0.20.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Generation {
+    /// A randomly generated password.
+    Password {
+        /// Character count; `None` uses SecretSpec's default.
+        length: Option<usize>,
+        /// Characters from which the password is drawn.
+        charset: PasswordCharset,
+    },
+    /// Random bytes rendered as hexadecimal.
+    Hex {
+        /// Byte count; `None` uses SecretSpec's default.
+        bytes: Option<usize>,
+    },
+    /// Random bytes rendered as Base64.
+    Base64 {
+        /// Byte count; `None` uses SecretSpec's default.
+        bytes: Option<usize>,
+    },
+    /// A random version-4 UUID.
+    Uuid,
+    /// The trimmed stdout of a shell command.
+    Command(String),
+    /// A PEM-encoded RSA private key.
+    RsaPrivateKey {
+        /// Key size in bits; `None` uses SecretSpec's default.
+        bits: Option<usize>,
+    },
+}
+
+impl Generation {
+    /// A password with SecretSpec's default length and alphanumeric charset.
+    pub fn password() -> Self {
+        Self::Password {
+            length: None,
+            charset: PasswordCharset::Alphanumeric,
+        }
+    }
+
+    /// Hexadecimal output with SecretSpec's default random-byte count.
+    pub fn hex() -> Self {
+        Self::Hex { bytes: None }
+    }
+
+    /// Base64 output with SecretSpec's default random-byte count.
+    pub fn base64() -> Self {
+        Self::Base64 { bytes: None }
+    }
+
+    /// A random version-4 UUID.
+    pub fn uuid() -> Self {
+        Self::Uuid
+    }
+
+    /// Generate from the trimmed stdout of `command`.
+    pub fn command(command: impl Into<String>) -> Self {
+        Self::Command(command.into())
+    }
+
+    /// An RSA private key with SecretSpec's default key size.
+    pub fn rsa_private_key() -> Self {
+        Self::RsaPrivateKey { bits: None }
+    }
+
+    fn into_config(self) -> (&'static str, GenerateConfig) {
+        match self {
+            Self::Password { length, charset } => (
+                "password",
+                GenerateConfig::Options(GenerateOptions {
+                    length,
+                    charset: Some(charset.as_str().to_string()),
+                    ..GenerateOptions::default()
+                }),
+            ),
+            Self::Hex { bytes } => (
+                "hex",
+                GenerateConfig::Options(GenerateOptions {
+                    bytes,
+                    ..GenerateOptions::default()
+                }),
+            ),
+            Self::Base64 { bytes } => (
+                "base64",
+                GenerateConfig::Options(GenerateOptions {
+                    bytes,
+                    ..GenerateOptions::default()
+                }),
+            ),
+            Self::Uuid => ("uuid", GenerateConfig::Bool(true)),
+            Self::Command(command) => (
+                "command",
+                GenerateConfig::Options(GenerateOptions {
+                    command: Some(command),
+                    ..GenerateOptions::default()
+                }),
+            ),
+            Self::RsaPrivateKey { bits } => (
+                "rsa_private_key",
+                GenerateConfig::Options(GenerateOptions {
+                    bits,
+                    ..GenerateOptions::default()
+                }),
+            ),
+        }
+    }
+}
+
+/// Character set used by [`Generation::Password`].
+///
+/// Available starting with SecretSpec 0.20.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PasswordCharset {
+    /// ASCII letters and decimal digits.
+    Alphanumeric,
+    /// Printable ASCII characters.
+    Ascii,
+}
+
+impl PasswordCharset {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Alphanumeric => "alphanumeric",
+            Self::Ascii => "ascii",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_builder_and_toml_compile_to_the_same_shape() {
+        let rust = Spec::builder("embedded")
+            .secret("TOKEN", Secret::required("API token").providers(["env"]))
+            .secret("OPTIONAL", Secret::optional("Optional value"))
+            .profile(
+                "production",
+                Profile::new().secret("TOKEN", Secret::required("Production API token")),
+            )
+            .scope("api", ["TOKEN"])
+            .build()
+            .unwrap();
+
+        let toml = Spec::from_toml(
+            r#"
+                [project]
+                name = "embedded"
+                revision = "1.0"
+
+                [profiles.default]
+                TOKEN = { description = "API token", required = true, providers = ["env"] }
+                OPTIONAL = { description = "Optional value", required = false }
+
+                [profiles.production]
+                TOKEN = { description = "Production API token", required = true }
+
+                [scopes.api]
+                secrets = ["TOKEN"]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(rust.project(), toml.project());
+        assert_eq!(
+            rust.profiles().collect::<Vec<_>>(),
+            toml.profiles().collect::<Vec<_>>()
+        );
+        for profile in rust.profiles() {
+            assert_eq!(
+                rust.secrets(profile).unwrap().collect::<Vec<_>>(),
+                toml.secrets(profile).unwrap().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn builder_rejects_duplicates_without_silent_overwrite() {
+        let error = Spec::builder("embedded")
+            .secret("TOKEN", Secret::required("first"))
+            .secret("TOKEN", Secret::required("second"))
+            .build()
+            .unwrap_err();
+
+        assert!(error.to_string().contains("duplicate secret 'TOKEN'"));
+    }
+
+    #[test]
+    fn builder_edits_a_copy_without_mutating_the_original_spec() {
+        let original = Spec::builder("embedded")
+            .secret("KEEP", Secret::required("Kept declaration"))
+            .secret("REMOVE", Secret::required("Removed declaration"))
+            .profile(
+                "production",
+                Profile::new().secret("OVERRIDE", Secret::required("Original declaration")),
+            )
+            .build()
+            .unwrap();
+
+        let edited = original
+            .to_builder()
+            .remove_secret("default", "REMOVE")
+            .add_secret("production", "ADDED", Secret::required("Added declaration"))
+            .replace_secret(
+                "production",
+                "OVERRIDE",
+                Secret::optional("Replacement declaration"),
+            )
+            .build()
+            .unwrap();
+
+        assert!(
+            original
+                .secrets("default")
+                .unwrap()
+                .any(|name| name == "REMOVE")
+        );
+        assert!(
+            !edited
+                .secrets("default")
+                .unwrap()
+                .any(|name| name == "REMOVE")
+        );
+        assert!(
+            edited
+                .secrets("production")
+                .unwrap()
+                .any(|name| name == "ADDED")
+        );
+
+        let replacement = &edited.compiled.profile("production").unwrap().secrets["OVERRIDE"];
+        assert_eq!(
+            replacement.config.description.as_deref(),
+            Some("Replacement declaration")
+        );
+        assert!(!replacement.declared_required);
+    }
+
+    #[test]
+    fn removing_an_override_reveals_the_default_declaration() {
+        let spec = Spec::builder("embedded")
+            .secret("TOKEN", Secret::required("Default token"))
+            .profile(
+                "production",
+                Profile::new()
+                    .secret("TOKEN", Secret::optional("Production override"))
+                    .secret("LOCAL", Secret::required("Production-only value")),
+            )
+            .build()
+            .unwrap();
+
+        let edited = spec
+            .into_builder()
+            .remove_secret("production", "TOKEN")
+            .build()
+            .unwrap();
+
+        let token = &edited.compiled.profile("production").unwrap().secrets["TOKEN"];
+        assert_eq!(token.config.description.as_deref(), Some("Default token"));
+        assert!(token.declared_required);
+    }
+
+    #[test]
+    fn edit_operations_report_missing_or_duplicate_targets() {
+        let spec = Spec::builder("embedded")
+            .secret("TOKEN", Secret::required("API token"))
+            .build()
+            .unwrap();
+
+        let error = spec
+            .to_builder()
+            .add_secret("default", "TOKEN", Secret::required("Duplicate"))
+            .replace_secret("default", "MISSING", Secret::required("Missing"))
+            .remove_secret("production", "TOKEN")
+            .build()
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("already contains that declaration"));
+        assert!(error.contains("does not contain that declaration"));
+        assert!(error.contains("profile 'production' does not exist"));
+    }
+
+    #[test]
+    fn removing_a_declaration_revalidates_its_dependents() {
+        let spec = Spec::builder("embedded")
+            .secret("KEEP", Secret::required("Kept declaration"))
+            .secret("TOKEN", Secret::required("API token"))
+            .scope("api", ["TOKEN"])
+            .build()
+            .unwrap();
+
+        let error = spec
+            .into_builder()
+            .remove_secret("default", "TOKEN")
+            .build()
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("Scope 'api' references secret 'TOKEN'"));
+    }
+
+    #[test]
+    fn string_input_rejects_unresolvable_extends() {
+        let error = Spec::from_toml(
+            r#"
+                [project]
+                name = "embedded"
+                revision = "1.0"
+                extends = ["../shared"]
+
+                [profiles.default]
+                TOKEN = { description = "API token" }
+            "#,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("Spec::try_from"));
+    }
+
+    #[test]
+    fn every_frontend_rejects_an_empty_declaration() {
+        let error = Spec::builder("embedded").build().unwrap_err();
+        assert!(error.to_string().contains("At least one profile"));
+
+        let error = Spec::from_toml(
+            r#"
+                [project]
+                name = "embedded"
+                revision = "1.0"
+
+                [profiles.default]
+            "#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("at least one secret"));
+    }
+
+    #[test]
+    fn loaded_spec_remembers_its_base_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("secretspec.toml");
+        std::fs::write(
+            &path,
+            r#"
+                [project]
+                name = "loaded"
+                revision = "1.0"
+
+                [profiles.default]
+                TOKEN = { description = "API token" }
+            "#,
+        )
+        .unwrap();
+
+        let spec = Spec::try_from(path.as_path()).unwrap();
+
+        assert_eq!(spec.base_dir.as_deref(), Some(directory.path()));
+
+        let edited = spec
+            .into_builder()
+            .replace_secret("default", "TOKEN", Secret::optional("Edited API token"))
+            .build()
+            .unwrap();
+        assert_eq!(edited.base_dir.as_deref(), Some(directory.path()));
+    }
+
+    #[test]
+    fn profile_required_default_applies_to_secrets_that_inherit_it() {
+        let declaration = Secret::new("Deployment token");
+        assert_eq!(declaration.required_setting(), None);
+
+        let spec = Spec::builder("embedded")
+            .profile(
+                "optional",
+                Profile::new()
+                    .inherit_default(false)
+                    .required_by_default(false)
+                    .secret("TOKEN", declaration),
+            )
+            .build()
+            .unwrap();
+
+        let secret = &spec.compiled.profile("optional").unwrap().secrets["TOKEN"];
+        assert_eq!(secret.config.required, Some(false));
+        assert!(!secret.declared_required);
+    }
+
+    #[test]
+    fn child_profile_can_disable_inherited_boolean_settings() {
+        let spec = Spec::builder("embedded")
+            .secret("PATH", Secret::required("Path value").as_path(true))
+            .secret("PROMPT", Secret::required("Prompted value").prompt(true))
+            .secret(
+                "GENERATED",
+                Secret::required("Generated value").generate(Generation::uuid()),
+            )
+            .profile(
+                "production",
+                Profile::new()
+                    .secret("PATH", Secret::required("Plain value").as_path(false))
+                    .secret("PROMPT", Secret::required("Stored value").prompt(false))
+                    .secret(
+                        "GENERATED",
+                        Secret::required("Stored value").disable_generation(),
+                    ),
+            )
+            .build()
+            .unwrap();
+
+        let secrets = &spec.compiled.profile("production").unwrap().secrets;
+        assert_eq!(secrets["PATH"].config.as_path, Some(false));
+        assert_eq!(secrets["PROMPT"].config.prompt, Some(false));
+        assert!(matches!(
+            secrets["GENERATED"].config.generate,
+            Some(GenerateConfig::Bool(false))
+        ));
+    }
+
+    #[test]
+    fn typed_generation_lowers_to_the_document_model() {
+        let secret = Secret::required("Random password").generate(Generation::Password {
+            length: Some(48),
+            charset: PasswordCharset::Ascii,
+        });
+
+        assert_eq!(secret.config.secret_type.as_deref(), Some("password"));
+        let Some(GenerateConfig::Options(options)) = secret.config.generate else {
+            panic!("password generation should carry its typed options");
+        };
+        assert_eq!(options.length, Some(48));
+        assert_eq!(options.charset.as_deref(), Some("ascii"));
+    }
+}

--- a/tests/integration/profile_inheritance_tests.rs
+++ b/tests/integration/profile_inheritance_tests.rs
@@ -1,5 +1,5 @@
 use crate::common::TestFixture;
-use secretspec::Config;
+use secretspec::Spec;
 
 // Integration tests for profile inheritance using the public API
 // (Unit tests for detailed inheritance logic are in src/tests.rs)
@@ -9,15 +9,15 @@ fn test_profile_inheritance_end_to_end() {
     let fixture = TestFixture::new();
     let (_, _, base_path) = fixture.create_extends_structure();
 
-    let config = Config::try_from(base_path.as_path()).unwrap();
+    let spec = Spec::try_from(base_path.as_path()).unwrap();
 
     // Verify basic inheritance functionality through public API
-    assert_eq!(config.project.name, "test_project");
+    assert_eq!(spec.project(), "test_project");
 
-    let default_profile = config.profiles.get("default").unwrap();
-    assert!(default_profile.secrets.contains_key("API_KEY"));
-    assert!(default_profile.secrets.contains_key("DATABASE_URL"));
-    assert!(default_profile.secrets.contains_key("REDIS_URL"));
-    assert!(default_profile.secrets.contains_key("JWT_SECRET"));
-    assert!(default_profile.secrets.contains_key("OAUTH_CLIENT_ID"));
+    let default_profile: Vec<_> = spec.secrets("default").unwrap().collect();
+    assert!(default_profile.contains(&"API_KEY"));
+    assert!(default_profile.contains(&"DATABASE_URL"));
+    assert!(default_profile.contains(&"REDIS_URL"));
+    assert!(default_profile.contains(&"JWT_SECRET"));
+    assert!(default_profile.contains(&"OAUTH_CLIENT_ID"));
 }


### PR DESCRIPTION
## What changed

- Add a public, Rust-first `Spec` API with builders for profiles, secrets, typed generation, and password character sets.
- Route TOML loading, runtime secret loading, derive-time code generation, CLI code generation, and shell-completion metadata through the same validated semantic `CompiledSpec` model.
- Expose `Secrets::from_spec` while keeping `Config` as an internal TOML wire format.
- Add a runnable Rust-first example, SDK documentation marked for 0.20+, tests, and an Unreleased changelog entry.

## Why

Rust callers should be able to describe secrets directly without constructing a TOML-shaped configuration type or serializing and reparsing TOML. Making every frontend lower through `Spec` gives Rust-first and file-backed projects identical validation, inheritance, generation, and provider behavior.

## Developer impact

New integrations can build a `Spec` and pass it directly to `Secrets::from_spec`. Existing TOML projects continue to use the same syntax, but parsing now crosses the public `Spec` abstraction. The old crate-root `Config` export is removed because it represented the storage format rather than the supported semantic API.

## Validation

- `devenv shell cargo check --workspace --all-targets`
- commit hooks: Clippy and Rustfmt
- `devenv shell cargo test -p secretspec spec::` (6 passed)
- `devenv shell cargo test -p secretspec cli::completion::tests` (12 passed)
- `devenv shell cargo test -p secretspec --lib` (1,223 passed, 4 ignored)
- `devenv shell cargo test -p secretspec-derive --test compile_tests`
- `devenv shell npm --prefix docs run build`
