### PR TITLE
Fix provider path boundary joining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OnePassword optional references whose item names resemble authentication
   diagnostics are omitted as missing instead of aborting batch resolution.
 
+### Fixed
+
+- The `awssm` provider now accepts a trailing slash in `?prefix=` without
+  inserting a second slash into the AWS secret name. For example,
+  `?prefix=myteam/` resolves to `myteam/secretspec/...`, matching
+  `?prefix=myteam`, and both spellings share one provider identity so import
+  diagnostics still recognize alias-specific references. This avoids silently
+  treating the secret as missing or writing to a distinct double-slash name. Closes
+  [#344](https://github.com/cachix/secretspec/issues/344).
+
 ## [0.19.1] - 2026-08-11
 
 Republishes 0.19.0's command-line artifacts. The library and CLI behave exactly

--- a/secretspec/src/provider/awssm.rs
+++ b/secretspec/src/provider/awssm.rs
@@ -47,7 +47,7 @@
 //! secretspec check --provider awssm://production@us-east-1
 //! ```
 
-use super::{Address, Provider, ProviderUrl};
+use super::{Address, Provider, ProviderUrl, join_slash_path};
 use crate::{Result, SecretSpecError};
 use aws_sdk_secretsmanager::Client;
 use aws_sdk_secretsmanager::error::{ProvideErrorMetadata, SdkError};
@@ -100,6 +100,15 @@ pub struct AwssmConfig {
     pub tags: BTreeMap<String, String>,
 }
 
+/// Removes redundant trailing separators without changing the effective AWS
+/// secret namespace. A slash-only prefix still represents the root namespace.
+fn canonicalize_prefix(prefix: &str) -> String {
+    match prefix.trim_end_matches('/') {
+        "" => "/".to_string(),
+        prefix => prefix.to_string(),
+    }
+}
+
 impl TryFrom<&ProviderUrl> for AwssmConfig {
     type Error = SecretSpecError;
 
@@ -123,7 +132,9 @@ impl TryFrom<&ProviderUrl> for AwssmConfig {
 
         let region = url.host().filter(|s| !s.is_empty());
 
-        let prefix = url.query_value("prefix");
+        let prefix = url
+            .query_value("prefix")
+            .map(|prefix| canonicalize_prefix(&prefix));
 
         let kms_key_id = url.query_value("kms_key_id");
 
@@ -210,9 +221,10 @@ impl AwssmProvider {
             ));
         }
 
+        let convention_name = format!("secretspec/{project}/{profile}/{key}");
         let secret_name = match prefix {
-            Some(p) => format!("{}/secretspec/{}/{}/{}", p, project, profile, key),
-            None => format!("secretspec/{}/{}/{}", project, profile, key),
+            Some(prefix) => join_slash_path(prefix, &convention_name),
+            None => convention_name,
         };
 
         // AWS secret names can be up to 512 characters
@@ -455,7 +467,10 @@ impl Provider for AwssmProvider {
         // iterates in sorted key order and `uri()` is deterministic.
         let mut params: Vec<String> = Vec::new();
         if let Some(prefix) = &self.config.prefix {
-            params.push(format!("prefix={}", ProviderUrl::encode_query(prefix)));
+            params.push(format!(
+                "prefix={}",
+                ProviderUrl::encode_query(&canonicalize_prefix(prefix))
+            ));
         }
         if let Some(kms_key_id) = &self.config.kms_key_id {
             params.push(format!(
@@ -553,6 +568,21 @@ mod tests {
     }
 
     #[test]
+    fn test_format_secret_name_normalizes_prefix_boundary() {
+        for (prefix, expected) in [
+            ("myteam", "myteam/secretspec/myapp/prod/DB_URL"),
+            ("myteam/", "myteam/secretspec/myapp/prod/DB_URL"),
+            ("myteam///", "myteam/secretspec/myapp/prod/DB_URL"),
+            ("/myteam/", "/myteam/secretspec/myapp/prod/DB_URL"),
+            ("/", "/secretspec/myapp/prod/DB_URL"),
+        ] {
+            let name =
+                AwssmProvider::format_secret_name(Some(prefix), "myapp", "prod", "DB_URL").unwrap();
+            assert_eq!(name, expected, "prefix {prefix:?}");
+        }
+    }
+
+    #[test]
     fn test_format_secret_name_too_long() {
         let long_key = "A".repeat(500);
         let result = AwssmProvider::format_secret_name(None, "myapp", "prod", &long_key);
@@ -579,6 +609,26 @@ mod tests {
         let p = AwssmProvider::new(config("awssm://us-east-1?prefix=myteam"));
         let coords = p.convention_address("proj", "default", "A").unwrap();
         assert_eq!(coords.item, "myteam/secretspec/proj/default/A");
+    }
+
+    #[test]
+    fn test_convention_address_with_trailing_slash_prefix() {
+        let p = AwssmProvider::new(config("awssm://us-east-1?prefix=myteam/"));
+        let coords = p.convention_address("proj", "default", "A").unwrap();
+        assert_eq!(coords.item, "myteam/secretspec/proj/default/A");
+    }
+
+    #[test]
+    fn trailing_slash_prefix_has_canonical_storage_identity() {
+        let canonical = AwssmProvider::new(config("awssm://us-east-1?prefix=myteam"));
+        let trailing_slash = AwssmProvider::new(config("awssm://us-east-1?prefix=myteam/"));
+
+        assert_eq!(trailing_slash.config.prefix.as_deref(), Some("myteam"));
+        assert_eq!(trailing_slash.uri(), canonical.uri());
+        assert!(crate::provider::same_storage_container(
+            &trailing_slash,
+            &canonical
+        ));
     }
 
     #[test]

--- a/secretspec/src/provider/infisical.rs
+++ b/secretspec/src/provider/infisical.rs
@@ -66,7 +66,9 @@
 //! Infisical's own precedence: a secret defined directly in the folder wins
 //! over an imported one, and a later import wins over an earlier one.
 
-use super::{Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env};
+use super::{
+    Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env, join_slash_path,
+};
 use crate::config::NativeAddress;
 use crate::{Result, SecretSpecError};
 use reqwest::StatusCode;
@@ -337,9 +339,7 @@ impl InfisicalProvider {
                 let secret_path = match folder {
                     "" => "/".to_string(),
                     relative if !relative.starts_with('/') => {
-                        // The prefix is `/` at the root, where a naive join
-                        // would double the separator.
-                        format!("{}/{relative}", self.config.path.trim_end_matches('/'))
+                        join_slash_path(&self.config.path, relative)
                     }
                     absolute => absolute.to_string(),
                 };

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -81,6 +81,7 @@ mod credentials;
 mod factory;
 #[macro_use]
 pub mod macros;
+mod path;
 mod preflight;
 mod registry;
 mod runtime;
@@ -105,6 +106,8 @@ pub(crate) use credentials::{ProviderCredentials, credential_or_env, credential_
 pub(crate) use factory::provider_from_spec;
 #[cfg(test)]
 pub(crate) use factory::provider_from_url;
+#[cfg(any(feature = "awssm", feature = "infisical", feature = "scaleway", test))]
+pub(crate) use path::join_slash_path;
 pub(crate) use preflight::ProviderWithPreflight;
 #[cfg(any(feature = "cli", test))]
 pub(crate) use registry::spec_provider_reads;

--- a/secretspec/src/provider/path.rs
+++ b/secretspec/src/provider/path.rs
@@ -1,0 +1,41 @@
+/// Joins two provider-native path fragments with exactly one forward slash at
+/// their boundary.
+///
+/// Only boundary slashes are normalized: leading and interior slashes keep
+/// their meaning. This is deliberately separate from [`std::path::Path`],
+/// whose platform-specific separators are wrong for remote provider paths.
+pub(crate) fn join_slash_path(left: &str, right: &str) -> String {
+    format!(
+        "{}/{}",
+        left.trim_end_matches('/'),
+        right.trim_start_matches('/')
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::join_slash_path;
+
+    #[test]
+    fn joins_with_exactly_one_boundary_slash() {
+        for (left, right, expected) in [
+            ("base", "child", "base/child"),
+            ("base/", "child", "base/child"),
+            ("base///", "//child", "base/child"),
+            ("/", "child", "/child"),
+            ("///", "/child", "/child"),
+            ("", "child", "/child"),
+            ("base", "", "base/"),
+        ] {
+            assert_eq!(join_slash_path(left, right), expected);
+        }
+    }
+
+    #[test]
+    fn preserves_slashes_away_from_the_boundary() {
+        assert_eq!(
+            join_slash_path("/base//nested/", "/child//nested/"),
+            "/base//nested/child//nested/"
+        );
+    }
+}

--- a/secretspec/src/provider/scaleway.rs
+++ b/secretspec/src/provider/scaleway.rs
@@ -38,7 +38,8 @@
 //! ```
 
 use super::{
-    Address, Provider, ProviderCredentials, ProviderUrl, credential_or_envs, preferred_env,
+    Address, Provider, ProviderCredentials, ProviderUrl, credential_or_envs, join_slash_path,
+    preferred_env,
 };
 use crate::config::NativeAddress;
 use crate::{Result, SecretSpecError};
@@ -185,10 +186,8 @@ impl ScalewayProvider {
                 )));
             }
         }
-        // `base` is already normalized ("/" or "/prefix"); trim its slash so we
-        // never emit a double slash when composing the hierarchy.
-        let base = base.trim_end_matches('/');
-        Ok(format!("{base}/secretspec/{project}/{profile}/{key}"))
+        let convention_name = format!("secretspec/{project}/{profile}/{key}");
+        Ok(join_slash_path(base, &convention_name))
     }
 
     /// Splits an absolute item path into `(secret_path, secret_name)`. The path


### PR DESCRIPTION
## Summary

- add a shared provider-native path joiner that normalizes only the slash boundary between fragments
- use it for AWS Secrets Manager convention names and the equivalent Scaleway and Infisical joins
- cover trailing, repeated, root, leading, and internal slash behavior
- document the AWSSM fix in the changelog

## Root cause and impact

The AWSSM provider appended `/secretspec/...` directly to the configured prefix. A prefix already ending in `/` therefore produced `myteam//secretspec/...`, which made reads look missing and could direct writes to a distinct secret name.

The join now guarantees exactly one boundary slash while preserving leading and internal slashes, so `?prefix=myteam` and `?prefix=myteam/` resolve to the same documented name.

## Validation

- `devenv shell cargo test -p secretspec --lib` — 1260 passed, 4 ignored
- `devenv shell prek run -a` — clippy and rustfmt passed
- `git diff --check origin/main...HEAD`

Closes #344
