### PR TITLE
fix(gcsm): make convention names collision-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Google Cloud Secret Manager convention names now encode the project,
+  profile, and key separately with lowercase, unpadded Base32. Distinct
+  logical addresses such as `my-app/prod/K` and `my/app-prod/K` can no longer
+  collide on one stored secret. Convention secrets created by SecretSpec 0.19
+  or earlier keep their old GCSM ids and must be re-stored for the 0.20 naming
+  convention; explicit `ref` addresses remain unchanged. ([#219])
+
+  [#219]: https://github.com/cachix/secretspec/issues/219
+
 - Bare `bws://<project-uuid>` provider URIs now target the Bitwarden US cloud
   vault instead of the public marketing site, restoring reads and writes while
   keeping the server pinned independently of ambient `bws` configuration.

--- a/docs/src/content/docs/providers/gcsm.md
+++ b/docs/src/content/docs/providers/gcsm.md
@@ -15,7 +15,7 @@ The Google Cloud Secret Manager provider integrates with GCP for centralized sec
 | Best for | Workloads and teams on Google Cloud |
 | Authentication | Google Application Default Credentials |
 | Build feature | `gcsm` |
-| Default storage | `secretspec-{project}-{profile}-{key}` |
+| Default storage | `secretspec--{base32(project)}--{base32(profile)}--{base32(key)}` (0.20+) |
 
 ## Quick start
 
@@ -77,9 +77,34 @@ DATABASE_URL = { description = "Database URL", providers = ["google"] }
 
 ## Storage model
 
-Secrets are stored as `secretspec-{project}-{profile}-{key}`. For example,
-project `myapp`, profile `production`, and key `DATABASE_URL` map to
-`secretspec-myapp-production-DATABASE_URL`.
+:::caution[Version compatibility]
+The collision-safe convention below is used starting with SecretSpec 0.20.
+Releases through 0.19 used `secretspec-{project}-{profile}-{key}`.
+:::
+
+SecretSpec encodes the project, profile, and key separately as lowercase,
+unpadded Base32, then joins them with `--`. Distinct logical addresses therefore
+cannot collapse onto one GCSM secret when a project or profile contains a
+hyphen. For example, project `myapp`, profile `production`, and key
+`DATABASE_URL` map to:
+
+```text
+secretspec--nv4wc4dq--obzg6zdvmn2gs33o--iraviqkcifjukx2vkjga
+```
+
+Existing convention secrets created by SecretSpec 0.19 or earlier retain their
+old GCSM ids and must be re-stored under the 0.20 convention before upgrading.
+To keep reading an old id during migration, address it explicitly with `ref`;
+native references are not renamed:
+
+```toml
+[profiles.production]
+DATABASE_URL = {
+  description = "DB",
+  ref = { item = "secretspec-myapp-production-DATABASE_URL" },
+  providers = ["google"]
+}
+```
 
 ## Use existing secrets
 

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -346,7 +346,7 @@ gcsm://my-gcp-project         # GCP project ID
 
 **Features**: Read/write, cloud sync, profiles, service account support
 **Prerequisites**: `gcloud` CLI, authenticated, Secret Manager API enabled, build with `--features gcsm`
-**Storage**: Secret name `secretspec-{project}-{profile}-{key}`
+**Storage (0.20+)**: Secret name `secretspec--{base32(project)}--{base32(profile)}--{base32(key)}`. Releases through 0.19 used `secretspec-{project}-{profile}-{key}`; existing convention secrets must be re-stored or addressed with an explicit `ref`.
 
 ## AWS Secrets Manager Provider
 

--- a/secretspec/src/provider/gcsm.rs
+++ b/secretspec/src/provider/gcsm.rs
@@ -15,7 +15,11 @@
 //!
 //! # Secret Naming
 //!
-//! Secrets are stored with the naming pattern: `secretspec-{project}-{profile}-{key}`
+//! Starting in SecretSpec 0.20, convention secrets are stored as
+//! `secretspec--{base32(project)}--{base32(profile)}--{base32(key)}`. Encoding
+//! each component separately keeps the mapping injective when project or
+//! profile names contain hyphens. Releases through 0.19 used the ambiguous
+//! `secretspec-{project}-{profile}-{key}` form.
 //!
 //! # Example
 //!
@@ -32,6 +36,7 @@
 
 use super::{Address, Provider, ProviderUrl};
 use crate::{Result, SecretSpecError};
+use data_encoding::BASE32_NOPAD;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use google_cloud_secretmanager_v1::model::{Replication, Secret, SecretPayload, replication};
 use secrecy::{ExposeSecret, SecretString};
@@ -187,21 +192,36 @@ impl GcsmProvider {
         Ok(())
     }
 
+    /// Encodes one convention component into a lowercase, GCSM-compatible,
+    /// injective representation. Base32 preserves the original bytes while
+    /// emitting no hyphens, so an encoded component cannot consume or shift
+    /// the `--` delimiters between project, profile, and key.
+    fn encode_name_component(component: &str) -> String {
+        BASE32_NOPAD
+            .encode(component.as_bytes())
+            .to_ascii_lowercase()
+    }
+
     /// Formats and validates the secret name for GCP Secret Manager.
     ///
-    /// Converts the SecretSpec path format to GCP-compatible name:
-    /// `secretspec-{project}-{profile}-{key}`
+    /// Converts the SecretSpec path format to the injective GCP-compatible
+    /// name `secretspec--{base32(project)}--{base32(profile)}--{base32(key)}`.
     ///
     /// GCP Secret Manager secret IDs must:
     /// - Be 1-255 characters long
     /// - Contain only alphanumeric characters, hyphens, and underscores
-    fn format_secret_name(&self, project: &str, profile: &str, key: &str) -> Result<String> {
+    fn format_secret_name(project: &str, profile: &str, key: &str) -> Result<String> {
         // Validate each component
         Self::validate_name_component("project", project)?;
         Self::validate_name_component("profile", profile)?;
         Self::validate_name_component("key", key)?;
 
-        let secret_name = format!("secretspec-{}-{}-{}", project, profile, key);
+        let secret_name = format!(
+            "secretspec--{}--{}--{}",
+            Self::encode_name_component(project),
+            Self::encode_name_component(profile),
+            Self::encode_name_component(key)
+        );
 
         // GCP secret IDs must be 1-255 characters
         if secret_name.len() > 255 {
@@ -343,9 +363,8 @@ impl GcsmProvider {
 }
 
 impl Provider for GcsmProvider {
-    /// Convention secrets are ids of the form
-    /// `secretspec-{project}-{profile}-{key}` (GCP secret ids cannot contain
-    /// slashes), read at their latest version.
+    /// Convention names use separately encoded Base32 components so distinct
+    /// project/profile/key triples always produce distinct GCSM secret ids.
     fn convention_address(
         &self,
         project: &str,
@@ -353,7 +372,7 @@ impl Provider for GcsmProvider {
         key: &str,
     ) -> Result<crate::config::NativeAddress> {
         Ok(crate::config::NativeAddress {
-            item: self.format_secret_name(project, profile, key)?,
+            item: Self::format_secret_name(project, profile, key)?,
             ..Default::default()
         })
     }
@@ -450,5 +469,78 @@ mod reference_tests {
         };
         let err = p.get(Address::Native(&addr)).unwrap_err();
         assert!(err.to_string().contains("`field`"), "{err}");
+    }
+
+    #[test]
+    fn convention_name_is_collision_safe() {
+        let first = GcsmProvider::format_secret_name("my-app", "prod", "K").unwrap();
+        let second = GcsmProvider::format_secret_name("my", "app-prod", "K").unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(first, "secretspec--nv4s2ylqoa--obzg6za--jm",);
+    }
+}
+
+/// Property tests for the injective convention-name mapping.
+#[cfg(test)]
+mod name_properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Exactly the component alphabet accepted by `validate_name_component`.
+    /// Delimiter-heavy alternatives are weighted because that is where the
+    /// legacy convention produced collisions.
+    fn component() -> impl Strategy<Value = String> {
+        prop_oneof!["[A-Za-z0-9_-]{1,8}", "[_-]{1,3}"]
+    }
+
+    fn triple() -> impl Strategy<Value = (String, String, String)> {
+        (component(), component(), component())
+    }
+
+    /// A left inverse proves that every encoded name identifies exactly the
+    /// triple that produced it.
+    fn decode_secret_name(name: &str) -> Option<(String, String, String)> {
+        let body = name.strip_prefix("secretspec--")?;
+        let parts: Vec<&str> = body.split("--").collect();
+        let [project, profile, key] = parts.as_slice() else {
+            return None;
+        };
+        let decode = |part: &str| {
+            let bytes = BASE32_NOPAD
+                .decode(part.to_ascii_uppercase().as_bytes())
+                .ok()?;
+            String::from_utf8(bytes).ok()
+        };
+        Some((decode(project)?, decode(profile)?, decode(key)?))
+    }
+
+    proptest! {
+        #[test]
+        fn convention_name_decodes_to_its_original_triple(
+            (project, profile, key) in triple()
+        ) {
+            let name = GcsmProvider::format_secret_name(&project, &profile, &key)
+                .expect("a valid component must format");
+            prop_assert_eq!(
+                decode_secret_name(&name),
+                Some((project, profile, key)),
+            );
+        }
+
+        #[test]
+        fn distinct_triples_never_share_a_convention_name(
+            triples in prop::collection::vec(triple(), 2..24)
+        ) {
+            let mut seen = std::collections::HashMap::new();
+            for (project, profile, key) in triples {
+                let triple = (project, profile, key);
+                let name = GcsmProvider::format_secret_name(&triple.0, &triple.1, &triple.2)
+                    .expect("a valid component must format");
+                if let Some(previous) = seen.insert(name.clone(), triple.clone()) {
+                    prop_assert_eq!(previous, triple, "collision at {}", name);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- replace ambiguous hyphen flattening with reversible lowercase Base32 components
- add an exact collision regression and property tests
- document the 0.20 naming migration; explicit ref addresses remain unchanged

Fixes #219

## Testing

- devenv shell cargo test -p secretspec gcsm
- devenv shell cargo test -p secretspec
- devenv shell npm --prefix docs run build