### PR TITLE
fix(gcsm): migrate convention names lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accepted but the new layout cannot represent, such as a project containing
   `--`, keep reading their 0.19 secret with a warning; writing them requires
   renaming the component or addressing the secret with a `ref`.
-  Explicit `ref` addresses remain unchanged. ([#219])
+  Secret-level IAM bindings on 0.19 ids also keep working when an unbound new
+  id returns permission denied, while other access failures remain errors
+  instead of being mistaken for missing values. Explicit `ref` addresses
+  remain unchanged. ([#219])
 
   [#219]: https://github.com/cachix/secretspec/issues/219
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Google Cloud Secret Manager convention names now use the readable,
+  versioned `secretspec2--{project}--{profile}--{key}` layout. Distinct logical
+  addresses such as `my-app/prod/K` and `my/app-prod/K` can no longer collide
+  on one stored secret. When the new id holds no value, reads fall back to the
+  matching 0.19 `secretspec-{project}-{profile}-{key}` secret and warn once per
+  run, so an upgraded project keeps working with no migration step and no new
+  permissions: the fallback only reads, and credentials that cannot create
+  secrets are unaffected. Writes always use the new id, so `secretspec set`
+  moves a secret, after which reads stop consulting the legacy id. The 0.19
+  secret is left in place for rollback and should only be deleted once its
+  value has been written under the new id. Names that releases through 0.19
+  accepted but the new layout cannot represent, such as a project containing
+  `--`, keep reading their 0.19 secret with a warning; writing them requires
+  renaming the component or addressing the secret with a `ref`.
+  Explicit `ref` addresses remain unchanged. ([#219])
+
+  [#219]: https://github.com/cachix/secretspec/issues/219
+
 - Bare `bws://<project-uuid>` provider URIs now target the Bitwarden US cloud
   vault instead of the public marketing site, restoring reads and writes while
   keeping the server pinned independently of ambient `bws` configuration.

--- a/docs/src/content/docs/providers/gcsm.md
+++ b/docs/src/content/docs/providers/gcsm.md
@@ -111,6 +111,12 @@ read falls back to the 0.19 `secretspec-{project}-{profile}-{key}` id and
 returns its latest value, printing one warning per run. A project upgraded from
 0.19 therefore keeps working with no migration step.
 
+With secret-level IAM, an unbound new id can return `PERMISSION_DENIED` instead
+of `NOT_FOUND`. SecretSpec still probes the legacy id in that case and uses it
+when readable. If the legacy id supplies no value, the original denial remains
+an error; failures other than the expected permission denial from a legacy-id
+probe are also reported rather than treated as a missing secret.
+
 The fallback is a read. Nothing is created, copied, or deleted, so the upgrade
 needs no new permissions: credentials holding only
 `roles/secretmanager.secretAccessor`, the usual CI principal, keep working

--- a/docs/src/content/docs/providers/gcsm.md
+++ b/docs/src/content/docs/providers/gcsm.md
@@ -15,7 +15,7 @@ The Google Cloud Secret Manager provider integrates with GCP for centralized sec
 | Best for | Workloads and teams on Google Cloud |
 | Authentication | Google Application Default Credentials |
 | Build feature | `gcsm` |
-| Default storage | `secretspec-{project}-{profile}-{key}` |
+| Default storage | `secretspec2--{project}--{profile}--{key}` (0.20+) |
 
 ## Quick start
 
@@ -77,9 +77,75 @@ DATABASE_URL = { description = "Database URL", providers = ["google"] }
 
 ## Storage model
 
-Secrets are stored as `secretspec-{project}-{profile}-{key}`. For example,
-project `myapp`, profile `production`, and key `DATABASE_URL` map to
-`secretspec-myapp-production-DATABASE_URL`.
+:::caution[Version compatibility]
+The collision-safe convention below is used starting with SecretSpec 0.20.
+Releases through 0.19 used `secretspec-{project}-{profile}-{key}`.
+:::
+
+SecretSpec joins the project, profile, and key with validated `--` boundaries.
+Distinct logical addresses therefore cannot collapse onto one GCSM secret when
+a project or profile contains a single internal hyphen. For example, project
+`myapp`, profile `production`, and key `DATABASE_URL` map to:
+
+```text
+secretspec2--myapp--production--DATABASE_URL
+```
+
+Each component may contain ASCII letters, digits, underscores, and single
+internal hyphens. A component cannot start or end with `-` or contain `--`,
+because those forms could overlap a boundary. The complete GCSM id must fit the
+service's 255-character limit.
+
+Releases through 0.19 accepted project, profile, and key names the new layout
+cannot represent, such as a project directory named `my--app`. Reads of such an
+address keep serving the 0.19 secret and print a warning, but writes fail until
+the name changes. Rename the offending component and run `secretspec set` to
+store the value under the new id, or address the secret with an explicit
+[`ref`](/reference/configuration/#secret-references), which is exempt from the
+convention.
+
+### Reading secrets stored by 0.19
+
+SecretSpec 0.20 reads the new id first. When that secret holds no value, the
+read falls back to the 0.19 `secretspec-{project}-{profile}-{key}` id and
+returns its latest value, printing one warning per run. A project upgraded from
+0.19 therefore keeps working with no migration step.
+
+The fallback is a read. Nothing is created, copied, or deleted, so the upgrade
+needs no new permissions: credentials holding only
+`roles/secretmanager.secretAccessor`, the usual CI principal, keep working
+unchanged.
+
+Writes always use the new id. Running `secretspec set` for a secret is what
+moves it, and afterwards reads stop consulting the legacy id. The 0.19 secret
+is left in place, so an older SecretSpec keeps reading the value it knows and a
+rollback needs no recovery step.
+
+Two consequences are worth planning for:
+
+- A secret still served by the fallback depends on the 0.19 id continuing to
+  exist. Delete legacy secrets only after the values that matter have been
+  written under the new id.
+- While a secret is served by the fallback, a 0.19 writer and a 0.20 writer
+  update different ids. Point every writer at the same SecretSpec version, or
+  set the secret with 0.20 to settle it on the new id.
+
+Only the value is read across. Labels, rotation settings, secret-level IAM
+bindings, and other resource metadata belong to the legacy secret; reproduce
+any such configuration when you write the secret under its new id. If the
+legacy id had already received writes from colliding logical addresses, the
+provider cannot determine which historical version belonged to which address.
+
+An explicit `ref` is a native address and is never renamed or migrated:
+
+```toml
+[profiles.production]
+DATABASE_URL = {
+  description = "DB",
+  ref = { item = "secretspec-myapp-production-DATABASE_URL" },
+  providers = ["google"]
+}
+```
 
 ## Use existing secrets
 

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -346,7 +346,7 @@ gcsm://my-gcp-project         # GCP project ID
 
 **Features**: Read/write, cloud sync, profiles, service account support
 **Prerequisites**: `gcloud` CLI, authenticated, Secret Manager API enabled, build with `--features gcsm`
-**Storage**: Secret name `secretspec-{project}-{profile}-{key}`
+**Storage (0.20+)**: Secret name `secretspec2--{project}--{profile}--{key}` with validated, non-overlapping `--` boundaries. Releases through 0.19 used `secretspec-{project}-{profile}-{key}`. When the new id holds no value, reads fall back to the 0.19 id and warn; the fallback writes nothing, so no new permissions are needed. Writes always use the new id, so `secretspec set` is what moves a secret, and the 0.19 secret is left in place. Names accepted through 0.19 that the new layout cannot represent, such as a project containing `--`, keep reading their 0.19 secret and must be renamed before they can be written. Explicit `ref` addresses are unaffected.
 
 ## AWS Secrets Manager Provider
 

--- a/secretspec/src/provider/gcsm.rs
+++ b/secretspec/src/provider/gcsm.rs
@@ -20,7 +20,8 @@
 //! the new namespace from every legacy id, while validated `--` delimiters keep
 //! project, profile, and key boundaries unambiguous. Releases through 0.19 used
 //! the ambiguous `secretspec-{project}-{profile}-{key}` form. A read falls back
-//! to the legacy id when the new one holds no value, so a 0.19 project keeps
+//! to the legacy id when the new one holds no value, including when secret-level
+//! IAM makes an unbound new id appear permission-denied, so a 0.19 project keeps
 //! working untouched; writes always use the new id, so setting a secret is what
 //! moves it.
 //!
@@ -356,6 +357,12 @@ impl GcsmProvider {
         s.contains("NOT_FOUND") || s.contains("notFound")
     }
 
+    /// Checks if an error indicates that the caller cannot access a resource.
+    fn is_permission_denied_error(e: &(impl std::error::Error + 'static)) -> bool {
+        let s = crate::error::display_error_chain(e);
+        s.contains("PERMISSION_DENIED") || s.contains("permissionDenied")
+    }
+
     /// Checks if an error indicates the resource already exists.
     fn is_already_exists_error(e: &(impl std::error::Error + 'static)) -> bool {
         let s = crate::error::display_error_chain(e);
@@ -399,24 +406,24 @@ impl GcsmProvider {
         Self::get_coords_with_backend(&backend, coords).await
     }
 
-    /// Reads the legacy id as a best-effort compatibility source. That id is an
+    /// Reads the legacy id as a compatibility source. That id is an
     /// implementation detail of the fallback rather than an address the caller
     /// chose: a project with secret-level IAM answers PERMISSION_DENIED rather
     /// than NOT_FOUND for an id nobody was granted a binding on, and that must
-    /// not turn an unset secret into a failed read.
+    /// not turn an unset secret into a failed read. All other failures still
+    /// describe a requested backend operation and must reach the caller.
     async fn read_legacy_value(
         backend: &impl GcsmBackend,
         legacy_name: &str,
-    ) -> Option<SecretString> {
-        backend
-            .access_secret_version(legacy_name, "latest")
-            .await
-            .ok()
-            .flatten()
+    ) -> Result<Option<SecretString>> {
+        match backend.access_secret_version(legacy_name, "latest").await {
+            Err(error) if Self::is_permission_denied_error(&error) => Ok(None),
+            result => result,
+        }
     }
 
     /// Reads the 0.20 convention id, falling back to the 0.19 id when the new
-    /// one holds no value.
+    /// one yields no value under the migration-compatible IAM cases.
     ///
     /// The fallback is a read: nothing is created, copied, or deleted. So
     /// credentials that can read secrets but not create them, the common CI
@@ -436,7 +443,7 @@ impl GcsmProvider {
             // represent. Serve what is already stored rather than failing the
             // read; `set` still carries the rename instruction.
             Err(naming_error) => {
-                let Some(value) = Self::read_legacy_value(backend, &legacy_name).await else {
+                let Some(value) = Self::read_legacy_value(backend, &legacy_name).await? else {
                     return Err(naming_error);
                 };
                 UNREPRESENTABLE_NAME_WARNING.call_once(|| {
@@ -451,21 +458,32 @@ impl GcsmProvider {
             }
         };
 
-        if let Some(value) = backend
-            .access_secret_version(&secret_name, "latest")
-            .await?
-        {
-            return Ok(Some(value));
-        }
+        let current_error = match backend.access_secret_version(&secret_name, "latest").await {
+            Ok(Some(value)) => return Ok(Some(value)),
+            Ok(None) => None,
+            Err(error) if Self::is_permission_denied_error(&error) => Some(error),
+            Err(error) => return Err(error),
+        };
 
-        let Some(value) = Self::read_legacy_value(backend, &legacy_name).await else {
-            return Ok(None);
+        let legacy_value = match Self::read_legacy_value(backend, &legacy_name).await {
+            Ok(value) => value,
+            // The current id may exist but be unreadable. If it was denied,
+            // retain that authoritative failure unless the legacy probe
+            // actually supplies the compatibility value.
+            Err(error) => return Err(current_error.unwrap_or(error)),
+        };
+        let Some(value) = legacy_value else {
+            return match current_error {
+                Some(error) => Err(error),
+                None => Ok(None),
+            };
         };
 
         LEGACY_FALLBACK_WARNING.call_once(|| {
             eprintln!(
                 "Warning: reading the SecretSpec 0.19 GCSM secret '{legacy_name}' because \
-                 '{secret_name}' holds no value. Run `secretspec set` for this secret to store it \
+                 '{secret_name}' did not yield a value. Run `secretspec set` for this secret to \
+                 store it \
                  under the current name; the 0.19 secret is left in place either way. Further \
                  secrets read this way are not reported again."
             )
@@ -738,7 +756,7 @@ mod name_properties {
 #[cfg(test)]
 mod legacy_fallback_tests {
     use super::*;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
     use std::sync::Mutex;
 
     const LEGACY: &str = "secretspec-my-app-prod-K";
@@ -751,7 +769,7 @@ mod legacy_fallback_tests {
         secrets: Mutex<HashMap<String, Vec<String>>>,
         accesses: Mutex<Vec<String>>,
         writes: Mutex<Vec<String>>,
-        unreadable: Mutex<HashSet<String>>,
+        failures: Mutex<HashMap<String, String>>,
     }
 
     impl FakeGcsmBackend {
@@ -781,7 +799,14 @@ mod legacy_fallback_tests {
         /// Simulates the secret-level IAM binding a caller was never granted:
         /// GCSM answers PERMISSION_DENIED rather than NOT_FOUND.
         fn deny_access(&self, name: &str) {
-            self.unreadable.lock().unwrap().insert(name.to_string());
+            self.fail_access(name, "PERMISSION_DENIED");
+        }
+
+        fn fail_access(&self, name: &str, message: &str) {
+            self.failures
+                .lock()
+                .unwrap()
+                .insert(name.to_string(), message.to_string());
         }
     }
 
@@ -795,9 +820,9 @@ mod legacy_fallback_tests {
                 .lock()
                 .unwrap()
                 .push(format!("{secret_name}@{version}"));
-            if self.unreadable.lock().unwrap().contains(secret_name) {
+            if let Some(message) = self.failures.lock().unwrap().get(secret_name) {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "Failed to access secret '{secret_name}': PERMISSION_DENIED"
+                    "Failed to access secret '{secret_name}': {message}"
                 )));
             }
 
@@ -934,16 +959,50 @@ mod legacy_fallback_tests {
         assert!(read(&backend).unwrap().is_none());
     }
 
-    /// The current id is the address the caller did choose, so it still fails
-    /// loudly instead of silently serving a stale 0.19 value.
+    /// A deployment with IAM bound directly to each 0.19 secret cannot read a
+    /// new id that has no binding. The readable legacy value still resolves.
     #[test]
-    fn an_unreadable_current_id_fails_the_read() {
+    fn a_denied_current_id_falls_back_to_the_legacy_value() {
         let backend = FakeGcsmBackend::default();
         backend.insert(LEGACY, "legacy-value");
         backend.deny_access(CURRENT);
 
+        let value = read(&backend).unwrap().unwrap();
+        assert_eq!(value.expose_secret(), "legacy-value");
+    }
+
+    /// If the compatibility probe finds no legacy value, the provider cannot
+    /// assume that the current id is absent: it may exist but be unreadable.
+    #[test]
+    fn a_denied_current_id_without_a_legacy_value_fails_the_read() {
+        let backend = FakeGcsmBackend::default();
+        backend.deny_access(CURRENT);
+
         let error = read(&backend).unwrap_err();
         assert!(error.to_string().contains("PERMISSION_DENIED"), "{error}");
+    }
+
+    #[test]
+    fn a_backend_failure_reading_the_legacy_id_is_preserved() {
+        let backend = FakeGcsmBackend::default();
+        backend.fail_access(LEGACY, "UNAVAILABLE: transient backend failure");
+
+        let error = read(&backend).unwrap_err();
+        assert!(error.to_string().contains("UNAVAILABLE"), "{error}");
+    }
+
+    #[test]
+    fn a_backend_failure_reading_the_current_id_does_not_serve_a_legacy_value() {
+        let backend = FakeGcsmBackend::default();
+        backend.insert(LEGACY, "legacy-value");
+        backend.fail_access(CURRENT, "RESOURCE_EXHAUSTED: retry later");
+
+        let error = read(&backend).unwrap_err();
+        assert!(error.to_string().contains("RESOURCE_EXHAUSTED"), "{error}");
+        assert_eq!(
+            backend.accesses.lock().unwrap().as_slice(),
+            &[format!("{CURRENT}@latest")]
+        );
     }
 
     #[test]

--- a/secretspec/src/provider/gcsm.rs
+++ b/secretspec/src/provider/gcsm.rs
@@ -15,7 +15,14 @@
 //!
 //! # Secret Naming
 //!
-//! Secrets are stored with the naming pattern: `secretspec-{project}-{profile}-{key}`
+//! Starting in SecretSpec 0.20, convention secrets are stored as
+//! `secretspec2--{project}--{profile}--{key}`. The versioned prefix separates
+//! the new namespace from every legacy id, while validated `--` delimiters keep
+//! project, profile, and key boundaries unambiguous. Releases through 0.19 used
+//! the ambiguous `secretspec-{project}-{profile}-{key}` form. A read falls back
+//! to the legacy id when the new one holds no value, so a 0.19 project keeps
+//! working untouched; writes always use the new id, so setting a secret is what
+//! moves it.
 //!
 //! # Example
 //!
@@ -148,6 +155,118 @@ pub struct GcsmProvider {
     config: GcsmConfig,
 }
 
+/// A project still on the 0.19 layout, or whose name the current convention
+/// cannot represent, reads the same way for every secret in a run. These
+/// warnings print once per process so a `run` over dozens of secrets stays
+/// readable.
+static LEGACY_FALLBACK_WARNING: std::sync::Once = std::sync::Once::new();
+static UNREPRESENTABLE_NAME_WARNING: std::sync::Once = std::sync::Once::new();
+
+/// The three GCSM operations the provider needs. Keeping the orchestration
+/// above the generated Google client makes reads, writes, and the legacy
+/// fallback independently testable.
+trait GcsmBackend {
+    async fn access_secret_version(
+        &self,
+        secret_name: &str,
+        version: &str,
+    ) -> Result<Option<SecretString>>;
+
+    /// Creating a secret that already exists succeeds: callers only need the
+    /// resource to be there before adding a version.
+    async fn create_secret(&self, secret_name: &str) -> Result<()>;
+
+    async fn add_secret_version(&self, secret_name: &str, value: &SecretString) -> Result<()>;
+}
+
+struct GoogleGcsmBackend<'a> {
+    project_id: &'a str,
+    client: SecretManagerService,
+}
+
+impl GcsmBackend for GoogleGcsmBackend<'_> {
+    async fn access_secret_version(
+        &self,
+        secret_name: &str,
+        version: &str,
+    ) -> Result<Option<SecretString>> {
+        let secret_version_path = format!(
+            "projects/{}/secrets/{secret_name}/versions/{version}",
+            self.project_id
+        );
+
+        match self
+            .client
+            .access_secret_version()
+            .set_name(&secret_version_path)
+            .send()
+            .await
+        {
+            Ok(response) => {
+                if let Some(payload) = response.payload {
+                    let data = String::from_utf8(payload.data.to_vec()).map_err(|error| {
+                        SecretSpecError::ProviderOperationFailed(format!(
+                            "Secret data is not valid UTF-8: {error}"
+                        ))
+                    })?;
+                    Ok(Some(SecretString::new(data.into())))
+                } else {
+                    Ok(None)
+                }
+            }
+            Err(error) if GcsmProvider::is_not_found_error(&error) => Ok(None),
+            Err(error) => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to access secret '{secret_name}': {}",
+                crate::error::display_error_chain(&error)
+            ))),
+        }
+    }
+
+    async fn create_secret(&self, secret_name: &str) -> Result<()> {
+        let result = self
+            .client
+            .create_secret()
+            .set_parent(format!("projects/{}", self.project_id))
+            .set_secret_id(secret_name)
+            .set_secret(Secret::default().set_replication(
+                Replication::default().set_automatic(replication::Automatic::default()),
+            ))
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(error) if GcsmProvider::is_already_exists_error(&error) => Ok(()),
+            Err(error) => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to create secret '{secret_name}': {}",
+                crate::error::display_error_chain(&error)
+            ))),
+        }
+    }
+
+    async fn add_secret_version(&self, secret_name: &str, value: &SecretString) -> Result<()> {
+        self.client
+            .add_secret_version()
+            .set_parent(format!(
+                "projects/{}/secrets/{secret_name}",
+                self.project_id
+            ))
+            .set_payload(
+                SecretPayload::default().set_data(value.expose_secret().as_bytes().to_vec()),
+            )
+            .send()
+            .await
+            .map_err(|error| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to add secret version for '{secret_name}': {}",
+                    crate::error::display_error_chain(&error)
+                ))
+            })?;
+
+        Ok(())
+    }
+}
+
 crate::register_provider! {
     struct: GcsmProvider,
     config: GcsmConfig,
@@ -165,7 +284,9 @@ impl GcsmProvider {
 
     /// Validates a secret name component for GCP Secret Manager.
     ///
-    /// Components must contain only alphanumeric characters, underscores, and hyphens.
+    /// Components contain only alphanumeric characters, underscores, and
+    /// internal single hyphens. A component may not contain `--` or begin or
+    /// end with `-`: either shape could consume or overlap a `--` boundary.
     fn validate_name_component(name: &str, component: &str) -> Result<()> {
         if component.is_empty() {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
@@ -184,24 +305,33 @@ impl GcsmProvider {
             }
         }
 
+        if component.starts_with('-') || component.ends_with('-') || component.contains("--") {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{name} '{component}' cannot start or end with a hyphen or contain `--`: the \
+                 GCSM convention separates project, profile, and key with `--`, so only single \
+                 internal hyphens stay unambiguous. Rename it and run `secretspec set` to store \
+                 the value under the new name, or address the secret with a `ref` entry."
+            )));
+        }
+
         Ok(())
     }
 
     /// Formats and validates the secret name for GCP Secret Manager.
     ///
-    /// Converts the SecretSpec path format to GCP-compatible name:
-    /// `secretspec-{project}-{profile}-{key}`
+    /// Converts the SecretSpec path format to the readable, injective,
+    /// GCP-compatible name `secretspec2--{project}--{profile}--{key}`.
     ///
     /// GCP Secret Manager secret IDs must:
     /// - Be 1-255 characters long
     /// - Contain only alphanumeric characters, hyphens, and underscores
-    fn format_secret_name(&self, project: &str, profile: &str, key: &str) -> Result<String> {
+    fn format_secret_name(project: &str, profile: &str, key: &str) -> Result<String> {
         // Validate each component
         Self::validate_name_component("project", project)?;
         Self::validate_name_component("profile", profile)?;
         Self::validate_name_component("key", key)?;
 
-        let secret_name = format!("secretspec-{}-{}-{}", project, profile, key);
+        let secret_name = format!("secretspec2--{project}--{profile}--{key}");
 
         // GCP secret IDs must be 1-255 characters
         if secret_name.len() > 255 {
@@ -212,6 +342,12 @@ impl GcsmProvider {
         }
 
         Ok(secret_name)
+    }
+
+    /// The ambiguous convention used through SecretSpec 0.19. This is only a
+    /// read fallback; writes and normal addressing never emit a legacy id.
+    fn format_legacy_secret_name(project: &str, profile: &str, key: &str) -> String {
+        format!("secretspec-{project}-{profile}-{key}")
     }
 
     /// Checks if an error indicates the resource was not found.
@@ -240,6 +376,14 @@ impl GcsmProvider {
         })
     }
 
+    async fn get_coords_with_backend(
+        backend: &impl GcsmBackend,
+        coords: &crate::config::NativeAddress,
+    ) -> Result<Option<SecretString>> {
+        let version = coords.version.as_deref().unwrap_or("latest");
+        backend.access_secret_version(&coords.item, version).await
+    }
+
     /// Resolves coordinates to a version resource and reads it, mapping "not
     /// found" to `None`: `item` is the secret id, `version` the version to read
     /// (defaulting to the latest).
@@ -247,105 +391,128 @@ impl GcsmProvider {
         &self,
         coords: &crate::config::NativeAddress,
     ) -> Result<Option<SecretString>> {
-        let version = coords.version.as_deref().unwrap_or("latest");
-        let secret_version_path = format!(
-            "projects/{}/secrets/{}/versions/{}",
-            self.config.project_id, coords.item, version
-        );
         let client = self.create_client().await?;
+        let backend = GoogleGcsmBackend {
+            project_id: &self.config.project_id,
+            client,
+        };
+        Self::get_coords_with_backend(&backend, coords).await
+    }
 
-        match client
-            .access_secret_version()
-            .set_name(&secret_version_path)
-            .send()
+    /// Reads the legacy id as a best-effort compatibility source. That id is an
+    /// implementation detail of the fallback rather than an address the caller
+    /// chose: a project with secret-level IAM answers PERMISSION_DENIED rather
+    /// than NOT_FOUND for an id nobody was granted a binding on, and that must
+    /// not turn an unset secret into a failed read.
+    async fn read_legacy_value(
+        backend: &impl GcsmBackend,
+        legacy_name: &str,
+    ) -> Option<SecretString> {
+        backend
+            .access_secret_version(legacy_name, "latest")
             .await
+            .ok()
+            .flatten()
+    }
+
+    /// Reads the 0.20 convention id, falling back to the 0.19 id when the new
+    /// one holds no value.
+    ///
+    /// The fallback is a read: nothing is created, copied, or deleted. So
+    /// credentials that can read secrets but not create them, the common CI
+    /// setup, keep working across the upgrade; no write can race with a
+    /// concurrent writer or shadow a newer value; and the next `secretspec set`
+    /// moves the secret to the current id on its own.
+    async fn get_convention_with_backend(
+        backend: &impl GcsmBackend,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<Option<SecretString>> {
+        let legacy_name = Self::format_legacy_secret_name(project, profile, key);
+        let secret_name = match Self::format_secret_name(project, profile, key) {
+            Ok(name) => name,
+            // Releases through 0.19 accepted names the 0.20 layout cannot
+            // represent. Serve what is already stored rather than failing the
+            // read; `set` still carries the rename instruction.
+            Err(naming_error) => {
+                let Some(value) = Self::read_legacy_value(backend, &legacy_name).await else {
+                    return Err(naming_error);
+                };
+                UNREPRESENTABLE_NAME_WARNING.call_once(|| {
+                    eprintln!(
+                        "Warning: reading the SecretSpec 0.19 GCSM secret '{legacy_name}' because \
+                         the current naming convention cannot represent this address: \
+                         {naming_error} Writes keep failing until the name changes. Further \
+                         secrets with this problem are not reported again."
+                    )
+                });
+                return Ok(Some(value));
+            }
+        };
+
+        if let Some(value) = backend
+            .access_secret_version(&secret_name, "latest")
+            .await?
         {
-            Ok(response) => {
-                if let Some(payload) = response.payload {
-                    let data = String::from_utf8(payload.data.to_vec()).map_err(|e| {
-                        SecretSpecError::ProviderOperationFailed(format!(
-                            "Secret data is not valid UTF-8: {}",
-                            e
-                        ))
-                    })?;
-                    Ok(Some(SecretString::new(data.into())))
-                } else {
-                    Ok(None)
-                }
-            }
-            Err(e) => {
-                // Check if the error is "not found" (secret doesn't exist)
-                if Self::is_not_found_error(&e) {
-                    Ok(None)
-                } else {
-                    Err(SecretSpecError::ProviderOperationFailed(format!(
-                        "Failed to access secret '{}': {}",
-                        coords.item,
-                        crate::error::display_error_chain(&e)
-                    )))
-                }
-            }
+            return Ok(Some(value));
         }
+
+        let Some(value) = Self::read_legacy_value(backend, &legacy_name).await else {
+            return Ok(None);
+        };
+
+        LEGACY_FALLBACK_WARNING.call_once(|| {
+            eprintln!(
+                "Warning: reading the SecretSpec 0.19 GCSM secret '{legacy_name}' because \
+                 '{secret_name}' holds no value. Run `secretspec set` for this secret to store it \
+                 under the current name; the 0.19 secret is left in place either way. Further \
+                 secrets read this way are not reported again."
+            )
+        });
+        Ok(Some(value))
+    }
+
+    async fn get_convention_async(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<Option<SecretString>> {
+        let client = self.create_client().await?;
+        let backend = GoogleGcsmBackend {
+            project_id: &self.config.project_id,
+            client,
+        };
+        Self::get_convention_with_backend(&backend, project, profile, key).await
     }
 
     /// Creates or updates a secret in GCP Secret Manager.
     ///
     /// Always attempts to create the secret first (idempotent operation), then adds a new version.
     /// This avoids TOCTOU race conditions by not checking existence before creation.
+    async fn set_secret_with_backend(
+        backend: &impl GcsmBackend,
+        secret_name: &str,
+        value: &SecretString,
+    ) -> Result<()> {
+        backend.create_secret(secret_name).await?;
+        backend.add_secret_version(secret_name, value).await
+    }
+
     async fn set_secret_async(&self, secret_name: &str, value: &SecretString) -> Result<()> {
         let client = self.create_client().await?;
-
-        // Always try to create the secret first (idempotent - ALREADY_EXISTS is expected for existing secrets)
-        let create_result = client
-            .create_secret()
-            .set_parent(format!("projects/{}", self.config.project_id))
-            .set_secret_id(secret_name)
-            .set_secret(Secret::default().set_replication(
-                Replication::default().set_automatic(replication::Automatic::default()),
-            ))
-            .send()
-            .await;
-
-        // Only fail on errors OTHER than ALREADY_EXISTS
-        if let Err(e) = create_result
-            && !Self::is_already_exists_error(&e)
-        {
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "Failed to create secret '{}': {}",
-                secret_name,
-                crate::error::display_error_chain(&e)
-            )));
-        }
-        // ALREADY_EXISTS is expected for existing secrets, continue to add version
-
-        // Add a new version with the secret data
-        client
-            .add_secret_version()
-            .set_parent(format!(
-                "projects/{}/secrets/{}",
-                self.config.project_id, secret_name
-            ))
-            .set_payload(
-                SecretPayload::default().set_data(value.expose_secret().as_bytes().to_vec()),
-            )
-            .send()
-            .await
-            .map_err(|e| {
-                SecretSpecError::ProviderOperationFailed(format!(
-                    "Failed to add secret version for '{}': {}",
-                    secret_name,
-                    crate::error::display_error_chain(&e)
-                ))
-            })?;
-
-        Ok(())
+        let backend = GoogleGcsmBackend {
+            project_id: &self.config.project_id,
+            client,
+        };
+        Self::set_secret_with_backend(&backend, secret_name, value).await
     }
 }
 
 impl Provider for GcsmProvider {
-    /// Convention secrets are ids of the form
-    /// `secretspec-{project}-{profile}-{key}` (GCP secret ids cannot contain
-    /// slashes), read at their latest version.
+    /// Convention names use validated `--` boundaries so distinct accepted
+    /// project/profile/key triples always produce distinct GCSM secret ids.
     fn convention_address(
         &self,
         project: &str,
@@ -353,7 +520,7 @@ impl Provider for GcsmProvider {
         key: &str,
     ) -> Result<crate::config::NativeAddress> {
         Ok(crate::config::NativeAddress {
-            item: self.format_secret_name(project, profile, key)?,
+            item: Self::format_secret_name(project, profile, key)?,
             ..Default::default()
         })
     }
@@ -372,8 +539,17 @@ impl Provider for GcsmProvider {
     }
 
     fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
-        let coords = self.resolve_coords(addr)?;
-        super::block_on(self.get_coords_async(&coords))
+        match addr {
+            Address::Convention {
+                project,
+                profile,
+                key,
+            } => super::block_on(self.get_convention_async(project, profile, key)),
+            Address::Native(_) => {
+                let coords = self.resolve_coords(addr)?;
+                super::block_on(self.get_coords_async(&coords))
+            }
+        }
     }
 
     fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
@@ -450,5 +626,355 @@ mod reference_tests {
         };
         let err = p.get(Address::Native(&addr)).unwrap_err();
         assert!(err.to_string().contains("`field`"), "{err}");
+    }
+
+    #[test]
+    fn convention_name_is_collision_safe() {
+        let first = GcsmProvider::format_secret_name("my-app", "prod", "K").unwrap();
+        let second = GcsmProvider::format_secret_name("my", "app-prod", "K").unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(first, "secretspec2--my-app--prod--K");
+        assert_eq!(second, "secretspec2--my--app-prod--K");
+    }
+
+    #[test]
+    fn convention_name_rejects_ambiguous_hyphen_shapes() {
+        for component in ["-app", "app-", "app--prod"] {
+            let error = GcsmProvider::format_secret_name(component, "prod", "K").unwrap_err();
+            assert!(
+                error.to_string().contains("cannot start or end")
+                    && error.to_string().contains("contain `--`"),
+                "{component}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn convention_name_enforces_gcsm_length_limit_after_framing() {
+        let largest_project = "a".repeat(236);
+        let name = GcsmProvider::format_secret_name(&largest_project, "p", "K").unwrap();
+        assert_eq!(name.len(), 255);
+
+        let error =
+            GcsmProvider::format_secret_name(&format!("{largest_project}a"), "p", "K").unwrap_err();
+        assert!(error.to_string().contains("256 characters"), "{error}");
+    }
+
+    #[test]
+    fn legacy_name_is_retained_only_as_a_read_fallback() {
+        assert_eq!(
+            GcsmProvider::format_legacy_secret_name("my-app", "prod", "K"),
+            "secretspec-my-app-prod-K"
+        );
+    }
+}
+
+/// Property tests for the injective convention-name mapping.
+#[cfg(test)]
+mod name_properties {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Components contain internal single hyphens but never a delimiter or a
+    /// leading/trailing hyphen, exactly matching the structural validator.
+    fn component() -> impl Strategy<Value = String> {
+        prop::collection::vec(
+            proptest::string::string_regex("[A-Za-z0-9_]{1,8}").unwrap(),
+            1..4,
+        )
+        .prop_map(|parts| parts.join("-"))
+    }
+
+    fn triple() -> impl Strategy<Value = (String, String, String)> {
+        (component(), component(), component())
+    }
+
+    /// A left inverse proves that every formatted name identifies exactly the
+    /// triple that produced it.
+    fn decode_secret_name(name: &str) -> Option<(String, String, String)> {
+        let body = name.strip_prefix("secretspec2--")?;
+        let parts: Vec<&str> = body.split("--").collect();
+        let [project, profile, key] = parts.as_slice() else {
+            return None;
+        };
+        Some((
+            (*project).to_string(),
+            (*profile).to_string(),
+            (*key).to_string(),
+        ))
+    }
+
+    proptest! {
+        #[test]
+        fn convention_name_decodes_to_its_original_triple(
+            (project, profile, key) in triple()
+        ) {
+            let name = GcsmProvider::format_secret_name(&project, &profile, &key)
+                .expect("a valid component must format");
+            prop_assert_eq!(
+                decode_secret_name(&name),
+                Some((project, profile, key)),
+            );
+        }
+
+        #[test]
+        fn distinct_triples_never_share_a_convention_name(
+            triples in prop::collection::vec(triple(), 2..24)
+        ) {
+            let mut seen = std::collections::HashMap::new();
+            for (project, profile, key) in triples {
+                let triple = (project, profile, key);
+                let name = GcsmProvider::format_secret_name(&triple.0, &triple.1, &triple.2)
+                    .expect("a valid component must format");
+                if let Some(previous) = seen.insert(name.clone(), triple.clone()) {
+                    prop_assert_eq!(previous, triple, "collision at {}", name);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod legacy_fallback_tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Mutex;
+
+    const LEGACY: &str = "secretspec-my-app-prod-K";
+    const CURRENT: &str = "secretspec2--my-app--prod--K";
+
+    #[derive(Default)]
+    struct FakeGcsmBackend {
+        /// An empty vector means that the Secret resource exists without a
+        /// version. Vector indices are the zero-based form of GCSM version ids.
+        secrets: Mutex<HashMap<String, Vec<String>>>,
+        accesses: Mutex<Vec<String>>,
+        writes: Mutex<Vec<String>>,
+        unreadable: Mutex<HashSet<String>>,
+    }
+
+    impl FakeGcsmBackend {
+        fn insert(&self, name: &str, value: &str) {
+            self.secrets
+                .lock()
+                .unwrap()
+                .insert(name.to_string(), vec![value.to_string()]);
+        }
+
+        fn insert_empty(&self, name: &str) {
+            self.secrets
+                .lock()
+                .unwrap()
+                .insert(name.to_string(), Vec::new());
+        }
+
+        fn value(&self, name: &str) -> Option<String> {
+            self.secrets
+                .lock()
+                .unwrap()
+                .get(name)
+                .and_then(|versions| versions.last())
+                .cloned()
+        }
+
+        /// Simulates the secret-level IAM binding a caller was never granted:
+        /// GCSM answers PERMISSION_DENIED rather than NOT_FOUND.
+        fn deny_access(&self, name: &str) {
+            self.unreadable.lock().unwrap().insert(name.to_string());
+        }
+    }
+
+    impl GcsmBackend for FakeGcsmBackend {
+        async fn access_secret_version(
+            &self,
+            secret_name: &str,
+            version: &str,
+        ) -> Result<Option<SecretString>> {
+            self.accesses
+                .lock()
+                .unwrap()
+                .push(format!("{secret_name}@{version}"));
+            if self.unreadable.lock().unwrap().contains(secret_name) {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Failed to access secret '{secret_name}': PERMISSION_DENIED"
+                )));
+            }
+
+            let secrets = self.secrets.lock().unwrap();
+            let value = secrets.get(secret_name).and_then(|versions| {
+                if version == "latest" {
+                    versions.last()
+                } else {
+                    version
+                        .parse::<usize>()
+                        .ok()
+                        .and_then(|number| number.checked_sub(1))
+                        .and_then(|index| versions.get(index))
+                }
+            });
+            Ok(value.cloned().map(|value| SecretString::new(value.into())))
+        }
+
+        async fn create_secret(&self, secret_name: &str) -> Result<()> {
+            self.writes
+                .lock()
+                .unwrap()
+                .push(format!("create {secret_name}"));
+            self.secrets
+                .lock()
+                .unwrap()
+                .entry(secret_name.to_string())
+                .or_default();
+            Ok(())
+        }
+
+        async fn add_secret_version(&self, secret_name: &str, value: &SecretString) -> Result<()> {
+            self.writes
+                .lock()
+                .unwrap()
+                .push(format!("add {secret_name}"));
+            let mut secrets = self.secrets.lock().unwrap();
+            let versions = secrets.get_mut(secret_name).ok_or_else(|| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "secret '{secret_name}' was not created"
+                ))
+            })?;
+            versions.push(value.expose_secret().to_string());
+            Ok(())
+        }
+    }
+
+    fn read(backend: &FakeGcsmBackend) -> Result<Option<SecretString>> {
+        read_project(backend, "my-app")
+    }
+
+    fn read_project(backend: &FakeGcsmBackend, project: &str) -> Result<Option<SecretString>> {
+        crate::provider::block_on(GcsmProvider::get_convention_with_backend(
+            backend, project, "prod", "K",
+        ))
+    }
+
+    fn write(backend: &FakeGcsmBackend, value: &str) -> Result<()> {
+        crate::provider::block_on(GcsmProvider::set_secret_with_backend(
+            backend,
+            CURRENT,
+            &SecretString::new(value.into()),
+        ))
+    }
+
+    /// A project written by 0.19 keeps reading after the upgrade, and the read
+    /// leaves GCSM untouched: no create, no version, no delete.
+    #[test]
+    fn a_missing_current_id_falls_back_to_the_legacy_value() {
+        let backend = FakeGcsmBackend::default();
+        backend.insert(LEGACY, "legacy-value");
+
+        let value = read(&backend).unwrap().unwrap();
+        assert_eq!(value.expose_secret(), "legacy-value");
+        assert!(backend.writes.lock().unwrap().is_empty());
+        assert_eq!(backend.value(LEGACY).as_deref(), Some("legacy-value"));
+        assert!(!backend.secrets.lock().unwrap().contains_key(CURRENT));
+    }
+
+    /// A Secret resource without a version reads as unset, so the fallback
+    /// covers a destination that a 0.20 write only partly created.
+    #[test]
+    fn a_current_id_without_a_version_falls_back_to_the_legacy_value() {
+        let backend = FakeGcsmBackend::default();
+        backend.insert(LEGACY, "legacy-value");
+        backend.insert_empty(CURRENT);
+
+        let value = read(&backend).unwrap().unwrap();
+        assert_eq!(value.expose_secret(), "legacy-value");
+        assert!(backend.writes.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn the_current_id_wins_without_reading_the_legacy_id() {
+        let backend = FakeGcsmBackend::default();
+        backend.insert(LEGACY, "legacy-value");
+        backend.insert(CURRENT, "current-value");
+
+        let value = read(&backend).unwrap().unwrap();
+        assert_eq!(value.expose_secret(), "current-value");
+        assert_eq!(
+            backend.accesses.lock().unwrap().as_slice(),
+            &[format!("{CURRENT}@latest")]
+        );
+    }
+
+    /// Writing is what moves a secret onto the current convention. The 0.19
+    /// secret is left in place, so an older SecretSpec keeps working until the
+    /// project chooses to delete it.
+    #[test]
+    fn a_write_moves_the_secret_to_the_current_id() {
+        let backend = FakeGcsmBackend::default();
+        backend.insert(LEGACY, "legacy-value");
+
+        write(&backend, "new-value").unwrap();
+        backend.accesses.lock().unwrap().clear();
+
+        let value = read(&backend).unwrap().unwrap();
+        assert_eq!(value.expose_secret(), "new-value");
+        assert_eq!(
+            backend.accesses.lock().unwrap().as_slice(),
+            &[format!("{CURRENT}@latest")]
+        );
+        assert_eq!(backend.value(LEGACY).as_deref(), Some("legacy-value"));
+    }
+
+    /// The legacy id is a compatibility source rather than an address the
+    /// caller chose, so being unable to read it means "nothing stored".
+    #[test]
+    fn an_unreadable_legacy_id_leaves_an_unset_secret_unset() {
+        let backend = FakeGcsmBackend::default();
+        backend.deny_access(LEGACY);
+
+        assert!(read(&backend).unwrap().is_none());
+    }
+
+    /// The current id is the address the caller did choose, so it still fails
+    /// loudly instead of silently serving a stale 0.19 value.
+    #[test]
+    fn an_unreadable_current_id_fails_the_read() {
+        let backend = FakeGcsmBackend::default();
+        backend.insert(LEGACY, "legacy-value");
+        backend.deny_access(CURRENT);
+
+        let error = read(&backend).unwrap_err();
+        assert!(error.to_string().contains("PERMISSION_DENIED"), "{error}");
+    }
+
+    #[test]
+    fn absent_current_and_legacy_ids_remain_a_miss() {
+        let backend = FakeGcsmBackend::default();
+
+        assert!(read(&backend).unwrap().is_none());
+        assert!(backend.secrets.lock().unwrap().is_empty());
+        assert!(backend.writes.lock().unwrap().is_empty());
+    }
+
+    /// Releases through 0.19 stored triples the current layout cannot
+    /// represent, such as a project directory named `my--app`. Reads keep
+    /// serving what is already stored.
+    #[test]
+    fn an_unrepresentable_name_still_reads_its_legacy_secret() {
+        let backend = FakeGcsmBackend::default();
+        backend.insert("secretspec-my--app-prod-K", "legacy-value");
+
+        let value = read_project(&backend, "my--app").unwrap().unwrap();
+        assert_eq!(value.expose_secret(), "legacy-value");
+        assert!(backend.writes.lock().unwrap().is_empty());
+    }
+
+    /// With nothing stored under either name there is no value to serve, so the
+    /// naming error carries the rename that makes the project usable.
+    #[test]
+    fn an_unrepresentable_name_reports_the_rename_when_nothing_is_stored() {
+        let backend = FakeGcsmBackend::default();
+
+        let error = read_project(&backend, "my--app").unwrap_err();
+        assert!(error.to_string().contains("Rename it"), "{error}");
     }
 }


### PR DESCRIPTION
## Summary

- replace ambiguous legacy GCSM IDs with readable, versioned `secretspec2--{project}--{profile}--{key}` names
- lazily copy the latest legacy payload on the first convention read, leaving the old secret unchanged
- make concurrent migration creation race-safe and keep explicit `ref` addresses unchanged
- document migration permissions, mixed-version rollout, metadata/IAM limitations, and cleanup

Fixes #219
Supersedes #367

## Testing

- `devenv shell cargo test -p secretspec gcsm`
- `devenv shell cargo test -p secretspec`
- `devenv shell npm --prefix docs run build`
- `devenv shell cargo clippy -p secretspec --lib --no-default-features --features gcsm -- -D warnings -A clippy::too_many_arguments -A dead_code`

The repository-wide pre-commit Clippy hook could not run because its all-features build requires a PHP executable that is unavailable in this environment. Rustfmt passed.