### PR TITLE
feat(codegen): emit description in JSON Schema properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   software, version, operation, and non-secret resource independently of the
   user-supplied access reason. Audit records and providers receive the context,
   but it never satisfies the `require_reason` policy.
+- A secret's declared `description` now reaches the generated JSON Schema as
+  a `description` key on its property. [quicktype](https://quicktype.io)
+  turns that into a native docstring in every target language, so SDKs
+  generated from a manifest carry the same descriptions the manifest already
+  declares, instead of losing them at the schema boundary.
 - The Fly.io `fly` provider publishes and deletes application secrets with
   `secretspec set` and `secretspec delete`, and discovers their names with
   `init --from`. Fly.io never exposes plaintext secret values, so the provider

--- a/secretspec/src/codegen.rs
+++ b/secretspec/src/codegen.rs
@@ -188,11 +188,21 @@ pub mod schema {
     fn property_type(field: &IrField) -> Value {
         // Every secret is a string; optional secrets are nullable. `as_path`
         // secrets are also strings (the file path), so they need no special type.
-        if field.optional {
+        let mut property = if field.optional {
             json!({ "type": ["string", "null"] })
         } else {
             json!({ "type": "string" })
+        };
+        if let Some(description) = &field.description {
+            property
+                .as_object_mut()
+                .expect("property_type always builds a JSON object")
+                .insert(
+                    "description".to_string(),
+                    Value::String(description.clone()),
+                );
         }
+        property
     }
 
     fn object_schema(title: &str, fields: &[IrField], additional_properties: bool) -> Value {
@@ -546,6 +556,33 @@ mod tests {
 
         // An unknown profile is an error.
         assert!(schema::emit(&ir, Some("nope")).is_err());
+    }
+
+    #[test]
+    fn schema_emits_description_when_declared() {
+        // quicktype turns a JSON Schema "description" into a native docstring
+        // in every target language, so a declared description should reach the
+        // generated schema even though it plays no role in the type itself.
+        let ir = build_ir(&config_with(vec![(
+            "default",
+            vec![
+                (
+                    "DATABASE_URL",
+                    secret(Some(true), None, Some("Postgres connection string")),
+                ),
+                ("API_KEY", secret(Some(true), None, None)),
+            ],
+        )]));
+
+        let union: serde_json::Value =
+            serde_json::from_str(&schema::emit(&ir, None).unwrap()).unwrap();
+        assert_eq!(
+            union["properties"]["DATABASE_URL"]["description"],
+            "Postgres connection string"
+        );
+        // A field without a declared description carries no key at all, rather
+        // than an empty or null one.
+        assert!(union["properties"]["API_KEY"].get("description").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`property_type` in `codegen.rs::schema` only emitted a property's `type`,
even though the IR already carries each field's `description` — populated
from the manifest by `build_union` and `build_profile_fields`. That
description never reached the generated JSON Schema.

[quicktype](https://quicktype.io) turns a JSON Schema `description` into a
native docstring in every target language, so this was a silent gap between
what a manifest declares and what an SDK type generated from it documents.

## Change

`property_type` now inserts a `description` key when the field has one, and
omits it entirely otherwise (rather than emitting an empty or null value).

## Validation

- `cargo test --package secretspec --all-features codegen::` — 11 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p secretspec --no-default-features --features cli -- -D
  warnings` — no new warnings in `codegen.rs` (3 pre-existing failures
  elsewhere, present on `main` before this change too)
