### PR TITLE
fix(infisical): read a ref's environment from the profile

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,9 @@
     "allow": [
       "Bash(mkdir:*)",
       "Bash(jq:*)",
-      "Bash(cat:*)"
+      "Bash(cat:*)",
+      "Bash(git add *)",
+      "Bash(git commit *)"
     ],
     "deny": []
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `secretspec set` against an Infisical secret names the environment in its
   pre-write preview, which the previous description left out.
 
-- Infisical import collision checks now recognize that a profile-derived
-  environment and an equivalent explicit `?env=` target the same secret,
-  preventing aliased destinations from overwriting one another.
+- Infisical import collision checks now recognize when aliases target the same
+  secret through a profile-derived versus explicit environment, or through an
+  absolute ref that overrides different configured path defaults, preventing
+  aliased destinations from overwriting one another.
 
 ## [0.19.1] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `secretspec set` against an Infisical secret names the environment in its
   pre-write preview, which the previous description left out.
 
+- Infisical import collision checks now recognize that a profile-derived
+  environment and an equivalent explicit `?env=` target the same secret,
+  preventing aliased destinations from overwriting one another.
+
 ## [0.19.1] - 2026-08-11
 
 Republishes 0.19.0's command-line artifacts. The library and CLI behave exactly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OnePassword optional references whose item names resemble authentication
   diagnostics are omitted as missing instead of aborting batch resolution.
 
+### Fixed
+
+- Infisical secret references no longer require `?env=` in the provider URI: a
+  `ref` names a folder and key but never an environment, so it now falls back to
+  the profile the run resolves under. One alias can therefore serve every profile
+  while naming secrets flat — `ref = { item = "/{key}" }` — instead of needing
+  one alias per environment. An explicit `?env=` still pins the environment.
+  Note that Infisical answers a missing secret, folder, environment and project
+  with the same 404, so a ref pointed at an environment that does not exist reads
+  as an unset secret rather than an error. A credential declared with a `ref`
+  still needs `?env=`, so it resolves the same way whichever profile is running.
+
+- `secretspec set` against an Infisical secret names the environment in its
+  pre-write preview, which the previous description left out.
+
 ## [0.19.1] - 2026-08-11
 
 Republishes 0.19.0's command-line artifacts. The library and CLI behave exactly

--- a/docs/src/content/docs/providers/infisical.mdx
+++ b/docs/src/content/docs/providers/infisical.mdx
@@ -198,7 +198,26 @@ API_KEY = { description = "Pinned key", ref = { item = "/infra/API_KEY", version
   `/secretspec` itself
 - `version`: an Infisical secret version. Version-pinned refs are read-only, since a past version cannot be rewritten
 
-A ref has no profile to name an environment with, so the provider URI must pin one with `?env=`.
+A ref names a folder and key but never an environment. The environment comes from `?env=`, or from
+the profile the run resolves under (0.20+) — the same environment a convention secret reads in that
+run.
+
+With the profile supplying the environment, one alias serves every profile and secrets can be named
+flat, with no `{project}/{profile}` folders:
+
+```toml
+[providers]
+# `production` reads Infisical's production environment, `dev` reads dev
+infisical_flat = { uri = "infisical://app.infisical.com/7e2f1a4c-...", ref = { item = "/{key}" } }
+```
+
+See [Secret References](/concepts/references/#different-coordinates-per-provider-019) for the
+alias-level `ref` template.
+
+A [provider credential](/reference/provider-credentials/) is the exception: it belongs to its alias
+rather than to a profile, and is read the same way whichever profile runs, so a credential declared
+with a `ref` needs `?env=`.
+
 Infisical secrets are single values with no sub-components, so `field`, `section` and `vault` are
 rejected.
 
@@ -252,7 +271,9 @@ so the value is written once the request is approved.
 - The project is addressed by UUID; Infisical's API does not accept a project slug
 - A project or profile whose name is not spellable as an Infisical folder (letters, digits, dashes,
   underscores) is refused rather than rewritten
-- Refs need `?env=`, having no profile to name an environment with
+- A ref reads the environment the profile names unless `?env=` pins one, and a wrong environment
+  reads as an unset secret rather than an error: Infisical answers a missing secret, folder,
+  environment and project with the same 404
 - `secretspec import infisical://…` is not supported: the provider does not enumerate existing
   secrets, so import has nothing to discover
 - The domain variables name a host, not a path: an instance served under a sub-path

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -557,7 +557,8 @@ legacy `INFISICAL_API_URL`, then defaults to Infisical Cloud.
 **Storage**: Secret `{key}` in folder `/secretspec/{project}/{profile}`, in the environment named by the profile (or by `?env=`). Keys are stored verbatim.
 
 By default the SecretSpec profile names the Infisical environment, so a `production` profile reads
-the `production` environment. Projects whose environments do not correspond to profiles pin one with
+the `production` environment. This covers refs as well as convention naming (0.20+).
+Projects whose environments do not correspond to profiles pin one with
 `?env=`; the profile still names the folder, so profiles never share a secret.
 
 Values are read with Infisical's secret references expanded, matching its own CLI, so a value of

--- a/secretspec/src/provider/infisical.rs
+++ b/secretspec/src/provider/infisical.rs
@@ -24,8 +24,10 @@
 //!
 //! - `env` -- environment slug. When omitted, the SecretSpec profile names the
 //!   environment, so a `production` profile reads Infisical's `production`
-//!   environment. Set it to read every profile from one environment, e.g. an
-//!   instance whose environments do not correspond to profiles.
+//!   environment. That holds for a `ref` too (0.20+), which names a folder and
+//!   key but never an environment. Set it to read every profile from one
+//!   environment, e.g. an instance whose environments do not correspond to
+//!   profiles.
 //! - `path` -- folder prefix holding SecretSpec's secrets (default:
 //!   `/secretspec`).
 //! - `tls` -- enable TLS: `true` (default) or `false`, for self-hosted
@@ -73,7 +75,7 @@ use reqwest::StatusCode;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 /// Default folder prefix holding SecretSpec's secrets.
 const DEFAULT_PATH: &str = "/secretspec";
@@ -251,7 +253,9 @@ impl TryFrom<&ProviderUrl> for InfisicalConfig {
     }
 }
 
-/// One secret's location in Infisical's own terms.
+/// One secret's location in Infisical's own terms. Holds no secret value, so it
+/// is safe to render in an error or a test failure.
+#[derive(Debug)]
 struct Location {
     environment: String,
     secret_path: String,
@@ -277,6 +281,15 @@ pub struct InfisicalProvider {
     /// One HTTP client for every request, so a run of secrets reuses the
     /// connection rather than building a pool per call.
     http: OnceLock<reqwest::Client>,
+    /// The session's profile, set by [`Provider::set_profile`] before any I/O.
+    ///
+    /// A convention address names the profile itself, so this only answers for a
+    /// `ref`, whose coordinates name a folder and key but never an environment.
+    /// It is deliberately not part of [`InfisicalConfig`]: the environment a
+    /// profile implies must not reach [`uri`](Provider::uri) or
+    /// [`storage_identity`](Provider::storage_identity), or the same store would
+    /// take one identity per profile.
+    profile: Mutex<Option<String>>,
 }
 
 crate::register_provider! {
@@ -297,6 +310,7 @@ impl InfisicalProvider {
             credentials: ProviderCredentials::new(),
             token: tokio::sync::OnceCell::new(),
             http: OnceLock::new(),
+            profile: Mutex::new(None),
         }
     }
 
@@ -305,24 +319,43 @@ impl InfisicalProvider {
         self.http.get_or_init(reqwest::Client::new)
     }
 
+    /// The profile this session resolves under, if [`Provider::set_profile`] has
+    /// run.
+    ///
+    /// A blank profile is treated as absent: an empty environment slug would
+    /// build a request Infisical answers with a 404 that reads as a missing
+    /// secret, rather than as the missing configuration it is.
+    fn session_profile(&self) -> Option<String> {
+        self.profile
+            .lock()
+            .ok()?
+            .as_deref()
+            .map(str::trim)
+            .filter(|profile| !profile.is_empty())
+            .map(str::to_string)
+    }
+
     /// Resolves an address to one secret's Infisical location.
     ///
     /// `item` carries the folder and the key together, so convention and `ref`
     /// addresses share one spelling of the layout. The environment comes from
-    /// the address itself, since the profile names it when `?env=` does not.
+    /// `?env=`, else the profile: a convention address names the profile, and a
+    /// `ref` takes the one the session resolves under, so both spell the same
+    /// environment for the same run.
     fn locate(&self, addr: Address<'_>) -> Result<Location> {
         let coords = self.resolve_coords(addr)?;
 
         let environment = match (&self.config.environment, addr) {
             (Some(env), _) => env.clone(),
             (None, Address::Convention { profile, .. }) => profile.to_string(),
-            (None, Address::Native(_)) => {
-                return Err(SecretSpecError::ProviderOperationFailed(
+            (None, Address::Native(_)) => self.session_profile().ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(
                     "No Infisical environment for this ref. Name one in the provider URI, \
-                     e.g. infisical://app.infisical.com/{project-id}?env=prod."
+                     e.g. infisical://app.infisical.com/{project-id}?env=prod. A provider \
+                     credential is resolved without a profile, so its ref always needs one."
                         .to_string(),
-                ));
-            }
+                )
+            })?,
         };
 
         // A leading slash distinguishes the two forms a ref can take: `/DB`
@@ -888,6 +921,31 @@ impl InfisicalProvider {
 }
 
 impl Provider for InfisicalProvider {
+    /// Keeps the session's profile as the environment a `ref` reads from when
+    /// the URI names none. Last write wins, matching the other session hooks.
+    fn set_profile(&self, profile: &str) {
+        if let Ok(mut held) = self.profile.lock() {
+            *held = Some(profile.to_string());
+        }
+    }
+
+    /// Names the environment as well as the folder and key.
+    ///
+    /// The environment is half the destination and is not in the coordinates,
+    /// which the default rendering shows; where the URI does not pin it, it is
+    /// not in [`uri`](Provider::uri) either, so a preview built from those two
+    /// would leave the profile-derived environment invisible on the one
+    /// operation that overwrites a value.
+    fn describe_write_target(&self, addr: Address<'_>) -> Result<String> {
+        let loc = self.locate(addr)?;
+        Ok(format!(
+            "environment {}, {}/{}",
+            loc.environment,
+            loc.secret_path.trim_end_matches('/'),
+            loc.key
+        ))
+    }
+
     /// A profile's secrets share one folder under the configured prefix, each
     /// under its own key. `item` carries the folder and the key together; the
     /// environment is resolved separately in [`locate`](Self::locate), since
@@ -1177,7 +1235,8 @@ mod tests {
         assert!(err.to_string().contains("`field`"), "{err}");
     }
 
-    /// A ref has no profile to name an environment with, so the URI must.
+    /// A ref names no environment, so one must come from `?env=` or the profile.
+    /// With neither — a library caller that never set one — the error says so.
     #[test]
     fn native_address_needs_an_environment() {
         let p = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
@@ -1418,6 +1477,109 @@ mod tests {
         ))
         .unwrap_err();
         assert!(err.to_string().contains("tls value 'banana'"), "{err}");
+    }
+
+    /// Without `?env=`, a ref reads the environment the session's profile names
+    /// — the same one a convention address would reach in that run.
+    #[test]
+    fn a_ref_without_env_reads_the_profile_environment() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+        p.set_profile("prod");
+
+        let addr = NativeAddress {
+            item: "/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        let loc = p.locate(Address::Native(&addr)).unwrap();
+        assert_eq!(loc.environment, "prod");
+        assert_eq!(loc.secret_path, "/");
+        assert_eq!(loc.key, "DB_PASSWORD");
+
+        // A convention address in the same run names the same environment.
+        let conv = p
+            .locate(Address::convention("myapp", "prod", "DB_PASSWORD"))
+            .unwrap();
+        assert_eq!(conv.environment, loc.environment);
+    }
+
+    /// `?env=` is an explicit pin, so it outranks the profile for refs exactly as
+    /// it already does for convention addresses.
+    #[test]
+    fn an_explicit_env_outranks_the_profile() {
+        let p = provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}?env=shared"
+        ));
+        p.set_profile("prod");
+
+        let addr = NativeAddress {
+            item: "/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            p.locate(Address::Native(&addr)).unwrap().environment,
+            "shared"
+        );
+        assert_eq!(
+            p.locate(Address::convention("myapp", "prod", "DB_PASSWORD"))
+                .unwrap()
+                .environment,
+            "shared"
+        );
+    }
+
+    /// With neither `?env=` nor a profile, a ref still fails with the error that
+    /// names the fix, rather than requesting an empty environment slug.
+    #[test]
+    fn a_ref_without_env_or_profile_still_explains_itself() {
+        let addr = NativeAddress {
+            item: "/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+
+        for profile in [None, Some(""), Some("   ")] {
+            let p = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+            if let Some(profile) = profile {
+                p.set_profile(profile);
+            }
+            let err = p.locate(Address::Native(&addr)).unwrap_err().to_string();
+            assert!(
+                err.contains("No Infisical environment for this ref"),
+                "{err}"
+            );
+        }
+    }
+
+    /// The profile is session context, not naming: an instance's URI must not
+    /// change with it, or one store would take a different cache identity under
+    /// every profile.
+    #[test]
+    fn the_profile_does_not_change_the_uri() {
+        let p = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+        let before = p.uri();
+        p.set_profile("prod");
+        assert_eq!(p.uri(), before);
+        assert_eq!(p.storage_identity(), before);
+    }
+
+    /// `set_profile` is shared by every provider, and a preflight-enabled one is
+    /// wrapped as `Box<Arc<P>>`, which a `&mut self` hook cannot reach through.
+    /// Infisical registers no preflight today, so this guards the trait's
+    /// contract rather than its own wrapping: it must stay a `&self` hook.
+    #[test]
+    fn set_profile_reaches_the_provider_through_arc() {
+        let p = std::sync::Arc::new(provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}"
+        )));
+        Provider::set_profile(&p, "prod");
+
+        let addr = NativeAddress {
+            item: "/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            p.locate(Address::Native(&addr)).unwrap().environment,
+            "prod"
+        );
     }
 
     /// A ref names the environment's root with a leading slash, and the

--- a/secretspec/src/provider/infisical.rs
+++ b/secretspec/src/provider/infisical.rs
@@ -335,6 +335,41 @@ impl InfisicalProvider {
             .map(str::to_string)
     }
 
+    /// Renders the provider URI with the supplied environment identity.
+    ///
+    /// The public URI passes the configured environment through. Entry
+    /// comparison omits it from the container and resolves it alongside the
+    /// address instead, so a profile-derived environment and an equivalent
+    /// explicit `?env=` can name the same entry without changing the provider's
+    /// cache identity.
+    fn render_uri(&self, environment: Option<&str>) -> String {
+        let plain_http = self.config.endpoint.starts_with("http://");
+        let host = self
+            .config
+            .endpoint
+            .trim_start_matches("https://")
+            .trim_start_matches("http://");
+        let mut uri = format!("infisical://{host}/{}", self.config.project_id);
+        let mut query = Vec::new();
+        if let Some(env) = environment {
+            query.push(format!("env={}", ProviderUrl::encode_query(env)));
+        }
+        if self.config.path != DEFAULT_PATH {
+            query.push(format!(
+                "path={}",
+                ProviderUrl::encode_query(&self.config.path)
+            ));
+        }
+        if plain_http {
+            query.push("tls=false".to_string());
+        }
+        if !query.is_empty() {
+            uri.push('?');
+            uri.push_str(&query.join("&"));
+        }
+        uri
+    }
+
     /// Resolves an address to one secret's Infisical location.
     ///
     /// `item` carries the folder and the key together, so convention and `ref`
@@ -993,6 +1028,36 @@ impl Provider for InfisicalProvider {
         })
     }
 
+    /// Resolves every part of the entry identity that Infisical sends to the
+    /// API. In particular, the environment may come from session profile
+    /// context rather than the provider URI or native coordinates.
+    fn entry_coordinates<'a>(
+        &self,
+        addr: Address<'a>,
+    ) -> Result<std::borrow::Cow<'a, NativeAddress>> {
+        let loc = self.locate(addr)?;
+        let version = match addr {
+            Address::Native(native) => native.version.clone(),
+            Address::Convention { .. } => None,
+        };
+
+        // NativeAddress has no environment coordinate. Encode the resolved
+        // Infisical tuple into its canonical item identity; query encoding
+        // keeps the component boundaries unambiguous. This value is used only
+        // for comparisons and is never sent to Infisical.
+        let item = format!(
+            "environment={}&path={}&key={}",
+            ProviderUrl::encode_query(&loc.environment),
+            ProviderUrl::encode_query(&loc.secret_path),
+            ProviderUrl::encode_query(&loc.key),
+        );
+        Ok(std::borrow::Cow::Owned(NativeAddress {
+            item,
+            version,
+            ..Default::default()
+        }))
+    }
+
     fn with_credentials(&mut self, credentials: ProviderCredentials) {
         self.credentials = credentials;
     }
@@ -1006,31 +1071,16 @@ impl Provider for InfisicalProvider {
     /// back as the same store. `tls` is the one that bites -- a plain-HTTP
     /// endpoint rendered without it comes back as HTTPS.
     fn uri(&self) -> String {
-        let plain_http = self.config.endpoint.starts_with("http://");
-        let host = self
-            .config
-            .endpoint
-            .trim_start_matches("https://")
-            .trim_start_matches("http://");
-        let mut uri = format!("infisical://{host}/{}", self.config.project_id);
-        let mut query = Vec::new();
-        if let Some(env) = &self.config.environment {
-            query.push(format!("env={}", ProviderUrl::encode_query(env)));
-        }
-        if self.config.path != DEFAULT_PATH {
-            query.push(format!(
-                "path={}",
-                ProviderUrl::encode_query(&self.config.path)
-            ));
-        }
-        if plain_http {
-            query.push("tls=false".to_string());
-        }
-        if !query.is_empty() {
-            uri.push('?');
-            uri.push_str(&query.join("&"));
-        }
-        uri
+        self.render_uri(self.config.environment.as_deref())
+    }
+
+    /// The environment is part of the resolved entry coordinates, not the
+    /// Infisical instance and project container. Omitting it here lets an
+    /// unpinned provider under profile `prod` compare equal to `?env=prod`;
+    /// [`storage_identity`](Provider::storage_identity) remains the public URI
+    /// and therefore never absorbs session profile context.
+    fn entry_container_identity(&self) -> String {
+        self.render_uri(None)
     }
 
     /// Infisical versions its secrets, so a `ref` may pin one. Its values are
@@ -1559,6 +1609,35 @@ mod tests {
         p.set_profile("prod");
         assert_eq!(p.uri(), before);
         assert_eq!(p.storage_identity(), before);
+    }
+
+    /// Entry collision checks must see the environment that operations resolve,
+    /// even when one alias derives it from the profile and another pins it in
+    /// the URI. The profile remains absent from the cache storage identity.
+    #[test]
+    fn entry_identity_resolves_the_profile_environment() {
+        let implicit = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+        implicit.set_profile("prod");
+        let pinned_prod = provider(&format!("infisical://app.infisical.com/{PROJECT}?env=prod"));
+        let pinned_dev = provider(&format!("infisical://app.infisical.com/{PROJECT}?env=dev"));
+        let addr = NativeAddress {
+            item: "/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+
+        assert_ne!(implicit.storage_identity(), pinned_prod.storage_identity());
+        assert!(
+            implicit
+                .same_entries(Address::Native(&addr), &pinned_prod, Address::Native(&addr),)
+                .unwrap(),
+            "profile prod and ?env=prod reach the same Infisical secret"
+        );
+        assert!(
+            !implicit
+                .same_entries(Address::Native(&addr), &pinned_dev, Address::Native(&addr),)
+                .unwrap(),
+            "different Infisical environments must remain distinct"
+        );
     }
 
     /// `set_profile` is shared by every provider, and a preflight-enabled one is

--- a/secretspec/src/provider/infisical.rs
+++ b/secretspec/src/provider/infisical.rs
@@ -335,14 +335,14 @@ impl InfisicalProvider {
             .map(str::to_string)
     }
 
-    /// Renders the provider URI with the supplied environment identity.
+    /// Renders the provider URI with the supplied entry-addressing defaults.
     ///
-    /// The public URI passes the configured environment through. Entry
-    /// comparison omits it from the container and resolves it alongside the
-    /// address instead, so a profile-derived environment and an equivalent
-    /// explicit `?env=` can name the same entry without changing the provider's
-    /// cache identity.
-    fn render_uri(&self, environment: Option<&str>) -> String {
+    /// The public URI passes the configured environment and path through. Entry
+    /// comparison omits both from the underlying project container and resolves
+    /// them alongside the address instead, so aliases with different defaults
+    /// can still compare the physical entries they actually reach without
+    /// changing either alias's cache identity.
+    fn render_uri(&self, environment: Option<&str>, path: Option<&str>) -> String {
         let plain_http = self.config.endpoint.starts_with("http://");
         let host = self
             .config
@@ -354,11 +354,8 @@ impl InfisicalProvider {
         if let Some(env) = environment {
             query.push(format!("env={}", ProviderUrl::encode_query(env)));
         }
-        if self.config.path != DEFAULT_PATH {
-            query.push(format!(
-                "path={}",
-                ProviderUrl::encode_query(&self.config.path)
-            ));
+        if let Some(path) = path.filter(|path| *path != DEFAULT_PATH) {
+            query.push(format!("path={}", ProviderUrl::encode_query(path)));
         }
         if plain_http {
             query.push("tls=false".to_string());
@@ -1071,16 +1068,20 @@ impl Provider for InfisicalProvider {
     /// back as the same store. `tls` is the one that bites -- a plain-HTTP
     /// endpoint rendered without it comes back as HTTPS.
     fn uri(&self) -> String {
-        self.render_uri(self.config.environment.as_deref())
+        self.render_uri(
+            self.config.environment.as_deref(),
+            Some(self.config.path.as_str()),
+        )
     }
 
-    /// The environment is part of the resolved entry coordinates, not the
-    /// Infisical instance and project container. Omitting it here lets an
-    /// unpinned provider under profile `prod` compare equal to `?env=prod`;
+    /// The environment and path are part of the resolved entry coordinates,
+    /// not the Infisical instance and project container. Omitting both here
+    /// lets an unpinned provider under profile `prod` compare equal to
+    /// `?env=prod`, and lets an absolute ref override different path defaults;
     /// [`storage_identity`](Provider::storage_identity) remains the public URI
-    /// and therefore never absorbs session profile context.
+    /// with its configured defaults and never absorbs session profile context.
     fn entry_container_identity(&self) -> String {
-        self.render_uri(None)
+        self.render_uri(None, None)
     }
 
     /// Infisical versions its secrets, so a `ref` may pin one. Its values are
@@ -1637,6 +1638,51 @@ mod tests {
                 .same_entries(Address::Native(&addr), &pinned_dev, Address::Native(&addr),)
                 .unwrap(),
             "different Infisical environments must remain distinct"
+        );
+    }
+
+    /// An absolute ref supplies the complete Infisical folder, so configured
+    /// path defaults do not distinguish two aliases that reach that same folder.
+    #[test]
+    fn entry_identity_uses_the_resolved_absolute_path() {
+        let left = provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}?env=prod&path=/left"
+        ));
+        let right = provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}?env=prod&path=/right"
+        ));
+        let addr = NativeAddress {
+            item: "/shared/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+
+        assert!(
+            left.same_entries(Address::Native(&addr), &right, Address::Native(&addr),)
+                .unwrap(),
+            "absolute refs that resolve to the same API path are one entry"
+        );
+    }
+
+    /// A relative ref is resolved under the configured path, so different path
+    /// defaults still keep the resulting Infisical entries distinct.
+    #[test]
+    fn entry_identity_resolves_relative_refs_under_the_configured_path() {
+        let left = provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}?env=prod&path=/left"
+        ));
+        let right = provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}?env=prod&path=/right"
+        ));
+        let addr = NativeAddress {
+            item: "shared/DB_PASSWORD".into(),
+            ..Default::default()
+        };
+
+        assert!(
+            !left
+                .same_entries(Address::Native(&addr), &right, Address::Native(&addr),)
+                .unwrap(),
+            "relative refs under different configured paths are distinct entries"
         );
     }
 

--- a/secretspec/src/provider/preflight.rs
+++ b/secretspec/src/provider/preflight.rs
@@ -226,6 +226,10 @@ impl Provider for PreflightGuard {
         self.inner.set_reason(reason);
     }
 
+    fn set_profile(&self, profile: &str) {
+        self.inner.set_profile(profile);
+    }
+
     fn with_base_dir(&mut self, base_dir: &std::path::Path) {
         self.inner.with_base_dir(base_dir);
     }

--- a/secretspec/src/provider/traits.rs
+++ b/secretspec/src/provider/traits.rs
@@ -396,6 +396,29 @@ pub trait Provider: Send + Sync {
     /// [`Secrets::with_reason`]: crate::Secrets::with_reason
     fn set_reason(&self, _reason: Option<String>) {}
 
+    /// Records the profile this session resolves under. Available starting with
+    /// SecretSpec 0.20.
+    ///
+    /// A [`Convention`](Address::Convention) address carries the profile, so a
+    /// provider whose namespace varies by profile reads it there. A
+    /// [`Native`](Address::Native) address carries coordinates only, and a
+    /// provider that needs the profile for something the coordinates do not name
+    /// — Infisical's environment, say — would otherwise have to reject every
+    /// native address. Such a provider keeps this as a fallback, behind whatever
+    /// its URI states explicitly.
+    ///
+    /// This is context, not naming: it must not change
+    /// [`uri`](Provider::uri) or
+    /// [`storage_identity`](Provider::storage_identity), or one store would take
+    /// a different identity under each profile and invalidate its own cache
+    /// entries.
+    ///
+    /// Takes `&self` (relying on interior mutability) so it can be applied after
+    /// the provider is wrapped in an `Arc` (as preflight-enabled providers are).
+    /// The default implementation ignores it, which is correct for providers
+    /// whose addresses already carry everything they need.
+    fn set_profile(&self, _profile: &str) {}
+
     /// Rebases any relative filesystem paths the provider holds against
     /// `base_dir`, the directory containing the `secretspec.toml` that
     /// configured it.
@@ -693,6 +716,9 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     }
     fn set_reason(&self, reason: Option<String>) {
         (**self).set_reason(reason);
+    }
+    fn set_profile(&self, profile: &str) {
+        (**self).set_profile(profile);
     }
     fn reflect(
         &self,

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1071,7 +1071,7 @@ impl Secrets {
     /// convention-path credentials live at `{project}/{profile}/{credential}`,
     /// so the provider must be built for the same profile its secrets are
     /// addressed under.
-    fn build_provider(
+    pub(crate) fn build_provider(
         &self,
         spec: String,
         profile: Option<&str>,
@@ -1117,7 +1117,12 @@ impl Secrets {
         let credentials = self
             .provider_credentials_cache
             .get_or_try_init(key, || self.resolve_provider_credentials(&spec, &profile))?;
-        self.build_provider_with_credentials(&spec, credentials, allow_inline_cached)
+        self.build_provider_with_credentials(
+            &spec,
+            credentials,
+            allow_inline_cached,
+            Some(&profile),
+        )
     }
 
     /// [`Self::build_provider`], memoized within one resolution so repeated
@@ -1156,8 +1161,21 @@ impl Secrets {
     /// credential source, so credential-source chains are at most one hop and
     /// cannot recurse, and for cache remediation, where the credential source
     /// itself may be what failed.
-    fn build_source_provider(&self, spec: &str) -> Result<Box<dyn ProviderTrait>> {
-        self.build_provider_with_credentials(spec, ProviderCredentials::new(), false)
+    ///
+    /// Deliberately hands the provider no profile: a credential belongs to the
+    /// alias rather than to any one profile ([`PROVIDER_CREDENTIAL_SCOPE`]), and
+    /// [`CredentialSource::address`] must round-trip whichever profile stores and
+    /// reads it. A `ref`-addressed credential would otherwise resolve in the
+    /// storing profile's Infisical environment and read from the reading
+    /// profile's, so a credential stored under `prod` would be missing under
+    /// `dev`. Such a ref keeps needing an explicit `?env=`, which is
+    /// profile-independent by construction.
+    ///
+    /// Cache remediation is the other caller and needs no profile either: it
+    /// addresses through [`Self::cache_address`], which is a convention address
+    /// carrying its own.
+    pub(crate) fn build_source_provider(&self, spec: &str) -> Result<Box<dyn ProviderTrait>> {
+        self.build_provider_with_credentials(spec, ProviderCredentials::new(), false, None)
     }
 
     /// The shared construction body behind generic, routed, and credential
@@ -1168,6 +1186,7 @@ impl Secrets {
         spec: &str,
         credentials: ProviderCredentials,
         allow_inline_cached: bool,
+        profile: Option<&str>,
     ) -> Result<Box<dyn ProviderTrait>> {
         // `build_source_provider` calls this body directly, so retain the guard
         // here as well as before credential initialization in the generic path.
@@ -1182,6 +1201,17 @@ impl Secrets {
             .map_err(|err| self.explain_unknown_provider(err, &resolved))?;
         provider.with_base_dir(&self.config_dir);
         provider.set_reason(self.reason.clone());
+        // Context a native address cannot carry: a `ref` names coordinates only,
+        // so a provider whose store is partitioned by something outside them
+        // (Infisical's environment) reads the operation's profile here. It is
+        // the profile the caller already resolved, so a provider and the
+        // addresses handed to it never disagree about which profile is running.
+        // `None` is for a credential source, which is profile-independent by
+        // contract. Naming stays with the address; this never reaches
+        // `uri`/`storage_identity`.
+        if let Some(profile) = profile {
+            provider.set_profile(profile);
+        }
         Ok(provider)
     }
 
@@ -1308,10 +1338,11 @@ impl Secrets {
         value: &SecretString,
     ) -> Result<String> {
         self.ensure_reason_for(AuditAction::Set, Some(name))?;
-        let provider = self.build_source_provider(&source.provider)?;
         // The store location is profile-independent (see `PROVIDER_CREDENTIAL_SCOPE`);
-        // the session profile is used only to attribute the audit event.
+        // the session profile attributes the audit event, and is the session
+        // context handed to the provider.
         let profile = self.resolve_profile_name(None);
+        let provider = self.build_source_provider(&source.provider)?;
         let project = self.config.project.name.clone();
         let address = source.address(&project, name);
         let result = provider

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -10762,3 +10762,82 @@ fn cache_clear_clears_what_it_can_before_reporting_a_failure() {
         "one unclearable cache must not leave the rest of the profile cached"
     );
 }
+
+/// A provider built for an operation carries that operation's profile, so an
+/// Infisical `ref` — whose coordinates name no environment — resolves in the
+/// environment the profile names. Deleting the `set_profile` call at the
+/// construction chokepoint leaves every other test green, so this is the one
+/// that holds the wiring in place.
+#[cfg(feature = "infisical")]
+#[test]
+fn a_built_provider_carries_the_operation_profile() {
+    use crate::provider::Address;
+
+    let config = Config {
+        project: Project {
+            name: "myapp".to_string(),
+            ..Default::default()
+        },
+        profiles: HashMap::new(),
+        providers: None,
+        scopes: None,
+    };
+    let mut secrets = Secrets::new(config, None, None, None);
+    secrets.set_profile("production");
+
+    let reference = crate::config::NativeAddress {
+        item: "/DB_PASSWORD".to_string(),
+        ..Default::default()
+    };
+    let provider = secrets
+        .build_provider(
+            "infisical://app.infisical.com/7e2f1a4c-0000-0000-0000-000000000000".to_string(),
+            None,
+        )
+        .unwrap();
+
+    let target = provider
+        .describe_write_target(Address::Native(&reference))
+        .unwrap();
+    assert!(
+        target.contains("environment production"),
+        "a ref must resolve in the operation's profile environment, got {target}"
+    );
+}
+
+/// A credential source gets no profile, so a `ref`-addressed Infisical
+/// credential still needs an explicit `?env=`. Without this the environment
+/// would come from whichever profile ran: a credential stored under `prod`
+/// would be missing under `dev`, breaking the round-trip
+/// `PROVIDER_CREDENTIAL_SCOPE` promises.
+#[cfg(feature = "infisical")]
+#[test]
+fn a_credential_source_provider_gets_no_profile() {
+    use crate::provider::Address;
+
+    let config = Config {
+        project: Project {
+            name: "myapp".to_string(),
+            ..Default::default()
+        },
+        profiles: HashMap::new(),
+        providers: None,
+        scopes: None,
+    };
+    let mut secrets = Secrets::new(config, None, None, None);
+    secrets.set_profile("production");
+
+    let reference = crate::config::NativeAddress {
+        item: "/ci/VAULT_TOKEN".to_string(),
+        ..Default::default()
+    };
+    let provider = secrets
+        .build_source_provider("infisical://app.infisical.com/7e2f1a4c-0000-0000-0000-000000000000")
+        .unwrap();
+
+    let err = provider
+        .describe_write_target(Address::Native(&reference))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("?env="), "{err}");
+}


### PR DESCRIPTION
## Summary

- An Infisical `ref` no longer requires `?env=`: the environment falls back to the profile the run resolves under. `?env=` still pins it.
- Adds `Provider::set_profile`, a defaulted trait method carrying the session profile, applied at the construction chokepoint from the profile the caller already resolved.

## Rationale

#181 proposed `?layout=flat` for Infisical stores whose secrets sit at the environment root. This is the other route: the 0.19 alias `ref` template already gives flat naming elsewhere, but an Infisical `ref` had no environment unless the URI pinned `?env=` — and pinning it fixes the environment for every profile, so flat naming cost one alias per environment. The profile is the environment a convention address reads in the same run, so a ref now falls back to it.

`set_profile` takes `&self`, like `set_reason`: the hook is shared by every provider, and a preflight-enabled one is wrapped as `Box<Arc<P>>`, which a `&mut self` hook cannot reach through. It is session context, never naming — `uri()` and `storage_identity()` are unchanged, so a store keeps one cache identity across profiles. It widens the public `Provider` trait, albeit with a default body; happy to take a different shape if you'd rather not.

A credential source is deliberately built without a profile, since a credential belongs to its alias and must round-trip whichever profile stores and reads it, so a `ref`-addressed credential keeps needing `?env=`.

One consequence worth your call: a ref pointed at an environment that does not exist now reads as an unset secret rather than failing, because Infisical answers a missing secret, folder, environment and project with the same 404. The write path already diagnoses a missing environment; the read path could too, at the cost of an extra API call per miss and turning a `None` into an error, which changes what a fallback chain does with a miss. Happy to follow up if you want that.

Tests cover the profile fallback, `?env=` outranking it, a blank or absent profile keeping the error, the identity invariant, forwarding through `Arc`, and both wiring paths through `Secrets`. Nothing runs against a real Infisical instance.
