### PR TITLE
feat(provider): add Kubernetes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
     - name: Check each provider feature standalone
       run: |
         set -euo pipefail
-        for feature in cli keyring keeper gcsm awssm vault openbao infisical bws akv aac sops bw; do
+        for feature in cli keyring keeper gcsm awssm vault openbao infisical bws akv aac sops bw kubernetes; do
           echo "::group::$feature"
           cargo check --package secretspec --no-default-features --features "$feature"
           echo "::endgroup::"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `extract` supports INI documents in SecretSpec 0.20+, selecting an
   unsectioned key with `/key` or a named-section key with `/section/key`.
 
+- **Kubernetes provider** (`k8s+<configmap|secret>://`, 0.20+): store and read
+  values from a Kubernetes ConfigMap or Secret using the current cluster.
 - **Azure App Configuration provider** (`aac://`, 0.20+): select direct
   values and Azure Key Vault references by label, prefix, and tags, with Entra
   ID or connection-string authentication and guarded writes, deletion, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +249,12 @@ checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayref"
@@ -1968,6 +1985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2676,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "granit-parser"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2998,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
+ "log",
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -3425,6 +3462,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,6 +3537,19 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e07021eefc09f897611b067ba7897b5e9266edfc902768418968772e5bb06a7"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3521,6 +3601,18 @@ dependencies = [
  "fraction",
  "num-cmp",
  "num-traits",
+ "serde_json",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
+dependencies = [
+ "base64",
+ "jiff",
+ "serde",
  "serde_json",
 ]
 
@@ -3630,6 +3722,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "kube"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "208d7fe1380066abb194812a8a8e303cb896a33bb3d7b3177b71bd03ff39bf18"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e940a73033a7c5c7918b5ece7851d84571b58be25e937198da37fa13f116d3"
+dependencies = [
+ "base64",
+ "bytes",
+ "either",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-timeout",
+ "hyper-util",
+ "jiff",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls 0.23.37",
+ "rustls-platform-verifier 0.7.0",
+ "secrecy",
+ "serde",
+ "serde-saphyr",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d2353c118cf3462c352ee0b5bd5b0cf17990af456dfd8662d136ff9812eeb4"
+dependencies = [
+ "derive_more",
+ "form_urlencoded",
+ "http 1.4.0",
+ "jiff",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3934,6 +4090,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4159,6 +4321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4423,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4274,6 +4455,48 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "pin-project"
@@ -4898,7 +5121,7 @@ dependencies = [
  "quinn",
  "rustls 0.23.37",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5109,7 +5332,28 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.10",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls 0.23.37",
@@ -5330,9 +5574,11 @@ dependencies = [
  "is_executable",
  "jiff",
  "jsonschema",
+ "k8s-openapi",
  "keepass",
  "keeper-secrets-manager-core",
  "keyring",
+ "kube",
  "libc",
  "linkme",
  "miette",
@@ -5454,6 +5700,35 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -5665,6 +5940,22 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -6268,6 +6559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
+ "base64",
  "bitflags",
  "bytes",
  "futures-core",
@@ -6276,12 +6568,14 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6302,6 +6596,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6428,6 +6723,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,12 +1226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,22 +3441,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -3470,7 +3448,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -3489,15 +3467,6 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -3540,6 +3509,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "jsonpath-rust"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,6 +3531,16 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3758,7 +3749,7 @@ dependencies = [
  "kube-core",
  "pem",
  "rustls 0.23.37",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "secrecy",
  "serde",
  "serde-saphyr",
@@ -3781,6 +3772,7 @@ dependencies = [
  "form_urlencoded",
  "http 1.4.0",
  "jiff",
+ "json-patch",
  "k8s-openapi",
  "serde",
  "serde-value",
@@ -5121,7 +5113,7 @@ dependencies = [
  "quinn",
  "rustls 0.23.37",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5326,34 +5318,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls 0.23.37",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls 0.23.37",
@@ -5573,6 +5544,7 @@ dependencies = [
  "inquire",
  "is_executable",
  "jiff",
+ "json-patch",
  "jsonschema",
  "k8s-openapi",
  "keepass",
@@ -7279,15 +7251,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7320,21 +7283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7372,12 +7320,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7390,12 +7332,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7405,12 +7341,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7438,12 +7368,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7453,12 +7377,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7474,12 +7392,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7489,12 +7401,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,9 @@ uuid = { version = "1", features = ["serde", "v4"] }
 data-encoding = "2"
 detect-coding-agent = "0.1"
 age = { version = "0.12", features = ["armor", "plugin", "ssh"] }
-kube = { version = "4.2", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs"] }
+kube = { version = "4.2", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs", "jsonpatch"] }
 k8s-openapi = { version = "0.28", features = ["v1_36"] }
+json-patch = "4.2.0"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ uuid = { version = "1", features = ["serde", "v4"] }
 data-encoding = "2"
 detect-coding-agent = "0.1"
 age = { version = "0.12", features = ["armor", "plugin", "ssh"] }
+kube = { version = "4.2", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs"] }
+k8s-openapi = { version = "0.28", features = ["v1_36"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -127,7 +127,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Azure App Configuration (0.20+), Infisical (0.16+), age (0.17+), or SOPS (0.17+). Fly.io application secrets can be published through the write-only fly provider (0.20+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
+Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Azure App Configuration (0.20+), Infisical (0.16+), age (0.17+), SOPS (0.17+), or Kubernetes (0.20+). Fly.io application secrets can be published through the write-only fly provider (0.20+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
         }),
       ],
       title: "SecretSpec",
@@ -376,6 +376,11 @@ Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv fil
               label: "SOPS",
               slug: "providers/sops",
               badge: { text: "0.17+", variant: "note" },
+            },
+            {
+              label: "Kubernetes",
+              slug: "providers/kubernetes",
+              badge: { text: "0.20+", variant: "note" },
             },
           ],
         },

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -68,6 +68,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [infisical](/providers/infisical/) (0.16+) | Infisical (requires the `infisical` build feature) | ✓ | ✓ | ✓ | — |
 | [age](/providers/age/) (0.17+) | An age-encrypted file (requires the `age` build feature) | ✓ | ✓ | ✓ | — |
 | [sops](/providers/sops/) (0.17+) | SOPS-encrypted files (requires the `sops` build feature and SOPS CLI) | ✓ | ✓ | ✓ | Depends on the configured SOPS key service |
+| [kubernetes](/providers/kubernetes/) (0.20+) | Kubernetes ConfigMaps and Secrets (requires the `kubernetes` build feature) | ✓ | ✓ | [Secrets can be encrypted at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#ensure-all-secrets-are-encrypted) | — |
 
 “TPM-backed keys” means the local key used by the provider can be protected by
 a [TPM 2.0](https://trustedcomputinggroup.org/resource/tpm-library-specification/)

--- a/docs/src/content/docs/providers/kubernetes.md
+++ b/docs/src/content/docs/providers/kubernetes.md
@@ -18,7 +18,7 @@ The `kubernetes` provider is added in SecretSpec 0.20.
 | Access | Read and write |
 | Best for | Accessing values stores in Kubernetes |
 | Authentication | Current cluster set in kubectl configuration |
-| Default storage | `secretspec-{project}-{profile}-{key}` |
+| Default storage | `secretspec--{project}--{profile}--{key}` |
 
 ## Quick start
 
@@ -84,9 +84,14 @@ DATABASE_URL = { description = "Database URL", providers = ["kube"] }
 ## Storage model
 
 Each secret is stored as a key in the Kubernetes ConfigMap or Secret. Each
-secret is stored as `secretspec-{project}-{profile}-{key}` under `.data`. A key
-cannot exceed 253 characters and can only contain alphanumeric characters,
-hypens, underscores, or periods.
+secret is stored as `secretspec--{project}--{profile}--{key}` under `.data`. A
+key cannot exceed 253 characters. Each component can only contain alphanumeric
+characters, underscores, periods, and internal hyphens. SecretSpec joins the
+project, profile, and key with validated `--` boundaries. Distinct logical
+addresses therefore cannot collapse onto one GCSM secret when a project or
+profile contains a single internal hyphen. As a consequence, a component cannot
+start or end with `-` or contain `--`, because those forms could overlap a
+boundary.
 
 ## Use existing secrets
 

--- a/docs/src/content/docs/providers/kubernetes.md
+++ b/docs/src/content/docs/providers/kubernetes.md
@@ -1,0 +1,100 @@
+---
+title: Kubernetes Provider
+description: Kubernetes ConfigMap & Secerts
+---
+
+The Kubernetes provider reads from and writes to Kubernetes ConfigMaps or
+Secrets.
+
+:::caution[Version compatibility]
+The `kubernetes` provider is added in SecretSpec 0.20.
+:::
+
+# At a glance
+| | |
+| --- | --- |
+| Provider | `kubernetes` |
+| URI | `k8s+<configmap\|secret>://NAME[@NAMESPACE]` |
+| Access | Read and write |
+| Best for | Accessing values stores in Kubernetes |
+| Authentication | Current cluster set in kubectl configuration |
+| Default storage | `secretspec-{project}-{profile}-{key}` |
+
+## Quick start
+
+```bash
+# Set a secret
+$ secretspec set DATABASE_URL --provider k8s+secret://secret-name
+Enter value for DATABASE_URL: postgresql://localhost/mydb
+✓ Secret DATABASE_URL saved to kubernetes
+
+# Get a secret
+$ secretspec get DATABASE_URL --provider k8s+secret://secret-name
+postgresql://localhost/mydb
+
+# Run with secrets
+$ secretspec run --provider k8s+secret://secret-name -- npm start
+```
+
+## Setup
+
+### Prerequisites
+
+- A Kubernetes cluster
+- Cluster connection configured in `$KUBECONFIG` (or `$HOME/.kube/config` as
+  fallback)
+- Build with `--features kubernetes`
+
+### Authentication
+
+Uses whatever authentication method is configured in the cluster configuration
+used by kubectl.
+
+## Configuration
+
+### URI format
+
+```
+k8s+KIND://NAME[@NAMESPACE]
+```
+
+- `NAME`: Name of the Kubernetes object
+- `KIND`: Kind of the Kubernetes object. Only supports `configmap` or `secret`.
+- `NAMESPACE`: Optional namespace where the Kubernetes object exists in. If
+  omitted, will use the cluster's default namespace.
+
+### URI examples
+
+```
+k8s+configmap://db-config@db-postgres
+k8s+configmap://db-config
+k8s+secret://db-credentials@db-postgres
+```
+
+### Project configuration
+
+```toml title="secretspec.toml"
+[providers]
+kube = "k8s+configmap://db-config@db-postgres"
+
+[profiles.default]
+DATABASE_URL = { description = "Database URL", providers = ["kube"] }
+```
+
+## Storage model
+
+Each secret is stored as a key in the Kubernetes ConfigMap or Secret. Each
+secret is stored as `secretspec-{project}-{profile}-{key}` under `.data`. A key
+cannot exceed 253 characters and can only contain alphanumeric characters,
+hypens, underscores, or periods.
+
+## Use existing secrets
+
+A secret's [`ref`](/reference/configuration/#secret-references) field names an
+existing secret instead: `item` is the secret name stored in `.data.item` of
+the Kubernetes object. Reads and writes target that entry in place.
+
+```toml
+[profiles.default]
+API_TOKEN = { description = "Token", ref = { item = "com.example.app" }, providers = ["k8s+secret://app-config"] }
+```

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -167,6 +167,7 @@ $ secretspec config global init  # 0.17+
   infisical: Infisical secret management (0.16+)
   age: age-encrypted file (0.17+)
   sops: SOPS encrypted files (0.17+)
+  kubernetes: Kubernetes (0.20+)
 ? Select your default profile:
   development
 > default

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -897,6 +897,7 @@ entry declares neither, it inherits whichever form `[profiles.default]` uses.
 | [Azure Key Vault (0.15+)](/providers/akv/#use-existing-secrets) | Secret name; `version` pins a version (0.20+) | Rejected | Reads latest or the pinned version (0.20+) | — (read-only) |
 | [Azure App Configuration (0.20+)](/providers/aac/#use-existing-key-values) | App Configuration key | Rejected | Reads the direct value or resolves its canonical Key Vault reference | — (read-only) |
 | [Infisical (0.16+)](/providers/infisical/#use-existing-secrets) | Folder and key; `version` also applies | Rejected | Reads the latest version | ✅ unless a version is pinned |
+| [Kubernetes (0.20+)](/providers/kubernetes/#use-existing-secrets) | Secret key | Rejected | Reads entry | ✅ |
 
 A provider rejects coordinates it has no equivalent for, with an error naming
 the coordinate (for example, `field` on the env provider).

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -671,7 +671,7 @@ k8s+secret://db-credentials@db-postgres
 **Prerequisites**: A Kubernetes configuration in `$KUBECONFIG` or
 `$HOME/.kube/config`; build with `--features kubernetes` (0.20+)
 **Authentication**: Configured in Kubernetes configuration
-**Storage**: `secretspec-{project}-{profile}-{key}` key under `.data` in the
+**Storage**: `secretspec--{project}--{profile}--{key}` key under `.data` in the
 Kubernetes object
 
 ## Provider Selection

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -651,6 +651,29 @@ per project/profile. A single-file provider supports `ref = { item = "..." }`
 as a root key (or a key in `[DEFAULT]` for INI); extra coordinates and refs
 through templated paths are rejected.
 
+
+## Kubernetes Provider (0.20+)
+
+:::caution[Version compatibility]
+The `kubernetes` provider is added in SecretSpec 0.20.
+:::
+
+**URI**: `k8s+KIND://NAME[@NAMESPACE]` - Stores secrets in a Kubernetes
+ConfigMap or Secret
+
+```text
+k8s+configmap://db-config@db-postgres
+k8s+configmap://db-config
+k8s+secret://db-credentials@db-postgres
+```
+
+**Features**: Read/write Kubernetes ConfigMaps and Secrets
+**Prerequisites**: A Kubernetes configuration in `$KUBECONFIG` or
+`$HOME/.kube/config`; build with `--features kubernetes` (0.20+)
+**Authentication**: Configured in Kubernetes configuration
+**Storage**: `secretspec-{project}-{profile}-{key}` key under `.data` in the
+Kubernetes object
+
 ## Provider Selection
 
 ### Command Line
@@ -711,3 +734,4 @@ $ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Infisical | ✅ Infisical-managed | Cloud (Infisical) or self-hosted | ✅ Yes |
 | age (0.17+) | ✅ age encryption | Local filesystem | ❌ No |
 | SOPS (0.17+) | ✅ Configured SOPS encryption | Local filesystem | Depends on configured key service |
+| Kubernetes (0.20+) | ❌ ConfigMap ✅ Secret if configured | Kubernetes server | ✅ Yes |

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -73,6 +73,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
   { slug: 'keyring', label: 'Credential Manager' },
   { icon: { src: sopsLogo, type: 'bundled' }, slug: 'sops', label: 'SOPS (0.17+)' },
+  { icon: 'kubernetes', slug: 'kubernetes', label: 'Kubernetes (0.20+)' },
 ];
 
 type ConsumerMetadata = {
@@ -160,6 +161,7 @@ const providerColors: Record<string, SyntaxColorName> = {
   'systemd-credential': 'blue',
   fly: 'magenta',
   sops: 'magenta',
+  kubernetes: 'blue',
 };
 
 const consumerColors: Record<string, SyntaxColorName> = {
@@ -558,6 +560,7 @@ const reelScriptData = {
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-orange)" href="/providers/awsps/"><span class="provider-name">awsps</span>: AWS Systems Manager Parameter Store (0.18+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/scaleway/"><span class="provider-name">scaleway</span>: Scaleway Secret Manager (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/dashlane/"><span class="provider-name">dashlane</span>: Dashlane password manager, read-only (0.18+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/kubernetes/"><span class="provider-name">kubernetes</span>: Kubernetes (0.20+)</a>
 <span class="landing-ok">✓</span> Saved to ~/.config/secretspec/config.toml</span>
 
 <span class="landing-run-step"><span class="tok-com"># 3. Run your app with secrets injected</span>

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -58,12 +58,14 @@ uuid.workspace = true
 data-encoding.workspace = true
 detect-coding-agent.workspace = true
 age = { workspace = true, optional = true }
+kube = { workspace = true, optional = true }
+k8s-openapi = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
 [features]
-default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "scaleway", "sops"]
+default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "scaleway", "sops", "kubernetes"]
 cli = ["dep:toml_edit", "dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
@@ -88,6 +90,7 @@ akv = ["dep:azure_core", "dep:azure_identity", "dep:azure_security_keyvault_secr
 aac = ["akv", "dep:reqwest", "azure_core/hmac_rust"]
 age = ["dep:age"]
 sops = []
+kubernetes = ["dep:kube", "dep:k8s-openapi"]
 
 [dev-dependencies]
 # Validates serialized resolution reports against the committed JSON Schema.

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -60,6 +60,7 @@ detect-coding-agent.workspace = true
 age = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
 k8s-openapi = { workspace = true, optional = true }
+json-patch = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
@@ -90,7 +91,7 @@ akv = ["dep:azure_core", "dep:azure_identity", "dep:azure_security_keyvault_secr
 aac = ["akv", "dep:reqwest", "azure_core/hmac_rust"]
 age = ["dep:age"]
 sops = []
-kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:base64"]
+kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:base64", "dep:json-patch"]
 
 [dev-dependencies]
 # Validates serialized resolution reports against the committed JSON Schema.

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -90,7 +90,7 @@ akv = ["dep:azure_core", "dep:azure_identity", "dep:azure_security_keyvault_secr
 aac = ["akv", "dep:reqwest", "azure_core/hmac_rust"]
 age = ["dep:age"]
 sops = []
-kubernetes = ["dep:kube", "dep:k8s-openapi"]
+kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:base64"]
 
 [dev-dependencies]
 # Validates serialized resolution reports against the committed JSON Schema.

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -54,6 +54,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [Infisical](https://secretspec.dev/providers/infisical) (0.16+)
   - [age](https://secretspec.dev/providers/age) (0.17+)
   - [SOPS](https://secretspec.dev/providers/sops) (0.17+)
+  - [Kubernetes](https://secretspec.dev/providers/kubernetes) (0.20+)
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
 - **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
@@ -107,6 +108,7 @@ $ secretspec config global init  # 0.17+
   infisical: Infisical secret management (0.16+)
   age: age-encrypted file (0.17+)
   sops: SOPS encrypted files (0.17+)
+  kubernetes: Kubernetes (0.20+)
 ? Select your default profile:
 > development
   default
@@ -229,6 +231,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Infisical](https://secretspec.dev/providers/infisical)** (0.16+) - Infisical secret management
 - **[age](https://secretspec.dev/providers/age)** (0.17+) - age-encrypted file
 - **[SOPS](https://secretspec.dev/providers/sops)** (0.17+) - SOPS-encrypted files
+- **[Kubernetes](https://secretspec.dev/providers/kubernetes)** (0.20+) - Kubernetes
 
 ```bash
 $ secretspec run --provider keyring -- npm start

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1,5 +1,9 @@
 use crate::config::{Config, GlobalConfig, GlobalDefaults, Profile as ConfigProfile, Project};
-use crate::provider::{Provider, providers, spec_names_known_provider};
+use crate::provider::{
+    Provider,
+    kubernetes::{KubernetesKind, KubernetesProvider},
+    providers, spec_names_known_provider,
+};
 use crate::{CallerContext, ExportFormat, Secrets};
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use miette::{IntoDiagnostic, Result, WrapErr, miette};
@@ -836,6 +840,34 @@ fn select_config_init_provider(provider: Option<String>) -> Result<String> {
             .prompt()
             .into_diagnostic()?;
         let spec = format!("file:{}", directory.trim());
+        Box::<dyn Provider>::try_from(spec.as_str())
+            .into_diagnostic()
+            .wrap_err("Invalid file provider configuration")?;
+        Ok(spec)
+    } else if selected_provider == "kubernetes" {
+        use inquire::Text;
+
+        let kind_choices = vec![KubernetesKind::ConfigMap, KubernetesKind::Secret];
+        let kind = Select::new(
+            "Select your preferred kubernetes object kind:",
+            kind_choices,
+        )
+        .prompt()
+        .into_diagnostic()?;
+        let name = Text::new("Kubernetes object name:")
+            .prompt()
+            .into_diagnostic()?;
+        let namespace = Text::new("Kubernetes namespace:")
+            .with_help_message("Leave empty to use the default cluster namespace")
+            .prompt()
+            .into_diagnostic()?;
+        let namespace = if namespace.is_empty() {
+            None
+        } else {
+            Some(namespace)
+        };
+
+        let spec = KubernetesProvider::build_uri(&kind, &name, &namespace);
         Box::<dyn Provider>::try_from(spec.as_str())
             .into_diagnostic()
             .wrap_err("Invalid file provider configuration")?;

--- a/secretspec/src/provider/kubernetes.rs
+++ b/secretspec/src/provider/kubernetes.rs
@@ -152,6 +152,15 @@ impl KubernetesProvider {
         }
     }
 
+    pub fn build_uri(kind: &KubernetesKind, name: &String, namespace: &Option<String>) -> String {
+        let mut uri = format!("k8s+{}://{}", kind, name);
+        if let Some(namespace) = namespace {
+            uri.push('@');
+            uri.push_str(namespace);
+        }
+        uri
+    }
+
     async fn client(&self) -> Result<&Client> {
         if let Some(client) = self.client.get() {
             return Ok(client);
@@ -384,12 +393,7 @@ impl Provider for KubernetesProvider {
     }
 
     fn uri(&self) -> String {
-        let mut uri = format!("k8s+{}://{}", self.config.kind, self.config.name);
-        if let Some(namespace) = &self.config.namespace {
-            uri.push('@');
-            uri.push_str(&namespace);
-        }
-        uri
+        Self::build_uri(&self.config.kind, &self.config.name, &self.config.namespace)
     }
 
     fn convention_address(

--- a/secretspec/src/provider/kubernetes.rs
+++ b/secretspec/src/provider/kubernetes.rs
@@ -166,35 +166,51 @@ impl KubernetesProvider {
         }
     }
 
-    fn validate_key(key: &String) -> Result<()> {
-        if key.is_empty() {
+    /// Validates a secret name component for Kubernetes.
+    ///
+    /// Components contain only alphanumeric characters, underscores, periods,
+    /// and internal hyphens: A component may not contain `--` or begin or
+    /// end with `-`: either shape could consume or overlap a `--` boundary.
+    fn validate_name_component(name: &str, component: &str) -> Result<()> {
+        if component.is_empty() {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "key cannot be empty"
+                "{} cannot be empty",
+                name
             )));
         }
 
-        if key.len() > 253 {
-            return Err(SecretSpecError::ProviderOperationFailed(format!(
-                "Key cannot be longer than 253 characters"
-            )));
-        }
-
-        for c in key.chars() {
-            if !c.is_ascii_alphanumeric() && c != '-' && c != '_' && c != '.' {
+        for c in component.chars() {
+            if !c.is_ascii_alphanumeric() && c != '_' && c != '-' && c != '.' {
                 return Err(SecretSpecError::ProviderOperationFailed(format!(
-                    "Name contains invalid character '{}'. \
-                    Only alphanumeric characters, hypens, underscores, and periods are allowed.",
-                    c
+                    "{} contains invalid character '{}'. \
+                    Only alphanumeric characters, underscores, periods, and hyphens are allowed",
+                    name, c
                 )));
             }
+        }
+
+        if component.starts_with('-') || component.ends_with('-') || component.contains("--") {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "{name} '{component}' cannot start or end with a hyphen or contain `--`: the \
+                 Kubernetes convention separates project, profile, and key with `--`, so only
+                 single internal hyphens stay unambiguous. Rename it and run `secretspec set` to |
+                 store the value under the new name, or address the secret with a `ref` entry."
+            )));
         }
 
         Ok(())
     }
 
     fn format_secret_name(project: &str, profile: &str, key: &str) -> Result<String> {
-        let secret_name = format!("secretspec-{}-{}-{}", project, profile, key);
-        Self::validate_key(&secret_name)?;
+        Self::validate_name_component("project", project)?;
+        Self::validate_name_component("profile", profile)?;
+        Self::validate_name_component("key", key)?;
+        let secret_name = format!("secretspec--{}--{}--{}", project, profile, key);
+        if secret_name.len() > 253 {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Key cannot be longer than 253 characters"
+            )));
+        }
         Ok(secret_name)
     }
 
@@ -419,7 +435,7 @@ mod tests {
     #[test]
     fn test_format_secret_name() {
         let name = KubernetesProvider::format_secret_name("myapp", "prod", "DB_URL").unwrap();
-        assert_eq!(name, "secretspec-myapp-prod-DB_URL");
+        assert_eq!(name, "secretspec--myapp--prod--DB_URL");
     }
 
     #[test]
@@ -432,6 +448,21 @@ mod tests {
     fn test_format_secret_name_too_long() {
         let long_key = "A".repeat(254);
         let result = KubernetesProvider::format_secret_name("myapp", "prod", &long_key);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_secret_name_rejects_component_with_surrounding_hyphens() {
+        let result = KubernetesProvider::format_secret_name("myapp", "prod-", "DB_URL");
+        assert!(result.is_err());
+
+        let result = KubernetesProvider::format_secret_name("myapp", "prod", "-DB_URL");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_secret_name_rejects_component_with_double_hyphens() {
+        let result = KubernetesProvider::format_secret_name("my--app", "prod", "DB_URL");
         assert!(result.is_err());
     }
 }

--- a/secretspec/src/provider/kubernetes.rs
+++ b/secretspec/src/provider/kubernetes.rs
@@ -136,7 +136,7 @@ crate::register_provider! {
     struct: KubernetesProvider,
     config: KubernetesConfig,
     name: "kubernetes",
-    description: "Kubernetes",
+    description: "Kubernetes (0.20+)",
     schemes: ["k8s+configmap", "k8s+secret"],
     examples: ["k8s+secret://db-config", "k8s+configmap://db-config@default"],
     deletes: true,

--- a/secretspec/src/provider/kubernetes.rs
+++ b/secretspec/src/provider/kubernetes.rs
@@ -368,7 +368,6 @@ impl Provider for KubernetesProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::ProviderCredentials;
     use url::Url;
 
     fn config(s: &str) -> KubernetesConfig {

--- a/secretspec/src/provider/kubernetes.rs
+++ b/secretspec/src/provider/kubernetes.rs
@@ -1,0 +1,428 @@
+//! Kubernetes provider
+use crate::{Result, SecretSpecError};
+
+use super::{Address, Provider, ProviderUrl};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use k8s_openapi::{
+    ByteString,
+    api::{
+        authorization::v1::{
+            ResourceAttributes, SelfSubjectAccessReview, SelfSubjectAccessReviewSpec,
+        },
+        core::v1::{ConfigMap, Secret},
+    },
+};
+use kube::{
+    Api, Client,
+    api::{Patch, PatchParams, PostParams},
+};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::{fmt::Display, format, sync::OnceLock, write};
+
+fn runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime for kube")
+    })
+}
+
+fn block_on<F>(future: F) -> F::Output
+where
+    F: std::future::Future + Send,
+    F::Output: Send,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(|| runtime().block_on(future))
+        }
+        Ok(_) => std::thread::scope(|scope| {
+            let worker = scope.spawn(move || runtime().block_on(future));
+            match worker.join() {
+                Ok(output) => output,
+                Err(panic) => std::panic::resume_unwind(panic),
+            }
+        }),
+        Err(_) => runtime().block_on(future),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum KubernetesKind {
+    ConfigMap,
+    Secret,
+}
+
+enum StringRepresentation {
+    Plain(String),
+    Base64(ByteString),
+}
+
+impl Display for KubernetesKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KubernetesKind::ConfigMap => write!(f, "configmap"),
+            KubernetesKind::Secret => write!(f, "secret"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KubernetesConfig {
+    pub kind: KubernetesKind,
+    pub name: String,
+    pub namespace: Option<String>,
+}
+
+impl TryFrom<&ProviderUrl> for KubernetesConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        let kind: KubernetesKind;
+        match url.scheme() {
+            "k8s+configmap" => kind = KubernetesKind::ConfigMap,
+            "k8s+secret" => kind = KubernetesKind::Secret,
+            scheme => {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Invalid scheme '{}' for kubernetes provider. Expected 'k8s+configmap' or 'k8s+secret'.",
+                    scheme
+                )));
+            }
+        }
+
+        let name: String;
+        let namespace: Option<String>;
+        match url.host() {
+            Some(host) => {
+                (name, namespace) = match url.username().as_str() {
+                    "" => (host, None),
+                    username => (username.into(), Some(host)),
+                }
+            }
+            None => {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "A Kubernetes objet identifier must be provided"
+                )));
+            }
+        }
+
+        Ok(Self {
+            kind,
+            name,
+            namespace,
+        })
+    }
+}
+
+pub struct KubernetesProvider {
+    config: KubernetesConfig,
+    client: OnceLock<Client>,
+}
+
+crate::register_provider! {
+    struct: KubernetesProvider,
+    config: KubernetesConfig,
+    name: "kubernetes",
+    description: "Kubernetes",
+    schemes: ["k8s+configmap", "k8s+secret"],
+    examples: ["k8s+secret://db-config", "k8s+configmap://db-config@default"],
+    deletes: true,
+}
+
+impl KubernetesProvider {
+    pub fn new(config: KubernetesConfig) -> Self {
+        Self {
+            config,
+            client: OnceLock::new(),
+        }
+    }
+
+    async fn client(&self) -> Result<&Client> {
+        if let Some(client) = self.client.get() {
+            return Ok(client);
+        }
+        let created = Client::try_default().await.map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to create Kubernetes client: {}",
+                crate::error::display_error_chain(&e)
+            ))
+        });
+        match created {
+            Ok(client) => Ok(self.client.get_or_init(|| client)),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn validate_key(key: &String) -> Result<()> {
+        if key.is_empty() {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "key cannot be empty"
+            )));
+        }
+
+        if key.len() > 253 {
+            return Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Key cannot be longer than 253 characters"
+            )));
+        }
+
+        for c in key.chars() {
+            if !c.is_ascii_alphanumeric() && c != '-' && c != '_' && c != '.' {
+                return Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Name contains invalid character '{}'. \
+                    Only alphanumeric characters, hypens, underscores, and periods are allowed.",
+                    c
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn format_secret_name(project: &str, profile: &str, key: &str) -> Result<String> {
+        let secret_name = format!("secretspec-{}-{}-{}", project, profile, key);
+        Self::validate_key(&secret_name)?;
+        Ok(secret_name)
+    }
+
+    async fn get_coords_async(&self, key: &str) -> Result<Option<SecretString>> {
+        let client = self.client().await?;
+        let namespace = match &self.config.namespace {
+            Some(ns) => ns.as_str(),
+            None => client.default_namespace(),
+        };
+        let name = self.config.name.as_str();
+        let value = match self.config.kind {
+            KubernetesKind::ConfigMap => {
+                let api: Api<ConfigMap> = Api::namespaced(client.clone(), &namespace);
+                api.get(name).await.map(|cm| {
+                    cm.data.map_or(None, |d| {
+                        d.get(key).map(|v| StringRepresentation::Plain(v.clone()))
+                    })
+                })
+            }
+            KubernetesKind::Secret => {
+                let api: Api<Secret> = Api::namespaced(client.clone(), &namespace);
+                api.get(name).await.map(|cm| {
+                    cm.data.map_or(None, |d| {
+                        d.get(key).map(|v| StringRepresentation::Base64(v.clone()))
+                    })
+                })
+            }
+        };
+        match value {
+            Ok(Some(StringRepresentation::Plain(s))) => Ok(Some(SecretString::new(s.into()))),
+            Ok(Some(StringRepresentation::Base64(s))) => match String::from_utf8(s.0) {
+                Ok(decoded) => Ok(Some(SecretString::new(decoded.into()))),
+                Err(e) => Err(SecretSpecError::ProviderOperationFailed(format!(
+                    "Cannot decode value for {}: {}",
+                    key,
+                    crate::error::display_error_chain(&e)
+                ))),
+            },
+            Ok(None) => Ok(None),
+            Err(e) => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Cannot get {}/{} in namespace {}: {}",
+                self.config.kind,
+                name,
+                namespace,
+                crate::error::display_error_chain(&e)
+            ))),
+        }
+    }
+
+    async fn set_secret_async(&self, key: &str, value: &SecretString) -> Result<()> {
+        let client = self.client().await?;
+        let namespace = match &self.config.namespace {
+            Some(ns) => ns.as_str(),
+            None => client.default_namespace(),
+        };
+        let name = self.config.name.as_str();
+        let secret = value.expose_secret();
+        let base64_secret = STANDARD.encode(secret);
+        let secret = match self.config.kind {
+            KubernetesKind::ConfigMap => secret,
+            KubernetesKind::Secret => base64_secret.as_str(),
+        };
+        let patch = serde_json::json!({
+            "data": {
+                key: secret,
+            },
+        });
+        let params = PatchParams::default();
+        let patch = Patch::Merge(&patch);
+        let patched = match self.config.kind {
+            KubernetesKind::ConfigMap => {
+                let api: Api<ConfigMap> = Api::namespaced(client.clone(), &namespace);
+                api.patch(name, &params, &patch).await.map(|_| ())
+            }
+            KubernetesKind::Secret => {
+                let api: Api<Secret> = Api::namespaced(client.clone(), &namespace);
+                api.patch(name, &params, &patch).await.map(|_| ())
+            }
+        };
+        patched.map_err(|e| {
+            SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to patch {}: {}",
+                self.config.kind,
+                crate::error::display_error_chain(&e)
+            ))
+        })
+    }
+
+    async fn can_i_patch(&self) -> Result<bool> {
+        let client = self.client().await?;
+        let namespace = match &self.config.namespace {
+            Some(ns) => ns.as_str(),
+            None => client.default_namespace(),
+        };
+        let spec = SelfSubjectAccessReviewSpec {
+            resource_attributes: Some(ResourceAttributes {
+                namespace: Some(namespace.into()),
+                verb: Some("patch".to_string()),
+                resource: Some(self.config.kind.to_string()),
+                group: Some(String::new()),
+                version: Some("v1".to_string()),
+                name: Some(self.config.name.clone()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let self_subject_access_review = SelfSubjectAccessReview {
+            spec,
+            ..Default::default()
+        };
+        let api: Api<SelfSubjectAccessReview> = Api::all(client.to_owned());
+        let response = api
+            .create(&PostParams::default(), &self_subject_access_review)
+            .await
+            .map_err(|e| {
+                SecretSpecError::ProviderOperationFailed(format!(
+                    "Cannot verify if {} resource can be patched: {}",
+                    self.config.kind,
+                    crate::error::display_error_chain(&e)
+                ))
+            });
+        response.map(|r| r.status.map(|s| s.allowed).unwrap_or(false))
+    }
+}
+
+impl Provider for KubernetesProvider {
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let mut uri = format!("k8s+{}://{}", self.config.kind, self.config.name);
+        if let Some(namespace) = &self.config.namespace {
+            uri.push('@');
+            uri.push_str(&namespace);
+        }
+        uri
+    }
+
+    fn convention_address(
+        &self,
+        project: &str,
+        profile: &str,
+        key: &str,
+    ) -> Result<crate::config::NativeAddress> {
+        Ok(crate::config::NativeAddress {
+            item: Self::format_secret_name(project, profile, key)?,
+            ..Default::default()
+        })
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let coords = self.resolve_coords(addr)?;
+        block_on(self.get_coords_async(&coords.item))
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        let coords = self.resolve_coords(addr)?;
+        block_on(self.set_secret_async(&coords.item, value))
+    }
+
+    fn check_writable(&self, _addr: Address<'_>) -> Result<()> {
+        let can_i_patch = block_on(self.can_i_patch())?;
+        if !can_i_patch {
+            let err_msg = if let Some(namespace) = &self.config.namespace {
+                format!(
+                    "Cannot patch {}/{} in {}",
+                    self.config.kind, self.config.name, namespace
+                )
+            } else {
+                format!("Cannot patch {}/{}", self.config.kind, self.config.name)
+            };
+            return Err(SecretSpecError::ProviderOperationFailed(err_msg));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::ProviderCredentials;
+    use url::Url;
+
+    fn config(s: &str) -> KubernetesConfig {
+        KubernetesConfig::try_from(&ProviderUrl::new(Url::parse(s).unwrap())).unwrap()
+    }
+
+    #[test]
+    fn test_uri_configmap_fully_qualified() {
+        let c = config("k8s+configmap://name@namespace");
+        assert_eq!(c.kind, KubernetesKind::ConfigMap);
+        assert_eq!(c.name, String::from("name"));
+        assert_eq!(c.namespace, Some(String::from("namespace")));
+    }
+
+    #[test]
+    fn test_uri_secret_fully_qualified() {
+        let c = config("k8s+secret://name@namespace");
+        assert_eq!(c.kind, KubernetesKind::Secret);
+        assert_eq!(c.name, String::from("name"));
+        assert_eq!(c.namespace, Some(String::from("namespace")));
+    }
+
+    #[test]
+    fn test_uri_without_namespace() {
+        let c = config("k8s+configmap://name");
+        assert_eq!(c.kind, KubernetesKind::ConfigMap);
+        assert_eq!(c.name, String::from("name"));
+        assert_eq!(c.namespace, None);
+    }
+
+    #[test]
+    fn test_uri_with_incorrect_kubernetes_kind() {
+        let uri = "k8s+pod://name@namespace";
+        let url = ProviderUrl::new(Url::parse(uri).unwrap());
+        let config = KubernetesConfig::try_from(&url);
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_format_secret_name() {
+        let name = KubernetesProvider::format_secret_name("myapp", "prod", "DB_URL").unwrap();
+        assert_eq!(name, "secretspec-myapp-prod-DB_URL");
+    }
+
+    #[test]
+    fn test_format_secret_name_rejects_invalid_chars() {
+        assert!(KubernetesProvider::format_secret_name("my/app", "prod", "DB_URL").is_err());
+        assert!(KubernetesProvider::format_secret_name("myapp", "prod", "DB URL").is_err());
+    }
+
+    #[test]
+    fn test_format_secret_name_too_long() {
+        let long_key = "A".repeat(254);
+        let result = KubernetesProvider::format_secret_name("myapp", "prod", &long_key);
+        assert!(result.is_err());
+    }
+}

--- a/secretspec/src/provider/kubernetes.rs
+++ b/secretspec/src/provider/kubernetes.rs
@@ -357,7 +357,8 @@ impl Provider for KubernetesProvider {
         block_on(self.set_secret_async(&coords.item, value))
     }
 
-    fn check_writable(&self, _addr: Address<'_>) -> Result<()> {
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        self.resolve_coords(addr)?;
         let can_i_patch = block_on(self.can_i_patch())?;
         if !can_i_patch {
             let err_msg = if let Some(namespace) = &self.config.namespace {

--- a/secretspec/src/provider/kubernetes.rs
+++ b/secretspec/src/provider/kubernetes.rs
@@ -57,6 +57,15 @@ pub enum KubernetesKind {
     Secret,
 }
 
+impl KubernetesKind {
+    fn plural(&self) -> &'static str {
+        match self {
+            KubernetesKind::ConfigMap => "configmaps",
+            KubernetesKind::Secret => "secret",
+        }
+    }
+}
+
 enum StringRepresentation {
     Plain(String),
     Base64(ByteString),
@@ -284,7 +293,7 @@ impl KubernetesProvider {
             resource_attributes: Some(ResourceAttributes {
                 namespace: Some(namespace.into()),
                 verb: Some("patch".to_string()),
-                resource: Some(self.config.kind.to_string()),
+                resource: Some(self.config.kind.plural().to_string()),
                 group: Some(String::new()),
                 version: Some("v1".to_string()),
                 name: Some(self.config.name.clone()),

--- a/secretspec/src/provider/kubernetes.rs
+++ b/secretspec/src/provider/kubernetes.rs
@@ -3,6 +3,7 @@ use crate::{Result, SecretSpecError};
 
 use super::{Address, Provider, ProviderUrl};
 use base64::{Engine, engine::general_purpose::STANDARD};
+use json_patch::jsonptr::Token;
 use k8s_openapi::{
     ByteString,
     api::{
@@ -15,6 +16,7 @@ use k8s_openapi::{
 use kube::{
     Api, Client,
     api::{Patch, PatchParams, PostParams},
+    core::Status,
 };
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -299,6 +301,46 @@ impl KubernetesProvider {
         })
     }
 
+    async fn delete_secret_async(&self, key: &str) -> Result<bool> {
+        let client = self.client().await?;
+        let namespace = match &self.config.namespace {
+            Some(ns) => ns.as_str(),
+            None => client.default_namespace(),
+        };
+        let name = self.config.name.as_str();
+        let params = PatchParams::default();
+        let patch = Patch::Json::<()>(json_patch::Patch(vec![json_patch::PatchOperation::Remove(
+            json_patch::RemoveOperation {
+                path: json_patch::jsonptr::PointerBuf::from_tokens(&[
+                    Token::new("data"),
+                    Token::new(key),
+                ]),
+            },
+        )]));
+        let patched = match self.config.kind {
+            KubernetesKind::ConfigMap => {
+                let api: Api<ConfigMap> = Api::namespaced(client.clone(), &namespace);
+                api.patch(name, &params, &patch).await.map(|_| ())
+            }
+            KubernetesKind::Secret => {
+                let api: Api<Secret> = Api::namespaced(client.clone(), &namespace);
+                api.patch(name, &params, &patch).await.map(|_| ())
+            }
+        };
+        match patched {
+            Ok(_) => Ok(true),
+            // This happens when we try to remove a path that doesn't exist
+            Err(kube::Error::Api(status)) if status.code == 422 && status.reason == "Invalid" => {
+                Ok(false)
+            }
+            Err(e) => Err(SecretSpecError::ProviderOperationFailed(format!(
+                "Failed to patch {}: {}",
+                self.config.kind,
+                crate::error::display_error_chain(&e)
+            ))),
+        }
+    }
+
     async fn can_i_patch(&self) -> Result<bool> {
         let client = self.client().await?;
         let namespace = match &self.config.namespace {
@@ -373,6 +415,11 @@ impl Provider for KubernetesProvider {
         block_on(self.set_secret_async(&coords.item, value))
     }
 
+    fn delete(&self, addr: Address<'_>) -> Result<bool> {
+        let coords = self.resolve_coords(addr)?;
+        block_on(self.delete_secret_async(&coords.item))
+    }
+
     fn check_writable(&self, addr: Address<'_>) -> Result<()> {
         self.resolve_coords(addr)?;
         let can_i_patch = block_on(self.can_i_patch())?;
@@ -388,6 +435,10 @@ impl Provider for KubernetesProvider {
             return Err(SecretSpecError::ProviderOperationFailed(err_msg));
         }
         Ok(())
+    }
+
+    fn supports_delete(&self) -> bool {
+        true
     }
 }
 

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -42,6 +42,7 @@
 //! - [`infisical::InfisicalProvider`]: Infisical integration (0.16+)
 //! - [`bw::BitwardenProvider`]: Bitwarden Password Manager (0.18+)
 //! - [`sops::SopsProvider`]: SOPS-encrypted file integration (0.17+)
+//! - [`kubernetes::KubernetesProvider`]: Kubernetes integration (0.20+)
 //!
 //! ## URI-Based Configuration
 //!
@@ -165,6 +166,8 @@ pub mod kdbx;
 pub mod keeper;
 #[cfg(feature = "keyring")]
 pub mod keyring;
+#[cfg(feature = "kubernetes")]
+pub mod kubernetes;
 pub mod lastpass;
 pub mod null;
 pub mod onepassword;


### PR DESCRIPTION
## Summary

- add Kubernetes provider support with refs, writes (including refs)
- can use either Kubernetes [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/) or [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
- reference Kubernetes object in specific namespace or omit for default cluster namespace
- document 0.20+ configuration

## Scenario coverage

- Secret value is stored in Kubernetes because it was generated by a helm provider
- Secret value is stored in Kubernetes and gets updated via cronjob so only accurate real-time value exists there
- User may lack permission to write to the Kubernetes ConfigMap or Secret
- User may want to reference a specific key in the Kubernetes ConfigMap/Secret via ref

## Validation

- `cargo test --all`
- `devenv shell -- prek run -a`
- `npm --prefix docs run build`
- Manually tested that getting and setting values worked for both ConfigMaps and Secrets, with or without explicit namespace, and with or without refs using an [AKS](https://learn.microsoft.com/en-us/azure/aks/) cluster.

Fixes #316