### PR TITLE
feat(node): publish musl builds of the native addon

### DIFF
--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -6,12 +6,18 @@ name: "Node addon"
 # optionalDependencies) using @napi-rs/cli, authenticated via npm Trusted
 # Publishing (OIDC) -- no NPM_TOKEN stored in CI.
 #
-# The Linux builds run inside manylinux_2_28 containers (AlmaLinux 8, glibc
-# 2.28), so the published addon loads on any distro with glibc >= 2.28
+# The glibc Linux builds run inside manylinux_2_28 containers (AlmaLinux 8,
+# glibc 2.28), so the published addon loads on any distro with glibc >= 2.28
 # (RHEL 8/9, Amazon Linux 2023, Debian 10+, Ubuntu 18.10+). Building on the bare
 # runner instead links the runner's glibc (2.39 on ubuntu-24.04), which broke
 # RHEL 9-family distros (issue #136). A post-build step fails the job if the
 # addon's glibc floor or NEEDED libraries regress.
+#
+# The musl Linux builds run inside musllinux_1_2 containers, which are Alpine
+# based, so they build and test natively against musl with no cross toolchain.
+# npm keeps the two libc variants apart through the `libc` field in each
+# platform package. The alpine-smoke job then loads the addon on node:alpine,
+# the image the SDK must support (issue #383).
 
 on:
   workflow_call:
@@ -58,12 +64,24 @@ jobs:
           # feeds the publish job below.
           - target: linux-x64
             platform: linux-x64-gnu
+            libc: gnu
             runner: ubuntu-latest
             container: quay.io/pypa/manylinux_2_28_x86_64:2026.08.05-1@sha256:e0b40ace8e818e96026eb47714b01998cbca022a6995797d0905474ce3e82ae8
           - target: linux-arm64
             platform: linux-arm64-gnu
+            libc: gnu
             runner: ubuntu-24.04-arm
             container: quay.io/pypa/manylinux_2_28_aarch64:2026.08.05-1@sha256:f766b402889e40f439e7a3ee5788eef1aa3ef399d0110107d27419fa2ba9d905
+          - target: linux-x64-musl
+            platform: linux-x64-musl
+            libc: musl
+            runner: ubuntu-latest
+            container: quay.io/pypa/musllinux_1_2_x86_64:2026.08.05-1@sha256:c7b2187aa4d095a8da73ea4db96acefd46701a13439a9cc4546f5d61a4b5bba1
+          - target: linux-arm64-musl
+            platform: linux-arm64-musl
+            libc: musl
+            runner: ubuntu-24.04-arm
+            container: quay.io/pypa/musllinux_1_2_aarch64:2026.08.05-1@sha256:668c455aeddf5e363bd6fd801f10b369a634a9f01974876cee8c8c518b44ef10
           - { target: darwin-arm64, platform: darwin-arm64, runner: macos-latest }
           - { target: win32-x64, platform: win32-x64-msvc, runner: windows-latest }
 
@@ -74,7 +92,7 @@ jobs:
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
 
-      - name: Install verified rustup (the manylinux container ships none)
+      - name: Install verified rustup (the build containers ship none)
         if: matrix.container
         run: |
           bash scripts/install-rustup.sh
@@ -82,7 +100,14 @@ jobs:
 
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
+      # setup-node serves glibc builds only, so the musl containers take Node
+      # from the Alpine package index instead. Alpine 3.22 carries Node 22, the
+      # same major version as the other legs.
+      - name: Install Node in the musl container
+        if: matrix.libc == 'musl'
+        run: apk add --no-cache nodejs npm
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: matrix.libc != 'musl'
         with:
           node-version: "22"
       - name: Install napi CLI
@@ -91,14 +116,27 @@ jobs:
 
       - name: Build the addon and run the SDK tests
         shell: bash
+        env:
+          # For a musl target napi-rs points cargo at a cross toolchain named
+          # <arch>-linux-musl-gcc. The musllinux containers build musl natively,
+          # where the compiler is plain gcc, so these two variables name it
+          # instead. napi-rs leaves an already-set linker alone, and the legs
+          # that build no musl target ignore both variables.
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: gcc
         run: |
           bash secretspec-node/scripts/build-addon.sh
           ( cd secretspec-node && node --test )
 
       - name: Verify addon portability (glibc <= 2.28, no libdbus)
-        if: matrix.container
+        if: matrix.libc == 'gnu'
         shell: bash
         run: bash scripts/check-linux-portability.sh secretspec-node/secretspec.node
+
+      - name: Verify addon portability (musl libc, no libdbus)
+        if: matrix.libc == 'musl'
+        shell: bash
+        run: bash scripts/check-musl-portability.sh secretspec-node/secretspec.node
 
       - name: Copy the addon to its platform-specific filename for publishing
         shell: bash
@@ -109,12 +147,48 @@ jobs:
           name: node-addon-${{ matrix.target }}
           path: secretspec-node/secretspec.${{ matrix.platform }}.node
 
+  alpine-smoke:
+    name: node:alpine (${{ matrix.target }})
+    # The musl legs build and test inside musllinux_1_2, which is a different
+    # Alpine release from the one a Node service runs. This job loads the
+    # uploaded addon on node:alpine to close that gap (issue #383). The SDK
+    # tests need only Node built-ins.
+    needs: addon
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: linux-x64-musl, runner: ubuntu-latest }
+          - { target: linux-arm64-musl, runner: ubuntu-24.04-arm }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: node-addon-${{ matrix.target }}
+          path: secretspec-node
+      - name: Run the SDK tests on node:alpine
+        shell: bash
+        run: |
+          # The artifact holds one addon, under its platform-specific name.
+          # index.js loads ./secretspec.node first, so use that name.
+          mv secretspec-node/secretspec.*.node secretspec-node/secretspec.node
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace/secretspec-node \
+            node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 \
+            node --test
+
   publish:
     name: publish to npm
     # Version tags publish automatically. A standalone manual run can opt in to
     # re-publishing one SDK, while reusable pre-release runs always leave this off.
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish
-    needs: [addon]
+    # alpine-smoke gates the release too. An addon that npm installs but cannot
+    # load is the failure this job checks for.
+    needs: [addon, alpine-smoke]
     runs-on: ubuntu-latest
     permissions:
       id-token: write # npm Trusted Publishing (OIDC), no token needed

--- a/.github/workflows/node-addon.yml
+++ b/.github/workflows/node-addon.yml
@@ -13,11 +13,9 @@ name: "Node addon"
 # RHEL 9-family distros (issue #136). A post-build step fails the job if the
 # addon's glibc floor or NEEDED libraries regress.
 #
-# The musl Linux builds run inside musllinux_1_2 containers, which are Alpine
-# based, so they build and test natively against musl with no cross toolchain.
-# npm keeps the two libc variants apart through the `libc` field in each
-# platform package. The alpine-smoke job then loads the addon on node:alpine,
-# the image the SDK must support (issue #383).
+# The musl builds live in a separate `musl` job, because an Alpine job container
+# cannot run JavaScript actions on an ARM runner. npm keeps the two libc variants
+# apart through the `libc` field in each platform package (issue #383).
 
 on:
   workflow_call:
@@ -64,24 +62,12 @@ jobs:
           # feeds the publish job below.
           - target: linux-x64
             platform: linux-x64-gnu
-            libc: gnu
             runner: ubuntu-latest
             container: quay.io/pypa/manylinux_2_28_x86_64:2026.08.05-1@sha256:e0b40ace8e818e96026eb47714b01998cbca022a6995797d0905474ce3e82ae8
           - target: linux-arm64
             platform: linux-arm64-gnu
-            libc: gnu
             runner: ubuntu-24.04-arm
             container: quay.io/pypa/manylinux_2_28_aarch64:2026.08.05-1@sha256:f766b402889e40f439e7a3ee5788eef1aa3ef399d0110107d27419fa2ba9d905
-          - target: linux-x64-musl
-            platform: linux-x64-musl
-            libc: musl
-            runner: ubuntu-latest
-            container: quay.io/pypa/musllinux_1_2_x86_64:2026.08.05-1@sha256:c7b2187aa4d095a8da73ea4db96acefd46701a13439a9cc4546f5d61a4b5bba1
-          - target: linux-arm64-musl
-            platform: linux-arm64-musl
-            libc: musl
-            runner: ubuntu-24.04-arm
-            container: quay.io/pypa/musllinux_1_2_aarch64:2026.08.05-1@sha256:668c455aeddf5e363bd6fd801f10b369a634a9f01974876cee8c8c518b44ef10
           - { target: darwin-arm64, platform: darwin-arm64, runner: macos-latest }
           - { target: win32-x64, platform: win32-x64-msvc, runner: windows-latest }
 
@@ -92,7 +78,7 @@ jobs:
       - name: Sync SDK package versions
         run: bash scripts/sync-sdk-versions.sh
 
-      - name: Install verified rustup (the build containers ship none)
+      - name: Install verified rustup (the manylinux container ships none)
         if: matrix.container
         run: |
           bash scripts/install-rustup.sh
@@ -100,14 +86,7 @@ jobs:
 
       - name: Install Rust (pinned by rust-toolchain.toml)
         run: rustup toolchain install
-      # setup-node serves glibc builds only, so the musl containers take Node
-      # from the Alpine package index instead. Alpine 3.22 carries Node 22, the
-      # same major version as the other legs.
-      - name: Install Node in the musl container
-        if: matrix.libc == 'musl'
-        run: apk add --no-cache nodejs npm
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: matrix.libc != 'musl'
         with:
           node-version: "22"
       - name: Install napi CLI
@@ -116,27 +95,14 @@ jobs:
 
       - name: Build the addon and run the SDK tests
         shell: bash
-        env:
-          # For a musl target napi-rs points cargo at a cross toolchain named
-          # <arch>-linux-musl-gcc. The musllinux containers build musl natively,
-          # where the compiler is plain gcc, so these two variables name it
-          # instead. napi-rs leaves an already-set linker alone, and the legs
-          # that build no musl target ignore both variables.
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: gcc
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: gcc
         run: |
           bash secretspec-node/scripts/build-addon.sh
           ( cd secretspec-node && node --test )
 
       - name: Verify addon portability (glibc <= 2.28, no libdbus)
-        if: matrix.libc == 'gnu'
+        if: matrix.container
         shell: bash
         run: bash scripts/check-linux-portability.sh secretspec-node/secretspec.node
-
-      - name: Verify addon portability (musl libc, no libdbus)
-        if: matrix.libc == 'musl'
-        shell: bash
-        run: bash scripts/check-musl-portability.sh secretspec-node/secretspec.node
 
       - name: Copy the addon to its platform-specific filename for publishing
         shell: bash
@@ -147,48 +113,94 @@ jobs:
           name: node-addon-${{ matrix.target }}
           path: secretspec-node/secretspec.${{ matrix.platform }}.node
 
-  alpine-smoke:
-    name: node:alpine (${{ matrix.target }})
-    # The musl legs build and test inside musllinux_1_2, which is a different
-    # Alpine release from the one a Node service runs. This job loads the
-    # uploaded addon on node:alpine to close that gap (issue #383). The SDK
-    # tests need only Node built-ins.
-    needs: addon
+  musl:
+    name: ${{ matrix.target }}
+    # GitHub Actions runs JavaScript actions inside an Alpine container only on
+    # x64 runners, so an Alpine job container breaks checkout on the ARM runner.
+    # These legs stay on the host and drive the build through docker run, the
+    # same shape dotnet-package.yml uses for its musl assets. Each image is
+    # Alpine based and matches its runner architecture, so the addon builds and
+    # tests natively against musl with no cross toolchain (issue #383).
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { target: linux-x64-musl, runner: ubuntu-latest }
-          - { target: linux-arm64-musl, runner: ubuntu-24.04-arm }
+          - target: linux-x64-musl
+            runner: ubuntu-latest
+            image: quay.io/pypa/musllinux_1_2_x86_64:2026.08.05-1@sha256:c7b2187aa4d095a8da73ea4db96acefd46701a13439a9cc4546f5d61a4b5bba1
+          - target: linux-arm64-musl
+            runner: ubuntu-24.04-arm
+            image: quay.io/pypa/musllinux_1_2_aarch64:2026.08.05-1@sha256:668c455aeddf5e363bd6fd801f10b369a634a9f01974876cee8c8c518b44ef10
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: node-addon-${{ matrix.target }}
-          path: secretspec-node
-      - name: Run the SDK tests on node:alpine
+      - name: Sync SDK package versions
+        run: bash scripts/sync-sdk-versions.sh
+
+      - name: Build the addon and run the SDK tests
         shell: bash
         run: |
-          # The artifact holds one addon, under its platform-specific name.
-          # index.js loads ./secretspec.node first, so use that name.
-          mv secretspec-node/secretspec.*.node secretspec-node/secretspec.node
+          # For a musl target napi-rs points cargo at a cross toolchain named
+          # <arch>-linux-musl-gcc. This container builds musl natively, where
+          # the compiler is plain gcc, so the variables below name it instead;
+          # napi-rs keeps a linker the environment already sets. napi-rs adds
+          # -C target-feature=-crt-static for musl targets on its own.
+          #
+          # Variables in this single-quoted script expand inside the container,
+          # not in the outer workflow shell.
+          # shellcheck disable=SC2016
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            --env CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=gcc \
+            --env CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=gcc \
+            "${{ matrix.image }}" \
+            bash -c '
+              set -euo pipefail
+              # setup-node serves glibc builds, so Node comes from Alpine.
+              apk add --no-cache nodejs npm
+              bash scripts/install-rustup.sh
+              export PATH="$HOME/.cargo/bin:$PATH"
+              rustup toolchain install
+              ( cd secretspec-node && npm ci )
+              bash secretspec-node/scripts/build-addon.sh
+              ( cd secretspec-node && node --test )
+            '
+
+      - name: Verify addon portability (musl libc, no libdbus)
+        shell: bash
+        run: bash scripts/check-musl-portability.sh secretspec-node/secretspec.node
+
+      - name: Load the addon on node:alpine
+        shell: bash
+        run: |
+          # musllinux_1_2 and node:alpine are different Alpine releases, so
+          # confirm the addon loads on the image a Node service runs.
           docker run --rm \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace/secretspec-node \
             node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 \
             node --test
 
+      - name: Copy the addon to its platform-specific filename for publishing
+        shell: bash
+        run: cp secretspec-node/secretspec.node "secretspec-node/secretspec.${{ matrix.target }}.node"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: node-addon-${{ matrix.target }}
+          path: secretspec-node/secretspec.${{ matrix.target }}.node
+
+
   publish:
     name: publish to npm
     # Version tags publish automatically. A standalone manual run can opt in to
     # re-publishing one SDK, while reusable pre-release runs always leave this off.
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish
-    # alpine-smoke gates the release too. An addon that npm installs but cannot
-    # load is the failure this job checks for.
-    needs: [addon, alpine-smoke]
+    needs: [addon, musl]
     runs-on: ubuntu-latest
     permissions:
       id-token: write # npm Trusted Publishing (OIDC), no token needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Inherited declarations remain in their parent files and are revalidated after
   every edit.
 
+- The Node.js SDK publishes musl builds of the native addon in 0.20+, so
+  `require("secretspec")` works on Alpine images such as `node:alpine`
+  ([#383]). npm picks the build that matches the host libc, on both x64 and
+  arm64.
+
+  [#383]: https://github.com/cachix/secretspec/issues/383
+
 - `extract` supports INI documents in SecretSpec 0.20+, selecting an
   unsectioned key with `/key` or a named-section key with `/section/key`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -76,6 +76,23 @@ Publisher configured (GitHub Actions, repo `cachix/secretspec`, workflow
 `node-addon.yml`, no environment), and the bootstrap token has been revoked.
 Nothing left to do — every release from here publishes via OIDC.
 
+### npm musl packages (0.20+) — bootstrap pending
+
+`secretspec-linux-x64-musl` and `secretspec-linux-arm64-musl` are new package
+names, so each needs the same manual first publish the four older platform
+packages had:
+
+1. Publish both once with a temporary granular access token, scope "All
+   Packages" / "Read and write". A "select packages" scope cannot name a
+   package that does not exist yet.
+2. Attach a Trusted Publisher to each (GitHub Actions, repo
+   `cachix/secretspec`, workflow `node-addon.yml`, no environment).
+3. Revoke the token.
+
+`napi pre-publish` publishes every platform package in one step, so until this
+is done the publish job in `node-addon.yml` fails and takes the main
+`secretspec` package with it.
+
 ### Hackage — token set, done
 
 Hackage doesn't support OIDC yet (tracked upstream:
@@ -264,8 +281,12 @@ self-contained, vendored build — not a module-proxy install).
   main `secretspec` package references via `optionalDependencies` and loads at
   runtime — the layout `@napi-rs/cli` automates (`napi create-npm-dirs` /
   `napi pre-publish`). Authenticated via **npm Trusted Publishing** (OIDC); no
-  token stored in CI.
-- **One-time setup:** already done — see "Before your first release" above.
+  token stored in CI. `napi.targets` in `secretspec-node/package.json` is the
+  source of truth for the platform list; `napi pre-publish` derives
+  `optionalDependencies` from it at publish time.
+- **One-time setup:** done for the four glibc, macOS, and Windows packages. The
+  two musl packages added in 0.20 still need it — see "Before your first
+  release" above.
 
 ## PHP (Packagist + extension) — `php-ext.yml`
 

--- a/docs/src/content/docs/development/sdks.md
+++ b/docs/src/content/docs/development/sdks.md
@@ -61,7 +61,7 @@ the Ruby gem, and the PHP extension binaries is added in SecretSpec 0.17.
 | --- | --- | --- | --- | --- | --- | --- |
 | Rust (source crate) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Python | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
-| Node.js | ✓ | ✓ | — | ✓ | ✓ | — |
+| Node.js | ✓ (glibc and musl 0.20+) | ✓ (glibc and musl 0.20+) | — | ✓ | ✓ | — |
 | Go | ✓ | ✓ | — | ✓ | ✓ | — |
 | Ruby | ✓ | ✓ | — | ✓ | ✓ (0.17+) | — |
 | C# | ✓ (glibc and musl) | ✓ (glibc and musl) | ✓ | ✓ | ✓ | ✓ |

--- a/docs/src/content/docs/sdk/nodejs.mdx
+++ b/docs/src/content/docs/sdk/nodejs.mdx
@@ -11,9 +11,9 @@ import typedAccessExample from '../../../../../secretspec-node/examples/typed_ac
 The Node.js / TypeScript SDK (`secretspec`) is a thin wrapper over a
 [napi-rs](https://napi.rs/) native addon that embeds the resolver. Resolution
 happens in the Rust core, so the SDK inherits every provider with no JS-side
-logic. The addon is built from the Rust core with `scripts/build-addon.sh`;
-prebuilt per-platform npm packages are a follow-up. TypeScript declarations ship
-in `index.d.ts`.
+logic. npm installs a prebuilt addon for the host platform: Linux x64 and
+arm64 (glibc, and musl for Alpine images in 0.20+), macOS on Apple silicon, and
+Windows x64. TypeScript declarations ship in `index.d.ts`.
 
 ## Quick start
 

--- a/scripts/check-musl-portability.sh
+++ b/scripts/check-musl-portability.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Verify a Linux native library built in the musllinux_1_2 container links
+# against musl and carries no system libdbus dependency.
+#
+#     check-musl-portability.sh <library> [arch]
+#
+# `arch` names the musl libc the library must use, as `uname -m` spells it, and
+# defaults to the host. Pass it for a cross-compiled library.
+#
+# Read the dynamic dependencies (readelf -d), not symbol versions. On ARM musl
+# the libgcc_s library exports a compatibility symbol version named GLIBC_2.0.
+# A symbol scan therefore reports a glibc need on a library that has none.
+set -euo pipefail
+
+library="${1:?usage: check-musl-portability.sh <library> [arch]}"
+arch="${2:-$(uname -m)}"
+
+case "$arch" in
+  x86_64 | amd64) expected_libc=libc.musl-x86_64.so.1 ;;
+  aarch64 | arm64) expected_libc=libc.musl-aarch64.so.1 ;;
+  *)
+    echo "unsupported musl architecture: $arch" >&2
+    exit 2
+    ;;
+esac
+
+needed=$(readelf -d "$library" | grep NEEDED)
+
+if grep -q '\[libc\.so\.6\]' <<<"$needed"; then
+  echo "$library links glibc instead of musl:" >&2
+  echo "$needed" >&2
+  exit 1
+fi
+if ! grep -Fq "[$expected_libc]" <<<"$needed"; then
+  echo "$library does not link $expected_libc:" >&2
+  echo "$needed" >&2
+  exit 1
+fi
+if grep -q dbus <<<"$needed"; then
+  echo "$library unexpectedly links libdbus dynamically:" >&2
+  echo "$needed" >&2
+  exit 1
+fi

--- a/secretspec-node/index.js
+++ b/secretspec-node/index.js
@@ -10,15 +10,47 @@ const fs = require('node:fs');
 // as_path) happens entirely in the Rust core; this layer marshals JSON and
 // exposes the builder API. TypeScript declarations ship in index.d.ts.
 
-// Maps process.platform-process.arch to the optionalDependency package that
-// carries the addon for that platform (see napi.targets in package.json and
-// the generated npm/<platform>/ package dirs).
+// Maps a platform key to the optionalDependency package that carries the addon
+// for it (see napi.targets in package.json and the generated npm/<platform>/
+// package dirs). Linux keys carry a libc suffix: a glibc addon cannot load on
+// musl, and npm keeps the two apart through the `libc` field that napi-rs
+// writes into each platform package.
 const PLATFORM_PACKAGES = {
-  'linux-x64': 'secretspec-linux-x64-gnu',
-  'linux-arm64': 'secretspec-linux-arm64-gnu',
+  'linux-x64-gnu': 'secretspec-linux-x64-gnu',
+  'linux-x64-musl': 'secretspec-linux-x64-musl',
+  'linux-arm64-gnu': 'secretspec-linux-arm64-gnu',
+  'linux-arm64-musl': 'secretspec-linux-arm64-musl',
   'darwin-arm64': 'secretspec-darwin-arm64',
   'win32-x64': 'secretspec-win32-x64-msvc',
 };
+
+// Node exposes no libc accessor, so read the diagnostic report the way napi-rs
+// does in its generated loaders. A glibc process reports a runtime glibc
+// version; a musl process reports none and loads a musl interpreter instead.
+function isMusl() {
+  if (typeof process.report?.getReport !== 'function') {
+    return false;
+  }
+  const report = process.report.getReport();
+  if (report.header?.glibcVersionRuntime) {
+    return false;
+  }
+  return (
+    Array.isArray(report.sharedObjects) &&
+    report.sharedObjects.some(
+      (object) => object.includes('libc.musl-') || object.includes('ld-musl-'),
+    )
+  );
+}
+
+// The key into PLATFORM_PACKAGES for the running process.
+function platformKey() {
+  const key = `${process.platform}-${process.arch}`;
+  if (process.platform !== 'linux') {
+    return key;
+  }
+  return `${key}-${isMusl() ? 'musl' : 'gnu'}`;
+}
 
 function loadNative() {
   try {
@@ -27,7 +59,7 @@ function loadNative() {
   } catch (localErr) {
     // Installed from npm: the addon lives in a platform-specific
     // optionalDependency package instead of being bundled here.
-    const key = `${process.platform}-${process.arch}`;
+    const key = platformKey();
     const pkg = PLATFORM_PACKAGES[key];
     if (!pkg) {
       throw new Error(`secretspec: unsupported platform ${key}`);

--- a/secretspec-node/npm/linux-arm64-musl/README.md
+++ b/secretspec-node/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `secretspec-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `secretspec`

--- a/secretspec-node/npm/linux-arm64-musl/package.json
+++ b/secretspec-node/npm/linux-arm64-musl/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "secretspec-linux-arm64-musl",
+  "version": "0.12.2",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "secretspec.linux-arm64-musl.node",
+  "files": [
+    "secretspec.linux-arm64-musl.node"
+  ],
+  "description": "A declarative interface for every secret provider. Node.js SDK.",
+  "homepage": "https://secretspec.dev/",
+  "license": "Apache-2.0",
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/secretspec-node/npm/linux-x64-musl/README.md
+++ b/secretspec-node/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `secretspec-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `secretspec`

--- a/secretspec-node/npm/linux-x64-musl/package.json
+++ b/secretspec-node/npm/linux-x64-musl/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "secretspec-linux-x64-musl",
+  "version": "0.12.2",
+  "cpu": [
+    "x64"
+  ],
+  "main": "secretspec.linux-x64-musl.node",
+  "files": [
+    "secretspec.linux-x64-musl.node"
+  ],
+  "description": "A declarative interface for every secret provider. Node.js SDK.",
+  "homepage": "https://secretspec.dev/",
+  "license": "Apache-2.0",
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/secretspec-node/package.json
+++ b/secretspec-node/package.json
@@ -20,6 +20,8 @@
     "targets": [
       "x86_64-unknown-linux-gnu",
       "aarch64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl",
+      "aarch64-unknown-linux-musl",
       "aarch64-apple-darwin",
       "x86_64-pc-windows-msvc"
     ]


### PR DESCRIPTION
`require("secretspec")` fails on `node:alpine`. The npm package declares four platform packages and all four are glibc. napi platform packages carry a `libc` constraint, so npm skips them on musl, the install reports success, and the failure only appears when the service starts. Alpine is a common base for Node services, so this blocks the SDK from those containers. #383 has the reproduction.

This adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to `napi.targets` and builds them in the pinned `musllinux_1_2` containers. Those images are Alpine based and match their runner architecture, so both legs build and test natively against musl with no cross toolchain. `dotnet-package.yml` already builds `secretspec-ffi` for the same two triples the same way, and both targets are already in `rust-toolchain.toml`, so the dependency graph needed nothing. There are no Rust source changes here.

The musl legs sit in their own `musl` job rather than in the `addon` matrix, because GitHub Actions runs JavaScript actions inside an Alpine container only on x64 runners. The job stays on the host and drives the build through `docker run`, which keeps `actions/checkout` outside the container, again matching `dotnet-package.yml`. The `addon` job is unchanged apart from its header comment. `publish` waits on both.

The loader in `index.js` reads the Node diagnostic report to tell glibc from musl and picks the matching platform package. After the build, the job loads the addon on `node:24-alpine` as a separate step, because `musllinux_1_2` and `node:alpine` are different Alpine releases and the second is what a Node service actually runs.

Two things need your attention.

The two musl package names are new on npm, and npm has no pending-publisher mechanism, so each needs a manual first publish before a Trusted Publisher can attach to it. `napi pre-publish` publishes every platform package in one step, so until that bootstrap happens the publish job fails and takes the main `secretspec` package with it. I wrote the steps into RELEASE.md next to the other one-time setup notes, but only a maintainer can run them.

I left `optionalDependencies` in `package.json` alone. `napi pre-publish` derives that field from `napi.targets` at publish time, which is why the committed values still read 0.12.2 while 0.19.1 shipped with 0.19.1 there. Adding the musl names by hand breaks `npm ci` on every leg, because the lockfile cannot resolve packages that do not exist yet.

Items 2 and 3 of the issue, the musl CLI assets and the CLI glibc floor, are not here. Both live in cargo-dist config, where `install-updater` is a global setting and dist refuses a target whose updater axoupdater does not publish. That looks like the constraint `aarch64-pc-windows-msvc` already hit, so it deserves its own PR.
