### PR TITLE
fix(infisical): diagnose missing environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,10 +102,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the profile the run resolves under. One alias can therefore serve every profile
   while naming secrets flat — `ref = { item = "/{key}" }` — instead of needing
   one alias per environment. An explicit `?env=` still pins the environment.
-  Note that Infisical answers a missing secret, folder, environment and project
-  with the same 404, so a ref pointed at an environment that does not exist reads
-  as an unset secret rather than an error. A credential declared with a `ref`
-  still needs `?env=`, so it resolves the same way whichever profile is running.
+  When every requested secret gets Infisical's ambiguous 404, SecretSpec now
+  checks the environment root once and reports a missing environment or project,
+  naming whether the profile or `?env=` selected it. A genuinely absent secret or
+  folder in an existing environment remains unset so provider fallback still
+  works. A credential declared with a `ref` still needs `?env=`, so it resolves
+  the same way whichever profile is running. ([#338])
+
+  [#338]: https://github.com/cachix/secretspec/issues/338
 
 - `secretspec set` against an Infisical secret names the environment in its
   pre-write preview, which the previous description left out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,11 +103,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while naming secrets flat — `ref = { item = "/{key}" }` — instead of needing
   one alias per environment. An explicit `?env=` still pins the environment.
   When every requested secret gets Infisical's ambiguous 404, SecretSpec now
-  checks the environment root once and reports a missing environment or project,
-  naming whether the profile or `?env=` selected it. A genuinely absent secret or
-  folder in an existing environment remains unset so provider fallback still
-  works. A credential declared with a `ref` still needs `?env=`, so it resolves
-  the same way whichever profile is running. ([#338])
+  checks the environment root once without requesting secret values and reports
+  a missing environment or project, naming whether the profile or `?env=`
+  selected it. A genuinely absent secret or folder in an existing environment
+  remains unset so provider fallback still works. A credential declared with a
+  `ref` still needs `?env=`, so it resolves the same way whichever profile is
+  running. ([#338])
 
   [#338]: https://github.com/cachix/secretspec/issues/338
 

--- a/docs/src/content/docs/providers/infisical.mdx
+++ b/docs/src/content/docs/providers/infisical.mdx
@@ -271,15 +271,16 @@ so the value is written once the request is approved.
 - The project is addressed by UUID; Infisical's API does not accept a project slug
 - A project or profile whose name is not spellable as an Infisical folder (letters, digits, dashes,
   underscores) is refused rather than rewritten
-- A ref reads the environment the profile names unless `?env=` pins one, and a wrong environment
-  reads as an unset secret rather than an error: Infisical answers a missing secret, folder,
-  environment and project with the same 404
+- A ref reads the environment the profile names unless `?env=` pins one. Infisical answers a
+  missing secret, folder, environment and project with the same 404. Starting in SecretSpec 0.20,
+  if every requested secret gets that ambiguous response, SecretSpec checks the environment root
+  once. A missing environment or project then becomes an error naming the selected environment and
+  whether the profile or `?env=` selected it; a missing secret or folder in an existing environment
+  remains unset so provider fallback still works
 - `secretspec import infisical://…` is not supported: the provider does not enumerate existing
   secrets, so import has nothing to discover
 - The domain variables name a host, not a path: an instance served under a sub-path
   (`https://example.com/infisical`) is not addressable. A trailing `/api` is the exception and is
   accepted, since Infisical's own CLI takes the domain in that form
-- An environment or project that does not exist reads as an unset secret rather than an error:
-  Infisical answers a missing secret, folder, environment and project with the same bare 404.
-  Writing one reports the environment by name. If a profile does not match an environment slug —
-  Infisical's own default projects use `dev`, `staging` and `prod` — pin the right one with `?env=`
+- If a profile does not match an environment slug — Infisical's own default projects use `dev`,
+  `staging` and `prod` — pin the right one with `?env=`

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -561,6 +561,12 @@ the `production` environment. This covers refs as well as convention naming (0.2
 Projects whose environments do not correspond to profiles pin one with
 `?env=`; the profile still names the folder, so profiles never share a secret.
 
+Infisical uses the same 404 for a missing secret, folder, environment, or
+project. In SecretSpec 0.20+, an all-missing read checks the environment root
+once and reports a missing environment or project, including whether the
+profile or `?env=` selected the environment. Ordinary missing secrets and
+folders remain unset so provider fallback continues.
+
 Values are read with Infisical's secret references expanded, matching its own CLI, so a value of
 `postgres://${DB_USER}@host` arrives resolved.
 

--- a/secretspec/src/provider/infisical.rs
+++ b/secretspec/src/provider/infisical.rs
@@ -269,6 +269,13 @@ struct Location {
     key: String,
 }
 
+/// The distinction an environment diagnostic needs to retain after a secret
+/// read. An HTTP 200 without a usable value is not Infisical's ambiguous 404.
+enum SecretRead {
+    Response(Option<SecretString>),
+    NotFound,
+}
+
 /// Infisical provider.
 pub struct InfisicalProvider {
     config: InfisicalConfig,
@@ -600,6 +607,21 @@ impl InfisicalProvider {
         ]
     }
 
+    /// A metadata-only root listing used solely to check whether an
+    /// environment exists.
+    ///
+    /// Unlike a secret read, this must not retrieve or expand values: every
+    /// secret at the root is unrelated to the missing entry being diagnosed.
+    fn environment_probe_query<'q>(&'q self, environment: &'q str) -> Vec<(&'static str, &'q str)> {
+        vec![
+            ("projectId", self.config.project_id.as_str()),
+            ("environment", environment),
+            ("secretPath", "/"),
+            ("expandSecretReferences", "false"),
+            ("viewSecretValue", "false"),
+        ]
+    }
+
     /// Reads one secret's value from its JSON, rejecting a value Infisical
     /// withheld.
     ///
@@ -643,11 +665,7 @@ impl InfisicalProvider {
     }
 
     /// Reads one secret, by version when the ref pins one.
-    async fn get_async(
-        &self,
-        loc: &Location,
-        version: Option<&str>,
-    ) -> Result<Option<SecretString>> {
+    async fn get_async(&self, loc: &Location, version: Option<&str>) -> Result<SecretRead> {
         let url = self.secret_url(&loc.key)?;
         let mut query = self.read_query(&loc.environment, &loc.secret_path);
         if let Some(version) = version {
@@ -665,20 +683,13 @@ impl InfisicalProvider {
                         "Failed to parse Infisical response: {e}"
                     ))
                 })?;
-                Self::secret_value(&parsed["secret"], &loc.key)
+                Self::secret_value(&parsed["secret"], &loc.key).map(SecretRead::Response)
             }
             // A 404 covers a missing secret, folder, environment and project
-            // alike, and only the message text tells them apart. Probe the
-            // environment's root, which always exists in a real environment,
-            // rather than turning control flow on response prose. This is a
-            // single-secret read, so the miss already means the whole read
-            // failed and the diagnostic request does not penalize a successful
-            // resolution.
-            StatusCode::NOT_FOUND => {
-                self.ensure_environment_exists_async(&loc.environment)
-                    .await?;
-                Ok(None)
-            }
+            // alike. The caller decides when an all-missing operation warrants
+            // an environment probe, so a batch can share one probe across all
+            // of its version-pinned reads.
+            StatusCode::NOT_FOUND => Ok(SecretRead::NotFound),
             _ => Err(self.http_error(status, &body, "reading a secret")),
         }
     }
@@ -786,15 +797,17 @@ impl InfisicalProvider {
     /// HTTP status avoids parsing or exposing any unrelated root-level secrets.
     async fn ensure_environment_exists_async(&self, environment: &str) -> Result<()> {
         let url = format!("{}/api/v4/secrets", self.config.endpoint);
-        let query = self.read_query(environment, "/");
+        let query = self.environment_probe_query(environment);
         let response = self.send(reqwest::Method::GET, &url, &query, None).await?;
         let status = response.status();
-        let body = Self::response_body(response).await?;
 
         match status {
             StatusCode::OK => Ok(()),
             StatusCode::NOT_FOUND => Err(self.missing_environment_error(environment)),
-            _ => Err(self.http_error(status, &body, "checking an environment")),
+            _ => {
+                let body = Self::response_body(response).await?;
+                Err(self.http_error(status, &body, "checking an environment"))
+            }
         }
     }
 
@@ -1139,7 +1152,17 @@ impl Provider for InfisicalProvider {
             Address::Native(native) => native.version.as_deref(),
             Address::Convention { .. } => None,
         };
-        super::block_on(self.get_async(&loc, version))
+        super::block_on(async {
+            let read = self.get_async(&loc, version).await?;
+            if matches!(&read, SecretRead::NotFound) {
+                self.ensure_environment_exists_async(&loc.environment)
+                    .await?;
+            }
+            Ok(match read {
+                SecretRead::Response(value) => value,
+                SecretRead::NotFound => None,
+            })
+        })
     }
 
     /// Secrets sharing a folder and environment are read with one list call
@@ -1152,15 +1175,42 @@ impl Provider for InfisicalProvider {
             |(_, addr)| matches!(addr, Address::Native(native) if native.version.is_some()),
         );
 
-        // Nothing about a versioned read is Infisical-specific, so it keeps the
-        // shared fetch, which already fetches one address once however many
-        // secrets name it, and fetches distinct ones concurrently.
+        // Versioned reads still share the generic deduplicated, concurrent
+        // fetch, but bypass `get`: its per-read diagnostic would issue one root
+        // probe for every miss. Their environments are checked together below
+        // only if the whole provider read is missing.
         let versioned: Vec<(&str, Address<'_>)> = versioned.into_iter().copied().collect();
+        let versioned_misses = Mutex::new(HashSet::new());
         let mut resolved = if versioned.is_empty() {
             HashMap::new()
         } else {
-            super::get_each(self, &versioned)?
+            super::get_each_with(&versioned, |addr| {
+                let loc = self.locate(addr)?;
+                let version = match addr {
+                    Address::Native(native) => native.version.as_deref(),
+                    Address::Convention { .. } => None,
+                };
+                match super::block_on(self.get_async(&loc, version))? {
+                    SecretRead::Response(value) => Ok(value),
+                    SecretRead::NotFound => {
+                        versioned_misses
+                            .lock()
+                            .map_err(|_| {
+                                SecretSpecError::ProviderOperationFailed(
+                                    "Infisical batch diagnostic state was poisoned".to_string(),
+                                )
+                            })?
+                            .insert(loc.environment);
+                        Ok(None)
+                    }
+                }
+            })?
         };
+        let versioned_environments = versioned_misses.into_inner().map_err(|_| {
+            SecretSpecError::ProviderOperationFailed(
+                "Infisical batch diagnostic state was poisoned".to_string(),
+            )
+        })?;
 
         super::block_on(async {
             // One list call per distinct folder and environment.
@@ -1178,7 +1228,7 @@ impl Provider for InfisicalProvider {
             // know the entire provider read missed; successful reads should not
             // pay for diagnostics on an unrelated optional secret.
             let mut known_environments = HashSet::new();
-            let mut uncertain_environments = HashSet::new();
+            let mut uncertain_environments = versioned_environments;
 
             for ((environment, secret_path), wanted) in folders {
                 match self.list_async(&environment, &secret_path).await? {
@@ -1273,11 +1323,25 @@ mod tests {
     fn response_server(
         responses: Vec<(&'static str, &'static str)>,
     ) -> (SocketAddr, std::thread::JoinHandle<Vec<String>>) {
+        response_server_with_lengths(
+            responses
+                .into_iter()
+                .map(|(status, body)| (status, body, body.len()))
+                .collect(),
+        )
+    }
+
+    /// As [`response_server`], with an independently declared content length.
+    /// A deliberately truncated body proves code only inspected the response
+    /// status instead of buffering data it did not need.
+    fn response_server_with_lengths(
+        responses: Vec<(&'static str, &'static str, usize)>,
+    ) -> (SocketAddr, std::thread::JoinHandle<Vec<String>>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let endpoint = listener.local_addr().unwrap();
         let server = std::thread::spawn(move || {
             let mut requests = Vec::new();
-            for (status, body) in responses {
+            for (status, body, content_length) in responses {
                 let (mut stream, _) = listener.accept().unwrap();
                 let mut reader = BufReader::new(&mut stream);
                 let mut request_line = String::new();
@@ -1294,7 +1358,7 @@ mod tests {
                     stream,
                     "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: \
                      {}\r\nConnection: close\r\n\r\n{body}",
-                    body.len()
+                    content_length
                 )
                 .unwrap();
             }
@@ -1360,6 +1424,59 @@ mod tests {
                 .is_empty()
         );
         assert_eq!(server.join().unwrap().len(), 2);
+    }
+
+    /// Distinct historical reads share one status-only, metadata-only root
+    /// probe when the whole batch is missing.
+    #[test]
+    fn versioned_batch_misses_probe_the_environment_once_without_values() {
+        let first_body = r#"{"message":"first version not found"}"#;
+        let second_body = r#"{"message":"second version not found"}"#;
+        let root_body = r#"{"secrets":[{"secretValue":"unrelated plaintext"}]}"#;
+        let (endpoint, server) = response_server_with_lengths(vec![
+            ("404 Not Found", first_body, first_body.len()),
+            ("404 Not Found", second_body, second_body.len()),
+            // Closing before the declared length makes consuming this body
+            // fail. A status-only probe succeeds without touching it.
+            ("200 OK", root_body, root_body.len() + 1024),
+        ]);
+        let provider = provider_with_token(endpoint, Some("development"));
+        let first = NativeAddress {
+            item: "/infra/FIRST".into(),
+            version: Some("1".into()),
+            ..Default::default()
+        };
+        let second = NativeAddress {
+            item: "/infra/SECOND".into(),
+            version: Some("2".into()),
+            ..Default::default()
+        };
+
+        assert!(
+            provider
+                .get_many(&[
+                    ("FIRST", Address::Native(&first)),
+                    ("SECOND", Address::Native(&second)),
+                ])
+                .expect("the environment exists")
+                .is_empty()
+        );
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 3);
+        let probes: Vec<_> = requests
+            .iter()
+            .filter(|request| request.starts_with("GET /api/v4/secrets?"))
+            .collect();
+        assert_eq!(probes.len(), 1, "{requests:#?}");
+        assert!(probes[0].contains("secretPath=%2F"), "{}", probes[0]);
+        assert!(
+            probes[0].contains("expandSecretReferences=false"),
+            "{}",
+            probes[0]
+        );
+        assert!(probes[0].contains("viewSecretValue=false"), "{}", probes[0]);
+        assert!(!probes[0].contains("viewSecretValue=true"), "{}", probes[0]);
     }
 
     /// The diagnostic tells users whether to rename a profile or change the

--- a/secretspec/src/provider/infisical.rs
+++ b/secretspec/src/provider/infisical.rs
@@ -67,6 +67,11 @@
 //! A folder that imports another resolves the imported keys too, with
 //! Infisical's own precedence: a secret defined directly in the folder wins
 //! over an imported one, and a later import wins over an earlier one.
+//!
+//! Starting in 0.20, an all-missing read probes the environment root once to
+//! distinguish an absent environment or project from ordinary absent secrets
+//! and folders. The resulting error names the environment and whether the
+//! profile or `?env=` selected it.
 
 use super::{
     Address, Provider, ProviderCredentials, ProviderUrl, credential_or_env, join_slash_path,
@@ -76,7 +81,7 @@ use crate::{Result, SecretSpecError};
 use reqwest::StatusCode;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
 /// Default folder prefix holding SecretSpec's secrets.
@@ -335,6 +340,22 @@ impl InfisicalProvider {
             .map(str::trim)
             .filter(|profile| !profile.is_empty())
             .map(str::to_string)
+    }
+
+    /// Explains which SecretSpec setting selected an environment Infisical
+    /// could not find.
+    fn missing_environment_error(&self, environment: &str) -> SecretSpecError {
+        let source = if self.config.environment.is_some() {
+            "The provider URI selected it with `?env=`."
+        } else {
+            "The active SecretSpec profile selected it because the provider URI does not pin an \
+             environment with `?env=`."
+        };
+        SecretSpecError::ProviderOperationFailed(format!(
+            "Infisical could not find environment '{}' in project {} (or the project itself is \
+             unavailable). {source}",
+            environment, self.config.project_id
+        ))
     }
 
     /// Renders the provider URI with the supplied entry-addressing defaults.
@@ -647,12 +668,17 @@ impl InfisicalProvider {
                 Self::secret_value(&parsed["secret"], &loc.key)
             }
             // A 404 covers a missing secret, folder, environment and project
-            // alike, and only the message text tells them apart. Reading it
-            // would make control flow turn on prose, so all four are taken as
-            // "nothing stored here", which `check` and provider fallback read
-            // as "not set". A misspelled `?env=` therefore looks like an unset
-            // secret until a write reports it.
-            StatusCode::NOT_FOUND => Ok(None),
+            // alike, and only the message text tells them apart. Probe the
+            // environment's root, which always exists in a real environment,
+            // rather than turning control flow on response prose. This is a
+            // single-secret read, so the miss already means the whole read
+            // failed and the diagnostic request does not penalize a successful
+            // resolution.
+            StatusCode::NOT_FOUND => {
+                self.ensure_environment_exists_async(&loc.environment)
+                    .await?;
+                Ok(None)
+            }
             _ => Err(self.http_error(status, &body, "reading a secret")),
         }
     }
@@ -712,7 +738,7 @@ impl InfisicalProvider {
         &self,
         environment: &str,
         secret_path: &str,
-    ) -> Result<HashMap<String, SecretString>> {
+    ) -> Result<Option<HashMap<String, SecretString>>> {
         let url = format!("{}/api/v4/secrets", self.config.endpoint);
         let query = self.read_query(environment, secret_path);
 
@@ -744,11 +770,31 @@ impl InfisicalProvider {
                     }
                 }
                 Self::merge_imports(&parsed, &mut listed)?;
-                Ok(listed)
+                Ok(Some(listed))
             }
-            // An absent folder holds no secrets, exactly like an empty one.
-            StatusCode::NOT_FOUND => Ok(HashMap::new()),
+            // The caller decides whether this is an absent folder or an absent
+            // environment. Infisical uses the same 404 for both.
+            StatusCode::NOT_FOUND => Ok(None),
             _ => Err(self.http_error(status, &body, "listing secrets")),
+        }
+    }
+
+    /// Checks the environment's root to distinguish an ordinary missing
+    /// secret/folder from an environment (or project) Infisical cannot find.
+    ///
+    /// The root folder always exists in a real environment. Inspecting only the
+    /// HTTP status avoids parsing or exposing any unrelated root-level secrets.
+    async fn ensure_environment_exists_async(&self, environment: &str) -> Result<()> {
+        let url = format!("{}/api/v4/secrets", self.config.endpoint);
+        let query = self.read_query(environment, "/");
+        let response = self.send(reqwest::Method::GET, &url, &query, None).await?;
+        let status = response.status();
+        let body = Self::response_body(response).await?;
+
+        match status {
+            StatusCode::OK => Ok(()),
+            StatusCode::NOT_FOUND => Err(self.missing_environment_error(environment)),
+            _ => Err(self.http_error(status, &body, "checking an environment")),
         }
     }
 
@@ -775,11 +821,7 @@ impl InfisicalProvider {
         // The folder is what is missing, unless the secret lives at the root,
         // which always exists -- then the 404 is the environment's.
         if loc.secret_path == "/" {
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "Infisical has no environment '{}' in project {}. Environments are \
-                 SecretSpec profiles here unless the provider URI pins one with `?env=`.",
-                loc.environment, self.config.project_id
-            )));
+            return Err(self.missing_environment_error(&loc.environment));
         }
         let refused = self.create_folder(loc).await?;
 
@@ -1131,12 +1173,41 @@ impl Provider for InfisicalProvider {
                     .push((name, loc.key));
             }
 
+            // A successful listing proves the environment exists. A 404 on a
+            // non-root folder is ambiguous, so defer its root probe until we
+            // know the entire provider read missed; successful reads should not
+            // pay for diagnostics on an unrelated optional secret.
+            let mut known_environments = HashSet::new();
+            let mut uncertain_environments = HashSet::new();
+
             for ((environment, secret_path), wanted) in folders {
-                let listed = self.list_async(&environment, &secret_path).await?;
-                for (name, key) in wanted {
-                    if let Some(value) = listed.get(&key) {
-                        resolved.insert(name.to_string(), value.clone());
+                match self.list_async(&environment, &secret_path).await? {
+                    Some(listed) => {
+                        known_environments.insert(environment);
+                        for (name, key) in wanted {
+                            if let Some(value) = listed.get(&key) {
+                                resolved.insert(name.to_string(), value.clone());
+                            }
+                        }
                     }
+                    None if secret_path == "/" => {
+                        // Listing the root itself removes the folder/secret
+                        // ambiguity without another request.
+                        return Err(self.missing_environment_error(&environment));
+                    }
+                    None => {
+                        uncertain_environments.insert(environment);
+                    }
+                }
+            }
+
+            if resolved.is_empty() {
+                let to_probe: Vec<String> = uncertain_environments
+                    .difference(&known_environments)
+                    .cloned()
+                    .collect();
+                for environment in to_probe {
+                    self.ensure_environment_exists_async(&environment).await?;
                 }
             }
 
@@ -1169,6 +1240,8 @@ impl Provider for InfisicalProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::{SocketAddr, TcpListener};
     use url::Url;
 
     const PROJECT: &str = "7e2f1a4c-0000-0000-0000-000000000000";
@@ -1181,6 +1254,62 @@ mod tests {
         InfisicalProvider::new(config(s))
     }
 
+    fn provider_with_token(endpoint: SocketAddr, environment: Option<&str>) -> InfisicalProvider {
+        let environment =
+            environment.map_or_else(String::new, |environment| format!("&env={environment}"));
+        let mut provider = provider(&format!(
+            "infisical://{endpoint}/{PROJECT}?tls=false{environment}"
+        ));
+        provider.with_credentials(ProviderCredentials::from([(
+            TOKEN.to_string(),
+            SecretString::new("test-token".to_string().into()),
+        )]));
+        provider
+    }
+
+    /// Serves a fixed sequence of Infisical-shaped responses and records the
+    /// request lines. Closing every response keeps the tiny fixture independent
+    /// of reqwest's connection-pool behavior.
+    fn response_server(
+        responses: Vec<(&'static str, &'static str)>,
+    ) -> (SocketAddr, std::thread::JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let mut requests = Vec::new();
+            for (status, body) in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(&mut stream);
+                let mut request_line = String::new();
+                reader.read_line(&mut request_line).unwrap();
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).unwrap();
+                    if line == "\r\n" || line.is_empty() {
+                        break;
+                    }
+                }
+                requests.push(request_line.trim_end().to_string());
+                write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: \
+                     {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .unwrap();
+            }
+            requests
+        });
+        (endpoint, server)
+    }
+
+    fn one_convention_request() -> [(&'static str, Address<'static>); 1] {
+        [(
+            "API_KEY",
+            Address::convention("myapp", "development", "API_KEY"),
+        )]
+    }
+
     #[test]
     fn uri_defaults_to_infisical_cloud() {
         let c = config(&format!("infisical:///{PROJECT}"));
@@ -1188,6 +1317,66 @@ mod tests {
         assert_eq!(c.project_id, PROJECT);
         assert_eq!(c.path, DEFAULT_PATH);
         assert_eq!(c.environment, None);
+    }
+
+    /// When the requested folder and the environment root both return 404,
+    /// the provider names the missing environment instead of reducing the
+    /// whole profile to a list of unset secrets.
+    #[test]
+    fn an_all_missing_batch_diagnoses_a_missing_profile_environment() {
+        let (endpoint, server) = response_server(vec![
+            ("404 Not Found", r#"{"message":"not found"}"#),
+            ("404 Not Found", r#"{"message":"not found"}"#),
+        ]);
+        let provider = provider_with_token(endpoint, None);
+        let error = provider
+            .get_many(&one_convention_request())
+            .expect_err("the absent environment must be reported")
+            .to_string();
+
+        assert!(error.contains("environment 'development'"), "{error}");
+        assert!(error.contains(PROJECT), "{error}");
+        assert!(error.contains("active SecretSpec profile"), "{error}");
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].contains("environment=development"));
+        assert!(requests[1].contains("secretPath=%2F"));
+    }
+
+    /// A missing non-root folder remains an ordinary miss when the root probe
+    /// proves the environment exists, preserving provider fallback behavior.
+    #[test]
+    fn a_missing_folder_in_an_existing_environment_stays_unset() {
+        let (endpoint, server) = response_server(vec![
+            ("404 Not Found", r#"{"message":"not found"}"#),
+            ("200 OK", r#"{"secrets":[]}"#),
+        ]);
+        let provider = provider_with_token(endpoint, None);
+
+        assert!(
+            provider
+                .get_many(&one_convention_request())
+                .expect("the environment exists")
+                .is_empty()
+        );
+        assert_eq!(server.join().unwrap().len(), 2);
+    }
+
+    /// The diagnostic tells users whether to rename a profile or change the
+    /// provider's explicit environment pin.
+    #[test]
+    fn a_missing_environment_names_how_it_was_selected() {
+        let implicit = provider(&format!("infisical://app.infisical.com/{PROJECT}"));
+        let implicit_error = implicit
+            .missing_environment_error("development")
+            .to_string();
+        assert!(implicit_error.contains("active SecretSpec profile"));
+
+        let pinned = provider(&format!(
+            "infisical://app.infisical.com/{PROJECT}?env=shared"
+        ));
+        let pinned_error = pinned.missing_environment_error("shared").to_string();
+        assert!(pinned_error.contains("provider URI selected it with `?env=`"));
     }
 
     #[test]

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -126,9 +126,9 @@ pub(crate) use registry::{
 pub(crate) use runtime::block_on;
 #[cfg(test)]
 pub(crate) use traits::GET_EACH_CONCURRENCY_ENV;
-#[cfg(any(feature = "infisical", test))]
+#[cfg(test)]
 pub(crate) use traits::get_each;
-#[cfg(any(feature = "openbao", feature = "vault"))]
+#[cfg(any(feature = "infisical", feature = "openbao", feature = "vault"))]
 pub(crate) use traits::get_each_with;
 pub(crate) use traits::{get_each_concurrency, map_concurrently, same_storage_container};
 pub(crate) use url::{ProviderUrl, URI_ENCODE_SET};


### PR DESCRIPTION
## Summary

- probe the root folder once when an entire batch returns missing
- distinguish a missing environment from legitimate missing folders or secrets
- identify whether the environment came from the profile or an explicit env query
- preserve unset and fallback behavior for valid missing data

Fixes #338

## Testing

- devenv shell cargo test -p secretspec provider::infisical::tests
- devenv shell cargo test -p secretspec
- devenv shell npm --prefix docs run build