### PR TITLE
fix(cli): restore the default SIGPIPE disposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Closing the output pipe now ends the CLI quietly on Unix, so
+  `secretspec export | head` and `secretspec check --json | head` behave like
+  any other Unix tool. Previously `export` reported `IO error: Broken pipe`
+  and exited 1, and `check --json` panicked with `failed printing to stdout`,
+  because Rust ignores `SIGPIPE` by default and surfaced `EPIPE` instead. The
+  entry point now restores the default `SIGPIPE` disposition, which covers
+  every command that writes to stdout.
+
 - Google Cloud Secret Manager convention names now use the readable,
   versioned `secretspec2--{project}--{profile}--{key}` layout. Distinct logical
   addresses such as `my-app/prod/K` and `my/app-prod/K` can no longer collide

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5272,6 +5272,7 @@ dependencies = [
  "keepass",
  "keeper-secrets-manager-core",
  "keyring",
+ "libc",
  "linkme",
  "miette",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ is_executable = "1.0"
 keyring = "4.1.6"
 keepass = { version = "0.13.17", features = ["save_kdbx4"] }
 keeper-secrets-manager-core = { version = "17.3.0", default-features = false, features = ["blocking"] }
+libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9"
 toml_edit = "0.23"

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -58,6 +58,9 @@ data-encoding.workspace = true
 detect-coding-agent.workspace = true
 age = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [features]
 default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "scaleway", "sops"]
 cli = ["dep:toml_edit", "dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable"]

--- a/secretspec/src/bin/secretspec.rs
+++ b/secretspec/src/bin/secretspec.rs
@@ -1,5 +1,14 @@
 use miette::Result;
 
 fn main() -> Result<()> {
+    // Rust's runtime ignores SIGPIPE by default, turning a closed pipe (e.g.
+    // `secretspec check | head`) into an EPIPE error instead of a quiet exit.
+    // Restore the default disposition so a broken pipe just terminates us,
+    // matching standard Unix CLI behavior.
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     secretspec::cli::main()
 }

--- a/secretspec/tests/sigpipe.rs
+++ b/secretspec/tests/sigpipe.rs
@@ -1,0 +1,105 @@
+//! A closed output pipe should terminate the CLI quietly, the way any other
+//! Unix tool does — `secretspec export | head` must not report an error.
+//!
+//! Rust's runtime ignores `SIGPIPE`, so without an explicit reset the write
+//! returns `EPIPE` instead: `export` surfaces it as `IO error: Broken pipe`
+//! and `check --json` panics out of `println!`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Read;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Command, Stdio};
+
+/// `SIGPIPE`. Hardcoded so the test needs no `libc` dev-dependency.
+const SIGPIPE: i32 = 13;
+
+/// Output big enough that the child keeps writing after the ~64KiB pipe
+/// buffer fills — otherwise everything fits and the pipe never breaks.
+/// `check --json` emits roughly 200 bytes per secret regardless of value
+/// size, so the count is what has to carry that path over the threshold.
+const SECRET_COUNT: usize = 500;
+const SECRET_LEN: usize = 200;
+
+/// Runs `secretspec <args>`, reads a few bytes, then closes the pipe.
+fn run_with_closed_stdout(args: &[&str]) -> std::process::Output {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_path = temp_dir.path().join("secretspec.toml");
+
+    let mut config = String::from(
+        r#"[project]
+name = "sigpipe-test"
+revision = "1.0"
+require_reason = false
+
+[providers]
+env = "env://"
+
+[profiles.default]
+"#,
+    );
+    for i in 0..SECRET_COUNT {
+        config.push_str(&format!(
+            "SECRET_{i} = {{ description = \"secret {i}\", providers = [\"env\"] }}\n"
+        ));
+    }
+    fs::write(&config_path, config).unwrap();
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_secretspec"));
+    command
+        .args(["--file", config_path.to_str().unwrap()])
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for i in 0..SECRET_COUNT {
+        command.env(format!("SECRET_{i}"), "v".repeat(SECRET_LEN));
+    }
+
+    let mut child = command.spawn().unwrap();
+
+    // Consume a little, then drop the read end. The child's next write to a
+    // pipe with no reader is what raises SIGPIPE.
+    let mut stdout = child.stdout.take().unwrap();
+    let mut head = [0u8; 16];
+    stdout.read_exact(&mut head).unwrap();
+    drop(stdout);
+
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn export_dies_on_sigpipe_instead_of_reporting_a_broken_pipe() {
+    let output = run_with_closed_stdout(&["export", "--provider", "env", "--format", "dotenv"]);
+
+    assert_eq!(
+        output.status.signal(),
+        Some(SIGPIPE),
+        "expected termination by SIGPIPE, got {}:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "a closed pipe should be silent, got:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn check_json_dies_on_sigpipe_instead_of_panicking() {
+    let output = run_with_closed_stdout(&["check", "--provider", "env", "--json"]);
+
+    assert_eq!(
+        output.status.signal(),
+        Some(SIGPIPE),
+        "expected termination by SIGPIPE, got {}:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "a closed pipe should be silent, got:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Follow-up to point 3 of your review on #373.

Rust's runtime ignores `SIGPIPE`, so a closed output pipe comes back as an
`EPIPE` write error instead of terminating the process. `secretspec` then
fails where every other Unix tool exits quietly:

```console
$ secretspec export --format dotenv | head
Error:   × Failed to export secrets
  ├─▶ IO error: Broken pipe (os error 32)
  ╰─▶ Broken pipe (os error 32)
$ echo $?
1

$ secretspec check --json | head
thread 'main' panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
$ echo $?
101
```

`check --json` is the worse of the two: it panics out of `println!` rather
than returning an error.

## The fix

Reset the disposition to `SIG_DFL` at the top of the binary entry point. Doing
it there fixes every stdout-writing command at once, instead of teaching each
call site to special-case `EPIPE` — which is why this is one small commit
rather than three.

After the change, both commands terminate on signal 13 with **empty stderr**,
and unpiped output is byte-for-byte unchanged.

## Tests

`secretspec/tests/sigpipe.rs` covers both paths: it spawns the real binary,
reads a few bytes, drops the read end, and asserts termination by `SIGPIPE`
with no stderr. The secret count is sized so output exceeds the ~64KiB pipe
buffer — below that the write fits in the buffer and the pipe never breaks.

I checked both tests fail without the fix, with exactly the errors quoted
above, so they're genuinely pinning the behavior rather than passing
vacuously.

## Note on `libc`

New direct dependency, declared only under `[target.'cfg(unix)'.dependencies]`.
It was already in `Cargo.lock` transitively, so nothing new is vendored. Happy
to drop it for a hand-rolled `extern "C"` declaration if you'd rather not add
the direct dep.