### PR TITLE
Format-preserving single-declaration edits on `Spec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Spec` can perform format-preserving single-declaration edits on the document
+  it was loaded from. `add_secret_to_text` and `remove_secret_from_text` return
+  a new fully revalidated `Spec` whose text differs only by that declaration,
+  leaving comments, key order, quoting, and syntax the model does not represent
+  byte for byte intact; `declares_secret_in_text` reports whether a name is
+  declared in this document rather than inherited; `preserved_text` exposes the
+  exact backing text, and `to_toml` renders freshly formatted TOML for any spec,
+  including one built with `Spec::builder`, which has no backing text. Adding a
+  declaration and then removing it restores the original bytes, so tooling that
+  proposes a manifest change as a reviewable one-line diff, or that compares
+  manifests byte for byte, can rely on it. A spec that inherits through
+  `project.extends` keeps its own root document as the preserved text and is
+  revalidated against its parents on every edit, so inherited declarations are
+  never inlined into the child file. The `toml_edit` surgery behind this moved
+  out of `cli` into a `manifest_edit` module behind a new `manifest-edit`
+  feature, so an embedder can take the editing surface without `clap` and
+  `inquire`; `cli` enables it, so nothing changes for existing users.
+
 - **Azure App Configuration provider** (`aac://`, 0.20+): select direct
   values and Azure Key Vault references by label, prefix, and tags, with Entra
   ID or connection-string authentication and guarded writes, deletion, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6112,6 +6112,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,10 @@ keepass = { version = "0.13.17", features = ["save_kdbx4"] }
 keeper-secrets-manager-core = { version = "17.3.0", default-features = false, features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9"
-toml_edit = "0.23"
+# `serde` powers `manifest_edit`'s full-declaration writer, which renders a
+# `Secret` through the same representation the parser reads so the written and
+# accepted keys cannot drift apart as the schema grows.
+toml_edit = { version = "0.23", features = ["serde"] }
 thiserror = "2.0"
 etcetera = "0.11"
 colored = "3.0"

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -60,7 +60,10 @@ age = { workspace = true, optional = true }
 
 [features]
 default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "scaleway", "sops"]
-cli = ["dep:toml_edit", "dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable"]
+cli = ["manifest-edit", "dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable"]
+# Format-preserving declaration edits, without the interactive CLI. Split out
+# so an embedder can take the editing surface without taking `clap`/`inquire`.
+manifest-edit = ["dep:toml_edit"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
 keeper = ["dep:keeper-secrets-manager-core"]

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1,4 +1,5 @@
 use crate::config::{Config, GlobalConfig, GlobalDefaults, Profile as ConfigProfile, Project};
+use crate::manifest_edit::{add_secret_to_manifest, validate_add_secret_name};
 use crate::provider::{Provider, providers, spec_names_known_provider};
 use crate::{CallerContext, ExportFormat, Secrets};
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
@@ -566,25 +567,6 @@ fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
     Ok(doc.to_string())
 }
 
-/// Rejects names that cannot occupy a flattened secret key in [`ConfigProfile`].
-fn validate_add_secret_name(name: &str) -> Result<()> {
-    if !crate::config::is_valid_identifier(name) {
-        return Err(miette!(
-            "Invalid secret name '{}': must be a valid identifier (alphanumeric and underscores, not starting with a number)",
-            name
-        ));
-    }
-    // `Profile` reserves this key for its defaults table before flattening all
-    // remaining keys into secret declarations. Without an explicit check, the
-    // edit would be valid TOML but would not actually declare a secret.
-    if name == "defaults" {
-        return Err(miette!(
-            "Secret name 'defaults' is reserved for profile defaults"
-        ));
-    }
-    Ok(())
-}
-
 /// Ensures `add` will create a new effective declaration in an existing profile.
 fn validate_add_target(app: &Secrets, profile: &str, name: &str) -> Result<()> {
     validate_add_secret_name(name)?;
@@ -607,57 +589,6 @@ fn validate_add_target(app: &Secrets, profile: &str, name: &str) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Adds one secret to a manifest document without re-serializing the rest.
-///
-/// `toml_edit` retains the user's comments, whitespace, ordering, and any syntax
-/// that is not represented by [`Config`]. The caller validates the selected
-/// profile against the fully loaded configuration first; this helper creates a
-/// local profile table when that profile currently comes only from `extends`.
-fn add_secret_to_manifest(
-    source: &str,
-    profile: &str,
-    name: &str,
-    description: &str,
-) -> Result<String> {
-    use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
-
-    validate_add_secret_name(name)?;
-    if description.trim().is_empty() {
-        return Err(miette!("Secret description cannot be empty"));
-    }
-
-    let mut doc = source
-        .parse::<DocumentMut>()
-        .into_diagnostic()
-        .wrap_err("Failed to parse secretspec.toml for editing")?;
-    let profiles = doc
-        .get_mut("profiles")
-        .and_then(Item::as_table_like_mut)
-        .ok_or_else(|| miette!("secretspec.toml does not contain a [profiles] table"))?;
-
-    if !profiles.contains_key(profile) {
-        profiles.insert(profile, Item::Table(Table::new()));
-    }
-    let profile_table = profiles
-        .get_mut(profile)
-        .and_then(Item::as_table_like_mut)
-        .ok_or_else(|| miette!("Profile '{}' is not a TOML table", profile))?;
-
-    if profile_table.contains_key(name) {
-        return Err(miette!(
-            "Secret '{}' is already declared in profile '{}'",
-            name,
-            profile
-        ));
-    }
-
-    let mut secret = InlineTable::new();
-    secret.insert("description", Value::from(description));
-    profile_table.insert(name, toml_edit::value(secret));
-
-    Ok(doc.to_string())
 }
 
 /// Replaces an existing manifest only after its complete replacement has been

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -1031,6 +1031,56 @@ impl ConfigGraphLoader {
         Ok(merged)
     }
 
+    /// Load a root document supplied as *text*, resolving its `extends` against
+    /// `base_dir`.
+    ///
+    /// [`Self::load`] cannot serve this: it reads the root from disk, and the
+    /// caller here holds a document that exists only in memory — an edited
+    /// manifest being revalidated before anyone commits to writing it.
+    /// Ancestors are still read from disk, and are still deduplicated and
+    /// cycle-checked by canonical path exactly as they would be under `load`.
+    ///
+    /// The root is overlaid last, so it stays the most specific document, which
+    /// is the same precedence `load` produces by emitting it last in post-order.
+    fn load_text(source: &str, base_dir: &Path) -> Result<Config, ParseError> {
+        let root = Config::parse_document(source)?;
+        let mut loader = Self {
+            active: HashSet::new(),
+            emitted: HashSet::new(),
+            documents: Vec::new(),
+        };
+        loader.visit_extends_of(&root, base_dir)?;
+
+        let mut documents = loader.documents.into_iter();
+        let Some(mut merged) = documents.next() else {
+            return Ok(root);
+        };
+        for document in documents {
+            merged.overlay_with(document);
+        }
+        merged.overlay_with(root);
+        Ok(merged)
+    }
+
+    /// Visit every document `config` extends, resolving each against `base_dir`.
+    fn visit_extends_of(&mut self, config: &Config, base_dir: &Path) -> Result<(), ParseError> {
+        for extend_path in config.project.extends.iter().flatten() {
+            let joined_path = base_dir.join(extend_path);
+            let full_path = if extend_path.ends_with(".toml") {
+                joined_path
+            } else {
+                joined_path.join("secretspec.toml")
+            };
+            if !full_path.exists() {
+                return Err(ParseError::ExtendedConfigNotFound(
+                    full_path.display().to_string(),
+                ));
+            }
+            self.visit(&full_path)?;
+        }
+        Ok(())
+    }
+
     fn visit(&mut self, path: &Path) -> Result<(), ParseError> {
         let canonical_path = path.canonicalize().map_err(|e| {
             ParseError::Io(io::Error::new(
@@ -1056,20 +1106,7 @@ impl ConfigGraphLoader {
         // relative to the symlink, not to the file it points at. Cycle detection
         // and dedup still key on `canonical_path`.
         let base_dir = path.parent().unwrap_or(Path::new("."));
-        for extend_path in config.project.extends.iter().flatten() {
-            let joined_path = base_dir.join(extend_path);
-            let full_path = if extend_path.ends_with(".toml") {
-                joined_path
-            } else {
-                joined_path.join("secretspec.toml")
-            };
-            if !full_path.exists() {
-                return Err(ParseError::ExtendedConfigNotFound(
-                    full_path.display().to_string(),
-                ));
-            }
-            self.visit(&full_path)?;
-        }
+        self.visit_extends_of(&config, base_dir)?;
 
         self.active.remove(&canonical_path);
         self.emitted.insert(canonical_path);
@@ -1098,6 +1135,18 @@ impl TryFrom<&Path> for Config {
     /// This supports configuration inheritance via `extends` and circular dependency detection.
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
         ConfigGraphLoader::load(path)
+    }
+}
+
+impl Config {
+    /// Parse and merge a root document held as text, resolving `extends`
+    /// against `base_dir`.
+    ///
+    /// The `extends`-aware counterpart to [`Config::from_str`], which has no
+    /// location to resolve inheritance against and so rejects it. Used to
+    /// revalidate an edited manifest that has not been written anywhere yet.
+    pub(crate) fn from_text_in(source: &str, base_dir: &Path) -> Result<Self, ParseError> {
+        ConfigGraphLoader::load_text(source, base_dir)
     }
 }
 

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -65,6 +65,11 @@ pub(crate) mod provider;
 #[cfg(feature = "cli")]
 pub mod cli;
 
+// Format-preserving manifest declaration edits. Its own feature so an
+// embedder can take the editing surface without the interactive CLI.
+#[cfg(feature = "manifest-edit")]
+pub mod manifest_edit;
+
 // Re-export only the types needed by users and generated code
 pub use caller::CallerContext;
 pub use config::Resolved;

--- a/secretspec/src/manifest_edit.rs
+++ b/secretspec/src/manifest_edit.rs
@@ -1,0 +1,451 @@
+//! Declaration edits to a `secretspec.toml` source string.
+//!
+//! Split out of the `cli` module, behind its own `manifest-edit` feature, so a
+//! caller can perform the edit without taking on the interactive CLI's
+//! dependency surface — `clap` and `inquire` come with `cli` and are not
+//! something every embedder wants.
+//!
+//! Everything here is pure: it takes manifest text and returns manifest text,
+//! touching no filesystem. Writing is deliberately the caller's problem,
+//! because the safe way to write differs by caller — the CLI replaces its
+//! manifest atomically through a temporary file, while a caller editing a file
+//! whose ownership or mode must survive has to write it in place.
+//!
+//! [`crate::Spec`] wraps these as `add_secret_to_text` and
+//! `remove_secret_from_text`, which additionally revalidate the result. Prefer
+//! those unless you specifically want the text without the semantic model.
+
+use miette::{IntoDiagnostic, Result, WrapErr, miette};
+
+/// Rejects names that cannot occupy a flattened secret key in a profile.
+pub(crate) fn validate_add_secret_name(name: &str) -> Result<()> {
+    if !crate::config::is_valid_identifier(name) {
+        return Err(miette!(
+            "Invalid secret name '{}': must be a valid identifier (alphanumeric and underscores, not starting with a number)",
+            name
+        ));
+    }
+    // `Profile` reserves this key for its defaults table before flattening all
+    // remaining keys into secret declarations. Without an explicit check, the
+    // edit would be valid TOML but would not actually declare a secret.
+    if name == "defaults" {
+        return Err(miette!(
+            "Secret name 'defaults' is reserved for profile defaults"
+        ));
+    }
+    Ok(())
+}
+
+/// Adds one secret to a manifest document without re-serializing the rest.
+///
+/// `toml_edit` retains the user's comments, whitespace, ordering, and any syntax
+/// that is not represented by [`crate::config::Config`]. The caller validates
+/// the selected profile against the fully loaded configuration first; this
+/// helper creates a local profile table when that profile currently comes only
+/// from `extends`.
+///
+/// Declares only a description, which is what `secretspec add` prompts for. Use
+/// [`add_secret_value_to_manifest`] to declare requiredness, a default, a
+/// presence group, or any other field.
+pub fn add_secret_to_manifest(
+    source: &str,
+    profile: &str,
+    name: &str,
+    description: &str,
+) -> Result<String> {
+    use toml_edit::{InlineTable, Value};
+
+    // Name before description, matching the order this has always reported the
+    // two: `insert_declaration` validates the name again, but only after the
+    // description check, which would silently reorder the diagnostics a caller
+    // sees for input that is wrong in both ways.
+    validate_add_secret_name(name)?;
+    if description.trim().is_empty() {
+        return Err(miette!("Secret description cannot be empty"));
+    }
+
+    let mut secret = InlineTable::new();
+    secret.insert("description", Value::from(description));
+    insert_declaration(source, profile, name, secret)
+}
+
+/// Insert a complete [`crate::config::Secret`] declaration into a manifest.
+///
+/// The general form of [`add_secret_to_manifest`], which covers only the one
+/// key the CLI's `add` prompts for. Every other declared field — `required`,
+/// `default`,
+/// `composed`, `providers`, `ref`/`refs`, `as_path`, `encoding`, `extract`,
+/// `generate`, `prompt`, and the presence groups — is emitted by the same serde
+/// representation the parser reads, so the written keys and the accepted keys
+/// cannot drift apart as the schema grows.
+///
+/// Unset fields are omitted rather than written as explicit nulls, which is what
+/// keeps the emitted declaration a single readable line and keeps the round-trip
+/// with [`remove_secret_from_manifest`] byte-exact.
+pub fn add_secret_value_to_manifest(
+    source: &str,
+    profile: &str,
+    name: &str,
+    secret: &crate::config::Secret,
+) -> Result<String> {
+    use toml_edit::ser::to_document;
+
+    if secret
+        .description
+        .as_deref()
+        .is_none_or(|description| description.trim().is_empty())
+    {
+        return Err(miette!("Secret description cannot be empty"));
+    }
+
+    // Serialized through a document and then flattened to an inline table: the
+    // value serializer refuses a nested table, which `ref`, `refs`, `extract`,
+    // `generate`, and a presence group's `required` all produce.
+    let document = to_document(secret)
+        .into_diagnostic()
+        .wrap_err("Failed to render the secret declaration as TOML")?;
+    let mut inline = toml_edit::InlineTable::new();
+    for (key, item) in document.as_table().iter() {
+        let value = item
+            .clone()
+            .into_value()
+            .map_err(|_| miette!("Secret field '{}' has no inline TOML form", key))?;
+        inline.insert(key, value);
+    }
+
+    insert_declaration(source, profile, name, inline)
+}
+
+/// Place `declaration` at `profile.name`, creating the profile table if needed.
+fn insert_declaration(
+    source: &str,
+    profile: &str,
+    name: &str,
+    declaration: toml_edit::InlineTable,
+) -> Result<String> {
+    use toml_edit::{DocumentMut, Item, Table};
+
+    validate_add_secret_name(name)?;
+
+    let mut doc = source
+        .parse::<DocumentMut>()
+        .into_diagnostic()
+        .wrap_err("Failed to parse secretspec.toml for editing")?;
+    let profiles = doc
+        .get_mut("profiles")
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| miette!("secretspec.toml does not contain a [profiles] table"))?;
+
+    if !profiles.contains_key(profile) {
+        profiles.insert(profile, Item::Table(Table::new()));
+    }
+    let profile_table = profiles
+        .get_mut(profile)
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| miette!("Profile '{}' is not a TOML table", profile))?;
+
+    if profile_table.contains_key(name) {
+        return Err(miette!(
+            "Secret '{}' is already declared in profile '{}'",
+            name,
+            profile
+        ));
+    }
+
+    profile_table.insert(name, toml_edit::value(declaration));
+    Ok(doc.to_string())
+}
+
+/// Whether `source` declares `name` in `profile`.
+///
+/// Parsed, not searched. A substring test would match the name inside a comment
+/// or another secret's description, and the inverse mistake is worse because it
+/// is silent — a caller relying on this to protect tracked declarations would
+/// get a wrong answer with no indication.
+///
+/// A malformed manifest is an `Err`, never a `false`. Callers using this as a
+/// guard must fail closed, and that decision belongs to them rather than being
+/// smuggled in here as a default: "I could not parse it" is not "the name is
+/// absent from it".
+pub fn declares_secret(source: &str, profile: &str, name: &str) -> Result<bool> {
+    use toml_edit::{DocumentMut, Item};
+
+    let doc = source
+        .parse::<DocumentMut>()
+        .into_diagnostic()
+        .wrap_err("Failed to parse secretspec.toml")?;
+    Ok(doc
+        .get("profiles")
+        .and_then(Item::as_table_like)
+        .and_then(|profiles| profiles.get(profile))
+        .and_then(Item::as_table_like)
+        .is_some_and(|table| table.contains_key(name)))
+}
+
+/// Remove a secret declaration from a `secretspec.toml` source string.
+///
+/// The inverse of [`add_secret_to_manifest`], and pure for the same reason.
+///
+/// `toml_edit` preserves the formatting of everything it does not touch, so
+/// removing a declaration that `add_secret_to_manifest` inserted restores the
+/// original text byte for byte. That matters more than it looks: the downstream
+/// boundary's `template-check` compares the runtime manifest against the tracked
+/// template as raw bytes, so "undo" has to mean *byte-identical*, not merely
+/// semantically equivalent.
+///
+/// Removing a name that is not declared is an error rather than a silent no-op.
+/// A caller undeclaring something already absent has a wrong model of the
+/// manifest, and saying so is cheaper than letting them believe they cleaned up
+/// state that was never there.
+pub fn remove_secret_from_manifest(source: &str, profile: &str, name: &str) -> Result<String> {
+    use toml_edit::{DocumentMut, Item};
+
+    validate_add_secret_name(name)?;
+
+    let mut doc = source
+        .parse::<DocumentMut>()
+        .into_diagnostic()
+        .wrap_err("Failed to parse secretspec.toml for editing")?;
+    let profiles = doc
+        .get_mut("profiles")
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| miette!("secretspec.toml does not contain a [profiles] table"))?;
+
+    let profile_table = profiles
+        .get_mut(profile)
+        .and_then(Item::as_table_like_mut)
+        .ok_or_else(|| miette!("Profile '{}' is not declared in this manifest", profile))?;
+
+    if profile_table.remove(name).is_none() {
+        return Err(miette!(
+            "Secret '{}' is not declared in profile '{}'",
+            name,
+            profile
+        ));
+    }
+
+    Ok(doc.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANIFEST: &str = r#"[project]
+name = "demo"
+revision = "1.0"
+
+[profiles.default]
+EXISTING = { description = "already here" }
+"#;
+
+    /// Declaration carrying `description` plus `required`, for the tests that
+    /// need a longer inline table than `add_secret_to_manifest` can produce.
+    fn required_secret(description: &str) -> crate::config::Secret {
+        crate::config::Secret {
+            description: Some(description.into()),
+            required: Some(true),
+            ..crate::config::Secret::default()
+        }
+    }
+
+    #[test]
+    fn removing_an_added_declaration_restores_the_original_bytes() {
+        // The property that makes "undo" usable by a caller comparing manifests
+        // as raw BYTES -- a drift checker diffing a live manifest against a
+        // tracked template gets a permanent false positive from anything
+        // weaker. toml_edit preserves untouched formatting; this proves it.
+        let added = add_secret_to_manifest(MANIFEST, "default", "SCRATCH", "temp").unwrap();
+        assert_ne!(added, MANIFEST, "add did not change anything");
+
+        let removed = remove_secret_from_manifest(&added, "default", "SCRATCH").unwrap();
+
+        assert_eq!(removed, MANIFEST);
+    }
+
+    #[test]
+    fn add_secret_to_manifest_declares_only_a_description() {
+        // Asserted on the emitted declaration, not on the whole document: a
+        // whole-file `contains("required")` would also be satisfied (or
+        // broken) by any sibling or comment carrying that word.
+        let added = add_secret_to_manifest(MANIFEST, "default", "SCRATCH", "temp").unwrap();
+        assert!(added.contains("SCRATCH = { description = \"temp\" }"));
+    }
+
+    #[test]
+    fn removing_a_multi_key_declaration_also_restores_the_original_bytes() {
+        // A second key makes the edit longer than the single-key path the
+        // round-trip test above covers, and the undo has to be just as exact.
+        let added =
+            add_secret_value_to_manifest(MANIFEST, "default", "SCRATCH", &required_secret("temp"))
+                .unwrap();
+        assert!(added.contains("required = true"), "{added}");
+        assert_ne!(added, MANIFEST, "add did not change anything");
+
+        let removed = remove_secret_from_manifest(&added, "default", "SCRATCH").unwrap();
+
+        assert_eq!(removed, MANIFEST);
+    }
+
+    #[test]
+    fn round_trip_survives_a_document_with_presence_groups_and_full_tables() {
+        // The fixture above is inline-table-only. toml_edit is likeliest to
+        // reserialize a document that mixes shapes, so the byte-exact claim is
+        // worth proving against one that does: a `required` *table* (presence
+        // group), a full `[profiles.x.y]` table, and a dotted key.
+        let manifest = r#"[project]
+name = "demo"
+revision = "1.0"
+
+[profiles.default]
+GROUPED = { description = "in a group", required = { at_least_one = "auth" } }
+"dotted.name" = { description = "quoted key" }
+
+[profiles.default.NESTED]
+description = "declared as a full table"
+required = false
+"#;
+
+        let added = add_secret_to_manifest(manifest, "default", "SCRATCH", "temp").unwrap();
+        let removed = remove_secret_from_manifest(&added, "default", "SCRATCH").unwrap();
+        assert_eq!(removed, manifest);
+
+        let added =
+            add_secret_value_to_manifest(manifest, "default", "SCRATCH", &required_secret("temp"))
+                .unwrap();
+        let removed = remove_secret_from_manifest(&added, "default", "SCRATCH").unwrap();
+        assert_eq!(removed, manifest);
+    }
+
+    #[test]
+    fn an_added_declaration_actually_compiles_to_what_was_asked_for() {
+        // The product claim, asserted through the engine rather than through
+        // the emitted text: the written bytes have to parse and validate into a
+        // secret carrying the requiredness the caller declared.
+        use crate::config::{Config, Secret};
+
+        let optional = Secret {
+            description: Some("temp".into()),
+            required: Some(false),
+            ..Secret::default()
+        };
+        let added =
+            add_secret_value_to_manifest(MANIFEST, "default", "SCRATCH", &optional).unwrap();
+
+        let config: Config = toml::from_str(&added).expect("edited manifest must parse");
+        config.validate().expect("edited manifest must validate");
+        assert_eq!(
+            config.profiles["default"].secrets["SCRATCH"].required,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn removing_a_declaration_that_is_not_there_is_an_error() {
+        let err = remove_secret_from_manifest(MANIFEST, "default", "ABSENT").unwrap_err();
+        assert!(err.to_string().contains("not declared"), "{err}");
+    }
+
+    #[test]
+    fn removing_leaves_sibling_declarations_alone() {
+        let added = add_secret_to_manifest(MANIFEST, "default", "SCRATCH", "temp").unwrap();
+        let removed = remove_secret_from_manifest(&added, "default", "SCRATCH").unwrap();
+        assert!(removed.contains("EXISTING"));
+    }
+
+    #[test]
+    fn declares_secret_sees_a_real_declaration() {
+        assert!(declares_secret(MANIFEST, "default", "EXISTING").unwrap());
+        assert!(!declares_secret(MANIFEST, "default", "ABSENT").unwrap());
+    }
+
+    #[test]
+    fn declares_secret_is_not_fooled_by_a_comment_or_a_description() {
+        // Why this is parsed rather than searched. Both of these contain the
+        // name as text while declaring nothing of the sort.
+        let manifest = r#"[project]
+name = "demo"
+
+[profiles.default]
+# TODO: declare LOOKALIKE next release
+OTHER = { description = "unrelated, mentions LOOKALIKE in prose" }
+"#;
+        assert!(!declares_secret(manifest, "default", "LOOKALIKE").unwrap());
+    }
+
+    #[test]
+    fn declares_secret_reports_an_unparseable_manifest_rather_than_false() {
+        // A guard built on this must fail closed, which it cannot do if a
+        // broken file is indistinguishable from an absent name.
+        assert!(declares_secret("this is not toml {{{", "default", "ANY").is_err());
+    }
+
+    #[test]
+    fn the_full_declaration_writer_emits_only_the_fields_that_were_set() {
+        // What keeps the emitted declaration a readable single line, and what
+        // makes the byte-exact undo possible at all: an unset field must be
+        // absent, not written as an explicit null or a default.
+        use crate::config::Secret as ConfigSecret;
+
+        let secret = ConfigSecret {
+            description: Some("temp".into()),
+            required: Some(true),
+            ..ConfigSecret::default()
+        };
+
+        let added = add_secret_value_to_manifest(MANIFEST, "default", "SCRATCH", &secret).unwrap();
+
+        assert!(added.contains("SCRATCH = { description = \"temp\", required = true }"));
+    }
+
+    #[test]
+    fn the_full_declaration_writer_round_trips_a_nested_field() {
+        // `ref` serializes as a nested table rather than a scalar, so a writer
+        // that only knew how to place scalars into an inline table would fail
+        // here -- and it has to undo just as exactly as a scalar-only one.
+        use crate::config::{NativeAddress, Secret as ConfigSecret};
+
+        let secret = ConfigSecret {
+            description: Some("temp".into()),
+            reference: Some(NativeAddress {
+                item: "db".into(),
+                field: Some("password".into()),
+                ..NativeAddress::default()
+            }),
+            ..ConfigSecret::default()
+        };
+
+        let added = add_secret_value_to_manifest(MANIFEST, "default", "SCRATCH", &secret).unwrap();
+        assert!(added.contains(r#"item = "db""#), "{added}");
+
+        let removed = remove_secret_from_manifest(&added, "default", "SCRATCH").unwrap();
+
+        assert_eq!(removed, MANIFEST);
+    }
+
+    #[test]
+    fn the_full_declaration_writer_still_requires_a_description() {
+        use crate::config::Secret as ConfigSecret;
+
+        let err =
+            add_secret_value_to_manifest(MANIFEST, "default", "SCRATCH", &ConfigSecret::default())
+                .unwrap_err();
+
+        assert!(err.to_string().contains("description"), "{err}");
+    }
+
+    #[test]
+    fn declares_secret_is_profile_scoped() {
+        let manifest = r#"[project]
+name = "demo"
+
+[profiles.default]
+ONLY_DEFAULT = { description = "d" }
+
+[profiles.production]
+ONLY_PROD = { description = "p" }
+"#;
+        assert!(declares_secret(manifest, "default", "ONLY_DEFAULT").unwrap());
+        assert!(!declares_secret(manifest, "production", "ONLY_DEFAULT").unwrap());
+    }
+}

--- a/secretspec/src/spec.rs
+++ b/secretspec/src/spec.rs
@@ -28,6 +28,15 @@ pub struct Spec {
     pub(crate) config: Config,
     pub(crate) compiled: CompiledSpec,
     pub(crate) base_dir: Option<PathBuf>,
+    /// The exact text this spec was parsed from, when there is one.
+    ///
+    /// The **root document only**, never the merged result of `extends`:
+    /// [`Config::try_from`] folds parents into the child, so retaining the
+    /// merged text and writing it back would silently inline every inherited
+    /// declaration into a file that had only referenced them.
+    ///
+    /// `None` for a [`SpecBuilder`]-built spec, which was never text.
+    pub(crate) source: Option<String>,
 }
 
 impl Spec {
@@ -53,7 +62,9 @@ impl Spec {
                     .to_string(),
             ));
         }
-        Self::from_config_document(config)
+        let mut spec = Self::from_config_document(config)?;
+        spec.source = Some(source.to_string());
+        Ok(spec)
     }
 
     /// The project name used for provider namespacing.
@@ -101,11 +112,139 @@ impl Spec {
             config,
             compiled,
             base_dir: None,
+            source: None,
         })
     }
 
     pub(crate) fn into_parts(self) -> (Config, CompiledSpec) {
         (self.config, self.compiled)
+    }
+
+    /// This spec's exact backing text, when the byte-exactness guarantee holds.
+    ///
+    /// `Spec::from_toml(s)?.preserved_text() == Some(s)`, and for a spec loaded
+    /// from a path this is the root file's own bytes — not the merged result of
+    /// `extends`.
+    ///
+    /// `None` for a [`SpecBuilder`]-built spec, which never had a document.
+    /// That is why this and [`Self::to_toml`] are separate methods: a single
+    /// renderer whose exactness depended on hidden state would silently hand a
+    /// regenerated document to exactly the callers who needed the original.
+    ///
+    /// Available starting with SecretSpec 0.20.
+    pub fn preserved_text(&self) -> Option<&str> {
+        self.source.as_deref()
+    }
+
+    /// Render these declarations as freshly formatted TOML.
+    ///
+    /// Always available, and never byte-exact: key order, whitespace, and
+    /// comments come from the serializer, not from any original document. Use
+    /// [`Self::preserved_text`] when the original formatting matters.
+    ///
+    /// Available starting with SecretSpec 0.20.
+    pub fn to_toml(&self) -> Result<String> {
+        toml::to_string_pretty(&self.config)
+            .map_err(|error| SecretSpecError::InvalidSpec(error.to_string()))
+    }
+
+    /// Whether `profile` declares `name` in this spec's own source text.
+    ///
+    /// Scoped to the retained document, so a declaration this spec only sees
+    /// through `extends` reads as absent — the question being answered is "is
+    /// this name editable here", which is what [`Self::remove_secret_from_text`]
+    /// can act on. [`Self::secrets`] answers the inherited-inclusive question.
+    ///
+    /// Parsed, not searched. A substring test would match the name inside a
+    /// comment or another secret's description, and would do so silently.
+    /// `false` for a spec with no source text, and for one whose text does not
+    /// parse — callers needing to distinguish those should check
+    /// [`Self::preserved_text`] first.
+    ///
+    /// Available starting with SecretSpec 0.20.
+    #[cfg(feature = "manifest-edit")]
+    pub fn declares_secret_in_text(&self, profile: &str, name: &str) -> bool {
+        self.source.as_deref().is_some_and(|source| {
+            crate::manifest_edit::declares_secret(source, profile, name).unwrap_or(false)
+        })
+    }
+
+    /// Add one declaration, returning a new fully revalidated `Spec` whose text
+    /// differs from this one's only by that declaration.
+    ///
+    /// Everything else in the document survives byte for byte: comments, key
+    /// order, quoting, and any syntax the semantic model does not represent.
+    ///
+    /// The new spec's `config` and `compiled` views are re-derived by reparsing
+    /// the edited text through the same validated path every other `Spec` goes
+    /// through, rather than being mutated in parallel with it. There is one
+    /// synchronization point instead of one per method, so the text and the
+    /// semantic view cannot disagree — and an edit that produces an invalid
+    /// spec fails here rather than at some later load.
+    ///
+    /// Errors when this spec has no source text (see [`Self::preserved_text`]),
+    /// when `profile` already declares `name`, or when the result would not
+    /// validate.
+    ///
+    /// Available starting with SecretSpec 0.20.
+    #[cfg(feature = "manifest-edit")]
+    pub fn add_secret_to_text(&self, profile: &str, name: &str, secret: Secret) -> Result<Self> {
+        let source = self.editable_source()?;
+        let edited = crate::manifest_edit::add_secret_value_to_manifest(
+            source,
+            profile,
+            name,
+            &secret.config,
+        )
+        .map_err(|error| SecretSpecError::InvalidSpec(error.to_string()))?;
+        self.reparse(edited)
+    }
+
+    /// Remove one declaration, returning a new fully revalidated `Spec`.
+    ///
+    /// The inverse of [`Self::add_secret_to_text`] and byte-exact in the same
+    /// way: adding a declaration and then removing it restores the original
+    /// document exactly, which is what makes an "undo" usable by callers that
+    /// compare manifests as bytes rather than semantically.
+    ///
+    /// Removing a name the profile does not declare *in this text* is an error
+    /// rather than a silent no-op — including a name it inherits through
+    /// `extends`, which is declared in the parent and cannot be edited here.
+    ///
+    /// Available starting with SecretSpec 0.20.
+    #[cfg(feature = "manifest-edit")]
+    pub fn remove_secret_from_text(&self, profile: &str, name: &str) -> Result<Self> {
+        let source = self.editable_source()?;
+        let edited = crate::manifest_edit::remove_secret_from_manifest(source, profile, name)
+            .map_err(|error| SecretSpecError::InvalidSpec(error.to_string()))?;
+        self.reparse(edited)
+    }
+
+    #[cfg(feature = "manifest-edit")]
+    fn editable_source(&self) -> Result<&str> {
+        self.source.as_deref().ok_or_else(|| {
+            SecretSpecError::InvalidSpec(
+                "this spec has no source text to edit; it was built with Spec::builder".to_string(),
+            )
+        })
+    }
+
+    /// Rebuild from edited text, preserving this spec's inheritance context.
+    ///
+    /// `Spec::from_toml` cannot serve here: it rejects a non-empty
+    /// `project.extends`, having no location to resolve the paths against. This
+    /// spec does have one — `base_dir`, recorded when it was loaded — so the
+    /// reparse resolves inheritance exactly as the original load did.
+    #[cfg(feature = "manifest-edit")]
+    fn reparse(&self, edited: String) -> Result<Self> {
+        let config = match self.base_dir.as_deref() {
+            Some(base_dir) => Config::from_text_in(&edited, base_dir)?,
+            None => Config::from_str(&edited)?,
+        };
+        let mut spec = Self::from_config_document(config)?;
+        spec.base_dir = self.base_dir.clone();
+        spec.source = Some(edited);
+        Ok(spec)
     }
 }
 
@@ -138,6 +277,12 @@ impl TryFrom<&Path> for Spec {
                 .map(Path::to_path_buf)
                 .unwrap_or_else(|| PathBuf::from(".")),
         );
+        // Read the root file again rather than reusing the loader's merged
+        // result: `config` above is every ancestor folded together, and the
+        // text has to stay the one document a caller could write back.
+        // A file that parsed but cannot be re-read leaves `source` unset, which
+        // degrades editing to unavailable rather than failing the load.
+        spec.source = std::fs::read_to_string(path).ok();
         Ok(spec)
     }
 }
@@ -1023,5 +1168,346 @@ mod tests {
         };
         assert_eq!(options.length, Some(48));
         assert_eq!(options.charset.as_deref(), Some("ascii"));
+    }
+
+    #[cfg(feature = "manifest-edit")]
+    mod text_edits {
+        use super::*;
+
+        /// Deliberately awkward: a comment, non-alphabetical key order, a
+        /// blank line, and a full `[profiles.x.NAME]` table beside inline
+        /// ones. Every one of these is something a regenerating writer would
+        /// silently normalize away.
+        const MANIFEST: &str = r#"[project]
+name = "demo"
+revision = "1.0"
+
+# Team convention: transport secrets first, then credentials.
+[profiles.default]
+ZULU = { description = "sorts last on purpose" }
+ALPHA = { description = "sorts first on purpose" }
+
+[profiles.default.NESTED]
+description = "declared as a full table"
+required = false
+"#;
+
+        #[test]
+        fn a_parsed_spec_preserves_the_exact_text_it_came_from() {
+            // The guarantee the whole surface rests on, stated as the issue
+            // states it: from_toml(s).preserved_text() == Some(s).
+            let spec = Spec::from_toml(MANIFEST).unwrap();
+
+            assert_eq!(spec.preserved_text(), Some(MANIFEST));
+        }
+
+        #[test]
+        fn adding_then_removing_a_declaration_restores_the_original_bytes() {
+            // Byte-exact, not merely semantically equivalent. Callers that
+            // compare manifests as raw bytes -- a drift checker diffing a
+            // runtime manifest against a tracked template -- get a permanent
+            // false positive from anything weaker.
+            let spec = Spec::from_toml(MANIFEST).unwrap();
+
+            let added = spec
+                .add_secret_to_text("default", "SCRATCH", Secret::required("temporary"))
+                .unwrap();
+            assert_ne!(added.preserved_text(), Some(MANIFEST));
+
+            let removed = added.remove_secret_from_text("default", "SCRATCH").unwrap();
+
+            assert_eq!(removed.preserved_text(), Some(MANIFEST));
+        }
+
+        #[test]
+        fn an_edit_leaves_comments_ordering_and_table_shapes_alone() {
+            // The point of doing this with toml_edit rather than a round-trip
+            // through the semantic model, asserted directly rather than only
+            // via the round-trip: a regenerated document would lose the
+            // comment, sort ZULU after ALPHA, and inline the NESTED table.
+            let spec = Spec::from_toml(MANIFEST).unwrap();
+
+            let text = spec
+                .add_secret_to_text("default", "SCRATCH", Secret::required("temporary"))
+                .unwrap();
+            let text = text.preserved_text().unwrap().to_string();
+
+            assert!(text.contains("# Team convention:"), "{text}");
+            assert!(
+                text.find("ZULU").unwrap() < text.find("ALPHA").unwrap(),
+                "declaration order was not preserved: {text}"
+            );
+            assert!(text.contains("[profiles.default.NESTED]"), "{text}");
+        }
+
+        #[test]
+        fn an_edited_spec_is_revalidated_not_just_rewritten() {
+            // The synchronization point. The returned Spec's semantic view is
+            // re-derived from the edited text, so it must already see the new
+            // declaration -- a version that edited text and left `compiled`
+            // stale would pass a bytes-only assertion and fail this.
+            let spec = Spec::from_toml(MANIFEST).unwrap();
+
+            let added = spec
+                .add_secret_to_text("default", "SCRATCH", Secret::required("temporary"))
+                .unwrap();
+
+            let secrets: Vec<&str> = added.secrets("default").unwrap().collect();
+            assert!(secrets.contains(&"SCRATCH"), "{secrets:?}");
+            // ...and the spec it was derived from is untouched.
+            let original: Vec<&str> = spec.secrets("default").unwrap().collect();
+            assert!(!original.contains(&"SCRATCH"), "{original:?}");
+        }
+
+        #[test]
+        fn an_edit_that_would_not_validate_fails_at_the_edit() {
+            // Reparsing through the validated path is what makes this a
+            // failure here rather than a surprise at some later load.
+            let spec = Spec::from_toml(MANIFEST).unwrap();
+
+            let err = spec
+                .add_secret_to_text(
+                    "default",
+                    "COMPOSED",
+                    Secret::required("bad template").composed("${NO_SUCH_SECRET}"),
+                )
+                .unwrap_err();
+
+            assert!(
+                err.to_string().contains("NO_SUCH_SECRET"),
+                "unexpected error: {err}"
+            );
+        }
+
+        #[test]
+        fn a_declaration_survives_every_field_it_was_given() {
+            // add_secret_to_text takes a whole `Secret`, not a description and
+            // a bool, so the richer fields have to reach the document -- and
+            // `ref`, which serializes as a nested table rather than a scalar,
+            // is exactly where a writer that only knows how to emit scalars
+            // into an inline table breaks.
+            let spec = Spec::from_toml(MANIFEST).unwrap();
+
+            let added = spec
+                .add_secret_to_text(
+                    "default",
+                    "RICH",
+                    Secret::required("fully specified")
+                        .providers(["env", "keyring"])
+                        .as_path(true)
+                        .reference(NativeAddress {
+                            item: "db".into(),
+                            field: Some("password".into()),
+                            ..NativeAddress::default()
+                        }),
+                )
+                .unwrap();
+
+            let text = added.preserved_text().unwrap();
+            assert!(text.contains("RICH = {"), "{text}");
+            assert!(text.contains(r#"providers = ["env", "keyring"]"#), "{text}");
+            assert!(text.contains("as_path = true"), "{text}");
+            assert!(text.contains(r#"item = "db""#), "{text}");
+            assert!(text.contains(r#"field = "password""#), "{text}");
+
+            // And it round-trips: the parser accepts every key the writer
+            // emitted, which is the property that keeps them from drifting.
+            let removed = added.remove_secret_from_text("default", "RICH").unwrap();
+            assert_eq!(removed.preserved_text(), Some(MANIFEST));
+        }
+
+        #[test]
+        fn declaring_a_name_twice_is_an_error() {
+            let spec = Spec::from_toml(MANIFEST).unwrap();
+
+            let err = spec
+                .add_secret_to_text("default", "ALPHA", Secret::required("duplicate"))
+                .unwrap_err();
+
+            assert!(err.to_string().contains("already declared"), "{err}");
+        }
+
+        #[test]
+        fn removing_a_name_that_is_not_declared_is_an_error() {
+            // Not a silent no-op: a caller undeclaring something already
+            // absent has a wrong model of the manifest.
+            let spec = Spec::from_toml(MANIFEST).unwrap();
+
+            let err = spec
+                .remove_secret_from_text("default", "ABSENT")
+                .unwrap_err();
+
+            assert!(err.to_string().contains("not declared"), "{err}");
+        }
+
+        #[test]
+        fn declares_secret_in_text_is_parsed_rather_than_searched() {
+            // Why this is not a substring test. Both of these carry the name
+            // as text while declaring nothing of the sort, and the inverse
+            // mistake would be silent.
+            let manifest = r#"[project]
+name = "demo"
+revision = "1.0"
+
+[profiles.default]
+# TODO: declare LOOKALIKE next release
+OTHER = { description = "unrelated, mentions LOOKALIKE in prose" }
+"#;
+            let spec = Spec::from_toml(manifest).unwrap();
+
+            assert!(spec.declares_secret_in_text("default", "OTHER"));
+            assert!(!spec.declares_secret_in_text("default", "LOOKALIKE"));
+        }
+
+        #[test]
+        fn a_builder_built_spec_has_no_text_and_says_so_rather_than_inventing_one() {
+            // The reason preserved_text() returns Option and to_toml() does
+            // not: a single renderer whose exactness depended on hidden state
+            // would hand this caller a regenerated document and call it the
+            // original.
+            let spec = Spec::builder("embedded")
+                .secret("TOKEN", Secret::required("API token"))
+                .build()
+                .unwrap();
+
+            assert_eq!(spec.preserved_text(), None);
+
+            let err = spec
+                .add_secret_to_text("default", "SCRATCH", Secret::required("temporary"))
+                .unwrap_err();
+            assert!(err.to_string().contains("Spec::builder"), "{err}");
+
+            // to_toml still works -- it never promised exactness.
+            let rendered = spec.to_toml().unwrap();
+            assert!(rendered.contains("TOKEN"), "{rendered}");
+        }
+
+        #[test]
+        fn to_toml_renders_a_spec_that_never_had_a_document() {
+            // Round-trips through the parser, so "freshly formatted" still
+            // means "valid", not merely "printable".
+            let spec = Spec::builder("embedded")
+                .secret("TOKEN", Secret::required("API token"))
+                .build()
+                .unwrap();
+
+            let reparsed = Spec::from_toml(&spec.to_toml().unwrap()).unwrap();
+
+            assert_eq!(reparsed.project(), "embedded");
+            let secrets: Vec<&str> = reparsed.secrets("default").unwrap().collect();
+            assert_eq!(secrets, vec!["TOKEN"]);
+        }
+    }
+
+    /// The `extends` wrinkle, which needs real files on disk.
+    #[cfg(feature = "manifest-edit")]
+    mod text_edits_with_inheritance {
+        use super::*;
+        use std::fs;
+
+        fn project_with_parent() -> tempfile::TempDir {
+            let dir = tempfile::tempdir().unwrap();
+            fs::write(
+                dir.path().join("base.toml"),
+                r#"[project]
+name = "demo"
+revision = "1.0"
+
+[profiles.default]
+INHERITED = { description = "declared by the parent" }
+"#,
+            )
+            .unwrap();
+            fs::write(
+                dir.path().join("secretspec.toml"),
+                r#"[project]
+name = "demo"
+revision = "1.0"
+extends = ["base.toml"]
+
+[profiles.default]
+OWN = { description = "declared by the child" }
+"#,
+            )
+            .unwrap();
+            dir
+        }
+
+        #[test]
+        fn the_retained_text_is_the_root_file_not_the_merged_result() {
+            // Config::try_from folds every parent into the child. Retaining
+            // that merged document as the child's text and writing it back
+            // would silently inline the parent's declarations into a file that
+            // had only referenced them -- turning inheritance into a copy.
+            let dir = project_with_parent();
+
+            let spec = Spec::try_from(dir.path().join("secretspec.toml").as_path()).unwrap();
+
+            let text = spec.preserved_text().unwrap();
+            assert!(text.contains("OWN"), "{text}");
+            assert!(
+                !text.contains("INHERITED"),
+                "the parent's declaration leaked into the child's text: {text}"
+            );
+            // ...while the semantic view still sees both.
+            let secrets: Vec<&str> = spec.secrets("default").unwrap().collect();
+            assert!(secrets.contains(&"INHERITED"), "{secrets:?}");
+        }
+
+        #[test]
+        fn editing_a_spec_that_extends_another_revalidates_against_the_parent() {
+            // The wrinkle. Spec::from_toml rejects a non-empty project.extends
+            // outright -- a string has nowhere to resolve the paths from -- so
+            // reparsing the edited text through it would fail on every
+            // inheriting project. The reparse is seeded with base_dir instead.
+            let dir = project_with_parent();
+            let spec = Spec::try_from(dir.path().join("secretspec.toml").as_path()).unwrap();
+
+            let added = spec
+                .add_secret_to_text("default", "SCRATCH", Secret::required("temporary"))
+                .unwrap();
+
+            // Inheritance survived the edit rather than being dropped...
+            let secrets: Vec<&str> = added.secrets("default").unwrap().collect();
+            assert!(secrets.contains(&"INHERITED"), "{secrets:?}");
+            assert!(secrets.contains(&"SCRATCH"), "{secrets:?}");
+            // ...and the edited text is still root-only.
+            assert!(!added.preserved_text().unwrap().contains("INHERITED"));
+
+            // Control: the same text has no chance through from_toml.
+            assert!(Spec::from_toml(added.preserved_text().unwrap()).is_err());
+        }
+
+        #[test]
+        fn an_inherited_declaration_is_not_editable_here() {
+            // declares_secret_in_text answers "can this be edited in this
+            // document", which is what remove_secret_from_text can act on --
+            // deliberately a different question from `secrets()`.
+            let dir = project_with_parent();
+            let spec = Spec::try_from(dir.path().join("secretspec.toml").as_path()).unwrap();
+
+            assert!(spec.declares_secret_in_text("default", "OWN"));
+            assert!(!spec.declares_secret_in_text("default", "INHERITED"));
+
+            let err = spec
+                .remove_secret_from_text("default", "INHERITED")
+                .unwrap_err();
+            assert!(err.to_string().contains("not declared"), "{err}");
+        }
+
+        #[test]
+        fn the_round_trip_still_holds_through_inheritance() {
+            let dir = project_with_parent();
+            let spec = Spec::try_from(dir.path().join("secretspec.toml").as_path()).unwrap();
+            let original = spec.preserved_text().unwrap().to_string();
+
+            let restored = spec
+                .add_secret_to_text("default", "SCRATCH", Secret::required("temporary"))
+                .unwrap()
+                .remove_secret_from_text("default", "SCRATCH")
+                .unwrap();
+
+            assert_eq!(restored.preserved_text(), Some(original.as_str()));
+        }
     }
 }


### PR DESCRIPTION
Closes #370.

Opening this against the shape you described on #357 — everything lands on `Spec`, `Config` stays internal, and no `toml_edit` or `Config` appears in any public signature.

### What it does

`Spec` can read a `secretspec.toml` and can build a new one, but cannot write an existing one back out. So editing one declaration in a real file means either regenerating the whole document from the parsed model — losing every comment and reordering every profile, since `Config.profiles` is a `HashMap` — or hand-rolling `toml_edit` outside the library.

Five methods, the surface proposed in the issue:

```rust
impl Spec {
    pub fn add_secret_to_text(&self, profile: &str, name: &str, secret: Secret) -> Result<Spec>;
    pub fn remove_secret_from_text(&self, profile: &str, name: &str) -> Result<Spec>;
    pub fn declares_secret_in_text(&self, profile: &str, name: &str) -> bool;
    pub fn preserved_text(&self) -> Option<&str>;
    pub fn to_toml(&self) -> Result<String>;
}
```

`Spec::from_toml(s)?.preserved_text() == Some(s)`, and add-then-remove of the same key returns the original bytes.

### How it stays safe

The edits are `toml_edit` surgery on the retained text; `config`/`compiled` are then re-derived by **reparsing the result through the same validated path every other `Spec` already goes through**. The semantic view is always derived from the text, never hand-mutated alongside it — one synchronization point instead of one per method, so the two cannot disagree, and an edit that would not validate fails at the edit rather than at some later load.

Per the issue, `SpecBuilder`'s general edit surface is **not** made format-preserving. `into_builder()`/`to_builder()` stays a hard boundary: only `Spec` carries source text.

### The two wrinkles I flagged, and how they're handled

**1. `extends`.** `Spec::from_toml` rejects a non-empty `project.extends`, having nowhere to resolve paths from, so reparsing edited text through it would fail on every inheriting project. `Config::from_text_in` is the `extends`-aware variant, seeded with the `base_dir` `Spec` already records. `ConfigGraphLoader` gained an in-memory entry point, and its `extends` walk is now shared with the path-based one rather than duplicated.

**2. Root file only.** `Config::try_from` folds parents into the child, so retaining the *merged* text and writing it back would silently inline every inherited declaration into a file that had merely referenced them. A test asserts the parent's declaration does not appear in the child's text while `secrets()` still sees it.

### Module and feature

The `toml_edit` surgery moves out of `cli` into a `manifest_edit` module behind a new `manifest-edit` feature, which `cli` enables — nothing changes for existing users, but an embedder can take the editing surface without `clap` and `inquire`.

`toml_edit` gains its `serde` feature so a whole `Secret` renders through the same representation the parser reads, keeping written and accepted keys from drifting as the schema grows. The value serializer refuses nested tables — which `ref`, `refs`, `extract`, `generate` and a presence group's `required` all produce — so declarations serialize via `to_document` and are flattened to an inline table. `Cargo.lock` gains only `serde_core` and `serde_spanned`, both already in the tree via `toml`; no new crates.

**Requiredness is untouched.** As I said on the issue, #334 settled it — `add_secret_to_manifest` keeps its existing description-only signature, and anything richer goes through the `Secret` that `add_secret_to_text` already takes.

### Two deviations from the issue's sketch, both deliberate

- `to_toml` returns `Result<String>`, not `String`. TOML serialization is fallible and I would rather surface that than unwrap inside the library.
- The three editing methods are `#[cfg(feature = "manifest-edit")]`, since they need `toml_edit`. `preserved_text` and `to_toml` are unconditional.

Happy to change either, or the naming, if you'd prefer something else.

### Tests

New tests cover the byte-exact round-trip; that comments, declaration order, and a full `[profiles.x.NAME]` table all survive an edit; that the returned `Spec` is revalidated rather than merely rewritten, and that the spec it derived from is untouched; that an invalid edit fails at the edit; that a declaration carrying `providers`, `as_path` and a nested `ref` round-trips; duplicate-add and absent-remove errors; `declares_secret_in_text` parsed rather than substring-matched, so a name inside a comment or another secret's description does not fool it; and a builder-built spec reporting no text rather than inventing one.

Four more cover inheritance against real files on disk: root-only retention, editing a spec that `extends` another, an inherited declaration not being editable in the child, and the round-trip holding through inheritance.

Full suite green on this branch. The 21 `provider::sops::*` failures in my environment are all `The 'sops' CLI is not installed` and occur identically on an unmodified `dfa4b10`.
