### PR TITLE
feat(sdk): expose Secrets::config() publicly (hidden)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Secrets::config()` is now `#[doc(hidden)] pub` instead of `pub(crate)`
+  behind the `cli` feature. Any embedder that needs the manifest without a
+  provider — an out-of-tree plugin inspecting declared secrets, for
+  instance — can now reach it without taking the whole `cli` feature.
 - Structured caller context lets CLI and SDK integrations identify the invoking
   software, version, operation, and non-secret resource independently of the
   user-supplied access reason. Audit records and providers receive the context,

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1883,10 +1883,17 @@ impl Secrets {
         Ok(())
     }
 
-    /// Get a reference to the project configuration. Used by `secretspec
-    /// codegen` (which needs the manifest, not a provider) and by tests.
-    #[cfg(any(feature = "cli", test))]
-    pub(crate) fn config(&self) -> &Config {
+    /// Get a reference to the project configuration.
+    ///
+    /// Used by `secretspec codegen`, which needs the manifest rather than a
+    /// provider. `pub(crate)` behind the `cli` feature meant any other
+    /// embedder needing the manifest without a provider — an out-of-tree
+    /// plugin (#64) inspecting declared secrets, for instance — had no way to
+    /// reach it short of taking the whole `cli` feature or re-parsing the
+    /// manifest itself. Hidden from the public SDK surface: ordinary callers
+    /// resolve secrets, not manifests.
+    #[doc(hidden)]
+    pub fn config(&self) -> &Config {
         &self.config
     }
 


### PR DESCRIPTION
## Summary

`Secrets::config()` was `pub(crate)`, gated behind
`#[cfg(any(feature = "cli", test))]`, for `secretspec codegen`'s use. Any
other embedder needing the manifest without a provider — an out-of-tree
plugin inspecting declared secrets, for instance (#64) — had no way to reach
it short of taking the whole `cli` feature or re-parsing the manifest itself.

## Change

`config()` is now `#[doc(hidden)] pub` and unconditional. `#[doc(hidden)]`
keeps it off the public SDK surface (ordinary callers resolve secrets, not
manifests) while making it reachable. This is additive and cannot break the
C ABI the FFI bindings expose.

## Validation

- `cargo check -p secretspec --all-features`
- `cargo check -p secretspec --no-default-features`
- `cargo test --package secretspec --all-features -- secrets::` — 37 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p secretspec --no-default-features --features cli -- -D
  warnings` — no new warnings
