### PR TITLE
fix(node): release AWS state before process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keeping the server pinned independently of ambient `bws` configuration.
   ([#359](https://github.com/cachix/secretspec/issues/359))
 
+- Node SDK processes using `loadAsync()` or `reportAsync()` with AWS Secrets
+  Manager or Parameter Store now exit normally after resolution. Provider
+  runtime and TLS state is torn down on a short-lived resolver thread instead
+  of remaining attached to a persistent libuv worker during macOS process
+  shutdown. ([#343])
+
+  [#343]: https://github.com/cachix/secretspec/issues/343
+
 - The `awssm` and `scaleway` providers now treat a JSON `null` in a `ref` field
   as no value, the same as an absent key, so the provider chain continues.
   Previously it was rendered as the four-character string `null`, which

--- a/secretspec-node/src/lib.rs
+++ b/secretspec-node/src/lib.rs
@@ -18,8 +18,9 @@ pub fn resolve(request_json: String) -> String {
     secretspec::resolve_json(&request_json)
 }
 
-/// Runs `resolve_json` on the libuv threadpool (via [`AsyncTask`]) so it never
-/// runs on the JS thread.
+/// Dispatches `resolve_json` from the libuv threadpool to one short-lived Rust
+/// thread, so it never runs on the JS thread and provider runtime/TLS state is
+/// torn down before the libuv worker is returned to Node.
 pub struct ResolveTask {
     request_json: String,
 }
@@ -29,7 +30,26 @@ impl Task for ResolveTask {
     type JsValue = String;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        Ok(secretspec::resolve_json(&self.request_json))
+        // A libuv threadpool worker lives until Node shuts down. Network stacks
+        // initialized directly on it may retain thread-local runtime/TLS state
+        // until that late teardown; on macOS the AWS clients could then leave a
+        // short-lived Node process stuck after the Promise had resolved. Keep
+        // the N-API async work as the dispatcher, but run providers on a thread
+        // whose lifetime ends with this operation so all per-thread state is
+        // destroyed before `compute` returns the worker to libuv.
+        std::thread::scope(|scope| {
+            let resolver = std::thread::Builder::new()
+                .name("secretspec-resolve".to_string())
+                .spawn_scoped(scope, || secretspec::resolve_json(&self.request_json))
+                .map_err(|error| {
+                    napi::Error::from_reason(format!(
+                        "failed to start the SecretSpec resolver thread: {error}"
+                    ))
+                })?;
+            resolver.join().map_err(|_| {
+                napi::Error::from_reason("the SecretSpec resolver thread panicked".to_string())
+            })
+        })
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -37,9 +57,10 @@ impl Task for ResolveTask {
     }
 }
 
-/// Async variant of [`resolve`]: resolves on the libuv threadpool so a provider
-/// doing network I/O (1Password, LastPass) does not block the Node event loop.
-/// Returns a Promise of the same JSON response envelope string.
+/// Async variant of [`resolve`]: dispatches from the libuv threadpool to a
+/// short-lived resolver thread so a provider doing network I/O does not block
+/// the Node event loop or leave provider thread state on a persistent libuv
+/// worker. Returns a Promise of the same JSON response envelope string.
 #[napi]
 pub fn resolve_async(request_json: String) -> AsyncTask<ResolveTask> {
     AsyncTask::new(ResolveTask { request_json })

--- a/secretspec-node/test/aws-async-exit.test.js
+++ b/secretspec-node/test/aws-async-exit.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const PACKAGE_DIR = path.resolve(__dirname, '..');
+
+function ensureAddon() {
+  const addon = path.join(PACKAGE_DIR, 'secretspec.node');
+  if (fs.existsSync(addon)) return;
+  require('node:child_process').execFileSync(
+    'bash',
+    [path.join(PACKAGE_DIR, 'scripts', 'build-addon.sh')],
+    { stdio: 'inherit' },
+  );
+}
+
+function manifest(provider) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ss-node-aws-exit-'));
+  const manifestPath = path.join(dir, 'secretspec.toml');
+  const [uri, item] = provider === 'awsps'
+    ? ['awsps://us-east-1', '/demo/parameter']
+    : ['awssm://us-east-1', 'demo/secret'];
+  fs.writeFileSync(manifestPath, `
+[project]
+name = "node-aws-exit"
+revision = "1.0"
+
+[providers]
+aws = "${uri}"
+
+[profiles.default.defaults]
+providers = ["aws"]
+required = true
+
+[profiles.default]
+SECRET = { description = "AWS secret", ref = { item = "${item}" } }
+`);
+  return manifestPath;
+}
+
+function mockResponse(provider) {
+  if (provider === 'awsps') {
+    return {
+      Parameters: [{
+        ARN: 'arn:aws:ssm:us-east-1:123456789012:parameter/demo/parameter',
+        DataType: 'text',
+        Name: '/demo/parameter',
+        Type: 'SecureString',
+        Value: 'parameter-value',
+        Version: 1,
+      }],
+      InvalidParameters: [],
+    };
+  }
+  return {
+    SecretValues: [{
+      ARN: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:demo/secret',
+      Name: 'demo/secret',
+      SecretString: 'secret-value',
+      VersionId: '00000000-0000-0000-0000-000000000000',
+      VersionStages: ['AWSCURRENT'],
+    }],
+    Errors: [],
+  };
+}
+
+async function mockAws(provider) {
+  const server = http.createServer((request, response) => {
+    request.resume();
+    response.writeHead(200, {
+      'content-type': 'application/x-amz-json-1.1',
+      'x-amzn-requestid': '00000000-0000-0000-0000-000000000000',
+    });
+    response.end(JSON.stringify(mockResponse(provider)));
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  return server;
+}
+
+function runAsyncResolve(manifestPath, endpoint) {
+  const script = `
+    const { SecretSpec } = require(${JSON.stringify(PACKAGE_DIR)});
+    (async () => {
+      const resolved = await SecretSpec.builder()
+        .withPath(process.argv[1])
+        .withReason('AWS async exit regression')
+        .loadAsync();
+      console.log(resolved.secrets.SECRET.get());
+      resolved.dispose();
+    })().catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  `;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['-e', script, manifestPath], {
+      env: {
+        ...process.env,
+        AWS_ACCESS_KEY_ID: 'test',
+        AWS_SECRET_ACCESS_KEY: 'test',
+        AWS_REGION: 'us-east-1',
+        AWS_EC2_METADATA_DISABLED: 'true',
+        AWS_ENDPOINT_URL: endpoint,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`child did not exit after resolving (stdout: ${stdout}, stderr: ${stderr})`));
+    }, 5_000);
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(`child exited with code ${code}, signal ${signal}: ${stderr}`));
+      }
+    });
+  });
+}
+
+ensureAddon();
+
+for (const provider of ['awsps', 'awssm']) {
+  test(`loadAsync exits cleanly after resolving with ${provider}`, async (t) => {
+    const server = await mockAws(provider);
+    t.after(() => server.close());
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    const value = await runAsyncResolve(
+      manifest(provider),
+      `http://127.0.0.1:${address.port}`,
+    );
+    assert.equal(value, provider === 'awsps' ? 'parameter-value' : 'secret-value');
+  });
+}


### PR DESCRIPTION
## Summary

- run each N-API async provider operation on a scoped Rust thread
- destroy provider thread-local runtime state before the libuv worker returns
- add natural child-process exit regressions for AWS Secrets Manager and Parameter Store using a local compatible server

Fixes #343

## Testing

- devenv shell npm --prefix secretspec-node test (17 of 17 passed)
- fresh isolated-branch AWS exit regression (2 of 2 passed)
- devenv shell cargo clippy -p secretspec-node-native --no-deps -- -D warnings

## Note

The original report is macOS-specific. Local validation was on Linux, so reporter confirmation on macOS remains useful.