### PR TITLE
feat(extract): select values from INI documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `extract` supports INI documents in SecretSpec 0.20+, selecting an
+  unsectioned key with `/key` or a named-section key with `/section/key`.
+
 - **Azure App Configuration provider** (`aac://`, 0.20+): select direct
   values and Azure Key Vault references by label, prefix, and tags, with Entra
   ID or connection-string authentication and guarded writes, deletion, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1623,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1829,6 +1855,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2671,6 +2706,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -3302,7 +3343,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4116,6 +4157,16 @@ name = "opentelemetry-semantic-conventions"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -4957,6 +5008,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5280,6 +5341,7 @@ dependencies = [
  "rand 0.9.2",
  "reqwest 0.12.28",
  "rsa",
+ "rust-ini",
  "same-file",
  "secrecy",
  "serde",
@@ -5948,6 +6010,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ dotenv = { package = "dotenv-ng", version = "1.0.0" }
 inquire = { version = "0.9.4", features = ["experimental-multiline-input"] }
 miette = { version = "7.6", features = ["fancy"] }
 serde_json = "1.0"
+ini = { package = "rust-ini", version = "0.21.3" }
 proptest = "1"
 tempfile = "3.0"
 same-file = "1.0"

--- a/docs/src/content/docs/providers/file.md
+++ b/docs/src/content/docs/providers/file.md
@@ -146,10 +146,11 @@ Referenced files are writable when filesystem permissions allow it. Treat
 runtime-managed mounts as read-only unless their owner explicitly permits
 SecretSpec to replace or delete entries.
 
-## Extract from JSON (0.19+)
+## Extract from a document (0.19+)
 
 :::caution[Version compatibility]
 Structured `extract` is available starting in SecretSpec 0.19.
+INI extraction with `format = "ini"` is available starting in SecretSpec 0.20.
 :::
 
 Several declarations can select values from one JSON file without making JSON
@@ -175,9 +176,24 @@ DATABASE_PASSWORD = {
 }
 ```
 
+An INI file is selected the same way with `format = "ini"` (0.20+), where
+`/key` reads an unsectioned key and `/section/key` reads a key in a named
+section:
+
+```toml title="secretspec.toml"
+[profiles.production]
+# format = "ini" requires SecretSpec 0.20+
+DATABASE_PASSWORD = {
+  description = "Database password",
+  providers = ["runtime_files"],
+  ref = { item = "application.ini" },
+  extract = { format = "ini", pointer = "/database/password" }
+}
+```
+
 The file provider returns the complete UTF-8 document; SecretSpec then applies
-the RFC 6901 pointer as a provider-independent stored-value transform. Extracted
-declarations are read-only in 0.19 so `set`, `delete`, generation, prompting,
+the pointer as a provider-independent stored-value transform. Extracted
+declarations are read-only so `set`, `delete`, generation, prompting,
 and import cannot overwrite or remove the containing file. See
 [Structured Extraction](/reference/configuration/#structured-extraction-019)
 for value rendering, error behavior, and composition with `encoding`.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -164,7 +164,7 @@ Each secret variable is defined as a table with the following fields:
 | `refs` (0.19+) | table | No | Provider-alias-scoped coordinates, keyed by leaf alias (e.g. `refs = { source = { item = "old" }, target = { item = "new" } }`); mutually exclusive with `ref` |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
 | `encoding` (0.19+) | `"base64"`, `"base64url"`, or `"hex"` | No | Encode logical values before storage writes and decode stored values after reads |
-| `extract` (0.19+) | table | No | Select one logical value from stored structured data, for example `extract = { format = "json", pointer = "/database/password" }` |
+| `extract` (0.19+) | table | No | Select one logical value from stored JSON (0.19+) or INI (0.20+) data with a pointer |
 | `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
 | `generate` | boolean or table | No | Enable auto-generation when secret is missing |
 | `prompt` (0.19+) | boolean | No | Securely prompt for a missing value during `secretspec run`; the selected provider controls persistence |
@@ -701,11 +701,12 @@ double encoding.
 
 :::caution[Version compatibility]
 Available starting in SecretSpec 0.19.
+INI extraction with `format = "ini"` is available starting in SecretSpec 0.20.
 :::
 
 `extract` (0.19+) selects one logical secret from structured text read from a
-provider or cache. JSON is the initial supported format, and `pointer` is an
-[RFC 6901 JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901):
+provider or cache. It supports JSON (0.19+) and INI (0.20+). JSON `pointer`
+values are [RFC 6901 JSON Pointers](https://www.rfc-editor.org/rfc/rfc6901):
 
 ```toml
 [providers]
@@ -737,6 +738,29 @@ pointer that does not match is a decoding error. Once a provider returns a
 document, extraction failure is not treated as a provider miss and does not
 continue along a fallback chain.
 
+INI extraction (0.20+) uses the same RFC 6901 escaping for pointer segments but
+accepts only value selectors. `/key` selects an unsectioned key, while
+`/section/key` selects a key in a named section:
+
+```toml
+[profiles.default]
+# format = "ini" requires SecretSpec 0.20+
+DB_PASSWORD = {
+  description = "Database password",
+  providers = ["documents"],
+  ref = { item = "application.ini" },
+  extract = { format = "ini", pointer = "/database/password" }
+}
+```
+
+For example, that pointer reads `password` from `[database]`. An explicit
+`[DEFAULT]` section is selected as `/DEFAULT/key`; it is distinct from an
+unsectioned `/key`. Section and key matching is case-sensitive. `~1` selects a
+literal `/` and `~0` selects a literal `~`, just as in JSON Pointer. INI values
+always remain strings, and literal backslashes are preserved. Empty pointers,
+pointers deeper than `/section/key`, malformed INI, and unmatched pointers are
+decoding errors.
+
 Stored-value transforms run in this order:
 
 ```text
@@ -749,7 +773,7 @@ both `encoding = "base64"` (0.19+) and `extract` (0.19+). A provider-native
 selected further. Defaults and composed values are already logical and are not
 extracted.
 
-Extracted secrets are read-only in 0.19. `set`, `delete`, interactive prompting,
+Extracted secrets are read-only. `set`, `delete`, interactive prompting,
 generation, and `import` reject them rather than replacing or removing the
 containing document and its sibling values. Update the document through its
 owning system instead.

--- a/docs/src/content/docs/sdk/rust.mdx
+++ b/docs/src/content/docs/sdk/rust.mdx
@@ -32,6 +32,13 @@ secretspec = "0.20"
 secretspec-derive = "0.20"
 ```
 
+:::caution[Version compatibility]
+Generated code reaches `serde` and `secrecy` through `secretspec` starting in
+SecretSpec 0.20. On 0.19 and earlier, also depend on `secrecy = { version =
+"0.10", features = ["serde"] }` and `serde = { version = "1", features =
+["derive"] }`.
+:::
+
 The examples on this page are compiled as Cargo examples in
 `secretspec-derive`. They generate their types from this manifest:
 

--- a/secretspec-derive/src/lib.rs
+++ b/secretspec-derive/src/lib.rs
@@ -780,7 +780,8 @@ mod secret_spec_generation {
     /// # Generated Code Example
     ///
     /// ```ignore
-    /// #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    /// #[derive(Debug, ::secretspec::__private::serde::Serialize, ::secretspec::__private::serde::Deserialize)]
+    /// #[serde(crate = "::secretspec::__private::serde")]
     /// pub struct SecretSpec {
     ///     pub database_url: String,
     ///     pub api_key: Option<String>,
@@ -791,8 +792,8 @@ mod secret_spec_generation {
         let fields = field_info.values().map(|info| info.generate_struct_field());
 
         quote! {
-            #[derive(Debug, serde::Serialize, serde::Deserialize)]
-            #[serde(crate = "serde")]
+            #[derive(Debug, ::secretspec::__private::serde::Serialize, ::secretspec::__private::serde::Deserialize)]
+            #[serde(crate = "::secretspec::__private::serde")]
             pub struct SecretSpec {
                 #(#fields,)*
             }
@@ -812,7 +813,8 @@ mod secret_spec_generation {
     /// # Generated Code Example
     ///
     /// ```ignore
-    /// #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    /// #[derive(Debug, ::secretspec::__private::serde::Serialize, ::secretspec::__private::serde::Deserialize)]
+    /// #[serde(crate = "::secretspec::__private::serde")]
     /// pub enum SecretSpecProfile {
     ///     Development {
     ///         database_url: String,
@@ -829,8 +831,8 @@ mod secret_spec_generation {
         profile_variants: &[proc_macro2::TokenStream],
     ) -> proc_macro2::TokenStream {
         quote! {
-            #[derive(Debug, serde::Serialize, serde::Deserialize)]
-            #[serde(crate = "serde")]
+            #[derive(Debug, ::secretspec::__private::serde::Serialize, ::secretspec::__private::serde::Deserialize)]
+            #[serde(crate = "::secretspec::__private::serde")]
             pub enum SecretSpecProfile {
                 #(#profile_variants,)*
             }
@@ -1441,7 +1443,7 @@ fn generate_secret_spec_code(ir: CodegenIr) -> proc_macro2::TokenStream {
 
     // Combine all components
     quote! {
-        use secretspec::__private::{secrecy::ExposeSecret, serde};
+        use ::secretspec::__private::secrecy::ExposeSecret;
 
         #secret_spec_struct
         #secret_spec_profile_enum

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -33,6 +33,7 @@ dotenv.workspace = true
 inquire.workspace = true
 miette.workspace = true
 serde_json.workspace = true
+ini.workspace = true
 tempfile.workspace = true
 same-file.workspace = true
 url.workspace = true

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -2010,6 +2010,11 @@ impl SecretEncoding {
 pub enum ExtractFormat {
     /// A JSON document selected with an RFC 6901 JSON Pointer.
     Json,
+    /// An INI document selected with an RFC 6901-escaped `/key` or
+    /// `/section/key` pointer.
+    ///
+    /// Available since SecretSpec 0.20.
+    Ini,
 }
 
 impl ExtractFormat {
@@ -2017,6 +2022,7 @@ impl ExtractFormat {
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Json => "json",
+            Self::Ini => "ini",
         }
     }
 }
@@ -2033,7 +2039,9 @@ impl ExtractFormat {
 pub struct SecretExtract {
     /// The structured-data format of the stored value.
     pub format: ExtractFormat,
-    /// RFC 6901 JSON Pointer selecting the logical value.
+    /// Slash-delimited pointer selecting the logical value. JSON accepts a
+    /// complete RFC 6901 JSON Pointer; INI accepts `/key` or `/section/key`
+    /// with RFC 6901 escaping for each segment.
     pub pointer: String,
 }
 
@@ -2041,6 +2049,7 @@ impl SecretExtract {
     fn validate(&self) -> Result<(), String> {
         match self.format {
             ExtractFormat::Json => validate_json_pointer(&self.pointer),
+            ExtractFormat::Ini => crate::ini_field::validate_pointer(&self.pointer),
         }
     }
 }
@@ -2048,7 +2057,7 @@ impl SecretExtract {
 /// Validate the JSON Pointer grammar independently of any particular document.
 /// An empty pointer selects the whole document; every non-empty pointer starts
 /// with `/`, and `~` escapes only `~0` and `~1`.
-fn validate_json_pointer(pointer: &str) -> Result<(), String> {
+pub(crate) fn validate_json_pointer(pointer: &str) -> Result<(), String> {
     if pointer.is_empty() {
         return Ok(());
     }
@@ -2138,9 +2147,11 @@ pub struct Secret {
     /// Available since SecretSpec 0.19.
     pub encoding: Option<SecretEncoding>,
     /// Structured stored-value extraction applied after optional decoding.
-    /// JSON extraction uses an RFC 6901 pointer. Extracted secrets are
-    /// read-only because a selected value cannot reconstruct its containing
-    /// document for a storage write.
+    /// JSON extraction uses an RFC 6901 pointer. INI extraction (0.20+) uses
+    /// `/key` for an unsectioned key or `/section/key` for a named section,
+    /// with RFC 6901 segment escaping. Extracted secrets are read-only because
+    /// a selected value cannot reconstruct its containing document for a
+    /// storage write.
     ///
     /// Available since SecretSpec 0.19.
     pub extract: Option<SecretExtract>,
@@ -4071,11 +4082,7 @@ encoding = "rot13""#,
 
     #[test]
     fn secret_extract_parses_round_trips_and_inherits() {
-        let secret: Secret = toml::from_str(
-            r#"description = "selected"
-extract = { format = "json", pointer = "/database/password" }"#,
-        )
-        .unwrap();
+        let secret = extract_secret("json", "/database/password");
         assert_eq!(
             secret.extract,
             Some(SecretExtract {
@@ -4104,16 +4111,30 @@ extract = { format = "json", pointer = "/database/password" }"#,
         )
         .unwrap();
         assert_eq!(inherited.extract, secret.extract);
+
+        let ini = extract_secret("ini", "/database/password");
+        assert_eq!(
+            ini.extract,
+            Some(SecretExtract {
+                format: ExtractFormat::Ini,
+                pointer: "/database/password".to_string(),
+            })
+        );
+        assert!(toml::to_string(&ini).unwrap().contains("format = \"ini\""));
+    }
+
+    /// A secret declaring nothing but the extract table under test.
+    fn extract_secret(format: &str, pointer: &str) -> Secret {
+        toml::from_str(&format!(
+            "description = \"selected\"\nextract = {{ format = \"{format}\", pointer = \"{pointer}\" }}"
+        ))
+        .unwrap()
     }
 
     #[test]
     fn secret_extract_validates_json_pointer_and_table_shape() {
         for pointer in ["database/password", "/bad~", "/bad~2escape"] {
-            let secret: Secret = toml::from_str(&format!(
-                "description = \"selected\"\nextract = {{ format = \"json\", pointer = \"{pointer}\" }}"
-            ))
-            .unwrap();
-            let error = secret.validate().unwrap_err();
+            let error = extract_secret("json", pointer).validate().unwrap_err();
             assert!(error.contains("`extract.pointer`"), "{error}");
         }
 
@@ -4137,11 +4158,27 @@ extract = { format = "yaml", pointer = "/x" }"#,
     #[test]
     fn secret_extract_accepts_root_and_escaped_json_pointers() {
         for pointer in ["", "/a~1b/~0key", "/items/0"] {
-            let secret: Secret = toml::from_str(&format!(
-                "description = \"selected\"\nextract = {{ format = \"json\", pointer = \"{pointer}\" }}"
-            ))
-            .unwrap();
-            secret.validate().unwrap();
+            extract_secret("json", pointer).validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn secret_extract_validates_ini_pointer_shape() {
+        for pointer in ["/token", "/database/password", "/a~1b/~0key"] {
+            extract_secret("ini", pointer).validate().unwrap();
+        }
+
+        for pointer in [
+            "",
+            "token",
+            "/",
+            "//password",
+            "/database/",
+            "/database/password/extra",
+            "/bad~2escape",
+        ] {
+            let error = extract_secret("ini", pointer).validate().unwrap_err();
+            assert!(error.contains("`extract.pointer`"), "{pointer}: {error}");
         }
     }
 

--- a/secretspec/src/ini_field.rs
+++ b/secretspec/src/ini_field.rs
@@ -1,0 +1,55 @@
+//! Selecting one value out of an INI document.
+//!
+//! An INI pointer is an RFC 6901 pointer restricted to the two depths an INI
+//! document can address: `/key` for an unsectioned key and `/section/key` for a
+//! key in a named section. The grammar, the message that states it, and the
+//! lookup that depends on it live together here, so a pointer accepted at
+//! config time is exactly one that resolution can follow.
+
+/// The one description of the accepted pointer shape, used to reject every
+/// other shape at config time.
+const POINTER_SHAPE: &str = "`extract.pointer` for INI must be `/key` for an unsectioned key or `/section/key` for a named section";
+
+/// Validate a pointer without reference to any particular document. The shape
+/// is checked before the shared RFC 6901 escape grammar, so a pointer that is
+/// not a value selector is reported as such rather than as a JSON Pointer that
+/// may also be empty.
+pub(crate) fn validate_pointer(pointer: &str) -> Result<(), String> {
+    pointer_parts(pointer).ok_or(POINTER_SHAPE)?;
+    crate::config::validate_json_pointer(pointer)
+}
+
+/// Select the value a pointer names from an INI document. The error names only
+/// the pointer and the parser location, never the document or the value.
+pub(crate) fn select(document: &str, pointer: &str) -> Result<String, String> {
+    let document = ini::Ini::load_from_str_noescape(document).map_err(|error| {
+        format!(
+            "stored value is not valid INI at line {}, column {}: {}",
+            error.line, error.col, error.msg
+        )
+    })?;
+    pointer_parts(pointer)
+        .and_then(|(section, key)| document.get_from(section, &key))
+        .map(str::to_owned)
+        .ok_or_else(|| format!("INI pointer '{pointer}' did not match the stored document"))
+}
+
+/// Split a pointer into its optional section and its key, with RFC 6901
+/// escapes resolved. `None` for any shape other than `/key` or `/section/key`.
+fn pointer_parts(pointer: &str) -> Option<(Option<String>, String)> {
+    let path = pointer.strip_prefix('/')?;
+    let (section, key) = match path.split_once('/') {
+        Some((section, key)) => (Some(section), key),
+        None => (None, path),
+    };
+    if section == Some("") || key.is_empty() || key.contains('/') {
+        return None;
+    }
+    Some((section.map(unescape_segment), unescape_segment(key)))
+}
+
+/// Resolve the two RFC 6901 escapes in one pointer segment: `~1` is a literal
+/// `/` and `~0` is a literal `~`.
+fn unescape_segment(segment: &str) -> String {
+    segment.replace("~1", "/").replace("~0", "~")
+}

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -50,6 +50,7 @@ mod composition;
 mod config;
 mod error;
 pub(crate) mod generator;
+pub(crate) mod ini_field;
 pub(crate) mod json_field;
 mod manifest;
 mod plan;

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -1771,23 +1771,20 @@ impl Secrets {
         diagnostic_name: &str,
         value: &str,
     ) -> Result<SecretString> {
+        let failed = |reason: String| SecretSpecError::DecodeFailed {
+            name: diagnostic_name.to_string(),
+            encoding: extract.format.as_str(),
+            reason,
+        };
         match extract.format {
             ExtractFormat::Json => {
-                let document: serde_json::Value =
-                    serde_json::from_str(value).map_err(|error| SecretSpecError::DecodeFailed {
-                        name: diagnostic_name.to_string(),
-                        encoding: extract.format.as_str(),
-                        reason: format!("stored value is not valid JSON: {error}"),
-                    })?;
+                let document: serde_json::Value = serde_json::from_str(value)
+                    .map_err(|error| failed(format!("stored value is not valid JSON: {error}")))?;
                 let selected = document.pointer(&extract.pointer).ok_or_else(|| {
-                    SecretSpecError::DecodeFailed {
-                        name: diagnostic_name.to_string(),
-                        encoding: extract.format.as_str(),
-                        reason: format!(
-                            "JSON Pointer '{}' did not match the stored document",
-                            extract.pointer
-                        ),
-                    }
+                    failed(format!(
+                        "JSON Pointer '{}' did not match the stored document",
+                        extract.pointer
+                    ))
                 })?;
                 // Rendering is shared with the awssm and scaleway providers.
                 // A null renders as "null" here: this caller was asked for one
@@ -1796,6 +1793,12 @@ impl Secrets {
                 // continues. See crate::json_field.
                 Ok(crate::json_field::render(selected))
             }
+            // The pointer grammar and the lookup that follows it live together
+            // in crate::ini_field, next to the validation that rejects every
+            // other shape at config time.
+            ExtractFormat::Ini => crate::ini_field::select(value, &extract.pointer)
+                .map(|selected| SecretString::new(selected.into()))
+                .map_err(failed),
         }
     }
 

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -8,7 +8,7 @@ use crate::validation::{ValidatedSecrets, ValidationErrors};
 use secrecy::ExposeSecret;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::{fs, io};
 use tempfile::TempDir;
@@ -5232,14 +5232,46 @@ BAD = { description = "invalid base64", encoding = "base64" }
     assert!(!error.to_string().contains("%%%"));
 }
 
-#[test]
-fn test_json_extract_resolves_structured_values_after_decoding() {
-    use std::fs;
-
+/// A store of documents on disk and a spec whose secrets extract from them.
+/// `secret_rows` is the `[profiles.default]` body. The returned `TempDir` must
+/// outlive the spec, and the returned path is the store root.
+fn extract_document_spec(
+    project: &str,
+    documents: &[(&str, &str)],
+    secret_rows: &str,
+) -> (TempDir, PathBuf, Secrets) {
     let temp_dir = TempDir::new().unwrap();
     let store = temp_dir.path().join("store");
     fs::create_dir(&store).unwrap();
-    let document_path = store.join("application.json");
+    for (name, contents) in documents {
+        fs::write(store.join(name), contents).unwrap();
+    }
+
+    let config_file = temp_dir.path().join("secretspec.toml");
+    let store_uri = toml::Value::String(format!("file:{}", store.display())).to_string();
+    fs::write(
+        &config_file,
+        format!(
+            r#"[project]
+name = "{project}"
+revision = "1.0"
+require_reason = false
+
+[providers]
+documents = {store_uri}
+
+[profiles.default]
+{secret_rows}"#
+        ),
+    )
+    .unwrap();
+
+    let config = Config::try_from(config_file.as_path()).unwrap();
+    (temp_dir, store, Secrets::new(config, None, None, None))
+}
+
+#[test]
+fn test_json_extract_resolves_structured_values_after_decoding() {
     let document = r#"{
   "database": {
     "password": "p@ss\nword",
@@ -5251,44 +5283,25 @@ fn test_json_extract_resolves_structured_values_after_decoding() {
   },
   "a/b": { "~key": "escaped" }
 }"#;
-    fs::write(&document_path, document).unwrap();
-    fs::write(
-        store.join("encoded.json"),
-        "eyJkYXRhIjp7InRva2VuIjoiYWJjIn19",
-    )
-    .unwrap();
-
-    let config_file = temp_dir.path().join("secretspec.toml");
-    let store_uri = toml::Value::String(format!("file:{}", store.display())).to_string();
-    fs::write(
-        &config_file,
-        format!(
-            r#"[project]
-name = "test-json-extract"
-revision = "1.0"
-require_reason = false
-
-[providers]
-documents = {store_uri}
-
-[profiles.default]
-PASSWORD = {{ description = "password", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/password" }} }}
-PORT = {{ description = "port", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/port" }} }}
-ENABLED = {{ description = "enabled", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/enabled" }} }}
-NULL_VALUE = {{ description = "null", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/nullable" }} }}
-OPTIONS = {{ description = "object", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/options" }} }}
-HOSTS = {{ description = "array", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/hosts" }} }}
-ESCAPED = {{ description = "escaped pointer", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/a~1b/~0key" }} }}
-OPTIONS_FILE = {{ description = "object as file", providers = ["documents"], ref = {{ item = "application.json" }}, extract = {{ format = "json", pointer = "/database/options" }}, as_path = true }}
-ENCODED = {{ description = "decoded document", providers = ["documents"], ref = {{ item = "encoded.json" }}, encoding = "base64", extract = {{ format = "json", pointer = "/data/token" }} }}
-FALLBACK = {{ description = "logical default", providers = ["documents"], ref = {{ item = "missing.json" }}, extract = {{ format = "json", pointer = "/ignored" }}, default = "already-logical" }}
-"#
-        ),
-    )
-    .unwrap();
-
-    let config = Config::try_from(config_file.as_path()).unwrap();
-    let spec = Secrets::new(config, None, None, None);
+    let (_temp_dir, store, spec) = extract_document_spec(
+        "test-json-extract",
+        &[
+            ("application.json", document),
+            ("encoded.json", "eyJkYXRhIjp7InRva2VuIjoiYWJjIn19"),
+        ],
+        r#"PASSWORD = { description = "password", providers = ["documents"], ref = { item = "application.json" }, extract = { format = "json", pointer = "/database/password" } }
+PORT = { description = "port", providers = ["documents"], ref = { item = "application.json" }, extract = { format = "json", pointer = "/database/port" } }
+ENABLED = { description = "enabled", providers = ["documents"], ref = { item = "application.json" }, extract = { format = "json", pointer = "/database/enabled" } }
+NULL_VALUE = { description = "null", providers = ["documents"], ref = { item = "application.json" }, extract = { format = "json", pointer = "/database/nullable" } }
+OPTIONS = { description = "object", providers = ["documents"], ref = { item = "application.json" }, extract = { format = "json", pointer = "/database/options" } }
+HOSTS = { description = "array", providers = ["documents"], ref = { item = "application.json" }, extract = { format = "json", pointer = "/database/hosts" } }
+ESCAPED = { description = "escaped pointer", providers = ["documents"], ref = { item = "application.json" }, extract = { format = "json", pointer = "/a~1b/~0key" } }
+OPTIONS_FILE = { description = "object as file", providers = ["documents"], ref = { item = "application.json" }, extract = { format = "json", pointer = "/database/options" }, as_path = true }
+ENCODED = { description = "decoded document", providers = ["documents"], ref = { item = "encoded.json" }, encoding = "base64", extract = { format = "json", pointer = "/data/token" } }
+FALLBACK = { description = "logical default", providers = ["documents"], ref = { item = "missing.json" }, extract = { format = "json", pointer = "/ignored" }, default = "already-logical" }
+"#,
+    );
+    let document_path = store.join("application.json");
     let validated = spec.validate().unwrap().unwrap();
     let values = &validated.resolved.secrets;
     assert_eq!(values["PASSWORD"].expose_secret(), "p@ss\nword");
@@ -5355,21 +5368,75 @@ fn test_json_extract_renders_a_null_while_a_provider_field_treats_it_as_absent()
 }
 
 #[test]
-fn test_json_extract_errors_do_not_expose_stored_documents() {
+fn test_ini_extract_resolves_sectioned_and_unsectioned_values() {
+    let (_temp_dir, _store, spec) = extract_document_spec(
+        "test-ini-extract",
+        &[(
+            "application.ini",
+            r#"root_token = root-value
+
+[database]
+password = p@ss#word;still-secret
+windows_path = C:\secrets\database
+
+[a/b]
+~key = escaped
+"#,
+        )],
+        r#"ROOT = { description = "root", providers = ["documents"], ref = { item = "application.ini" }, extract = { format = "ini", pointer = "/root_token" } }
+PASSWORD = { description = "password", providers = ["documents"], ref = { item = "application.ini" }, extract = { format = "ini", pointer = "/database/password" } }
+WINDOWS_PATH = { description = "literal backslashes", providers = ["documents"], ref = { item = "application.ini" }, extract = { format = "ini", pointer = "/database/windows_path" } }
+ESCAPED = { description = "escaped pointer", providers = ["documents"], ref = { item = "application.ini" }, extract = { format = "ini", pointer = "/a~1b/~0key" } }
+"#,
+    );
+    let validated = spec.validate().unwrap().unwrap();
+    let values = &validated.resolved.secrets;
+    assert_eq!(values["ROOT"].expose_secret(), "root-value");
+    assert_eq!(values["PASSWORD"].expose_secret(), "p@ss#word;still-secret");
+    assert_eq!(
+        values["WINDOWS_PATH"].expose_secret(),
+        r"C:\secrets\database"
+    );
+    assert_eq!(values["ESCAPED"].expose_secret(), "escaped");
+}
+
+/// No extract format may quote the stored document or the selected value in a
+/// failure. Every format is covered here so a new one inherits the invariant.
+#[test]
+fn test_extract_errors_do_not_expose_stored_documents() {
     use crate::config::{ExtractFormat, SecretExtract};
 
-    let extract = SecretExtract {
-        format: ExtractFormat::Json,
-        pointer: "/database/password".to_string(),
-    };
-    for stored in [
-        r#"{"database":"sensitive-invalid-document""#,
-        r#"{"other":"sensitive-missing-pointer"}"#,
-    ] {
-        let error = Secrets::extract_stored_value(&extract, "PASSWORD", stored).unwrap_err();
-        assert_eq!(error.kind(), "decode_failed");
-        assert!(error.to_string().contains("using json"));
-        assert!(!error.to_string().contains("sensitive"));
+    let cases = [
+        (
+            ExtractFormat::Json,
+            [
+                r#"{"database":"sensitive-invalid-document""#,
+                r#"{"other":"sensitive-missing-pointer"}"#,
+            ],
+        ),
+        (
+            ExtractFormat::Ini,
+            [
+                "[database\npassword=sensitive-invalid-document",
+                "[database]\nother=sensitive-missing-pointer",
+            ],
+        ),
+    ];
+    for (format, documents) in cases {
+        let extract = SecretExtract {
+            format,
+            pointer: "/database/password".to_string(),
+        };
+        for stored in documents {
+            let error = Secrets::extract_stored_value(&extract, "PASSWORD", stored).unwrap_err();
+            assert_eq!(error.kind(), "decode_failed", "{format:?}");
+            let message = error.to_string();
+            assert!(
+                message.contains(&format!("using {}", format.as_str())),
+                "{message}"
+            );
+            assert!(!message.contains("sensitive"), "{message}");
+        }
     }
 }
 


### PR DESCRIPTION
Split out of #362, which had bundled this alongside the IPC work.

## What

`extract` could only read a JSON document, so a secret stored inside an INI
file had to be extracted by whatever wrote it. INI now joins JSON as a stored
format:

```toml
[profiles.default]
DB_PASSWORD = {
  description = "Database password",
  providers = ["documents"],
  ref = { item = "application.ini" },
  extract = { format = "ini", pointer = "/database/password" }
}
```

`/key` selects an unsectioned key, `/section/key` selects a key in a named
section.

## Pointer shape

Segments keep RFC 6901 escaping, so `~1` selects a literal `/` and `~0` a
literal `~`. The shape is restricted to those two depths: an INI document has no
deeper structure to address, so a pointer implying one is rejected at validation
rather than silently missing at resolution.

Values stay strings and backslashes stay literal, so a Windows path survives
extraction unchanged. An explicit `[DEFAULT]` section is `/DEFAULT/key`, distinct
from an unsectioned `/key`. Matching is case-sensitive.

Extraction failures name only the secret, format, pointer, and parser location,
never the stored document or the selected value.

## Scope

Extracted secrets stay read-only, as in 0.19: a selected value cannot
reconstruct its containing document for a storage write.

Docs are labeled `0.20+` at each point of use, per the repository's release
visibility rules.

---
Created by Claude Code (see https://github.com/cli/cli/issues/13904 for why this note is here rather than in the GitHub API).