### PR TITLE
feat(cli): declare secret requiredness at add time, extracting manifest_edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Provider behavior, configuration, and supported URIs remain unchanged after
   reorganizing the shared provider infrastructure into focused modules.
+- `add_secret_to_manifest` moved from the `cli` module into a new
+  `manifest_edit` module, gated by its own `manifest-edit` feature (which
+  `cli` still enables). Behavior is unchanged; a caller that only needs to
+  add a secret declaration can now take that feature alone, without the
+  CLI's shell-completion tooling.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `secretspec add` takes `--optional` and `--required`, writing
+  `required = false` or `required = true` on the new declaration. Omitting both
+  writes no `required` key, exactly as before, leaving the secret to inherit
+  `[defaults] required` from its profile. Previously there was no flag at all,
+  so a secret only some environments need had no CLI path to being optional
+  short of editing the manifest by hand — and in a profile whose defaults set
+  `required = false`, no path to being required either. The two flags are
+  mutually exclusive.
 - Structured caller context lets CLI and SDK integrations identify the invoking
   software, version, operation, and non-secret resource independently of the
   user-supplied access reason. Audit records and providers receive the context,

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -351,11 +351,13 @@ TypeScript `Convert.toSecretSpec(resolved.fieldsJson())`, Ruby
 
 Add a secret declaration to an existing `secretspec.toml`. This edits only the
 selected profile and preserves the manifest's comments, formatting, and
-unrelated tables. The new declaration follows the profile's defaults; without
-a `required` profile default, it is required like any other declaration.
+unrelated tables. By default the declaration carries no `required` key at all,
+so it inherits the profile's `[defaults] required` — which is itself required
+unless the profile says otherwise.
 
 ```bash
 $ secretspec add <NAME> [--description <DESCRIPTION>] [--profile <PROFILE>] # 0.18+
+$ secretspec add <NAME> [--description <DESCRIPTION>] [--optional | --required] # 0.20+
 ```
 
 **Arguments and options:**
@@ -367,6 +369,17 @@ $ secretspec add <NAME> [--description <DESCRIPTION>] [--profile <PROFILE>] # 0.
 - `-P, --profile <PROFILE>` - Profile to edit. When omitted, SecretSpec uses the
   normal active-profile resolution, including `SECRETSPEC_PROFILE` and the
   user-global default.
+- `--optional` (0.20+) - Write `required = false`, overriding a profile default
+  of `required = true`. `check` then does not fail *because this secret is
+  unset* — it can still fail for another secret.
+- `--required` (0.20+) - Write `required = true`. Only needed in a profile
+  whose `[defaults]` set `required = false`, where omitting both flags would
+  otherwise inherit optional. Cannot be combined with `--optional`.
+
+Omitting both flags writes exactly what `add` wrote before 0.20. There is no
+flag for the `at_least_one`/`exactly_one` presence-group form of `required`:
+that spans several secrets at once and doesn't fit a single-secret `add`, so
+edit the manifest directly for it.
 
 ```bash
 $ secretspec add API_KEY --description "API access token" # 0.18+

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -60,7 +60,11 @@ age = { workspace = true, optional = true }
 
 [features]
 default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "infisical", "bw", "age", "scaleway", "sops"]
-cli = ["dep:toml_edit", "dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable"]
+cli = ["manifest-edit", "dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable"]
+# Pure manifest declaration edits (`add_secret_to_manifest`), split out so a
+# caller can perform them without the CLI-only tooling `cli` also pulls in
+# (shell-completion generation via clap_complete/is_executable).
+manifest-edit = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
 keeper = ["dep:keeper-secrets-manager-core"]

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -567,28 +567,9 @@ fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
     Ok(doc.to_string())
 }
 
-/// Rejects names that cannot occupy a flattened secret key in [`Profile`].
-fn validate_add_secret_name(name: &str) -> Result<()> {
-    if !crate::config::is_valid_identifier(name) {
-        return Err(miette!(
-            "Invalid secret name '{}': must be a valid identifier (alphanumeric and underscores, not starting with a number)",
-            name
-        ));
-    }
-    // `Profile` reserves this key for its defaults table before flattening all
-    // remaining keys into secret declarations. Without an explicit check, the
-    // edit would be valid TOML but would not actually declare a secret.
-    if name == "defaults" {
-        return Err(miette!(
-            "Secret name 'defaults' is reserved for profile defaults"
-        ));
-    }
-    Ok(())
-}
-
 /// Ensures `add` will create a new effective declaration in an existing profile.
 fn validate_add_target(app: &Secrets, profile: &str, name: &str) -> Result<()> {
-    validate_add_secret_name(name)?;
+    crate::manifest_edit::validate_add_secret_name(name)?;
 
     if !app.config().profiles.contains_key(profile) {
         let mut available: Vec<&str> = app.config().profiles.keys().map(String::as_str).collect();
@@ -608,57 +589,6 @@ fn validate_add_target(app: &Secrets, profile: &str, name: &str) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Adds one secret to a manifest document without re-serializing the rest.
-///
-/// `toml_edit` retains the user's comments, whitespace, ordering, and any syntax
-/// that is not represented by [`Config`]. The caller validates the selected
-/// profile against the fully loaded configuration first; this helper creates a
-/// local profile table when that profile currently comes only from `extends`.
-fn add_secret_to_manifest(
-    source: &str,
-    profile: &str,
-    name: &str,
-    description: &str,
-) -> Result<String> {
-    use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
-
-    validate_add_secret_name(name)?;
-    if description.trim().is_empty() {
-        return Err(miette!("Secret description cannot be empty"));
-    }
-
-    let mut doc = source
-        .parse::<DocumentMut>()
-        .into_diagnostic()
-        .wrap_err("Failed to parse secretspec.toml for editing")?;
-    let profiles = doc
-        .get_mut("profiles")
-        .and_then(Item::as_table_like_mut)
-        .ok_or_else(|| miette!("secretspec.toml does not contain a [profiles] table"))?;
-
-    if !profiles.contains_key(profile) {
-        profiles.insert(profile, Item::Table(Table::new()));
-    }
-    let profile_table = profiles
-        .get_mut(profile)
-        .and_then(Item::as_table_like_mut)
-        .ok_or_else(|| miette!("Profile '{}' is not a TOML table", profile))?;
-
-    if profile_table.contains_key(name) {
-        return Err(miette!(
-            "Secret '{}' is already declared in profile '{}'",
-            name,
-            profile
-        ));
-    }
-
-    let mut secret = InlineTable::new();
-    secret.insert("description", Value::from(description));
-    profile_table.insert(name, toml_edit::value(secret));
-
-    Ok(doc.to_string())
 }
 
 /// Replaces an existing manifest only after its complete replacement has been
@@ -1063,7 +993,12 @@ pub fn main() -> Result<()> {
             let source = fs::read_to_string(&manifest_path)
                 .into_diagnostic()
                 .wrap_err_with(|| format!("Failed to read {}", manifest_path.display()))?;
-            let updated = add_secret_to_manifest(&source, &profile, &name, description)?;
+            let updated = crate::manifest_edit::add_secret_to_manifest(
+                &source,
+                &profile,
+                &name,
+                description,
+            )?;
             write_manifest_atomically(&manifest_path, &updated)?;
 
             println!(
@@ -2287,57 +2222,6 @@ mod tests {
     }
 
     #[test]
-    fn add_secret_to_manifest_preserves_comments_and_other_tables() {
-        let source = r#"# Project documentation
-[project]
-name = "demo"
-revision = "1.0"
-
-[profiles.default]
-# Keep this explanation attached to the existing secret.
-DATABASE_URL = { description = "Database connection string" }
-
-[providers]
-local = "dotenv://.env"
-"#;
-
-        let updated =
-            add_secret_to_manifest(source, "default", "API_KEY", "API access token").unwrap();
-
-        assert!(updated.contains("# Project documentation"));
-        assert!(updated.contains("# Keep this explanation attached to the existing secret."));
-        assert!(updated.contains("local = \"dotenv://.env\""));
-        assert!(updated.contains("API_KEY = { description = \"API access token\" }"));
-
-        let config: Config = toml::from_str(&updated).expect("edited manifest must parse");
-        config.validate().expect("edited manifest must validate");
-        assert_eq!(
-            config.profiles["default"].secrets["API_KEY"]
-                .description
-                .as_deref(),
-            Some("API access token")
-        );
-    }
-
-    #[test]
-    fn add_secret_to_manifest_can_overlay_an_inherited_profile() {
-        let source = r#"[project]
-name = "demo"
-revision = "1.0"
-extends = ["../shared"]
-
-[profiles.default]
-LOCAL = { description = "Local secret" }
-"#;
-
-        let updated =
-            add_secret_to_manifest(source, "production", "API_KEY", "API access token").unwrap();
-
-        assert!(updated.contains("[profiles.production]"));
-        assert!(updated.contains("API_KEY = { description = \"API access token\" }"));
-    }
-
-    #[test]
     fn add_target_rejects_inherited_secrets_and_unknown_profiles() {
         let config: Config = toml::from_str(
             r#"[project]
@@ -2364,33 +2248,6 @@ API_KEY = { description = "API access token" }
         assert!(unknown.contains("Available profiles: default, development"));
 
         validate_add_target(&app, "development", "NEW_KEY").unwrap();
-    }
-
-    #[test]
-    fn add_secret_to_manifest_rejects_invalid_or_duplicate_declarations() {
-        let source = r#"[profiles.default]
-API_KEY = { description = "Existing" }
-"#;
-
-        let invalid = add_secret_to_manifest(source, "default", "1BAD", "Description")
-            .unwrap_err()
-            .to_string();
-        assert!(invalid.contains("Invalid secret name"));
-
-        let reserved = add_secret_to_manifest(source, "default", "defaults", "Description")
-            .unwrap_err()
-            .to_string();
-        assert!(reserved.contains("reserved for profile defaults"));
-
-        let duplicate = add_secret_to_manifest(source, "default", "API_KEY", "Description")
-            .unwrap_err()
-            .to_string();
-        assert!(duplicate.contains("already declared"));
-
-        let empty = add_secret_to_manifest(source, "default", "NEW_KEY", "   ")
-            .unwrap_err()
-            .to_string();
-        assert!(empty.contains("description cannot be empty"));
     }
 
     #[test]

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -101,6 +101,13 @@ enum Commands {
         /// Profile to add the secret to
         #[arg(short = 'P', long, env = "SECRETSPEC_PROFILE", add = clap_complete::ArgValueCompleter::new(completion::profiles))]
         profile: Option<String>,
+        /// Declare the secret optional, writing `required = false` (0.20+)
+        #[arg(long, conflicts_with = "required")]
+        optional: bool,
+        /// Declare the secret required, writing `required = true`. Only needed
+        /// in a profile whose `[defaults]` set `required = false` (0.20+)
+        #[arg(long)]
+        required: bool,
     },
     /// Set a secret value
     Set {
@@ -970,7 +977,17 @@ pub fn main() -> Result<()> {
             name,
             description,
             profile,
+            optional,
+            required,
         } => {
+            // Tri-state: neither flag omits the key entirely, leaving the
+            // secret to inherit `[defaults] required` from its profile. clap
+            // guarantees the two are never both set.
+            let requiredness = match (optional, required) {
+                (true, _) => Some(false),
+                (_, true) => Some(true),
+                _ => None,
+            };
             let app = load_secrets(&cli.file, &cli.reason, &caller)?;
             let profile = app.resolve_profile_name(profile.as_deref());
             validate_add_target(&app, &profile, &name)?;
@@ -998,6 +1015,7 @@ pub fn main() -> Result<()> {
                 &profile,
                 &name,
                 description,
+                requiredness,
             )?;
             write_manifest_atomically(&manifest_path, &updated)?;
 
@@ -2212,13 +2230,71 @@ mod tests {
                 name,
                 description,
                 profile,
+                optional,
+                required,
             } => {
                 assert_eq!(name, "API_KEY");
                 assert_eq!(description.as_deref(), Some("API access token"));
                 assert_eq!(profile.as_deref(), Some("production"));
+                assert!(!optional);
+                assert!(!required);
             }
             _ => panic!("expected Add command"),
         }
+    }
+
+    #[test]
+    fn add_parses_each_requiredness_flag() {
+        let parse = |flag: &str| {
+            Cli::try_parse_from([
+                "secretspec",
+                "add",
+                "API_KEY",
+                "--description",
+                "API access token",
+                flag,
+            ])
+            .unwrap()
+            .command
+        };
+
+        match parse("--optional") {
+            Commands::Add {
+                optional, required, ..
+            } => {
+                assert!(optional);
+                assert!(!required);
+            }
+            _ => panic!("expected Add command"),
+        }
+
+        match parse("--required") {
+            Commands::Add {
+                optional, required, ..
+            } => {
+                assert!(!optional);
+                assert!(required);
+            }
+            _ => panic!("expected Add command"),
+        }
+    }
+
+    #[test]
+    fn add_rejects_both_requiredness_flags_at_once() {
+        // They map to one tri-state, so accepting both would force the handler
+        // to silently pick a winner.
+        assert!(
+            Cli::try_parse_from([
+                "secretspec",
+                "add",
+                "API_KEY",
+                "--description",
+                "API access token",
+                "--optional",
+                "--required",
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -62,6 +62,11 @@ pub(crate) mod provider;
 #[cfg(feature = "cli")]
 pub mod cli;
 
+// Manifest declaration edits, split out so a caller can perform them without
+// the CLI-only shell-completion tooling `cli` also pulls in.
+#[cfg(feature = "manifest-edit")]
+pub mod manifest_edit;
+
 // Re-export only the types needed by users and generated code
 pub use caller::CallerContext;
 pub use config::Resolved;

--- a/secretspec/src/manifest_edit.rs
+++ b/secretspec/src/manifest_edit.rs
@@ -1,0 +1,169 @@
+//! Declaration edits to a `secretspec.toml` source string.
+//!
+//! Split out of the `cli` module so a caller can perform the edit without
+//! the CLI-only shell-completion tooling `cli` also pulls in
+//! (`clap_complete`, `clap_complete_nushell`, `is_executable`). `cli` still
+//! depends on this module — nothing about its behavior changes — but a
+//! caller that only needs to add a secret declaration can take
+//! `manifest-edit` alone.
+//!
+//! Everything here is pure — it takes manifest text and returns manifest
+//! text. Writing is the caller's problem, deliberately: different callers
+//! have different write strategies (the CLI replaces its manifest atomically
+//! via a temporary file).
+
+use miette::{IntoDiagnostic, Result, WrapErr, miette};
+
+/// Rejects names that cannot occupy a flattened secret key in [`crate::Profile`].
+pub(crate) fn validate_add_secret_name(name: &str) -> Result<()> {
+    if !crate::config::is_valid_identifier(name) {
+        return Err(miette!(
+            "Invalid secret name '{}': must be a valid identifier (alphanumeric and underscores, not starting with a number)",
+            name
+        ));
+    }
+    // `Profile` reserves this key for its defaults table before flattening all
+    // remaining keys into secret declarations. Without an explicit check, the
+    // edit would be valid TOML but would not actually declare a secret.
+    if name == "defaults" {
+        return Err(miette!(
+            "Secret name 'defaults' is reserved for profile defaults"
+        ));
+    }
+    Ok(())
+}
+
+/// Adds one secret to a manifest document without re-serializing the rest.
+///
+/// `toml_edit` retains the user's comments, whitespace, ordering, and any syntax
+/// that is not represented by [`crate::Config`]. The caller validates the selected
+/// profile against the fully loaded configuration first; this helper creates a
+/// local profile table when that profile currently comes only from `extends`.
+pub fn add_secret_to_manifest(
+    source: &str,
+    profile: &str,
+    name: &str,
+    description: &str,
+) -> Result<String> {
+    use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
+
+    validate_add_secret_name(name)?;
+    if description.trim().is_empty() {
+        return Err(miette!("Secret description cannot be empty"));
+    }
+
+    let mut doc = source
+        .parse::<DocumentMut>()
+        .into_diagnostic()
+        .wrap_err("Failed to parse secretspec.toml for editing")?;
+    let profiles = doc
+        .get_mut("profiles")
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| miette!("secretspec.toml does not contain a [profiles] table"))?;
+
+    if !profiles.contains_key(profile) {
+        profiles.insert(profile, Item::Table(Table::new()));
+    }
+    let profile_table = profiles
+        .get_mut(profile)
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| miette!("Profile '{}' is not a TOML table", profile))?;
+
+    if profile_table.contains_key(name) {
+        return Err(miette!(
+            "Secret '{}' is already declared in profile '{}'",
+            name,
+            profile
+        ));
+    }
+
+    let mut secret = InlineTable::new();
+    secret.insert("description", Value::from(description));
+    profile_table.insert(name, toml_edit::value(secret));
+
+    Ok(doc.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Config;
+
+    #[test]
+    fn add_secret_to_manifest_preserves_comments_and_other_tables() {
+        let source = r#"# Project documentation
+[project]
+name = "demo"
+revision = "1.0"
+
+[profiles.default]
+# Keep this explanation attached to the existing secret.
+DATABASE_URL = { description = "Database connection string" }
+
+[providers]
+local = "dotenv://.env"
+"#;
+
+        let updated =
+            add_secret_to_manifest(source, "default", "API_KEY", "API access token").unwrap();
+
+        assert!(updated.contains("# Project documentation"));
+        assert!(updated.contains("# Keep this explanation attached to the existing secret."));
+        assert!(updated.contains("local = \"dotenv://.env\""));
+        assert!(updated.contains("API_KEY = { description = \"API access token\" }"));
+
+        let config: Config = toml::from_str(&updated).expect("edited manifest must parse");
+        config.validate().expect("edited manifest must validate");
+        assert_eq!(
+            config.profiles["default"].secrets["API_KEY"]
+                .description
+                .as_deref(),
+            Some("API access token")
+        );
+    }
+
+    #[test]
+    fn add_secret_to_manifest_can_overlay_an_inherited_profile() {
+        let source = r#"[project]
+name = "demo"
+revision = "1.0"
+extends = ["../shared"]
+
+[profiles.default]
+LOCAL = { description = "Local secret" }
+"#;
+
+        let updated =
+            add_secret_to_manifest(source, "production", "API_KEY", "API access token").unwrap();
+
+        assert!(updated.contains("[profiles.production]"));
+        assert!(updated.contains("API_KEY = { description = \"API access token\" }"));
+    }
+
+    #[test]
+    fn add_secret_to_manifest_rejects_invalid_or_duplicate_declarations() {
+        let source = r#"[profiles.default]
+API_KEY = { description = "Existing" }
+"#;
+
+        let invalid = add_secret_to_manifest(source, "default", "1BAD", "Description")
+            .unwrap_err()
+            .to_string();
+        assert!(invalid.contains("Invalid secret name"));
+
+        let reserved = add_secret_to_manifest(source, "default", "defaults", "Description")
+            .unwrap_err()
+            .to_string();
+        assert!(reserved.contains("reserved for profile defaults"));
+
+        let duplicate = add_secret_to_manifest(source, "default", "API_KEY", "Description")
+            .unwrap_err()
+            .to_string();
+        assert!(duplicate.contains("already declared"));
+
+        let empty = add_secret_to_manifest(source, "default", "NEW_KEY", "   ")
+            .unwrap_err()
+            .to_string();
+        assert!(empty.contains("description cannot be empty"));
+    }
+}

--- a/secretspec/src/manifest_edit.rs
+++ b/secretspec/src/manifest_edit.rs
@@ -39,11 +39,25 @@ pub(crate) fn validate_add_secret_name(name: &str) -> Result<()> {
 /// that is not represented by [`crate::Config`]. The caller validates the selected
 /// profile against the fully loaded configuration first; this helper creates a
 /// local profile table when that profile currently comes only from `extends`.
+///
+/// `required` is tri-state, and the third state is why it is not a plain
+/// `bool`. `None` writes no `required` key, leaving the secret to inherit
+/// `[defaults] required` from its profile. `Some(v)` writes `required = v`
+/// explicitly, the same shape `secretspec init`'s generator emits.
+///
+/// Treating an omitted flag as "required" would be wrong: a profile carrying
+/// `defaults = { required = false }` makes an omitted key resolve to
+/// *optional*, so without an explicit `Some(true)` there would be no way to
+/// declare a required secret in such a profile at all.
+///
+/// A presence group (`at_least_one`/`exactly_one`) is out of scope here: it
+/// spans several secrets at once and does not fit a single-secret declaration.
 pub fn add_secret_to_manifest(
     source: &str,
     profile: &str,
     name: &str,
     description: &str,
+    required: Option<bool>,
 ) -> Result<String> {
     use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
 
@@ -79,6 +93,9 @@ pub fn add_secret_to_manifest(
 
     let mut secret = InlineTable::new();
     secret.insert("description", Value::from(description));
+    if let Some(required) = required {
+        secret.insert("required", Value::from(required));
+    }
     profile_table.insert(name, toml_edit::value(secret));
 
     Ok(doc.to_string())
@@ -105,7 +122,7 @@ local = "dotenv://.env"
 "#;
 
         let updated =
-            add_secret_to_manifest(source, "default", "API_KEY", "API access token").unwrap();
+            add_secret_to_manifest(source, "default", "API_KEY", "API access token", None).unwrap();
 
         assert!(updated.contains("# Project documentation"));
         assert!(updated.contains("# Keep this explanation attached to the existing secret."));
@@ -134,7 +151,8 @@ LOCAL = { description = "Local secret" }
 "#;
 
         let updated =
-            add_secret_to_manifest(source, "production", "API_KEY", "API access token").unwrap();
+            add_secret_to_manifest(source, "production", "API_KEY", "API access token", None)
+                .unwrap();
 
         assert!(updated.contains("[profiles.production]"));
         assert!(updated.contains("API_KEY = { description = \"API access token\" }"));
@@ -146,24 +164,111 @@ LOCAL = { description = "Local secret" }
 API_KEY = { description = "Existing" }
 "#;
 
-        let invalid = add_secret_to_manifest(source, "default", "1BAD", "Description")
+        let invalid = add_secret_to_manifest(source, "default", "1BAD", "Description", None)
             .unwrap_err()
             .to_string();
         assert!(invalid.contains("Invalid secret name"));
 
-        let reserved = add_secret_to_manifest(source, "default", "defaults", "Description")
+        let reserved = add_secret_to_manifest(source, "default", "defaults", "Description", None)
             .unwrap_err()
             .to_string();
         assert!(reserved.contains("reserved for profile defaults"));
 
-        let duplicate = add_secret_to_manifest(source, "default", "API_KEY", "Description")
+        let duplicate = add_secret_to_manifest(source, "default", "API_KEY", "Description", None)
             .unwrap_err()
             .to_string();
         assert!(duplicate.contains("already declared"));
 
-        let empty = add_secret_to_manifest(source, "default", "NEW_KEY", "   ")
+        let empty = add_secret_to_manifest(source, "default", "NEW_KEY", "   ", None)
             .unwrap_err()
             .to_string();
         assert!(empty.contains("description cannot be empty"));
+    }
+
+    const MANIFEST: &str = r#"[project]
+name = "demo"
+revision = "1.0"
+
+[profiles.default]
+EXISTING = { description = "already here" }
+"#;
+
+    #[test]
+    fn add_secret_to_manifest_omits_required_when_unspecified() {
+        // Asserted on the emitted declaration rather than the whole document:
+        // a document-wide `contains("required")` would also be satisfied, or
+        // broken, by any sibling or comment carrying that word.
+        let added = add_secret_to_manifest(MANIFEST, "default", "SCRATCH", "temp", None).unwrap();
+        assert!(added.contains("SCRATCH = { description = \"temp\" }"));
+    }
+
+    #[test]
+    fn add_secret_to_manifest_writes_the_requiredness_it_is_given() {
+        let optional =
+            add_secret_to_manifest(MANIFEST, "default", "SCRATCH", "temp", Some(false)).unwrap();
+        assert!(optional.contains("SCRATCH = { description = \"temp\", required = false }"));
+
+        let required =
+            add_secret_to_manifest(MANIFEST, "default", "SCRATCH", "temp", Some(true)).unwrap();
+        assert!(required.contains("SCRATCH = { description = \"temp\", required = true }"));
+    }
+
+    #[test]
+    fn an_explicit_requiredness_survives_into_the_loaded_config() {
+        // The product claim, asserted through the config model rather than the
+        // emitted text: `check` fails on a required-but-unset secret and
+        // passes on an optional-but-unset one, so the written bytes have to
+        // load as a secret carrying that requiredness.
+        for requiredness in [Some(true), Some(false)] {
+            let added =
+                add_secret_to_manifest(MANIFEST, "default", "SCRATCH", "temp", requiredness)
+                    .unwrap();
+            let config: Config = toml::from_str(&added).expect("edited manifest must parse");
+            config.validate().expect("edited manifest must validate");
+
+            assert_eq!(
+                config.profiles["default"].secrets["SCRATCH"].required,
+                requiredness
+            );
+        }
+    }
+
+    #[test]
+    fn an_explicit_requiredness_leaves_richer_documents_untouched() {
+        // The fixtures above are inline-table-only. toml_edit is likeliest to
+        // reserialize a document that mixes shapes, so the "touches nothing
+        // else" claim is worth proving against one that does: a `required`
+        // *table* (presence group), a full `[profiles.x.y]` table, and a
+        // quoted dotted key.
+        let manifest = r#"[project]
+name = "demo"
+revision = "1.0"
+
+[profiles.default]
+GROUPED = { description = "in a group", required = { at_least_one = "auth" } }
+"dotted.name" = { description = "quoted key" }
+
+[profiles.default.NESTED]
+description = "declared as a full table"
+required = false
+"#;
+
+        for requiredness in [None, Some(true), Some(false)] {
+            let added =
+                add_secret_to_manifest(manifest, "default", "SCRATCH", "temp", requiredness)
+                    .unwrap();
+
+            for untouched in [
+                r#"GROUPED = { description = "in a group", required = { at_least_one = "auth" } }"#,
+                r#""dotted.name" = { description = "quoted key" }"#,
+                "[profiles.default.NESTED]",
+                r#"description = "declared as a full table""#,
+            ] {
+                assert!(
+                    added.contains(untouched),
+                    "{requiredness:?} lost: {untouched}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

`secretspec add` could only ever write a declaration that inherits
`[defaults] required` from its profile — it emits a `description` key and
nothing else. A secret that only some environments need had no CLI path to
being declared optional, short of editing the manifest by hand.

That is not cosmetic: `check` fails on a required-but-unset secret and passes
on an optional-but-unset one, so the missing flag decided whether `check`, and
anything gating on it, goes red in an environment that legitimately does not
set the secret.

Two commits, kept separate so the refactor stays readable:

1. **`refactor(cli): extract manifest_edit module`** — moves
   `add_secret_to_manifest` (and `validate_add_secret_name`) out of `cli` into
   a new `manifest_edit` module behind its own `manifest-edit` feature, which
   `cli` still enables. Behavior unchanged; a caller that only needs to add a
   declaration can take that feature alone, without `cli`'s shell-completion
   tooling (`clap_complete`, `clap_complete_nushell`, `is_executable`).
2. **`feat(cli): declare secret requiredness`** — adds `--optional` and
   `--required`.

They are in one PR deliberately: the second commit adds a parameter to
`add_secret_to_manifest`, and the first is what first makes that function
`pub`. Landing them together means no published signature ever changes.

## Requiredness is tri-state

`None` omits the key entirely (unchanged behavior, byte-identical output),
`Some(true)`/`Some(false)` write it explicitly.

Collapsing that to "omitting the flag means required" would be wrong, and this
is the part worth checking: a profile carrying `defaults = { required = false }`
makes an omitted key resolve to *optional*. So `--optional` on its own would
leave "declare a required secret in that profile" unreachable — hence
`--required` as well. The two are `conflicts_with`, so the handler never has to
silently pick a winner.

No flag is offered for the `at_least_one`/`exactly_one` presence-group form of
`required`: it spans several secrets at once and does not fit a single-secret
declaration.

## Validation

- `cargo test --package secretspec --all-features -- manifest_edit` — 7 passed
- `cargo test --package secretspec --all-features cli::tests::add` — 5 passed
- `cargo test --package secretspec --all-features --lib` — 1256 passed, 26
  pre-existing failures (21 `provider::sops::*` from the sops CLI not being
  installed, 5 `cli::completion::tests` that depend on the working directory).
  Both sets fail identically on this branch with the second commit reverted.
- `cargo fmt --all -- --check`
- `cargo clippy -p secretspec --no-default-features --features cli` — no new
  warnings

Tests cover the emitted text for all three states, that an explicit
requiredness survives into the loaded `Config` rather than only into the bytes,
that a document mixing a presence group, a full table and a quoted dotted key
is left untouched, and that the two flags are refused together.