### PR TITLE
docs(awssm): grant BatchGetSecretValue on "*", not a secret ARN

### DIFF
--- a/docs/src/content/docs/providers/awssm.md
+++ b/docs/src/content/docs/providers/awssm.md
@@ -48,50 +48,76 @@ AWS Secrets Manager uses the standard AWS SDK credential chain:
 
 ### Required IAM permissions
 
+For identities used only to read secrets, such as those running
+`secretspec get`, `secretspec check`, or `secretspec run`, use a read-only
+policy. Replace the example region and account ID with your own:
+
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "SecretspecSecrets",
-      "Effect": "Allow",
-      "Action": [
-        "secretsmanager:GetSecretValue",
-        "secretsmanager:CreateSecret",
-        "secretsmanager:PutSecretValue"
-      ],
-      "Resource": "arn:aws:secretsmanager:*:*:secret:secretspec/*"
-    },
-    {
       "Sid": "SecretspecBatchFetch",
       "Effect": "Allow",
       "Action": "secretsmanager:BatchGetSecretValue",
-      "Resource": "*"
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "us-east-1"
+        }
+      }
+    },
+    {
+      "Sid": "SecretspecRead",
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "arn:aws:secretsmanager:us-east-1:123456789012:secret:secretspec/*"
     }
   ]
 }
 ```
 
-If you use a prefix such as `?prefix=myteam`, adjust the resource ARN in the
-first statement:
+Identities that run `secretspec set` also need this statement in the policy's
+`Statement` array:
+
+```json
+{
+  "Sid": "SecretspecWrite",
+  "Effect": "Allow",
+  "Action": [
+    "secretsmanager:CreateSecret",
+    "secretsmanager:PutSecretValue"
+  ],
+  "Resource": "arn:aws:secretsmanager:us-east-1:123456789012:secret:secretspec/*"
+}
+```
+
+If you use a prefix such as `?prefix=myteam`, adjust the secret ARN in the read
+and write statements:
 
 ```
-arn:aws:secretsmanager:*:*:secret:myteam/secretspec/*
+arn:aws:secretsmanager:us-east-1:123456789012:secret:myteam/secretspec/*
 ```
 
 :::note
 `BatchGetSecretValue` is used automatically during `check` and `run` to fetch
 secrets in batches of 20 instead of one call each.
 
-It must be granted on `"*"`. AWS treats it as an account-level action that takes
-no resource, so a statement scoping it to a secret ARN never grants it and those
-two commands fail with `AccessDeniedException`.
+AWS Secrets Manager [does not support resource-level permissions][aws-actions]
+for `BatchGetSecretValue`, so that action must use `"Resource": "*"`. Scoping
+it to a secret ARN does not grant the permission, and the batch request fails
+with `AccessDeniedException`. The `aws:RequestedRegion` condition limits the
+wildcard statement to the configured region.
 
-Granting it on `"*"` does not widen which secrets can be read. AWS requires
-`secretsmanager:GetSecretValue` for every secret returned by a batch, and that
-permission stays scoped to the ARN above — so the first statement is still what
-decides access.
+The wildcard does not authorize access to secret contents by itself. AWS also
+requires `secretsmanager:GetSecretValue` for every secret returned by a batch,
+and that permission remains scoped to the secret ARN. SecretSpec supplies an
+explicit list of secret IDs, so the [filter-only `ListSecrets` permission][batch]
+is not required.
 :::
+
+[aws-actions]: https://docs.aws.amazon.com/service-authorization/latest/reference/list_secretsmanager.html
+[batch]: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_BatchGetSecretValue.html
 
 :::note
 Using `tag.NAME=VALUE` additionally requires `secretsmanager:TagResource`, and a

--- a/docs/src/content/docs/providers/awssm.md
+++ b/docs/src/content/docs/providers/awssm.md
@@ -53,28 +53,44 @@ AWS Secrets Manager uses the standard AWS SDK credential chain:
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "SecretspecSecrets",
       "Effect": "Allow",
       "Action": [
         "secretsmanager:GetSecretValue",
-        "secretsmanager:BatchGetSecretValue",
         "secretsmanager:CreateSecret",
         "secretsmanager:PutSecretValue"
       ],
       "Resource": "arn:aws:secretsmanager:*:*:secret:secretspec/*"
+    },
+    {
+      "Sid": "SecretspecBatchFetch",
+      "Effect": "Allow",
+      "Action": "secretsmanager:BatchGetSecretValue",
+      "Resource": "*"
     }
   ]
 }
 ```
 
-If you use a prefix such as `?prefix=myteam`, adjust the resource ARN:
+If you use a prefix such as `?prefix=myteam`, adjust the resource ARN in the
+first statement:
 
 ```
 arn:aws:secretsmanager:*:*:secret:myteam/secretspec/*
 ```
 
 :::note
-The `BatchGetSecretValue` permission is required for batch fetching, which is
-used automatically during `check` and `run` commands to reduce API calls.
+`BatchGetSecretValue` is used automatically during `check` and `run` to fetch
+secrets in batches of 20 instead of one call each.
+
+It must be granted on `"*"`. AWS treats it as an account-level action that takes
+no resource, so a statement scoping it to a secret ARN never grants it and those
+two commands fail with `AccessDeniedException`.
+
+Granting it on `"*"` does not widen which secrets can be read. AWS requires
+`secretsmanager:GetSecretValue` for every secret returned by a batch, and that
+permission stays scoped to the ARN above — so the first statement is still what
+decides access.
 :::
 
 :::note


### PR DESCRIPTION
Closes #342.

## The problem

The documented IAM policy puts `secretsmanager:BatchGetSecretValue` in a statement scoped to `arn:aws:secretsmanager:*:*:secret:secretspec/*`. AWS treats it as an account-level action that takes no resource, so a resource-scoped statement never grants it.

That isn't a corner case: `get_many()` batches through `BatchGetSecretValue` (`awssm.rs:330`, reached from `secrets.rs:2346`), and that is the path `check` and `run` resolve through. The page's own note already says batching happens automatically during those two commands. So anyone who copies the policy hits `AccessDeniedException` on the two most common commands — which is what @moltar reported.

## The change

Split into two statements: the batch action on `"*"`, everything else still scoped to the `secretspec/` prefix.

**`ListSecrets` is deliberately not added.** AWS requires it only for the filter form of the call; this provider addresses secrets with `secret_id_list` (`awssm.rs:332`), so the permission would be unnecessary privilege.

The note now explains two things, because granting anything on `"*"` rightly invites a second look:

1. Why `"*"` is required — the action takes no resource, so ARN-scoping silently grants nothing
2. Why it does not widen access — AWS requires `secretsmanager:GetSecretValue` for every secret a batch returns, and that stays scoped to the ARN, so the first statement is still what decides which secrets are readable

Sids added so the two statements are distinguishable when this gets pasted into a larger policy.

## Verification

I do not have an AWS account to run the policy against, so this rests on the AWS API reference for `BatchGetSecretValue` ("Required permissions: `secretsmanager:BatchGetSecretValue`, and you must have `secretsmanager:GetSecretValue` for each secret") plus @moltar's report of the failure. What I did verify directly is the call path in this repo — that the batch action is genuinely on the `check`/`run` path, and that `secret_id_list` rather than filters is used, which is what makes `ListSecrets` unnecessary. The policy JSON parses.

No CHANGELOG entry: `AGENTS.md` scopes that to Rust changes and this is docs-only. Happy to add one if you would rather it were recorded.