### PR TITLE
Add Fly.io secrets provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The Fly.io `flyctl` provider publishes and deletes application secrets with
+  `secretspec set` and `secretspec delete`, and discovers their names with
+  `init --from`. Fly.io never exposes plaintext secret values, so the provider
+  clearly rejects read operations and CLI guidance recommends only supported
+  workflows. Writes keep values off process arguments by streaming them to
+  `flyctl secrets set` over stdin, refuse boundary whitespace that `flyctl`
+  would silently trim, and scrub ambient Fly token variables before injecting
+  the token selected through the provider credential mechanism.
 - `secretspec completions <shell>` generates completion scripts for Bash,
   Elvish, Fish, Nushell, PowerShell, and Zsh directly from the CLI definition,
   including descriptions and contextual suggestions for profiles, scopes,

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -127,7 +127,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
+Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Infisical (0.16+), age (0.17+), or SOPS (0.17+). Fly.io application secrets can be published through the write-only flyctl provider (0.20+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
         }),
       ],
       title: "SecretSpec",
@@ -286,6 +286,11 @@ Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv fil
               label: "systemd Credentials",
               slug: "providers/systemd-credential",
               badge: { text: "0.17+", variant: "note" },
+            },
+            {
+              label: "Fly.io Secrets",
+              slug: "providers/flyctl",
+              badge: { text: "0.20+", variant: "note" },
             },
             { label: "Pass", slug: "providers/pass" },
             { label: "Proton Pass", slug: "providers/protonpass" },

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -46,6 +46,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ | — |
 | [null](/providers/null/) (0.19+) | No storage; uses a manifest default, ephemeral generation, or an ephemeral run prompt | ✗ | ✗ | N/A | — |
 | [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |
+| [flyctl](/providers/flyctl/) (0.20+) | Fly.io application secrets through `flyctl` | ✗ | ✓ | ✓ | — |
 | [pass](/providers/pass/) | Unix `pass` password store | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [gopass](/providers/gopass/) (0.15+) | `gopass` password store (git-synced, GPG-encrypted) | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [protonpass](/providers/protonpass/) | Proton Pass | ✓ | ✓ | ✓ | — |

--- a/docs/src/content/docs/providers/flyctl.mdx
+++ b/docs/src/content/docs/providers/flyctl.mdx
@@ -1,0 +1,240 @@
+---
+title: Fly.io secrets provider
+description: Publish SecretSpec values to Fly.io application secrets through flyctl
+---
+
+import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+The Fly.io provider publishes declared values to an application's encrypted
+secret vault through [`flyctl`](https://fly.io/docs/flyctl/).
+
+:::note[Version compatibility]
+The Fly.io `flyctl` provider is added in SecretSpec 0.20.
+:::
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `flyctl` (0.20+) |
+| URI | `flyctl://APP[?stage=true][&detach=true]` |
+| Access | Write, delete, and discover names; plaintext values cannot be read back |
+| Best for | Publishing secrets to a Fly.io app from a separate source of truth |
+| Authentication | `flyctl` login or an app-scoped deploy token |
+| Availability | Built into SecretSpec 0.20+ |
+| Default storage | Fly app secret named `{key}` |
+
+## Quick start
+
+Complete [Setup](#setup) first, then use the checked-in alias from the project
+configuration below:
+
+```bash
+# Publish or replace DATABASE_URL, reading the value securely from the terminal
+$ secretspec set DATABASE_URL --profile production --provider fly_prod
+
+# Remove the Fly app secret
+$ secretspec delete DATABASE_URL --profile production --provider fly_prod
+```
+
+Fly.io never returns the plaintext value, so `secretspec get`, `check`, and
+`run` cannot resolve a value from this provider. Keep the authoritative value
+in a readable provider and use `fly_prod` explicitly when publishing it.
+
+## Setup
+
+### Prerequisites
+
+- SecretSpec 0.20 or newer
+- A Fly.io application
+- [`flyctl`](https://fly.io/docs/flyctl/install/) installed on `PATH`
+- Permission to list and change the selected app's secrets
+
+For local use, authenticate the CLI normally:
+
+```bash
+$ fly auth login
+```
+
+If the executable has another name or location, set
+`SECRETSPEC_FLYCTL_PATH` to it.
+
+### Authentication with provider credentials
+
+SecretSpec 0.20+ declares `access_token` as a
+[provider credential](/reference/provider-credentials/). An app-scoped deploy
+token is the narrowest standard Fly.io token that can update one app:
+
+```bash
+$ fly tokens create deploy -a my-app -x 720h
+```
+
+Load that token from a bootstrap provider instead of committing it in the URI:
+
+```toml title="secretspec.toml"
+[providers]
+bootstrap = "keyring://"
+
+[providers.fly_prod]
+uri = "flyctl://my-app"
+credentials = { access_token = "bootstrap" }
+
+[profiles.production]
+DATABASE_URL = { description = "Production database URL" }
+```
+
+Store the token once:
+
+```bash
+$ secretspec config provider login fly_prod
+Enter access_token for provider 'fly_prod' (source: bootstrap): ****
+```
+
+SecretSpec passes the token only in the child process environment and passes
+the application secret value over stdin. Neither value is placed in
+`flyctl`'s process arguments. SecretSpec removes both Fly token variables from
+the child environment, then re-injects only the token selected through the
+provider credential mechanism. This prevents `flyctl` from independently
+choosing an ambient token with different precedence.
+
+### Environment fallback
+
+In CI, set `FLY_API_TOKEN` (preferred) or `FLY_ACCESS_TOKEN`. An explicit
+`access_token` provider credential takes precedence, followed by those two
+variables in that order. If none is set, `flyctl` uses its existing login
+session.
+
+## Provider credentials
+
+<ProviderCredentials provider="flyctl" />
+
+## Configuration
+
+### URI format
+
+```text
+flyctl://APP[?stage=true][&detach=true]
+```
+
+- `APP` is required and always passed through `--app`; the provider does not
+  depend on a nearby `fly.toml`.
+- `stage=true` registers changes without immediately updating existing
+  Machines.
+- `detach=true` starts the Machine update but returns without monitoring it.
+
+Only the literal values `true` and `false` are accepted. Explicit `false`
+values behave like omitted options and are left out of the provider's
+canonical URI.
+
+### URI examples
+
+```text
+flyctl://my-app
+flyctl://my-app?stage=true
+flyctl://my-app?detach=true
+flyctl://my-app?stage=true&detach=true
+```
+
+### Project configuration
+
+Use one alias per Fly app. Because an app is the isolation boundary, profiles
+that deploy to different apps should select different aliases:
+
+```toml title="secretspec.toml"
+[providers]
+fly_staging = "flyctl://my-app-staging?stage=true"
+fly_prod = "flyctl://my-app-production"
+
+[profiles.staging]
+DATABASE_URL = { description = "Staging database URL" }
+
+[profiles.production]
+DATABASE_URL = { description = "Production database URL" }
+```
+
+```bash
+$ secretspec set DATABASE_URL --profile staging --provider fly_staging
+$ fly secrets deploy --app my-app-staging
+
+$ secretspec set DATABASE_URL --profile production --provider fly_prod
+```
+
+## Storage model
+
+The provider maps a declaration's key directly to a Fly application secret.
+For example, `DATABASE_URL` in any SecretSpec project or profile maps to:
+
+```text
+app:    URI authority (for example, my-app-production)
+secret: DATABASE_URL
+```
+
+Project and profile names are not added to the secret name. The app selected by
+the alias supplies that isolation and lets the value appear under the expected
+environment-variable name inside every Machine.
+
+By default, `flyctl secrets set` updates the app's Machines. This restarts them
+and resets their ephemeral filesystems. Use `stage=true` to group multiple
+changes before running `fly secrets deploy --app APP` yourself.
+
+## Use existing secrets
+
+A [`ref`](/reference/configuration/#secret-references) changes the Fly secret
+name updated or deleted by SecretSpec:
+
+```toml title="secretspec.toml"
+[providers]
+fly_prod = "flyctl://my-app-production"
+
+[profiles.production]
+DATABASE_URL = {
+  description = "Production database URL",
+  ref = { item = "PRIMARY_DATABASE_URL" }
+}
+```
+
+With `--provider fly_prod`, `set` writes `PRIMARY_DATABASE_URL` and `delete`
+removes it. A ref still cannot read that value; Fly.io exposes only names,
+digests, and deployment status.
+
+## Discover secret names
+
+`flyctl secrets list --json` exposes enough metadata for SecretSpec to discover
+declarations without reading values:
+
+```bash
+$ secretspec init --from flyctl://my-app-production \
+    --project my-app --profile production
+```
+
+The generated manifest contains required declarations for the listed names,
+not defaults or secret values.
+
+## CI/CD
+
+Install `flyctl`, provide an expiring app-scoped deploy token, and select the
+provider alias explicitly. For example:
+
+```yaml
+- uses: superfly/flyctl-actions/setup-flyctl@master
+- run: secretspec set DATABASE_URL --profile production --provider fly_prod
+  env:
+    FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+```
+
+Use the shortest practical token lifetime and scope it to the app named in the
+provider URI.
+
+## Security considerations and limitations
+
+- Fly.io's API servers encrypt application secrets but cannot decrypt them.
+  This provider therefore cannot support `get`, `check`, `run`, fallback reads,
+  generation-on-miss, prompting-on-miss, or value comparisons.
+- `secretspec set` uses `flyctl secrets set NAME=-` and writes the value to the
+  child process's stdin. The secret is not exposed in argv or the provider URI.
+  Because `flyctl` trims stdin values, SecretSpec refuses values with leading
+  or trailing whitespace instead of silently storing a different value.
+- A normal write or delete updates the app's Machines unless `stage=true` is
+  configured. Review the rollout effect before using the provider in a loop.
+- `secretspec delete` first lists names so it can report whether anything was
+  removed. The listing never contains plaintext values.

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -140,6 +140,7 @@ $ secretspec config global init  # 0.17+
   env: Read-only environment variables
   null: Use defaults, generation, or run prompts without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
+  flyctl: Fly.io application secrets via flyctl, write-only (0.20+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
   protonpass: Proton Pass via official pass-cli

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -857,6 +857,7 @@ entry declares neither, it inherits whichever form `[profiles.default]` uses.
 | [file (0.19+)](/providers/file/#use-existing-files) | Relative file path beneath the configured root | Rejected | Reads the complete UTF-8 file | ✅ |
 | [env](/providers/env/#use-existing-secrets) | Variable name | Rejected | Reads the variable | — (read-only) |
 | [systemd credentials (0.17+)](/providers/systemd-credential/#use-an-existing-credential-name) | Credential filename | Rejected | Reads the credential | — (read-only) |
+| [Fly.io secrets (0.20+)](/providers/flyctl/#use-existing-secrets) | Fly app secret name | Rejected | Error: Fly.io does not expose plaintext values | ✅ write-only via `flyctl secrets set` |
 | [pass](/providers/pass/#use-existing-secrets) | Entry path | Rejected | Reads the entry | ✅ |
 | [Gopass (0.15+)](/providers/gopass/#use-existing-secrets) | Entry path, including any mount-point prefix | Rejected | Reads the entry | ✅ |
 | [LastPass](/providers/lastpass/#use-existing-secrets) | Item name | Rejected | Reads the item | ✅ |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -303,6 +303,39 @@ passbolt://?template=teams/{project}/{profile}/{key}   # Replace the convention 
 
 **Write limitation**: `go-passbolt-cli` accepts created/updated values only as flags, so a value being written is visible in the child process argv until it exits. See the [Passbolt provider security notes](/providers/passbolt/#security-considerations-and-limitations).
 
+## Fly.io secrets provider (0.20+)
+
+**Availability**: Added in SecretSpec 0.20.
+
+**URI**: `flyctl://APP[?stage=true][&detach=true]` - Publishes application
+secrets through `flyctl secrets`
+
+```text
+flyctl://my-app                    # Update Machines and monitor the rollout
+flyctl://my-app?stage=true         # Register changes without deploying them
+flyctl://my-app?detach=true        # Start the rollout without monitoring it
+```
+
+**Features (0.20+)**: Write, delete, provider credentials, and name-only
+discovery through `init --from`; secret values are sent to `flyctl` over stdin
+instead of process arguments
+
+**Prerequisites (0.20+)**: `flyctl`, an authenticated login or an
+`access_token` provider credential (`FLY_API_TOKEN` and `FLY_ACCESS_TOKEN` are
+fallbacks), and permission to manage the app named in the URI
+
+**Storage (0.20+)**: Fly app secret `{key}`. The app URI, rather than the
+SecretSpec project or profile name, supplies isolation.
+
+**Read limitation**: Fly.io exposes secret names and digests but never
+plaintext values. `get`, `check`, `run`, fallback reads, generation-on-miss,
+and prompting-on-miss cannot use this write-only provider. See the
+[Fly.io provider guide](/providers/flyctl/).
+
+**Write limitation (0.20+)**: `flyctl` trims values read from stdin. SecretSpec
+rejects leading or trailing whitespace rather than silently publishing a
+different value.
+
 ## Google Cloud Secret Manager Provider
 
 **URI**: `gcsm://PROJECT_ID` - Stores secrets in Google Cloud Secret Manager
@@ -617,6 +650,7 @@ $ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Gopass | ✅ GPG encryption | Local filesystem | ❌ No |
 | Proton Pass | ✅ End-to-end | Cloud (Proton) | ✅ Yes |
 | Passbolt (0.19+) | ✅ End-to-end | Self-hosted (Passbolt server) | ✅ Yes |
+| Fly.io secrets (0.20+) | ✅ Fly.io-managed | Cloud (Fly.io app vault) | ✅ Yes |
 | LastPass | ✅ End-to-end | Cloud (LastPass) | ✅ Yes |
 | Dashlane (0.18+) | ✅ End-to-end | Cloud (Dashlane), synced locally | Yes — `dcli` auto-syncs hourly |
 | 1Password | ✅ End-to-end | Cloud (1Password) | ✅ Yes |

--- a/docs/src/data/provider-credentials.json
+++ b/docs/src/data/provider-credentials.json
@@ -54,6 +54,17 @@
     ]
   },
   {
+    "provider": "flyctl",
+    "implementationSources": ["secretspec/src/provider/flyctl.rs"],
+    "credentials": [
+      {
+        "name": "access_token",
+        "environmentFallbacks": ["FLY_API_TOKEN", "FLY_ACCESS_TOKEN"],
+        "since": "0.20"
+      }
+    ]
+  },
+  {
     "provider": "infisical",
     "implementationSources": ["secretspec/src/provider/infisical.rs"],
     "credentials": [

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -67,6 +67,7 @@ const providerMetadata: ProviderMetadata[] = [
   { slug: 'env', label: 'Environment variables' },
   { slug: 'null', label: 'Defaults / ephemeral values (null, 0.19+)' },
   { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials (0.17+)' },
+  { slug: 'flyctl', label: 'Fly.io secrets (write-only, 0.20+)' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden Secrets Manager' },
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
   { slug: 'keyring', label: 'Credential Manager' },
@@ -155,6 +156,7 @@ const providerColors: Record<string, SyntaxColorName> = {
   dotenv: 'green',
   env: 'comment',
   'systemd-credential': 'blue',
+  flyctl: 'magenta',
   sops: 'magenta',
 };
 
@@ -535,6 +537,7 @@ const reelScriptData = {
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/age/"><span class="provider-name">age</span>: age-encrypted file (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/sops/"><span class="provider-name">sops</span>: SOPS encrypted files (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/systemd-credential/"><span class="provider-name">systemd-credential</span>: Read-only systemd service credentials (0.17+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/flyctl/"><span class="provider-name">flyctl</span>: Fly.io application secrets, write-only (0.20+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-orange)" href="/providers/awsps/"><span class="provider-name">awsps</span>: AWS Systems Manager Parameter Store (0.18+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/scaleway/"><span class="provider-name">scaleway</span>: Scaleway Secret Manager (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/dashlane/"><span class="provider-name">dashlane</span>: Dashlane password manager, read-only (0.18+)</a>

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -40,6 +40,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [environment variables](https://secretspec.dev/providers/env)
   - [null](https://secretspec.dev/providers/null) (0.19+)
   - [systemd credentials](https://secretspec.dev/providers/systemd-credential) (0.17+)
+  - [Fly.io application secrets](https://secretspec.dev/providers/flyctl) (0.20+, write-only)
   - [Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
   - [AWS Systems Manager Parameter Store](https://secretspec.dev/providers/awsps) (0.18+)
@@ -85,6 +86,7 @@ $ secretspec config global init  # 0.17+
   env: Read-only environment variables
   null: Use defaults, generation, or run prompts without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
+  flyctl: Fly.io application secrets via flyctl, write-only (0.20+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
   protonpass: Proton Pass via official pass-cli
@@ -203,6 +205,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Environment variables](https://secretspec.dev/providers/env)** - Read-only for CI/CD
 - **[Null](https://secretspec.dev/providers/null)** (0.19+) - Use committed defaults, ephemeral generation, or ephemeral run prompts without secret storage
 - **[systemd credentials](https://secretspec.dev/providers/systemd-credential)** (0.17+) - Read-only credentials passed to the current service
+- **[Fly.io application secrets](https://secretspec.dev/providers/flyctl)** (0.20+) - Write and delete app secrets through `flyctl`; Fly.io does not expose plaintext values
 - **[Pass](https://secretspec.dev/providers/pass)** - Unix password manager with GPG encryption
 - **[Gopass](https://secretspec.dev/providers/gopass)** (0.15+) - GPG-based password manager with git-synced password store
 - **[Proton Pass](https://secretspec.dev/providers/protonpass)** - End-to-end encrypted via Proton's official pass-cli

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -894,6 +894,7 @@ pub fn main() -> Result<()> {
 
             // Create provider from the specification string.
             let provider: Box<dyn Provider> = from.as_str().try_into().into_diagnostic()?;
+            let source_reads = crate::provider::spec_provider_reads(&from);
 
             // Discover declarations in the namespace the new manifest will use.
             let secrets = provider
@@ -945,18 +946,34 @@ pub fn main() -> Result<()> {
             // If we discovered a populated provider, explain how to copy its
             // values after reviewing the declarations.
             if secret_count > 0 {
-                println!("\nTo migrate your secrets from {}:", from);
-                println!("  1. Review secretspec.toml and adjust as needed");
-                println!(
-                    "  2. {}    # Import secret values",
-                    migration_command(&from, &profile)
-                );
+                if source_reads {
+                    println!("\nTo migrate your secrets from {}:", from);
+                    println!("  1. Review secretspec.toml and adjust as needed");
+                    println!(
+                        "  2. {}    # Import secret values",
+                        migration_command(&from, &profile)
+                    );
+                } else {
+                    println!(
+                        "\nDiscovered secret names from {from}, but this write-only provider cannot return plaintext values to import."
+                    );
+                }
             }
 
             println!("\nNext steps:");
-            println!("  1. secretspec config global init    # Set up user defaults (0.17+)");
-            println!("  2. secretspec check          # Verify all secrets and set them");
-            println!("  3. secretspec run -- your-command  # Run with secrets");
+            if source_reads {
+                println!("  1. secretspec config global init    # Set up user defaults (0.17+)");
+                println!("  2. secretspec check          # Verify all secrets and set them");
+                println!("  3. secretspec run -- your-command  # Run with secrets");
+            } else {
+                println!("  1. Review secretspec.toml and adjust the discovered names");
+                println!(
+                    "  2. secretspec config global init    # Set up defaults for readable providers"
+                );
+                println!(
+                    "  3. Use secretspec set with an explicit provider to publish secret values"
+                );
+            }
 
             Ok(())
         }
@@ -1176,6 +1193,9 @@ pub fn main() -> Result<()> {
                         let app = load_secrets(&cli.file, &cli.reason)?;
                         let credentials =
                             app.declared_provider_credentials(&name).into_diagnostic()?;
+                        let provider_reads = crate::provider::spec_provider_reads(
+                            &app.resolve_provider_spec(name.clone()),
+                        );
                         if credentials.is_empty() {
                             println!("Provider alias '{name}' declares no credentials.");
                             return Ok(());
@@ -1201,9 +1221,15 @@ pub fn main() -> Result<()> {
                                 .into_diagnostic()?;
                             println!("✓ stored {credential_name} in {location}");
                         }
-                        println!(
-                            "\nRun 'secretspec check --provider {name}' to verify authentication."
-                        );
+                        if provider_reads {
+                            println!(
+                                "\nRun 'secretspec check --provider {name}' to verify authentication."
+                            );
+                        } else {
+                            println!(
+                                "\nProvider alias '{name}' is write-only; authentication will be verified on its next write."
+                            );
+                        }
                         Ok(())
                     }
                 }

--- a/secretspec/src/provider/flyctl.rs
+++ b/secretspec/src/provider/flyctl.rs
@@ -1,0 +1,673 @@
+//! Fly.io application-secrets provider backed by `flyctl secrets`.
+//!
+//! Fly.io's secrets service can encrypt values but cannot decrypt them, so the
+//! provider intentionally supports writes, deletion, and name discovery while
+//! rejecting value reads. Secret values are sent to `flyctl` over stdin rather
+//! than placed in process arguments.
+
+use super::{Address, DiscoveryContext, Provider, ProviderCredentials, ProviderUrl};
+use crate::config::{NativeAddress, Secret};
+use crate::{Result, SecretSpecError};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::process::{Command, Output, Stdio};
+
+const ACCESS_TOKEN: &str = "access_token";
+const API_TOKEN_ENV: &str = "FLY_API_TOKEN";
+const ACCESS_TOKEN_ENV: &str = "FLY_ACCESS_TOKEN";
+const CLI_PATH_ENV: &str = "SECRETSPEC_FLYCTL_PATH";
+
+/// Configuration for one Fly.io application's secrets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlyctlConfig {
+    /// Fly.io application name.
+    pub app: String,
+    /// Register changes without immediately updating the app's Machines.
+    pub stage: bool,
+    /// Return without monitoring the Machine update.
+    pub detach: bool,
+}
+
+impl TryFrom<&ProviderUrl> for FlyctlConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "flyctl" {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Invalid scheme '{}' for flyctl provider",
+                url.scheme()
+            )));
+        }
+
+        if !url.username().is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "flyctl:// takes the Fly.io app name as its authority, not a username".to_string(),
+            ));
+        }
+
+        let app = url.host().filter(|app| !app.is_empty()).ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(
+                "flyctl provider requires a Fly.io app name, for example flyctl://my-app"
+                    .to_string(),
+            )
+        })?;
+
+        let path = url.path();
+        if !path.is_empty() && path != "/" {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "flyctl:// takes no path; put the Fly.io app name in the URI authority".to_string(),
+            ));
+        }
+
+        let mut stage = None;
+        let mut detach = None;
+        for (key, value) in url.query_pairs() {
+            let slot = match key.as_ref() {
+                "stage" => &mut stage,
+                "detach" => &mut detach,
+                unknown => {
+                    return Err(SecretSpecError::ProviderOperationFailed(format!(
+                        "unknown flyctl query parameter '{unknown}'; supported parameters are `stage` and `detach`"
+                    )));
+                }
+            };
+            if slot.is_some() {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "duplicate flyctl query parameter '{key}'"
+                )));
+            }
+            *slot = Some(parse_bool(&key, &value)?);
+        }
+
+        Ok(Self {
+            app,
+            stage: stage.unwrap_or(false),
+            detach: detach.unwrap_or(false),
+        })
+    }
+}
+
+fn parse_bool(name: &str, value: &str) -> Result<bool> {
+    match value {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(SecretSpecError::ProviderOperationFailed(format!(
+            "flyctl query parameter `{name}` must be `true` or `false`"
+        ))),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ListedSecret {
+    #[serde(alias = "Name")]
+    name: String,
+}
+
+/// A write-only provider for Fly.io application secrets.
+pub struct FlyctlProvider {
+    config: FlyctlConfig,
+    credentials: ProviderCredentials,
+    cli_binary_path: String,
+}
+
+crate::register_provider! {
+    struct: FlyctlProvider,
+    config: FlyctlConfig,
+    name: "flyctl",
+    description: "Fly.io application secrets via flyctl, write-only (0.20+)",
+    schemes: ["flyctl"],
+    examples: ["flyctl://my-app", "flyctl://my-app?stage=true"],
+    credential_names: [ACCESS_TOKEN],
+    reads: false,
+    deletes: true,
+}
+
+impl FlyctlProvider {
+    pub fn new(config: FlyctlConfig) -> Self {
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+            cli_binary_path: std::env::var(CLI_PATH_ENV).unwrap_or_else(|_| "flyctl".to_string()),
+        }
+    }
+
+    fn effective_access_token(&self) -> Option<String> {
+        super::credential_or_envs(
+            &self.credentials,
+            ACCESS_TOKEN,
+            &["FLY_API_TOKEN", "FLY_ACCESS_TOKEN"],
+        )
+    }
+
+    fn command(&self) -> Command {
+        self.command_with_access_token(self.effective_access_token())
+    }
+
+    fn command_with_access_token(&self, token: Option<String>) -> Command {
+        let mut command = Command::new(&self.cli_binary_path);
+        // Never let flyctl resolve credentials independently from the parent
+        // environment. SecretSpec selects the provider credential (including
+        // its documented environment fallbacks), scrubs both flyctl variables,
+        // and injects only that selected value.
+        command.env_remove(API_TOKEN_ENV);
+        command.env_remove(ACCESS_TOKEN_ENV);
+        if let Some(token) = token {
+            command.env(API_TOKEN_ENV, token);
+        }
+        command
+    }
+
+    fn deployment_args(&self, command: &mut Command) {
+        if self.config.stage {
+            command.arg("--stage");
+        }
+        if self.config.detach {
+            command.arg("--detach");
+        }
+    }
+
+    fn finish(&self, output: Output) -> Result<Output> {
+        if output.status.success() {
+            return Ok(output);
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let detail = if stderr.trim().is_empty() {
+            stdout.trim()
+        } else {
+            stderr.trim()
+        };
+        Err(SecretSpecError::ProviderOperationFailed(format!(
+            "flyctl failed for app '{}': {}",
+            self.config.app,
+            if detail.is_empty() {
+                "command exited unsuccessfully"
+            } else {
+                detail
+            }
+        )))
+    }
+
+    fn spawn_error(&self, error: io::Error) -> SecretSpecError {
+        let message = if error.kind() == io::ErrorKind::NotFound {
+            format!(
+                "flyctl executable '{}' was not found; install flyctl from https://fly.io/docs/flyctl/install/ or set {CLI_PATH_ENV}",
+                self.cli_binary_path
+            )
+        } else {
+            format!("failed to execute '{}': {error}", self.cli_binary_path)
+        };
+        SecretSpecError::ProviderOperationFailed(message)
+    }
+
+    fn list(&self) -> Result<Vec<ListedSecret>> {
+        let output = self
+            .command()
+            .args([
+                "secrets",
+                "list",
+                "--app",
+                self.config.app.as_str(),
+                "--json",
+            ])
+            .output()
+            .map_err(|error| self.spawn_error(error))?;
+        let output = self.finish(output)?;
+        serde_json::from_slice(&output.stdout).map_err(|error| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "flyctl returned invalid JSON while listing secrets for app '{}': {error}",
+                self.config.app
+            ))
+        })
+    }
+
+    fn secret_name<'a>(&self, addr: Address<'a>) -> Result<std::borrow::Cow<'a, str>> {
+        let name = super::flat_item(self, addr)?;
+        if name.is_empty() || name.contains('=') || name.contains('\0') {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "'{}' is not a valid Fly.io secret name: names must be non-empty and cannot contain `=` or NUL",
+                name
+            )));
+        }
+        Ok(name)
+    }
+}
+
+impl Provider for FlyctlProvider {
+    /// Fly application secrets become environment variables, so convention
+    /// addresses use the declared key directly. The app URI provides project
+    /// and environment isolation.
+    fn convention_address(
+        &self,
+        _project: &str,
+        _profile: &str,
+        key: &str,
+    ) -> Result<NativeAddress> {
+        Ok(NativeAddress {
+            item: key.to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let mut parameters = Vec::new();
+        if self.config.stage {
+            parameters.push("stage=true");
+        }
+        if self.config.detach {
+            parameters.push("detach=true");
+        }
+        let base = format!("flyctl://{}", ProviderUrl::encode(&self.config.app));
+        if parameters.is_empty() {
+            base
+        } else {
+            format!("{base}?{}", parameters.join("&"))
+        }
+    }
+
+    /// Deployment options change how an update is rolled out, not which Fly
+    /// vault stores the secret.
+    fn storage_identity(&self) -> String {
+        format!("flyctl://{}", self.config.app)
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let _ = self.secret_name(addr)?;
+        Err(SecretSpecError::ProviderOperationFailed(
+            "Fly.io application secrets are write-only and their plaintext values cannot be read back; use the flyctl provider with `secretspec set`, `secretspec delete`, or `secretspec init --from`"
+                .to_string(),
+        ))
+    }
+
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        self.secret_name(addr).map(|_| ())
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let value = value.expose_secret();
+        if value.trim() != value {
+            return Err(SecretSpecError::ProviderOperationFailed(
+                "flyctl trims leading and trailing whitespace from values supplied on stdin; refusing to store a changed secret value"
+                    .to_string(),
+            ));
+        }
+        let name = self.secret_name(addr)?;
+        let assignment = format!("{name}=-");
+        let mut command = self.command();
+        command
+            .args([
+                "secrets",
+                "set",
+                assignment.as_str(),
+                "--app",
+                self.config.app.as_str(),
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        self.deployment_args(&mut command);
+
+        let mut child = command.spawn().map_err(|error| self.spawn_error(error))?;
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            SecretSpecError::ProviderOperationFailed(
+                "failed to open flyctl stdin for the secret value".to_string(),
+            )
+        })?;
+        stdin.write_all(value.as_bytes())?;
+        drop(stdin);
+        let output = child
+            .wait_with_output()
+            .map_err(|error| self.spawn_error(error))?;
+        self.finish(output).map(|_| ())
+    }
+
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        self.secret_name(addr).map(|_| ())
+    }
+
+    fn delete(&self, addr: Address<'_>) -> Result<bool> {
+        self.check_deletable(addr)?;
+        let name = self.secret_name(addr)?;
+        if !self.list()?.iter().any(|secret| secret.name == name) {
+            return Ok(false);
+        }
+
+        let mut command = self.command();
+        command.args([
+            "secrets",
+            "unset",
+            name.as_ref(),
+            "--app",
+            self.config.app.as_str(),
+        ]);
+        self.deployment_args(&mut command);
+        let output = command.output().map_err(|error| self.spawn_error(error))?;
+        self.finish(output).map(|_| true)
+    }
+
+    fn describe_write_target(&self, addr: Address<'_>) -> Result<String> {
+        let name = self.secret_name(addr)?;
+        let rollout = if self.config.stage {
+            ", staged without an immediate deployment"
+        } else if self.config.detach {
+            ", deployment detached"
+        } else {
+            ""
+        };
+        Ok(format!(
+            "Fly.io app '{}' secret '{}'{}",
+            self.config.app, name, rollout
+        ))
+    }
+
+    fn reflect(&self, _context: DiscoveryContext<'_>) -> Result<HashMap<String, Secret>> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .map(|listed| {
+                let name = listed.name;
+                let secret = Secret {
+                    description: Some(format!("{name} Fly.io app secret")),
+                    required: Some(true),
+                    ..Default::default()
+                };
+                (name, secret)
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_url(spec: &str) -> ProviderUrl {
+        ProviderUrl::new(url::Url::parse(spec).unwrap())
+    }
+
+    fn config(spec: &str) -> FlyctlConfig {
+        FlyctlConfig::try_from(&provider_url(spec)).unwrap()
+    }
+
+    #[test]
+    fn parses_app_and_rollout_options() {
+        assert_eq!(
+            config("flyctl://my-app?stage=true&detach=true"),
+            FlyctlConfig {
+                app: "my-app".to_string(),
+                stage: true,
+                detach: true,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_missing_app_path_and_bad_queries() {
+        for spec in [
+            "flyctl://",
+            "flyctl://my-app/path",
+            "flyctl://my-app?unknown=true",
+            "flyctl://my-app?stage=yes",
+            "flyctl://my-app?stage=true&stage=false",
+        ] {
+            assert!(
+                FlyctlConfig::try_from(&provider_url(spec)).is_err(),
+                "{spec}"
+            );
+        }
+    }
+
+    #[test]
+    fn uri_round_trips_and_store_identity_ignores_rollout() {
+        let provider = FlyctlProvider::new(config("flyctl://my-app?stage=true&detach=true"));
+        assert_eq!(provider.uri(), "flyctl://my-app?stage=true&detach=true");
+        assert_eq!(provider.storage_identity(), "flyctl://my-app");
+        assert_eq!(config(&provider.uri()), provider.config);
+    }
+
+    #[test]
+    fn convention_uses_the_environment_variable_name_directly() {
+        let provider = FlyctlProvider::new(config("flyctl://my-app"));
+        let address = provider
+            .convention_address("project", "production", "DATABASE_URL")
+            .unwrap();
+        assert_eq!(address.item, "DATABASE_URL");
+        assert!(address.field.is_none());
+    }
+
+    #[test]
+    fn reads_explain_fly_write_only_semantics() {
+        let provider = FlyctlProvider::new(config("flyctl://my-app"));
+        let error = provider
+            .get(Address::convention("project", "default", "API_KEY"))
+            .unwrap_err();
+        assert!(error.to_string().contains("write-only"), "{error}");
+        assert!(error.to_string().contains("cannot be read back"), "{error}");
+    }
+
+    #[test]
+    fn invalid_secret_names_are_rejected_before_a_write() {
+        let provider = FlyctlProvider::new(config("flyctl://my-app"));
+        for item in ["", "BAD=NAME", "BAD\0NAME"] {
+            let native = NativeAddress {
+                item: item.to_string(),
+                ..Default::default()
+            };
+            assert!(provider.check_writable(Address::Native(&native)).is_err());
+        }
+    }
+
+    #[test]
+    fn registration_declares_the_provider_capabilities() {
+        let registration = crate::provider::PROVIDER_REGISTRY
+            .iter()
+            .find(|registration| registration.info.name == "flyctl")
+            .unwrap();
+        assert_eq!(registration.credential_names, &[ACCESS_TOKEN]);
+        assert!(!registration.reads);
+        assert!(!crate::provider::spec_provider_reads("flyctl://my-app"));
+        assert!(crate::provider::spec_provider_reads("dotenv://.env"));
+        assert!(registration.deletes);
+    }
+
+    #[test]
+    fn injected_access_token_is_applied_to_the_child_environment() {
+        let mut provider = FlyctlProvider::new(config("flyctl://my-app"));
+        let mut credentials = ProviderCredentials::new();
+        credentials.insert(
+            ACCESS_TOKEN.to_string(),
+            SecretString::new("fly-token".into()),
+        );
+        provider.with_credentials(credentials);
+        let command = provider.command();
+        let envs: HashMap<_, _> = command
+            .get_envs()
+            .filter_map(|(key, value)| {
+                Some((
+                    key.to_string_lossy().into_owned(),
+                    value?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect();
+        assert_eq!(
+            envs.get(API_TOKEN_ENV).map(String::as_str),
+            Some("fly-token")
+        );
+        let inherited_access_token = command
+            .get_envs()
+            .find(|(key, _)| key.to_string_lossy() == ACCESS_TOKEN_ENV)
+            .expect("the higher-precedence access token must be overridden");
+        assert!(
+            inherited_access_token.1.is_none(),
+            "FLY_ACCESS_TOKEN must be removed from the child environment"
+        );
+        assert!(!provider.uri().contains("fly-token"));
+    }
+
+    #[test]
+    fn command_without_a_selected_token_scrubs_fly_credentials() {
+        let provider = FlyctlProvider::new(config("flyctl://my-app"));
+        let command = provider.command_with_access_token(None);
+        for credential_env in [API_TOKEN_ENV, ACCESS_TOKEN_ENV] {
+            let override_value = command
+                .get_envs()
+                .find(|(key, _)| key.to_string_lossy() == credential_env)
+                .unwrap_or_else(|| panic!("{credential_env} must be scrubbed"));
+            assert!(
+                override_value.1.is_none(),
+                "{credential_env} must not be inherited by flyctl"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    struct FakeFlyctl {
+        dir: tempfile::TempDir,
+        provider: FlyctlProvider,
+    }
+
+    #[cfg(unix)]
+    impl FakeFlyctl {
+        fn new(spec: &str) -> Self {
+            use std::os::unix::fs::PermissionsExt;
+
+            let dir = tempfile::tempdir().unwrap();
+            let binary = dir.path().join("flyctl");
+            let scratch = dir.path().join("flyctl.script");
+            std::fs::write(
+                &scratch,
+                r#"#!/bin/sh
+fixture_dir=$(dirname "$0")
+printf '%s\n' "$*" >> "$fixture_dir/invocations.log"
+printf '%s' "${FLY_API_TOKEN:-}" >> "$fixture_dir/token.log"
+case "$1 $2" in
+  "secrets list") cat "$fixture_dir/list.json" ;;
+  "secrets set") cat > "$fixture_dir/stdin.log" ;;
+  "secrets unset") ;;
+  *) printf 'unexpected flyctl invocation: %s\n' "$*" >&2; exit 2 ;;
+esac
+"#,
+            )
+            .unwrap();
+            // Install only after the writer has closed. Concurrent subprocess
+            // tests can otherwise inherit the write descriptor and make Linux
+            // reject execution with ETXTBSY.
+            std::fs::rename(&scratch, &binary).unwrap();
+            let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+            permissions.set_mode(0o700);
+            std::fs::set_permissions(&binary, permissions).unwrap();
+            std::fs::write(
+                dir.path().join("list.json"),
+                r#"[{"name":"EXISTING","digest":"abc","status":"Deployed"},{"Name":"LEGACY","Digest":"def"}]"#,
+            )
+            .unwrap();
+
+            let mut provider = FlyctlProvider::new(config(spec));
+            provider.cli_binary_path = binary.to_string_lossy().into_owned();
+            let mut credentials = ProviderCredentials::new();
+            credentials.insert(
+                ACCESS_TOKEN.to_string(),
+                SecretString::new("injected-token".into()),
+            );
+            provider.with_credentials(credentials);
+            Self { dir, provider }
+        }
+
+        fn read(&self, name: &str) -> String {
+            std::fs::read_to_string(self.dir.path().join(name)).unwrap_or_default()
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_keeps_the_value_off_argv_and_sends_it_on_stdin() {
+        let fake = FakeFlyctl::new("flyctl://my-app?stage=true&detach=true");
+        let value = SecretString::new("super-secret-value\nwith-newline".into());
+        fake.provider
+            .set(
+                Address::convention("project", "production", "API_KEY"),
+                &value,
+            )
+            .unwrap();
+
+        let invocation = fake.read("invocations.log");
+        assert!(
+            invocation.contains("secrets set API_KEY=- --app my-app --stage --detach"),
+            "{invocation}"
+        );
+        assert!(!invocation.contains("super-secret-value"));
+        assert_eq!(fake.read("stdin.log"), value.expose_secret());
+        assert_eq!(fake.read("token.log"), "injected-token");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_rejects_boundary_whitespace_before_invoking_flyctl() {
+        let fake = FakeFlyctl::new("flyctl://my-app");
+        for value in [" leading", "trailing ", "final-newline\n"] {
+            let error = fake
+                .provider
+                .set(
+                    Address::convention("project", "production", "API_KEY"),
+                    &SecretString::new(value.into()),
+                )
+                .unwrap_err();
+            assert!(error.to_string().contains("whitespace"), "{error}");
+            assert!(error.to_string().contains("refusing"), "{error}");
+        }
+        assert!(fake.read("invocations.log").is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delete_is_idempotent_and_unsets_existing_names() {
+        let fake = FakeFlyctl::new("flyctl://my-app?stage=true");
+        assert!(
+            fake.provider
+                .delete(Address::convention("project", "production", "EXISTING"))
+                .unwrap()
+        );
+        assert!(
+            !fake
+                .provider
+                .delete(Address::convention("project", "production", "MISSING"))
+                .unwrap()
+        );
+
+        let invocations = fake.read("invocations.log");
+        assert!(
+            invocations.contains("secrets unset EXISTING --app my-app --stage"),
+            "{invocations}"
+        );
+        assert!(!invocations.contains("secrets unset MISSING"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovery_uses_names_without_trying_to_read_values() {
+        let fake = FakeFlyctl::new("flyctl://my-app");
+        let reflected = fake
+            .provider
+            .reflect(DiscoveryContext::new("project", "production"))
+            .unwrap();
+        assert_eq!(reflected.len(), 2);
+        assert!(reflected.contains_key("EXISTING"));
+        assert!(reflected.contains_key("LEGACY"));
+        assert_eq!(
+            fake.read("invocations.log"),
+            "secrets list --app my-app --json\n"
+        );
+    }
+}

--- a/secretspec/src/provider/macros.rs
+++ b/secretspec/src/provider/macros.rs
@@ -9,6 +9,13 @@ pub struct ProviderRegistration {
     /// Semantic credential names accepted by the provider. Empty for providers
     /// that accept no injected credentials; used to reject unsupported names.
     pub credential_names: &'static [&'static str],
+    /// Whether the provider can return plaintext secret values through
+    /// [`Provider::get`](super::Provider::get).
+    ///
+    /// Most providers can, so registrations opt out only for write-only stores.
+    /// CLI workflows use this to avoid recommending read-dependent commands.
+    #[cfg_attr(not(any(feature = "cli", test)), allow(dead_code))]
+    pub reads: bool,
     /// Whether the provider implements [`Provider::delete`](super::Provider::delete).
     ///
     /// Declared here rather than probed on an instance, so routing that needs an
@@ -23,6 +30,16 @@ pub struct ProviderRegistration {
 #[doc(hidden)]
 pub const fn declared_flag(values: &[bool]) -> bool {
     matches!(values, [true, ..])
+}
+
+/// Folds an optional read-capability flag, defaulting to `true` for existing
+/// providers and requiring only write-only providers to opt out.
+#[doc(hidden)]
+pub const fn declared_read_capability(values: &[bool]) -> bool {
+    match values {
+        [reads, ..] => *reads,
+        [] => true,
+    }
 }
 
 /// Distributed slice that collects all provider registrations.
@@ -60,6 +77,21 @@ pub static PROVIDER_REGISTRY: [ProviderRegistration];
 ///     schemes: ["bws"],
 ///     examples: ["bws://project-uuid"],
 ///     credential_names: ["access_token"],
+/// }
+/// ```
+///
+/// Write-only providers declare that `get` cannot return plaintext values, so
+/// CLI workflows do not recommend read-dependent follow-up commands:
+///
+/// ```ignore
+/// register_provider! {
+///     struct: WriteOnlyProvider,
+///     config: WriteOnlyConfig,
+///     name: "write-only",
+///     description: "A write-only store",
+///     schemes: ["write-only"],
+///     examples: ["write-only://store"],
+///     reads: false,
 /// }
 /// ```
 ///
@@ -105,12 +137,14 @@ macro_rules! register_provider {
         schemes: [$($scheme:expr),* $(,)?],
         examples: [$($example:expr),* $(,)?]
         $(, credential_names: [$($credential_name:expr),* $(,)?])?
+        $(, reads: $reads:literal)?
         $(, deletes: $deletes:literal)? $(,)?
     ) => {
         $crate::register_provider!(@register
             $struct_name, $config_type, $name, $description,
             [$($scheme,)*], [$($example,)*],
             [$($($credential_name,)*)?],
+            [$($reads,)?],
             [$($deletes,)?],
             |provider| {
                 Ok($crate::provider::ProviderWithPreflight {
@@ -130,6 +164,7 @@ macro_rules! register_provider {
         schemes: [$($scheme:expr),* $(,)?],
         examples: [$($example:expr),* $(,)?],
         $(credential_names: [$($credential_name:expr),* $(,)?],)?
+        $(reads: $reads:literal,)?
         $(deletes: $deletes:literal,)?
         preflight: $preflight:ident $(,)?
     ) => {
@@ -137,6 +172,7 @@ macro_rules! register_provider {
             $struct_name, $config_type, $name, $description,
             [$($scheme,)*], [$($example,)*],
             [$($($credential_name,)*)?],
+            [$($reads,)?],
             [$($deletes,)?],
             |provider| {
                 let provider = std::sync::Arc::new(provider);
@@ -154,6 +190,7 @@ macro_rules! register_provider {
         $struct_name:ident, $config_type:ty, $name:expr, $description:expr,
         [$($scheme:expr,)*], [$($example:expr,)*],
         [$($credential_name:expr,)*],
+        [$($reads:literal,)?],
         [$($deletes:literal,)?],
         $wrap:expr
     ) => {
@@ -172,6 +209,7 @@ macro_rules! register_provider {
                 },
                 schemes: &[$($scheme,)*],
                 credential_names: &[$($credential_name,)*],
+                reads: $crate::provider::declared_read_capability(&[$($reads,)?]),
                 deletes: $crate::provider::declared_flag(&[$($deletes,)?]),
                 factory: |url, credentials| {
                     let config = <$config_type>::try_from(url)?;

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -22,6 +22,7 @@
 //! - [`env::EnvProvider`]: Environment variables (read-only)
 //! - [`null::NullProvider`]: Defaults, generation, or run prompts without storage (0.19+)
 //! - [`file::FileProvider`]: Plaintext file-per-secret storage (0.19+)
+//! - [`flyctl::FlyctlProvider`]: Fly.io application secrets, write-only (0.20+)
 //! - [`pass::PassProvider`]: Pass integration
 //! - [`gopass::GoPassProvider`]: Gopass integration
 //! - [`systemd_credential::SystemdCredentialProvider`]: systemd service credentials (0.17+)
@@ -290,6 +291,7 @@ pub mod dashlane;
 pub mod dotenv;
 pub mod env;
 pub mod file;
+pub mod flyctl;
 #[cfg(feature = "gcsm")]
 pub mod gcsm;
 pub mod gopass;
@@ -514,7 +516,9 @@ pub(crate) fn flat_item<'a, P: Provider + ?Sized>(
 }
 
 /// Macro support types
-pub use macros::{PROVIDER_REGISTRY, ProviderRegistration, declared_flag};
+pub use macros::{
+    PROVIDER_REGISTRY, ProviderRegistration, declared_flag, declared_read_capability,
+};
 
 /// Returns a list of all available providers with their metadata.
 ///
@@ -588,6 +592,17 @@ pub(crate) fn spec_names_known_provider(spec: &str) -> Result<bool> {
 pub(crate) fn credential_names_for_spec(spec: &str) -> &'static [&'static str] {
     let (scheme, _) = split_spec(spec);
     registration_for_scheme(scheme).map_or(&[], |reg| reg.credential_names)
+}
+
+/// Whether the provider named by `spec` can return plaintext secret values.
+///
+/// Read from registration metadata so CLI guidance can inspect an alias target
+/// without constructing it, fetching its credentials, or running preflight.
+/// Unknown schemes return `false`; callers validate provider specs separately.
+#[cfg_attr(not(any(feature = "cli", test)), allow(dead_code))]
+pub(crate) fn spec_provider_reads(spec: &str) -> bool {
+    let (scheme, _) = split_spec(spec);
+    registration_for_scheme(scheme).is_some_and(|reg| reg.reads)
 }
 
 /// Whether the provider `spec` names implements [`Provider::delete`].


### PR DESCRIPTION
## Summary

- add a write-only `flyctl://APP` provider for setting, deleting, and discovering Fly.io application secret names
- stream secret values to `flyctl secrets set` over stdin, with `stage`, `detach`, and `access_token` support
- document the provider as a SecretSpec 0.20 feature across all provider listings and references

## Why

Fly.io application secrets cannot be decrypted after they are stored. SecretSpec should still be able to publish and remove values safely, and discover existing secret names, without pretending that plaintext reads are available.

## Impact

Users can target `flyctl://APP` from `set`, `delete`, and `init --from`. Read-dependent operations fail with an explicit explanation because Fly.io does not expose plaintext values.

## Validation

- `devenv shell cargo test --all`
- `devenv shell npm --prefix docs run build`
- `devenv shell cargo clippy`
- `devenv shell cargo fmt --all -- --check`
- repository pre-commit hooks (`clippy`, `rustfmt`)
- `git diff --check`