### PR TITLE
fix(bws): use vault host for bare provider URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bare `bws://<project-uuid>` provider URIs now target the Bitwarden US cloud
+  vault instead of the public marketing site, restoring reads and writes while
+  keeping the server pinned independently of ambient `bws` configuration.
+  ([#359](https://github.com/cachix/secretspec/issues/359))
+
 - The `awssm` and `scaleway` providers now treat a JSON `null` in a `ref` field
   as no value, the same as an absent key, so the provider chain continues.
   Previously it was rendered as the four-character string `null`, which

--- a/docs/src/content/docs/providers/bws.mdx
+++ b/docs/src/content/docs/providers/bws.mdx
@@ -103,7 +103,8 @@ bws://[SERVER_BASE@]PROJECT_UUID
 
 - `PROJECT_UUID`: Your Bitwarden Secrets Manager project UUID
 - `SERVER_BASE` (optional): Hostname of the Bitwarden instance for EU cloud or
-  self hosted deployments. Defaults to `bitwarden.com` (US cloud) when omitted.
+  self hosted deployments. Defaults to `vault.bitwarden.com` (US cloud) when
+  omitted.
 
 In SecretSpec 0.17 and later, `SERVER_BASE` is passed to each CLI invocation as
 `--server-url https://SERVER_BASE`, overriding the CLI's saved server

--- a/secretspec/src/provider/bws.rs
+++ b/secretspec/src/provider/bws.rs
@@ -15,7 +15,7 @@
 //! `bws://[server-base@]project-uuid`
 //!
 //! Server Base is a hostname pointing to the bitwarden vault instance.
-//! Defaults to bitwarden.com
+//! Defaults to vault.bitwarden.com
 //!
 //! The UUID identifies the Bitwarden Secrets Manager project where secrets are stored.
 //! This provides namespace isolation — different projects use different BWS project IDs.
@@ -116,7 +116,7 @@ pub struct BwsProvider {
 const ACCESS_TOKEN: &str = "access_token";
 const BWS_ACCESS_TOKEN_ENV: &str = "BWS_ACCESS_TOKEN";
 const BWS_CLI_PATH_ENV: &str = "SECRETSPEC_BWS_CLI_PATH";
-const DEFAULT_SERVER_URL: &str = "https://bitwarden.com";
+const DEFAULT_SERVER_URL: &str = "https://vault.bitwarden.com";
 
 /// Fields consumed from `bws secret list --output json`.
 #[derive(Debug, Clone, Deserialize)]
@@ -582,7 +582,12 @@ mod tests {
 
         assert_eq!(
             args,
-            ["--color", "no", "--server-url", "https://bitwarden.com"]
+            [
+                "--color",
+                "no",
+                "--server-url",
+                "https://vault.bitwarden.com"
+            ]
         );
     }
 
@@ -684,7 +689,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(args_log).unwrap(),
-            "--color\nno\n--server-url\nhttps://bitwarden.com\nsecret\nedit\n\
+            "--color\nno\n--server-url\nhttps://vault.bitwarden.com\nsecret\nedit\n\
              11111111-1111-1111-1111-111111111111\n--value=--password\n--output\nnone\n"
         );
     }
@@ -717,7 +722,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(args_log).unwrap(),
-            "--color\nno\n--server-url\nhttps://bitwarden.com\nsecret\ncreate\n--output\nnone\n--\n\
+            "--color\nno\n--server-url\nhttps://vault.bitwarden.com\nsecret\ncreate\n--output\nnone\n--\n\
              --API_KEY\n--password\na9230ec4-5507-4870-b8b5-b3f500587e4c\n"
         );
     }


### PR DESCRIPTION
## Summary

- pin bare `bws://<project-uuid>` URIs to `https://vault.bitwarden.com` instead of the public marketing site
- preserve the existing guarantee that ambient `bws` profiles and server settings cannot redirect a hostless provider
- update provider documentation, regression expectations, and the changelog

## Testing

- `devenv shell cargo test --all`
- `devenv shell cargo fmt --all -- --check`
- `devenv shell npm --prefix docs run build`
- pre-commit Clippy and rustfmt hooks

Closes #359