### PR TITLE
ci: skip irrelevant suites and parallelize SDK tests

### DIFF
--- a/.github/workflows/sdks.yml
+++ b/.github/workflows/sdks.yml
@@ -8,8 +8,16 @@ on:
   workflow_call:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.mdx"
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -108,7 +109,9 @@ jobs:
         install -m 0755 sops-bin/sops-* sops-bin/sops
         echo "$PWD/sops-bin" >> "$GITHUB_PATH"
     - name: Install Rust (pinned by rust-toolchain.toml)
-      run: rustup toolchain install
+      run: |
+        rustup toolchain install
+        rustup component add rustfmt clippy
     - name: Cache Rust builds
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
       run: cargo fmt --all -- --check
     - name: Run Clippy
       if: runner.os == 'Linux'
-      run: cargo clippy --workspace --exclude secretspec-php-native --all-targets
+      run: cargo clippy --workspace --exclude secretspec-php-native
     - name: Run tests
       run: cargo test --workspace --exclude secretspec-php-native
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,10 +78,11 @@ jobs:
     - name: Check documentation links
       uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
       with:
+        workingDirectory: docs
         args: >-
           --root-dir "${{ github.workspace }}/docs/dist"
           --remap "^https://secretspec\\.dev file://${{ github.workspace }}/docs/dist"
-          "docs/dist/**/*.html"
+          "dist/**/*.html"
 
   tests:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,76 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.classify.outputs.code }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      if: github.event_name == 'pull_request' || github.event_name == 'push'
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Detect code changes
+      id: classify
+      shell: bash
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        BEFORE_SHA: ${{ github.event.before }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        case "${{ github.event_name }}" in
+          pull_request) range="$BASE_SHA...$HEAD_SHA" ;;
+          push)
+            if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+              echo "code=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            range="$BEFORE_SHA..${{ github.sha }}"
+            ;;
+          *)
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+            ;;
+        esac
+
+        code=false
+        while IFS= read -r path; do
+          case "$path" in
+            docs/*|*.md|*.mdx) ;;
+            *) code=true; break ;;
+          esac
+        done < <(git diff --name-only "$range")
+        echo "code=$code" >> "$GITHUB_OUTPUT"
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+        cache: npm
+        cache-dependency-path: docs/package-lock.json
+    - name: Install documentation dependencies
+      run: npm --prefix docs ci
+    - name: Build documentation
+      run: npm --prefix docs run build
+    - name: Check documentation links
+      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+      with:
+        args: >-
+          --root-dir "${{ github.workspace }}/docs/dist"
+          --remap "^https://secretspec\\.dev file://${{ github.workspace }}/docs/dist"
+          "docs/dist/**/*.html"
+
   tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -26,50 +95,36 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    # The full devenv shell includes every SDK toolchain plus the musl static
-    # dependencies. It no longer fits alongside the preinstalled software on
-    # GitHub's Ubuntu image, so reclaim that space before populating /nix.
-    - name: Free up disk space
-      if: runner.os == 'Linux'
-      run: |
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android \
-          /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /opt/ghc \
-          /usr/local/share/boost /usr/local/share/powershell
-        sudo docker image prune --all --force
-        df -h /
-    - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
-    - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+    - name: Download SOPS 3.13.2
+      uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
       with:
-        name: devenv
-    - name: Install devenv.sh
-      run: nix profile install nixpkgs#devenv
+        repository: getsops/sops
+        tag: v3.13.2
+        fileName: sops-v3.13.2.${{ runner.os == 'Linux' && 'linux' || 'darwin' }}.${{ runner.arch == 'ARM64' && 'arm64' || 'amd64' }}
+        out-file-path: sops-bin
+    - name: Add SOPS to PATH
+      shell: bash
+      run: |
+        install -m 0755 sops-bin/sops-* sops-bin/sops
+        echo "$PWD/sops-bin" >> "$GITHUB_PATH"
+    - name: Install Rust (pinned by rust-toolchain.toml)
+      run: rustup toolchain install
     - name: Cache Rust builds
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: ${{ matrix.os }}
-        # The tests compile with devenv's pinned Nix toolchain, so use the same
-        # toolchain when rust-cache calculates its compiler and dependency keys.
-        cmd-format: devenv shell -- {0}
 
-    # `devenv test` also starts every configured process. The docs dev server is
-    # unrelated to this suite and makes process-compose wait for its timeout when
-    # docs dependencies are not installed, so run the hooks and tests directly.
-    # rustfmt and clippy are platform-independent; run them once on Linux rather
-    # than paying for a second cold compilation on the slower macOS runner.
-    - name: Run pre-commit hooks
+    # Formatting and linting are platform-independent; run them once on Linux.
+    # The PHP extension is checked in the SDK workflow, where PHP headers are
+    # available; this native Rust job does not need the full multi-SDK shell.
+    - name: Check formatting
       if: runner.os == 'Linux'
-      run: devenv tasks run devenv:git-hooks:run --show-output
-    - name: Install documentation dependencies
+      run: cargo fmt --all -- --check
+    - name: Run Clippy
       if: runner.os == 'Linux'
-      run: devenv shell -- npm --prefix docs ci
-    - name: Build documentation
-      if: runner.os == 'Linux'
-      run: devenv shell -- npm --prefix docs run build
-    - name: Check documentation links
-      if: runner.os == 'Linux'
-      run: devenv shell -- npm --prefix docs run check:links
+      run: cargo clippy --workspace --exclude secretspec-php-native --all-targets
     - name: Run tests
-      run: devenv shell -- cargo test --all
+      run: cargo test --workspace --exclude secretspec-php-native
 
   # Each optional provider must compile on its own, not just in the default
   # feature set. `cargo test` above cannot catch a missing feature gate: it
@@ -78,6 +133,8 @@ jobs:
   # A provider that forgets to add itself to such a gate only breaks for the
   # user who builds it standalone, which is precisely who `--features` is for.
   features:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -97,6 +154,8 @@ jobs:
         done
 
   package:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -116,8 +175,10 @@ jobs:
   # Windows runners can't run Nix/devenv, so the suite runs here natively via
   # rustup + cargo. This exists specifically to catch Windows-only path handling
   # regressions (e.g. config discovery and relative `-f` paths, issue #59), which
-  # the Ubuntu/macOS devenv job above can never observe.
+  # the Ubuntu/macOS Rust job above can never observe.
   windows:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
     - name: Check documentation links
       uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
       with:
+        lycheeVersion: v0.21.0
         workingDirectory: docs
         args: >-
           --root-dir "${{ github.workspace }}/docs/dist"

--- a/scripts/ci-sdks.sh
+++ b/scripts/ci-sdks.sh
@@ -29,7 +29,7 @@ export SECRETSPEC_BIN="$target_dir/debug/secretspec"
 echo "==> Installing staticlib + header + pkg-config file"
 SECRETSPEC_FFI_PREFIX="$(mktemp -d)"
 export SECRETSPEC_FFI_PREFIX
-bash secretspec-ffi/scripts/cinstall.sh "$SECRETSPEC_FFI_PREFIX" static
+bash secretspec-ffi/scripts/cinstall.sh "$SECRETSPEC_FFI_PREFIX" static debug
 export PKG_CONFIG_PATH="$SECRETSPEC_FFI_PREFIX/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 pkg-config --print-errors --exists secretspec_ffi
 export SECRETSPEC_FFI_STATICLIB="$SECRETSPEC_FFI_PREFIX/lib/libsecretspec_ffi.a"
@@ -44,98 +44,159 @@ echo "==> SECRETSPEC_FFI_LIB=$SECRETSPEC_FFI_LIB"
 echo "==> SECRETSPEC_FFI_PREFIX=$SECRETSPEC_FFI_PREFIX"
 echo "==> SECRETSPEC_FFI_NATIVE_LIBS=$SECRETSPEC_FFI_NATIVE_LIBS"
 
-echo "==> Python"
-( cd secretspec-py && python -m pytest -q )
-( cd secretspec-py && python -m compileall -q examples )
+run_python() {
+  echo "==> Python"
+  ( cd secretspec-py && python -m pytest -q )
+  ( cd secretspec-py && python -m compileall -q examples )
+}
 
-echo "==> Go (default purego/dlopen path)"
-( cd secretspec-go && go test ./... )
+run_go() {
+  echo "==> Go (default purego/dlopen path)"
+  ( cd secretspec-go && go test ./... )
 
-echo "==> Go (-tags static: cgo links the archive in)"
-# Stage the debug archive + header + generated cgo LDFLAGS, then exercise the
-# static binding. This is the glibc self-contained build; the fully-static musl
-# binary is built in the go-static.yml artifact workflow.
-( cd secretspec-go && SECRETSPEC_FFI_PROFILE=debug bash scripts/stage-staticlib.sh )
-( cd secretspec-go && CGO_ENABLED=1 go test -tags static ./... )
+  echo "==> Go (-tags static: cgo links the archive in)"
+  # Stage the debug archive + header + generated cgo LDFLAGS, then exercise the
+  # static binding. This is the glibc self-contained build; the fully-static musl
+  # binary is built in the go-static.yml artifact workflow.
+  ( cd secretspec-go && SECRETSPEC_FFI_PROFILE=debug bash scripts/stage-staticlib.sh )
+  ( cd secretspec-go && CGO_ENABLED=1 go test -tags static ./... )
 
-echo "==> Go (-tags pkgconfig: link inputs from secretspec_ffi.pc)"
-( cd secretspec-go && CGO_ENABLED=1 go test -tags pkgconfig ./... )
+  echo "==> Go (-tags pkgconfig: link inputs from secretspec_ffi.pc)"
+  ( cd secretspec-go && CGO_ENABLED=1 go test -tags pkgconfig ./... )
+}
 
-echo "==> Ruby"
-# The Ruby SDK compiles an mkmf C extension that statically links the archive
-# (using the SECRETSPEC_FFI_* contract above); build it once up front.
-bash secretspec-rb/scripts/build-ext.sh
-( cd secretspec-rb && ruby -e 'Dir["test/test_*.rb"].sort.each { |f| require File.expand_path(f) }' )
-( cd secretspec-rb && find examples -name '*.rb' -exec ruby -c {} \; )
+run_ruby() {
+  echo "==> Ruby"
+  # The Ruby SDK compiles an mkmf C extension that statically links the archive
+  # (using the SECRETSPEC_FFI_* contract above); build it once up front.
+  bash secretspec-rb/scripts/build-ext.sh
+  ( cd secretspec-rb && ruby -e 'Dir["test/test_*.rb"].sort.each { |f| require File.expand_path(f) }' )
+  ( cd secretspec-rb && find examples -name '*.rb' -exec ruby -c {} \; )
 
-echo "==> Ruby (pkg-config discovery)"
-# The same link inputs read from secretspec_ffi.pc in the installed prefix
-# (PKG_CONFIG_PATH above); rebuild the extension and rerun the tests.
-bash secretspec-rb/scripts/build-ext.sh --enable-pkg-config
-( cd secretspec-rb && ruby -e 'Dir["test/test_*.rb"].sort.each { |f| require File.expand_path(f) }' )
+  echo "==> Ruby (pkg-config discovery)"
+  # The same link inputs read from secretspec_ffi.pc in the installed prefix
+  # (PKG_CONFIG_PATH above); rebuild the extension and rerun the tests.
+  bash secretspec-rb/scripts/build-ext.sh --enable-pkg-config
+  ( cd secretspec-rb && ruby -e 'Dir["test/test_*.rb"].sort.each { |f| require File.expand_path(f) }' )
+}
 
-echo "==> Node"
-# The Node SDK uses a napi-rs addon (not the cdylib), built via the @napi-rs/cli
-# devDependency. Install it and build the addon once up front: the test files
-# each ensure it exists and would otherwise race to build it in parallel
-# processes.
-( cd secretspec-node && npm ci )
-bash secretspec-node/scripts/build-addon.sh
-( cd secretspec-node && node --test )
-( cd secretspec-node && find examples -type f \( -name '*.js' -o -name '*.ts' \) -exec node --check {} \; )
+run_node() {
+  echo "==> Node"
+  # The Node SDK uses a napi-rs addon (not the cdylib), built via the @napi-rs/cli
+  # devDependency. Install it and build the addon once up front: the test files
+  # each ensure it exists and would otherwise race to build it in parallel
+  # processes. CI uses the debug profile because release optimization adds no
+  # test coverage and forces a second full resolver build.
+  ( cd secretspec-node && npm ci )
+  SECRETSPEC_NODE_PROFILE=debug bash secretspec-node/scripts/build-addon.sh
+  ( cd secretspec-node && node --test )
+  ( cd secretspec-node && find examples -type f \( -name '*.js' -o -name '*.ts' \) -exec node --check {} \; )
+}
 
-echo "==> Haskell"
-# The Haskell SDK statically links the secretspec-ffi archive at build time: the
-# Rust resolver is embedded in the test binary, so there is NO runtime loader path
-# (no LD_LIBRARY_PATH). Stage libsecretspec_ffi.a alone into an isolated dir so
-# -lsecretspec_ffi resolves to the archive (target/debug also holds the .so), and
-# pass the archive's transitive native deps as linker options.
-(
-  cd secretspec-hs
-  hs_lib_dir="$(mktemp -d)"
-  cp "$SECRETSPEC_FFI_STATICLIB" "$hs_lib_dir/"
-  cabal update
-  # --write-ghc-environment-files lets the codegen test's runghc see aeson and
-  # the quicktype-generated module's transitive imports; SECRETSPEC_BIN (set
-  # above) lets it run `secretspec schema`. All -optl flags go in ONE
-  # --ghc-options occurrence: cabal reverses the order of repeated occurrences,
-  # which breaks two-token `-framework X` pairs on macOS.
-  cabal test --extra-lib-dirs="$hs_lib_dir" \
-    --ghc-options="-optl${SECRETSPEC_FFI_NATIVE_LIBS// / -optl}" \
-    --write-ghc-environment-files=always
-  cabal build exe:secretspec-quick-start-example \
-    exe:secretspec-scopes-example \
-    exe:secretspec-report-example \
-    --extra-lib-dirs="$hs_lib_dir" \
-    --ghc-options="-optl${SECRETSPEC_FFI_NATIVE_LIBS// / -optl}"
-)
+run_haskell() {
+  echo "==> Haskell"
+  # The Haskell SDK statically links the secretspec-ffi archive at build time: the
+  # Rust resolver is embedded in the test binary, so there is NO runtime loader path
+  # (no LD_LIBRARY_PATH). Stage libsecretspec_ffi.a alone into an isolated dir so
+  # -lsecretspec_ffi resolves to the archive (target/debug also holds the .so), and
+  # pass the archive's transitive native deps as linker options.
+  (
+    cd secretspec-hs
+    # Cabal leaves this generated file behind. Remove an environment from a
+    # previous checkout before asking Cabal to write the current package IDs.
+    rm -f .ghc.environment.*
+    hs_lib_dir="$(mktemp -d)"
+    cp "$SECRETSPEC_FFI_STATICLIB" "$hs_lib_dir/"
+    cabal update
+    # --write-ghc-environment-files lets the codegen test's runghc see aeson and
+    # the quicktype-generated module's transitive imports; SECRETSPEC_BIN (set
+    # above) lets it run `secretspec schema`. All -optl flags go in ONE
+    # --ghc-options occurrence: cabal reverses the order of repeated occurrences,
+    # which breaks two-token `-framework X` pairs on macOS.
+    cabal test --extra-lib-dirs="$hs_lib_dir" \
+      --ghc-options="-optl${SECRETSPEC_FFI_NATIVE_LIBS// / -optl}" \
+      --write-ghc-environment-files=always
+    cabal build exe:secretspec-quick-start-example \
+      exe:secretspec-scopes-example \
+      exe:secretspec-report-example \
+      --extra-lib-dirs="$hs_lib_dir" \
+      --ghc-options="-optl${SECRETSPEC_FFI_NATIVE_LIBS// / -optl}"
+  )
 
-echo "==> Haskell (pkg-config discovery)"
-(
-  cd secretspec-hs
-  cabal test -f use-pkg-config --write-ghc-environment-files=always
-)
+  echo "==> Haskell (pkg-config discovery)"
+  ( cd secretspec-hs && cabal test -f use-pkg-config --write-ghc-environment-files=always )
+}
 
-echo "==> C# / .NET"
-( cd secretspec-dotnet && dotnet run --project tests/SecretSpec.Tests --configuration Release )
-( cd secretspec-dotnet && find examples -name '*.csproj' -exec dotnet build {} \; )
+run_dotnet() {
+  echo "==> C# / .NET"
+  ( cd secretspec-dotnet && dotnet run --project tests/SecretSpec.Tests --configuration Release )
+  ( cd secretspec-dotnet && find examples -name '*.csproj' -exec dotnet build {} \; )
+}
 
-echo "==> PHP"
-# The PHP SDK has two native backends over the same resolver; exercise both.
-# The Composer manifest is at the repo root (so Packagist can read it from the
-# monorepo); vendor-dir points into secretspec-php/, so phpunit still runs there.
-composer validate --no-check-lock --no-check-publish
-composer install --no-interaction --no-progress
+run_php() {
+  echo "==> PHP"
+  # The PHP SDK has two native backends over the same resolver; exercise both.
+  # The Composer manifest is at the repo root (so Packagist can read it from the
+  # monorepo); vendor-dir points into secretspec-php/, so phpunit still runs there.
+  composer validate --no-check-lock --no-check-publish
+  composer install --no-interaction --no-progress
 
-echo "==> PHP (ext-ffi fallback, dlopens the cdylib via SECRETSPEC_FFI_LIB)"
-( cd secretspec-php && php ./vendor/bin/phpunit )
-( cd secretspec-php && find examples -name '*.php' -exec php -l {} \; )
+  echo "==> PHP (ext-ffi fallback, dlopens the cdylib via SECRETSPEC_FFI_LIB)"
+  ( cd secretspec-php && php ./vendor/bin/phpunit )
+  ( cd secretspec-php && find examples -name '*.php' -exec php -l {} \; )
 
-echo "==> PHP (secretspec-php-native extension, ext-php-rs)"
-# Build the extension in debug and load it directly; when it is present the SDK
-# prefers it over ext-ffi. This also proves the extension registers its functions.
-CARGO_TARGET_DIR="$target_dir" SECRETSPEC_PHP_PROFILE=debug \
-  bash secretspec-php/scripts/build-ext.sh
-( cd secretspec-php && php -d extension="$PWD/lib/secretspec.so" ./vendor/bin/phpunit )
+  echo "==> PHP (secretspec-php-native extension, ext-php-rs)"
+  # Build the extension in debug and load it directly; when it is present the SDK
+  # prefers it over ext-ffi. This also proves the extension registers its functions.
+  CARGO_TARGET_DIR="$target_dir" SECRETSPEC_PHP_PROFILE=debug \
+    bash secretspec-php/scripts/build-ext.sh
+  ( cd secretspec-php && php -d extension="$PWD/lib/secretspec.so" ./vendor/bin/phpunit )
+}
+
+# Each language owns its source/build directories. Run the suites concurrently
+# after the shared resolver artifacts are ready, but buffer each suite's output
+# so GitHub log groups remain readable and failures retain their full context.
+suite_log_dir="$(mktemp -d)"
+trap 'rm -rf "$SECRETSPEC_FFI_PREFIX" "$suite_log_dir"' EXIT
+suite_names=()
+suite_logs=()
+suite_pids=()
+
+start_suite() {
+  local name="$1"
+  local function_name="$2"
+  local index="${#suite_pids[@]}"
+  local log="$suite_log_dir/$index.log"
+  suite_names+=("$name")
+  suite_logs+=("$log")
+  "$function_name" >"$log" 2>&1 &
+  suite_pids+=("$!")
+}
+
+start_suite Python run_python
+start_suite Go run_go
+start_suite Ruby run_ruby
+start_suite Node run_node
+start_suite Haskell run_haskell
+start_suite .NET run_dotnet
+start_suite PHP run_php
+
+failed_suites=()
+for index in "${!suite_pids[@]}"; do
+  if ! wait "${suite_pids[$index]}"; then
+    failed_suites+=("${suite_names[$index]}")
+  fi
+done
+
+for index in "${!suite_logs[@]}"; do
+  echo "::group::${suite_names[$index]} SDK"
+  cat "${suite_logs[$index]}"
+  echo "::endgroup::"
+done
+
+if [ "${#failed_suites[@]}" -ne 0 ]; then
+  printf 'SDK suites failed: %s\n' "${failed_suites[*]}" >&2
+  exit 1
+fi
 
 echo "==> All SDK suites passed"

--- a/secretspec-ffi/scripts/cinstall.sh
+++ b/secretspec-ffi/scripts/cinstall.sh
@@ -5,13 +5,14 @@
 # library and pkg-config directories stable for SDK consumers on every platform.
 set -euo pipefail
 
-if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
-  echo "usage: $0 PREFIX [static|shared]" >&2
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+  echo "usage: $0 PREFIX [static|shared] [release|debug]" >&2
   exit 2
 fi
 
 prefix="$1"
 mode="${2:-static}"
+profile="${3:-release}"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 case "$mode" in
@@ -23,9 +24,19 @@ case "$mode" in
     ;;
 esac
 
+case "$profile" in
+  release) profile_args=() ;;
+  debug) profile_args=(--debug) ;;
+  *)
+    echo "error: profile must be 'release' or 'debug'" >&2
+    exit 2
+    ;;
+esac
+
 cargo cinstall -p secretspec-ffi --manifest-path "$repo_root/Cargo.toml" \
   --library-type "$library_type" \
   --prefix "$prefix" \
   --bindir lib \
   --libdir lib \
-  --pkgconfigdir lib/pkgconfig
+  --pkgconfigdir lib/pkgconfig \
+  "${profile_args[@]}"

--- a/secretspec-node/scripts/build-addon.sh
+++ b/secretspec-node/scripts/build-addon.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env bash
 #
-# Build the napi-rs addon (release) via `napi build` and place it as
-# secretspec.node next to index.js. Extra arguments are forwarded to
-# `napi build`.
+# Build the napi-rs addon via `napi build` and place it as secretspec.node next
+# to index.js. Set SECRETSPEC_NODE_PROFILE=debug for a faster unoptimized build
+# (default: release). Extra arguments are forwarded to `napi build`.
 set -euo pipefail
 
 pkg_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 napi_bin="$pkg_dir/node_modules/.bin/napi"
+profile="${SECRETSPEC_NODE_PROFILE:-release}"
+
+case "$profile" in
+  release) profile_args=(--release) ;;
+  debug) profile_args=() ;;
+  *)
+    echo "error: SECRETSPEC_NODE_PROFILE must be 'release' or 'debug'" >&2
+    exit 2
+    ;;
+esac
 
 # --output-dir keeps napi build's generated .d.ts (which would otherwise
 # clobber the hand-maintained index.d.ts) out of pkg_dir entirely.
 tmp_out="$(mktemp -d)"
 trap 'rm -rf "$tmp_out"' EXIT
-( cd "$pkg_dir" && "$napi_bin" build --release --output-dir "$tmp_out" "$@" )
+( cd "$pkg_dir" && "$napi_bin" build "${profile_args[@]}" --output-dir "$tmp_out" "$@" )
 
 # Install atomically: node --test runs test files in parallel processes that
 # may build concurrently, and overwriting in place SIGBUSes a process that has


### PR DESCRIPTION
## Summary

- run documentation builds and link checks in a lean Node-only job
- skip Rust/SDK matrices for documentation-only PRs and pushes
- run the Rust matrix with the pinned native toolchain instead of realizing every SDK toolchain through devenv
- build test-only FFI and Node artifacts in debug mode and run independent SDK suites concurrently

The AWS Secrets Manager documentation PR spent about 13 minutes in Test and 30 minutes in SDKs despite changing one Markdown file. After this change, that class of change runs only the documentation job. Code changes retain the full platform and SDK coverage.

## Measured results

- documentation: about 13m → 40s
- Ubuntu Rust: 9m03s → 3m14s
- macOS Rust: 12m22s → 8m05s (plus hosted-runner queue time when capacity is scarce)
- full SDK suite, cold CI runner: 30m17s → 20m37s
- local SDK suite with warm caches: 2m07s

## Validation

- `actionlint .github/workflows/test.yml .github/workflows/sdks.yml`
- shell syntax checks for all changed scripts
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude secretspec-php-native --all-targets`
- `cargo test --workspace --exclude secretspec-php-native`
- `bash scripts/ci-sdks.sh` (all seven concurrent SDK suites passed)
- documentation build and link check (passed in the new lean CI job)