### PR TITLE
fix(provider): add Provider::supports_delete capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   treating the secret as missing or writing to a distinct double-slash name. Closes
   [#344](https://github.com/cachix/secretspec/issues/344).
 
+- `import --delete-source` no longer fails partway through, after already
+  writing the destination, for a provider that cannot delete. `check_deletable`
+  previously answered whether an address's coordinates resolve, not whether
+  the provider supports deletion at all, so a provider inheriting the default
+  `delete` (which errors) still passed preflight. A new `Provider::supports_delete`
+  capability lets `check_deletable` reject those providers up front, before the
+  copy phase runs.
+
 - Infisical secret references no longer require `?env=` in the provider URI: a
   `ref` names a folder and key but never an environment, so it now falls back to
   the profile the run resolves under. One alias can therefore serve every profile

--- a/secretspec/src/provider/age.rs
+++ b/secretspec/src/provider/age.rs
@@ -454,6 +454,10 @@ impl Provider for AgeProvider {
         Ok(true)
     }
 
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
     /// Decrypts the blob once and serves every requested key from it
     fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
         let vars = self.load()?;

--- a/secretspec/src/provider/dotenv.rs
+++ b/secretspec/src/provider/dotenv.rs
@@ -380,6 +380,10 @@ impl Provider for DotEnvProvider {
         Ok(true)
     }
 
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
     fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
         self.check_writable(addr)
     }

--- a/secretspec/src/provider/file.rs
+++ b/secretspec/src/provider/file.rs
@@ -374,6 +374,10 @@ impl Provider for FileProvider {
         Ok(true)
     }
 
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }

--- a/secretspec/src/provider/fly.rs
+++ b/secretspec/src/provider/fly.rs
@@ -332,6 +332,10 @@ impl Provider for FlyProvider {
         self.finish(output).map(|_| ())
     }
 
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
     fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
         self.secret_name(addr).map(|_| ())
     }

--- a/secretspec/src/provider/gopass.rs
+++ b/secretspec/src/provider/gopass.rs
@@ -270,6 +270,10 @@ impl Provider for GoPassProvider {
         )))
     }
 
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
     fn name(&self) -> &'static str {
         Self::PROVIDER_NAME
     }

--- a/secretspec/src/provider/keeper.rs
+++ b/secretspec/src/provider/keeper.rs
@@ -520,6 +520,10 @@ impl Provider for KeeperProvider {
         Ok(true)
     }
 
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
     fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
         if matches!(addr, Address::Native(_)) {
             return Err(SecretSpecError::ProviderOperationFailed(

--- a/secretspec/src/provider/keyring.rs
+++ b/secretspec/src/provider/keyring.rs
@@ -214,6 +214,10 @@ impl Provider for KeyringProvider {
             Err(error) => Err(error.into()),
         }
     }
+
+    fn supports_delete(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/secretspec/src/provider/openbao.rs
+++ b/secretspec/src/provider/openbao.rs
@@ -194,6 +194,10 @@ impl Provider for OpenBaoProvider {
         self.core.delete(&coords)
     }
 
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
     fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
         self.core.check_deletable(addr)
     }

--- a/secretspec/src/provider/pass.rs
+++ b/secretspec/src/provider/pass.rs
@@ -317,6 +317,10 @@ impl Provider for PassProvider {
             "pass command failed: {stderr}"
         )))
     }
+
+    fn supports_delete(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/secretspec/src/provider/preflight.rs
+++ b/secretspec/src/provider/preflight.rs
@@ -163,6 +163,10 @@ impl Provider for PreflightGuard {
         self.inner.delete(addr)
     }
 
+    fn supports_delete(&self) -> bool {
+        self.inner.supports_delete()
+    }
+
     fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
         self.inner.check_deletable(addr)
     }

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -2231,3 +2231,97 @@ fn file_write_read_symmetry() {
 fn mock_provider_write_read_symmetry() {
     assert_write_read_symmetry(&MockProvider::new());
 }
+
+/// A provider that opts into deletion, as the real ones do.
+struct DeletingProvider;
+
+impl Provider for DeletingProvider {
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: format!("{}/{}/{}", project, profile, key),
+            ..Default::default()
+        })
+    }
+
+    fn get(&self, _addr: Address<'_>) -> Result<Option<SecretString>> {
+        Ok(None)
+    }
+
+    fn set(&self, _addr: Address<'_>, _value: &SecretString) -> Result<()> {
+        Ok(())
+    }
+
+    fn delete(&self, _addr: Address<'_>) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "deleting"
+    }
+
+    fn uri(&self) -> String {
+        "deleting://".to_string()
+    }
+}
+
+#[test]
+fn check_deletable_refuses_a_provider_that_cannot_delete() {
+    // The regression. `CountingProvider` inherits the default `delete`, which
+    // errors, so the preflight must refuse it. Previously the default
+    // `check_deletable` only resolved coordinates and returned Ok, so every
+    // such provider passed preflight and failed later in the deletion phase --
+    // after `import --delete-source` had already written the destination.
+    let provider = CountingProvider::new(&[]);
+    let addr = Address::convention("proj", "default", "API_KEY");
+
+    let err = provider
+        .check_deletable(addr)
+        .expect_err("a provider without delete must not pass the deletion preflight");
+
+    assert!(
+        err.to_string()
+            .contains("does not support deleting secrets"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn check_deletable_and_delete_refuse_with_the_same_reason() {
+    // The preflight's promise is that it predicts the operation. If the two
+    // disagreed, the preflight would be reporting on something else.
+    let provider = CountingProvider::new(&[]);
+    let addr = Address::convention("proj", "default", "API_KEY");
+
+    let preflight = provider.check_deletable(addr).unwrap_err().to_string();
+    let attempted = provider.delete(addr).unwrap_err().to_string();
+
+    assert_eq!(preflight, attempted);
+}
+
+#[test]
+fn check_deletable_admits_a_provider_that_opts_in() {
+    // Control: the guard rejects on capability, not unconditionally.
+    let provider = DeletingProvider;
+    let addr = Address::convention("proj", "default", "API_KEY");
+
+    provider
+        .check_deletable(addr)
+        .expect("a provider that implements delete must pass preflight");
+}
+
+#[test]
+fn providers_do_not_support_deletion_unless_they_say_so() {
+    // `supports_delete` defaults to false in lockstep with `delete`, so adding
+    // the method cannot silently make destructive behaviour available.
+    assert!(!CountingProvider::new(&[]).supports_delete());
+    assert!(DeletingProvider.supports_delete());
+}

--- a/secretspec/src/provider/traits.rs
+++ b/secretspec/src/provider/traits.rs
@@ -195,10 +195,33 @@ pub trait Provider: Send + Sync {
     /// addresses they merely asked about.
     fn delete(&self, addr: Address<'_>) -> Result<bool> {
         let _ = addr;
-        Err(SecretSpecError::ProviderOperationFailed(format!(
+        Err(self.deletion_unsupported())
+    }
+
+    /// Whether this provider implements [`delete`](Provider::delete) at all.
+    ///
+    /// Defaults to `false`, matching the default `delete`. A provider that
+    /// overrides `delete` must override this too, so that
+    /// [`check_deletable`](Provider::check_deletable) can answer the coarse
+    /// question — *can this provider delete anything?* — without performing a
+    /// deletion to find out.
+    ///
+    /// This is deliberately separate from `check_deletable`: that method
+    /// answers whether one specific address is deletable, which a provider may
+    /// refuse for reasons of its own, while this one reports a static property
+    /// of the implementation.
+    fn supports_delete(&self) -> bool {
+        false
+    }
+
+    /// The error both `delete` and `check_deletable` report for a provider that
+    /// cannot delete. Shared so the preflight and the operation cannot disagree
+    /// about the reason.
+    fn deletion_unsupported(&self) -> SecretSpecError {
+        SecretSpecError::ProviderOperationFailed(format!(
             "provider '{}' does not support deleting secrets",
             self.name()
-        )))
+        ))
     }
 
     /// Reports whether this provider can delete `addr`, without changing the
@@ -209,7 +232,18 @@ pub trait Provider: Send + Sync {
     /// source entries have already been removed. Providers with deletion
     /// policies beyond coordinate support must override this method and have
     /// [`delete`](Provider::delete) enforce the same policy.
+    ///
+    /// The default first rejects providers that cannot delete at all. Without
+    /// that, every provider inheriting the default `delete` — which errors —
+    /// still passed preflight, because resolving coordinates says nothing about
+    /// whether the store can be written to. `import --delete-source` then
+    /// aborted in its deletion phase, after the copy phase had already mutated
+    /// the destination, which is the late discovery this method exists to
+    /// prevent.
     fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        if !self.supports_delete() {
+            return Err(self.deletion_unsupported());
+        }
         self.resolve_coords(addr).map(|_| ())
     }
 
@@ -682,6 +716,9 @@ impl<T: Provider> Provider for std::sync::Arc<T> {
     }
     fn delete(&self, addr: Address<'_>) -> Result<bool> {
         (**self).delete(addr)
+    }
+    fn supports_delete(&self) -> bool {
+        (**self).supports_delete()
     }
     fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
         (**self).check_deletable(addr)

--- a/secretspec/src/provider/vault.rs
+++ b/secretspec/src/provider/vault.rs
@@ -182,6 +182,10 @@ impl Provider for VaultProvider {
         self.core.delete(&coords)
     }
 
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
     fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
         self.core.check_deletable(addr)
     }


### PR DESCRIPTION
## Summary

`check_deletable` only resolved an address's coordinates and returned `Ok`,
saying nothing about whether the provider implements `delete` at all. Every
provider inheriting the default `delete` (which errors) still passed the
deletion preflight, so `import --delete-source` could write the destination
during its copy phase and only then discover, in its deletion phase, that the
source provider cannot delete — after the copy had already happened.

This adds `Provider::supports_delete`, defaulting to `false` in lockstep with
the default `delete`, and overrides it `true` on the ten providers that
already override `delete` (age, dotenv, file, fly, gopass, keeper, keyring,
openbao, pass, vault). `check_deletable`'s default now rejects a provider that
answers `false` before resolving coordinates, sharing the exact error message
`delete` itself returns (`deletion_unsupported`), so preflight and the
operation cannot disagree about the reason.

## Why now

`delete` (#237) and per-provider `check_deletable` overrides (dotenv, fly,
keeper, openbao/vault via `vault_common`) already exist and correctly gate on
provider-specific policy. But the ~19 providers that implement neither
`delete` nor `check_deletable` — akv, awsps, awssm, bw, bws, dashlane, env,
gcsm, infisical, kdbx, lastpass, null, onepassword, passbolt, path,
protonpass, scaleway, sops, systemd_credential — inherit only the coordinate
check, which says nothing about capability. #245 raised a related but
separate concern (orphan-secret cleanup, which needs state tracking); this is
narrower and fixes a real preflight bug independent of that discussion.

## Validation

- `cargo test --package secretspec --all-features provider::` — 724 passed
  (pre-existing sops-CLI-not-installed failures unrelated, same on `main`)
- `cargo fmt --all -- --check`
- `cargo clippy -p secretspec --no-default-features --features cli -- -D
  warnings` — 3 pre-existing failures in `config.rs`/`secrets.rs`, unrelated
  to this change and present on `main` before it too
