### PR TITLE
fix(bw): isolate convention secrets by project and profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bitwarden convention item names now preserve project and profile isolation
+  when either contains `/`, and `secretspec init --from bw://` recognizes
+  existing convention names case-insensitively while retaining legacy items'
+  native references for migration.
+
 - Dotenv parsing and rendering now use dotenv-ng throughout the dotenv
   provider, age-encrypted dotenv blobs, and `secretspec export --format
   dotenv`. Values containing `$` remain literal, output uses only the quoting
@@ -105,6 +110,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   diagnostics are omitted as missing instead of aborting batch resolution.
 
 ### Fixed
+
+- Bitwarden Password Manager convention secrets now use
+  `secretspec/{project}/{profile}/{key}` item titles, preventing a same-named
+  secret in another project or profile from being read or overwritten. The
+  existing `?folder=` option customizes that title prefix. Bare items created
+  by releases through 0.19 can be renamed to the namespaced title or retained
+  with an explicit `ref`; declaration discovery emits those legacy bare items
+  as refs automatically. ([#369])
+
+  [#369]: https://github.com/cachix/secretspec/issues/369
 
 - Format-preserving `Spec` edits now keep inherited declarations separate after
   semantic builder changes, resolve parent specs independently of later working

--- a/docs/src/content/docs/providers/bw.md
+++ b/docs/src/content/docs/providers/bw.md
@@ -8,6 +8,11 @@ using the official `bw` CLI.
 
 :::note[Version compatibility]
 The Bitwarden Password Manager provider was added in SecretSpec 0.18.
+
+SecretSpec 0.20+ isolates convention-managed items by project and profile. It
+stores `DATABASE_URL` under an item title such as
+`secretspec/my-project/default/DATABASE_URL`; releases through 0.19 used the
+bare title `DATABASE_URL`. See [Migrating bare item names](#migrating-bare-item-names-020).
 :::
 
 ## At a glance
@@ -110,6 +115,7 @@ bw://[collection]
 bw://[org@collection]
 bw://?server=https://vault.company.com
 bw://?type=login&field=password
+bw://?folder=team/{project}/{profile} # 0.20+
 ```
 
 - `collection`: Target collection, by name or by ID
@@ -117,6 +123,10 @@ bw://?type=login&field=password
 - `type`: Item type to require when matching an existing item and to use when
   creating a new one (`login`, `card`, `identity`, `sshkey`, or `securenote`)
 - `field`: Built-in or custom field to read or write
+- `folder` (0.20+): Convention item-title prefix. Supports `{project}` and
+  `{profile}` and defaults to `secretspec/{project}/{profile}`. This is not a
+  Bitwarden folder: Bitwarden folders are personal to each vault user and
+  therefore cannot provide a shared project namespace.
 - `server`: The self-hosted server this configuration expects. This does **not**
   configure the CLI — it is a guard that fails with remediation steps when the
   `bw` CLI is pointed somewhere else. See [Self-hosted servers](#self-hosted-servers).
@@ -193,18 +203,23 @@ $ secretspec init --from 'bw://myorg@dev-secrets?type=login' # 0.18+
 ✓ Created secretspec.toml with 8 secrets
 ```
 
-Each item name becomes a SecretSpec key. Names must therefore contain only
-letters, numbers, and underscores, cannot start with a number, and cannot be
-the reserved name `defaults`. Bitwarden allows duplicate names and matches them
-case-insensitively; discovery stops when two selected items collide under those
-rules instead of generating an ambiguous manifest. Rename the items or use
-`?type=` to select one type.
+In SecretSpec 0.20+, an item under the selected project/profile convention
+prefix becomes a convention declaration: for example,
+`secretspec/payments/production/API_KEY` becomes `API_KEY`. Items under another
+project/profile prefix are skipped. A bare existing item such as `LEGACY_TOKEN`
+is still discovered, but its declaration receives `ref = { item =
+"LEGACY_TOKEN" }` so it remains directly addressable.
 
-Discovery writes only names and generated descriptions to `secretspec.toml`;
-it never writes secret values. The `--project` and `--profile` discovery
-context does not change Bitwarden item names. To migrate the discovered values
-after reviewing the declarations, run the `secretspec import` command printed
-by `init`.
+Discovered keys must contain only letters, numbers, and underscores, cannot
+start with a number, and cannot be the reserved name `defaults`. Bitwarden
+allows duplicate names and matches them case-insensitively; discovery stops
+when two selected items map to colliding keys instead of generating an
+ambiguous manifest. Rename an item or narrow discovery with `?type=`.
+
+Discovery never writes secret values. In SecretSpec 0.20+, `--project` and
+`--profile` select the convention prefix used to recognize managed items; they
+do not rename anything in Bitwarden. To migrate values after reviewing the
+declarations, run the `secretspec import` command printed by `init`.
 
 ### Environment overrides
 
@@ -236,6 +251,18 @@ way as values in the URI. The complete precedence is:
 | Field | Secret `ref.field`, `BITWARDEN_DEFAULT_FIELD`, provider URI, item-type default |
 
 ## Storage model
+
+### Convention item names (0.20+)
+
+SecretSpec-managed convention items use the title
+`secretspec/{project}/{profile}/{key}` by default. Project and profile are part
+of the title so the same collection or personal vault can safely hold
+`DATABASE_URL` for several projects and environments. `?folder=` replaces the
+`secretspec/{project}/{profile}` prefix, and the key is appended to it.
+
+The prefix is an item-title namespace, not a Bitwarden `folderId`. Explicit
+`ref.item` coordinates always name the complete existing item title and do not
+receive the prefix.
 
 The Bitwarden provider supports every Password Manager item type. When an item
 type is selected through `BITWARDEN_DEFAULT_TYPE` or `?type=`, it filters reads
@@ -337,7 +364,7 @@ unintended partial match. `field = "notes"` addresses a Secure Note's body.
 
 ### How items are matched (0.18+)
 
-Item names are matched **in full, case-insensitively** — `test database` finds
+Resolved item titles are matched **in full, case-insensitively** — `test database` finds
 `Test Database`, but `API_KEY` never matches `API_KEY_OLD`. The `bw` CLI itself
 accepts a substring here, which works well interactively because it prints the
 candidates and lets you choose; a name in `secretspec.toml` is resolved with
@@ -358,14 +385,9 @@ $ secretspec get API_KEY --provider "bw://?type=card"
 
 ## Use existing secrets
 
-The secret name selects an existing Bitwarden item by default:
-
-```bash
-$ secretspec get 'MyApp Database' --provider 'bw://?type=login'
-```
-
-Use a `ref` when the SecretSpec key and Bitwarden item name differ, or when a
-specific field is required:
+Use a `ref` for an existing Bitwarden item that does not use SecretSpec's
+project/profile title convention, when the SecretSpec key differs from the
+item title, or when a specific field is required:
 
 ```toml title="secretspec.toml"
 [profiles.default]
@@ -373,6 +395,25 @@ DATABASE_URL = { description = "Application database", ref = { item = "MyApp Dat
 ```
 
 `ref.item` is matched against the Bitwarden item name, not its item ID.
+
+### Migrating bare item names (0.20+)
+
+Releases through 0.19 wrote convention secrets under their bare keys. Those
+titles contain no project or profile ownership, so SecretSpec cannot safely
+guess which project should inherit one. Version 0.20 therefore does not fall
+back to a bare item during convention reads or writes.
+
+Rename a SecretSpec-managed item from, for example, `DATABASE_URL` to
+`secretspec/my-project/default/DATABASE_URL`. If an item is intentionally
+shared or externally managed, keep its existing title and declare it explicitly:
+
+```toml title="secretspec.toml"
+[profiles.default]
+DATABASE_URL = { description = "Shared database", ref = { item = "DATABASE_URL" }, providers = ["bw"] }
+```
+
+`secretspec init --from bw://` in 0.20+ generates this native `ref` form for
+bare existing items automatically.
 
 ## CI/CD
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -82,6 +82,10 @@ $ secretspec init --from 'bw://dev-secrets?type=login'
 ✓ Created secretspec.toml with 8 secrets
 ```
 
+For Bitwarden in SecretSpec 0.20+, items under the selected
+`secretspec/{project}/{profile}/` title prefix become convention declarations;
+bare existing items are emitted with explicit `ref.item` coordinates.
+
 ### config global init
 Initialize user-global configuration. The explicit `global` namespace is
 available in SecretSpec 0.17+; without options, the command prompts for the

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -466,6 +466,7 @@ bw://dev-secrets                        # Collection, by name or ID
 bw://myorg@dev-secrets                  # Organization and collection
 bw://?server=https://vault.company.com  # Expected self-hosted server (guard)
 bw://?type=login&field=username         # Default item type and field
+bw://?folder=team/{project}/{profile}   # Convention title prefix (0.20+)
 ```
 
 Organizations and collections may be named or given as IDs; SecretSpec resolves
@@ -484,6 +485,14 @@ narrows both reads and writes to that item type, keeping a Card and a same-named
 Login separately addressable. An unsupported `?type=`, or an unknown query
 parameter, is rejected when the address is parsed rather than ignored.
 
+SecretSpec 0.20+ convention items use the title
+`secretspec/{project}/{profile}/{key}`. `?folder=` replaces the prefix before
+the key; it is an item-title namespace, not a Bitwarden folder. Explicit
+`ref.item` values remain complete, unprefixed item titles. Releases through
+0.19 wrote bare convention titles, which must be renamed to the 0.20 layout or
+kept with an explicit `ref = { item = "OLD_TITLE" }`; there is no automatic
+bare-name fallback because a bare item carries no project/profile ownership.
+
 `?server=` does not configure the CLI. The `bw` CLI takes its server only from
 `bw config server`, which must be run while logged out, so self-hosted users
 configure the CLI themselves and SecretSpec verifies the setting matches before
@@ -491,7 +500,7 @@ each operation. See the [provider guide](/providers/bw/#self-hosted-servers).
 
 **Features**: Read/write, all vault item types (logins, cards, identities, SSH keys, secure notes), organization/collection addressing by name or ID, field selection, `ref = { item, field }` mapping in `secretspec.toml`, declaration discovery through `init --from` (0.18+)
 **Prerequisites**: Bitwarden CLI (`bw`), signed in and unlocked (`BW_SESSION` env var), self-hosted servers set with `bw config server` before login, build with `--features bw`
-**Storage**: One vault item per secret; reads use per-type default fields unless `?field=` or a `ref` mapping selects one
+**Storage**: One vault item per secret; convention title `secretspec/{project}/{profile}/{key}` (0.20+, customizable with `?folder=`), with per-type default fields unless `?field=` or a `ref` mapping selects one
 
 ## Bitwarden Secrets Manager Provider
 

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -551,6 +551,15 @@ fn generate_toml_with_comments(config: &Config) -> crate::Result<String> {
             if let Some(composed) = &secret_config.composed {
                 inline.insert("composed", Value::from(composed.as_str()));
             }
+            if let Some(reference) = &secret_config.reference {
+                let mut native_address = InlineTable::new();
+                for (coordinate, value) in reference.coordinates() {
+                    if let Some(value) = value {
+                        native_address.insert(coordinate, Value::from(value));
+                    }
+                }
+                inline.insert("ref", Value::InlineTable(native_address));
+            }
             profile_table.insert(&secret_name, toml_edit::value(inline));
         }
 
@@ -2048,6 +2057,32 @@ mod tests {
         assert!(
             out.contains(", composed = \"postgres://${USER}@${HOST}/db\""),
             "got: {out}"
+        );
+    }
+
+    #[test]
+    fn generate_toml_preserves_native_references() {
+        let out = generate_toml_with_comments(&config_with_secret(Secret {
+            description: Some("legacy".to_string()),
+            reference: Some(crate::config::NativeAddress {
+                item: "LEGACY_TOKEN".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .unwrap();
+
+        assert!(
+            out.contains(", ref = { item = \"LEGACY_TOKEN\" }"),
+            "got: {out}"
+        );
+        let parsed: Config = toml::from_str(&out).expect("must round-trip");
+        assert_eq!(
+            parsed.profiles["default"].secrets["S"]
+                .reference
+                .as_ref()
+                .map(|reference| reference.item.as_str()),
+            Some("LEGACY_TOKEN")
         );
     }
 

--- a/secretspec/src/provider/bw.rs
+++ b/secretspec/src/provider/bw.rs
@@ -371,7 +371,7 @@ pub struct BitwardenConfig {
     /// When set, the CLI will be configured to use the specified server
     /// instead of the default bitwarden.com. Should include the full URL.
     pub server: Option<String>,
-    /// Optional folder name prefix for organizing secrets in Bitwarden.
+    /// Optional convention item-title prefix for organizing secrets in Bitwarden.
     ///
     /// Supports placeholders: {project} and {profile}.
     /// Defaults to "secretspec/{project}/{profile}" if not specified.
@@ -457,8 +457,9 @@ impl TryFrom<&ProviderUrl> for BitwardenConfig {
 /// Provider implementation for Bitwarden password manager.
 ///
 /// This provider integrates with Bitwarden CLI (`bw`) to store and retrieve
-/// secrets. It organizes secrets in a hierarchical structure within Bitwarden
-/// items using a configurable format string that defaults to: `secretspec/{project}/{profile}`.
+/// secrets. Starting in SecretSpec 0.20, it organizes convention secrets with
+/// item titles that default to `secretspec/{project}/{profile}/{key}`. The
+/// configurable `folder_prefix` is a title prefix, not a Bitwarden folder ID.
 ///
 /// # Authentication
 ///
@@ -470,11 +471,11 @@ impl TryFrom<&ProviderUrl> for BitwardenConfig {
 ///
 /// # Storage Structure
 ///
-/// Secrets are stored as Secure Note items in Bitwarden with:
-/// - Name: formatted according to folder_prefix configuration
-/// - Type: Secure Note (type 2)
-/// - Fields: project, profile, key, value
-/// - Notes: metadata about the secret
+/// Secrets are stored as Bitwarden items with:
+/// - Name: `{folder_prefix}/{key}` for convention addresses
+/// - Type: Login by default, or the type selected with `?type=`
+/// - Value: the item type's default field, or the field selected with `?field=`
+/// - Notes: SecretSpec management metadata on newly created items
 ///
 /// # Example Usage
 ///
@@ -1078,16 +1079,36 @@ fn find_addressed_item<'a>(
     }
 }
 
+/// Removes a prefix using the same Unicode-aware lowercasing as Bitwarden
+/// item lookup, while returning the suffix from the original title.
+///
+/// Calling `strip_prefix` after lowercasing would lose that original suffix,
+/// and lowercasing can change a character's byte length. Compare one source
+/// character at a time instead, then slice at its original byte boundary.
+fn strip_prefix_case_insensitive<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    let mut source = value.char_indices();
+    for expected in prefix.chars() {
+        let (_, actual) = source.next()?;
+        if actual.to_lowercase().ne(expected.to_lowercase()) {
+            return None;
+        }
+    }
+    let suffix_start = source.next().map_or(value.len(), |(index, _)| index);
+    Some(&value[suffix_start..])
+}
+
 /// Builds declarations for the Bitwarden items the provider can address.
 ///
-/// Reflection uses the same optional type filter as reads and writes. Item
-/// names are otherwise direct convention addresses, so every reflected name
-/// must already be a valid SecretSpec identifier. Bitwarden compares names
-/// case-insensitively and permits duplicates; reject either kind of collision
-/// instead of generating declarations that would be ambiguous at read time.
+/// Reflection uses the same optional type filter as reads and writes. Items in
+/// the requested project/profile title namespace become convention
+/// declarations; bare existing items become native refs, and items in another
+/// slash-delimited namespace are skipped. Bitwarden compares names
+/// case-insensitively and permits duplicates, so reject collisions instead of
+/// generating declarations that would be ambiguous at read time.
 fn declarations_from_items(
     items: &[BitwardenItem],
     required_type: Option<BitwardenItemType>,
+    convention_prefix: &str,
 ) -> Result<HashMap<String, Secret>> {
     let mut declarations = HashMap::new();
     let mut seen_names = HashMap::<String, &BitwardenItem>::new();
@@ -1096,7 +1117,21 @@ fn declarations_from_items(
         .iter()
         .filter(|item| required_type.is_none_or(|item_type| item.item_type == item_type))
     {
-        if !crate::config::is_valid_identifier(&item.name) {
+        let (name, is_native_reference) =
+            match strip_prefix_case_insensitive(&item.name, convention_prefix) {
+                Some(key) if !key.is_empty() && !key.contains('/') => (key, false),
+                // Another project/profile's convention item is outside this
+                // discovery namespace. A slash cannot occur in a SecretSpec key,
+                // so skipping it cannot hide a directly declarable legacy item.
+                Some(_) => continue,
+                None if item.name.contains('/') => continue,
+                // Preserve discovery of existing, externally managed Bitwarden
+                // items. They need a native ref because convention addressing is
+                // namespaced starting in 0.20.
+                None => (item.name.as_str(), true),
+            };
+
+        if !crate::config::is_valid_identifier(name) {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
                 "Bitwarden item '{}' cannot become a SecretSpec declaration: names must be \
                  alphanumeric and underscores and cannot start with a number. Rename the item \
@@ -1104,7 +1139,7 @@ fn declarations_from_items(
                 item.name
             )));
         }
-        if item.name == "defaults" {
+        if name == "defaults" {
             return Err(SecretSpecError::ProviderOperationFailed(
                 "Bitwarden item 'defaults' cannot become a SecretSpec declaration because \
                  that name is reserved for profile defaults. Rename the item or narrow \
@@ -1113,7 +1148,7 @@ fn declarations_from_items(
             ));
         }
 
-        let folded_name = item.name.to_lowercase();
+        let folded_name = name.to_lowercase();
         if let Some(previous) = seen_names.insert(folded_name, item) {
             return Err(SecretSpecError::ProviderOperationFailed(format!(
                 "Bitwarden items '{}' ({}) and '{}' ({}) have names that collide \
@@ -1123,10 +1158,14 @@ fn declarations_from_items(
             )));
         }
 
-        declarations.insert(
-            item.name.clone(),
-            Secret::required(format!("{} Bitwarden secret", item.name)),
-        );
+        let mut declaration = Secret::required(format!("{name} Bitwarden secret"));
+        if is_native_reference {
+            declaration = declaration.reference(crate::config::NativeAddress {
+                item: item.name.clone(),
+                ..Default::default()
+            });
+        }
+        declarations.insert(name.to_string(), declaration);
     }
 
     Ok(declarations)
@@ -1169,6 +1208,37 @@ impl BitwardenProvider {
 
         #[cfg(not(test))]
         Command::new("bw")
+    }
+
+    /// Renders the namespace shared by every convention item in one project
+    /// profile. Bitwarden folders are personal to each user, so this is an
+    /// item-title prefix rather than a `folderId`.
+    fn convention_folder(&self, project: &str, profile: &str) -> String {
+        // Escape both `%` and `/`: the latter is our namespace separator, and
+        // escaping `%` keeps a literal percent-encoded-looking name distinct
+        // from the component it might otherwise decode to.
+        fn encode_component(component: &str) -> String {
+            component.replace('%', "%25").replace('/', "%2F")
+        }
+
+        self.config
+            .folder_prefix
+            .as_deref()
+            .unwrap_or("secretspec/{project}/{profile}")
+            .replace("{project}", &encode_component(project))
+            .replace("{profile}", &encode_component(profile))
+    }
+
+    /// Compiles a convention key into the Bitwarden item title used by reads
+    /// and writes.
+    fn convention_item_name(&self, project: &str, profile: &str, key: &str) -> String {
+        format!("{}/{key}", self.convention_folder(project, profile))
+    }
+
+    /// Prefix used to recognize this project/profile's convention items while
+    /// discovering declarations.
+    fn convention_item_prefix(&self, project: &str, profile: &str) -> String {
+        format!("{}/", self.convention_folder(project, profile))
     }
 
     /// The organization the address asks for, before resolution.
@@ -2553,16 +2623,16 @@ impl BitwardenProvider {
 }
 
 impl Provider for BitwardenProvider {
-    /// Convention items are addressed by the secret key name directly,
-    /// leveraging Bitwarden's vault-wide search.
+    /// Convention items use a project/profile title prefix so one Bitwarden
+    /// scope can safely hold the same key for multiple projects and profiles.
     fn convention_address(
         &self,
-        _project: &str,
-        _profile: &str,
+        project: &str,
+        profile: &str,
         key: &str,
     ) -> Result<crate::config::NativeAddress> {
         Ok(crate::config::NativeAddress {
-            item: key.to_string(),
+            item: self.convention_item_name(project, profile, key),
             ..Default::default()
         })
     }
@@ -2715,7 +2785,7 @@ impl Provider for BitwardenProvider {
         self.set_to_password_manager(item_name, target_field, value)
     }
 
-    fn reflect(&self, _context: DiscoveryContext<'_>) -> Result<HashMap<String, Secret>> {
+    fn reflect(&self, context: DiscoveryContext<'_>) -> Result<HashMap<String, Secret>> {
         if !self.is_authenticated()? {
             return Err(SecretSpecError::ProviderOperationFailed(
                 "Bitwarden authentication required. Please run 'bw login' and 'bw unlock', then set the BW_SESSION environment variable.".to_string(),
@@ -2723,7 +2793,11 @@ impl Provider for BitwardenProvider {
         }
 
         let items = self.list_items(None)?;
-        declarations_from_items(&items, self.resolved_item_type()?)
+        declarations_from_items(
+            &items,
+            self.resolved_item_type()?,
+            &self.convention_item_prefix(context.project, context.profile),
+        )
     }
 }
 
@@ -4100,8 +4174,12 @@ mod tests {
             named_item("token", "CARD_TOKEN", BitwardenItemType::Card),
         ];
 
-        let declarations = declarations_from_items(&items, Some(BitwardenItemType::Card))
-            .expect("the type filter makes every item addressable");
+        let declarations = declarations_from_items(
+            &items,
+            Some(BitwardenItemType::Card),
+            "secretspec/project/default/",
+        )
+        .expect("the type filter makes every item addressable");
 
         assert_eq!(declarations.len(), 2);
         assert_eq!(
@@ -4113,6 +4191,60 @@ mod tests {
     }
 
     #[test]
+    fn reflection_uses_the_current_namespace_and_preserves_legacy_items_as_refs() {
+        let items = [
+            named_item(
+                "current",
+                "secretspec/payments/production/API_KEY",
+                BitwardenItemType::Login,
+            ),
+            named_item(
+                "other",
+                "secretspec/orders/production/API_KEY",
+                BitwardenItemType::Login,
+            ),
+            named_item("legacy", "LEGACY_TOKEN", BitwardenItemType::Login),
+        ];
+
+        let declarations =
+            declarations_from_items(&items, None, "secretspec/payments/production/").unwrap();
+
+        assert_eq!(declarations.len(), 2);
+        assert!(declarations.contains_key("API_KEY"));
+        assert_eq!(
+            declarations["LEGACY_TOKEN"]
+                .clone()
+                .into_config()
+                .reference
+                .as_ref()
+                .map(|reference| reference.item.as_str()),
+            Some("LEGACY_TOKEN"),
+            "a bare legacy item must be emitted with a native ref",
+        );
+    }
+
+    #[test]
+    fn reflection_recognizes_convention_prefixes_case_insensitively() {
+        let items = [named_item(
+            "current",
+            "SecretSpec/payments/production/API_KEY",
+            BitwardenItemType::Login,
+        )];
+
+        let declarations =
+            declarations_from_items(&items, None, "secretspec/payments/production/").unwrap();
+
+        assert!(declarations.contains_key("API_KEY"));
+        assert!(
+            declarations["API_KEY"]
+                .clone()
+                .into_config()
+                .reference
+                .is_none()
+        );
+    }
+
+    #[test]
     fn reflection_rejects_names_that_cannot_be_declared() {
         let items = [named_item(
             "invalid",
@@ -4120,7 +4252,7 @@ mod tests {
             BitwardenItemType::Login,
         )];
 
-        let err = declarations_from_items(&items, None)
+        let err = declarations_from_items(&items, None, "secretspec/project/default/")
             .unwrap_err()
             .to_string();
 
@@ -4140,7 +4272,7 @@ mod tests {
             BitwardenItemType::SecureNote,
         )];
 
-        let err = declarations_from_items(&items, None)
+        let err = declarations_from_items(&items, None, "secretspec/project/default/")
             .unwrap_err()
             .to_string();
 
@@ -4154,7 +4286,7 @@ mod tests {
             named_item("second", "api_key", BitwardenItemType::Login),
         ];
 
-        let err = declarations_from_items(&items, None)
+        let err = declarations_from_items(&items, None, "secretspec/project/default/")
             .unwrap_err()
             .to_string();
 
@@ -4332,6 +4464,13 @@ mod tests {
         fn with_items(self, items: serde_json::Value) -> Self {
             std::fs::write(self.dir.join("items.json"), items.to_string())
                 .expect("write items fixture");
+            self
+        }
+
+        /// Persists created and edited items so one test can exercise a sequence
+        /// of provider operations against the same fake vault.
+        fn with_stateful_vault(self) -> Self {
+            std::fs::write(self.dir.join("stateful"), "").expect("enable stateful fake vault");
             self
         }
 
@@ -4963,12 +5102,20 @@ mod tests {
                 "name": "dev-secrets",
                 "organizationId": "org-id"
             }]))
-            .with_items(json!([{
-                "id": "item-id",
-                "name": "API_KEY",
-                "type": 1,
-                "login": {"password": "must-not-appear"}
-            }]));
+            .with_items(json!([
+                {
+                    "id": "item-id",
+                    "name": "secretspec/payments/production/API_KEY",
+                    "type": 1,
+                    "login": {"password": "must-not-appear"}
+                },
+                {
+                    "id": "other-item-id",
+                    "name": "secretspec/orders/production/API_KEY",
+                    "type": 1,
+                    "login": {"password": "other-project"}
+                }
+            ]));
 
         fake.run(|| {
             let provider = BitwardenProvider::new(BitwardenConfig {
@@ -4976,7 +5123,7 @@ mod tests {
                 ..Default::default()
             });
             let declarations = provider
-                .reflect(DiscoveryContext::new("ignored", "ignored"))
+                .reflect(DiscoveryContext::new("payments", "production"))
                 .unwrap();
 
             assert_eq!(declarations.len(), 1);
@@ -5083,6 +5230,52 @@ mod tests {
         assert_eq!(sent["name"], "Vault");
         assert_eq!(sent["type"], 1);
         assert_eq!(sent["login"]["password"], "s3cret");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convention_sets_keep_same_named_secrets_separate_between_projects() {
+        let fake = FakeBw::new().with_stateful_vault();
+        fake.run(|| {
+            let provider = BitwardenProvider::new(BitwardenConfig::default());
+            let project_a = Address::convention("project-a", "default", "DATABASE_URL");
+            let project_b = Address::convention("project-b", "default", "DATABASE_URL");
+
+            provider
+                .set(project_a, &SecretString::new("postgres://a".into()))
+                .unwrap();
+            provider
+                .set(project_b, &SecretString::new("postgres://b".into()))
+                .unwrap();
+
+            assert_eq!(
+                provider
+                    .get(project_a)
+                    .unwrap()
+                    .map(|value| value.expose_secret().to_string()),
+                Some("postgres://a".to_string())
+            );
+            assert_eq!(
+                provider
+                    .get(project_b)
+                    .unwrap()
+                    .map(|value| value.expose_secret().to_string()),
+                Some("postgres://b".to_string())
+            );
+        });
+
+        let log = fake.invocations();
+        assert_eq!(
+            log.lines()
+                .filter(|line| line.contains("<create> <item>"))
+                .count(),
+            2,
+            "each project must create its own item: {log}"
+        );
+        assert!(
+            !log.contains("<edit> <item>"),
+            "project B must not overwrite project A: {log}"
+        );
     }
 
     #[cfg(unix)]
@@ -5247,7 +5440,7 @@ mod tests {
         // The Provider trait entry point maps the convention address onto
         // the item name and delegates to the password-manager read.
         let fake = FakeBw::new().with_items(json!([{
-            "id": "it1", "name": "Vault", "type": 1,
+            "id": "it1", "name": "secretspec/myapp/production/Vault", "type": 1,
             "login": {"password": "pw"}
         }]));
         fake.run(|| {
@@ -5301,6 +5494,10 @@ mod tests {
                 .contains("argv: <--nointeraction> <create> <item>"),
             "{}",
             fake.invocations()
+        );
+        assert_eq!(
+            decode_stdin_line(&fake, "create")["name"],
+            "secretspec/myapp/production/Vault"
         );
     }
 
@@ -5763,12 +5960,95 @@ mod tests {
     // -- addressing and placement -------------------------------------------
 
     #[test]
-    fn convention_address_names_the_secret_key_as_the_item() {
+    fn convention_addresses_isolate_projects_and_profiles() {
         let provider = BitwardenProvider::new(BitwardenConfig::default());
-        let address = provider
+        let first = provider
             .convention_address("project", "default", "DATABASE_URL")
             .unwrap();
-        assert_eq!(address.item, "DATABASE_URL");
+        let other_project = provider
+            .convention_address("other", "default", "DATABASE_URL")
+            .unwrap();
+        let other_profile = provider
+            .convention_address("project", "production", "DATABASE_URL")
+            .unwrap();
+
+        assert_eq!(first.item, "secretspec/project/default/DATABASE_URL");
+        assert_eq!(other_project.item, "secretspec/other/default/DATABASE_URL");
+        assert_eq!(
+            other_profile.item,
+            "secretspec/project/production/DATABASE_URL"
+        );
+        assert_ne!(first.item, other_project.item);
+        assert_ne!(first.item, other_profile.item);
+    }
+
+    #[test]
+    fn convention_address_uses_the_configured_folder_prefix() {
+        let provider = BitwardenProvider::new(BitwardenConfig {
+            folder_prefix: Some("team/{profile}/{project}".to_string()),
+            ..Default::default()
+        });
+
+        let address = provider
+            .convention_address("payments", "production", "DATABASE_URL")
+            .unwrap();
+
+        assert_eq!(address.item, "team/production/payments/DATABASE_URL");
+    }
+
+    #[test]
+    fn convention_address_escapes_namespace_component_separators() {
+        let provider = BitwardenProvider::default();
+
+        let project_slash = provider.convention_address("a/b", "c", "KEY").unwrap();
+        let profile_slash = provider.convention_address("a", "b/c", "KEY").unwrap();
+        let literal_escape = provider.convention_address("a%2Fb", "c", "KEY").unwrap();
+
+        assert_eq!(project_slash.item, "secretspec/a%2Fb/c/KEY");
+        assert_eq!(profile_slash.item, "secretspec/a/b%2Fc/KEY");
+        assert_eq!(literal_escape.item, "secretspec/a%252Fb/c/KEY");
+        assert_ne!(project_slash.item, profile_slash.item);
+        assert_ne!(project_slash.item, literal_escape.item);
+    }
+
+    #[test]
+    fn folder_prefix_does_not_rewrite_an_explicit_item_reference() {
+        let provider = BitwardenProvider::new(BitwardenConfig {
+            folder_prefix: Some("team/{project}/{profile}".to_string()),
+            ..Default::default()
+        });
+        let native = crate::config::NativeAddress {
+            item: "Existing Login".to_string(),
+            ..Default::default()
+        };
+
+        let resolved = provider.resolve_coords(Address::Native(&native)).unwrap();
+
+        assert_eq!(resolved.item, "Existing Login");
+    }
+
+    #[test]
+    fn different_folder_prefixes_are_different_convention_entries() {
+        with_clean_env(|| {
+            let left = BitwardenProvider::new(BitwardenConfig {
+                folder_prefix: Some("left/{project}/{profile}".to_string()),
+                ..Default::default()
+            });
+            let right = BitwardenProvider::new(BitwardenConfig {
+                folder_prefix: Some("right/{project}/{profile}".to_string()),
+                ..Default::default()
+            });
+
+            assert!(
+                !left
+                    .same_entries(
+                        Address::convention("project", "default", "TOKEN"),
+                        &right,
+                        Address::convention("project", "default", "TOKEN"),
+                    )
+                    .unwrap()
+            );
+        });
     }
 
     #[test]

--- a/tests/fixtures/bw-shim.sh
+++ b/tests/fixtures/bw-shim.sh
@@ -15,6 +15,7 @@
 #   organizations.json - `bw list organizations` output (default: [])
 #   collections.json   - `bw list collections` output (default: [])
 #   items.json         - `bw list items` / `bw get item` source (default: [])
+#   stateful            - when present, persist create/edit calls to items.json
 #
 # Every invocation is appended to $BW_SHIM_DIR/invocations.log as:
 #   argv: <--nointeraction> <status> ...     (one per call)
@@ -152,13 +153,33 @@ case "$sub" in
   create)
     # create item [--organizationid X]; the item arrives base64 on stdin.
     [ "${1:-}" = "item" ] || { printf 'shim: unsupported create: %s\n' "$1" >&2; exit 1; }
-    log_and_decode_stdin | jq -c '. + {id: "shim-created"}'
+    if [ -f "$DIR/stateful" ]; then
+      current="$(read_fixture items.json)"
+      next_id="shim-created-$(printf '%s' "$current" | jq 'length')"
+      created="$(log_and_decode_stdin | jq -c --arg id "$next_id" '. + {id: $id}')"
+      tmp="$DIR/items.json.tmp"
+      printf '%s' "$current" | jq -c --argjson item "$created" '. + [$item]' > "$tmp"
+      mv "$tmp" "$DIR/items.json"
+      printf '%s\n' "$created"
+    else
+      log_and_decode_stdin | jq -c '. + {id: "shim-created"}'
+    fi
     ;;
 
   edit)
     # edit item <id> [--organizationid X]; the item arrives base64 on stdin.
     [ "${1:-}" = "item" ] || { printf 'shim: unsupported edit: %s\n' "$1" >&2; exit 1; }
-    log_and_decode_stdin | jq -c --arg id "${2:-shim-edited}" '. + {id: $id}'
+    if [ -f "$DIR/stateful" ]; then
+      id="${2:-shim-edited}"
+      edited="$(log_and_decode_stdin | jq -c --arg id "$id" '. + {id: $id}')"
+      tmp="$DIR/items.json.tmp"
+      read_fixture items.json | jq -c --arg id "$id" --argjson item "$edited" \
+        'map(if .id == $id then $item else . end)' > "$tmp"
+      mv "$tmp" "$DIR/items.json"
+      printf '%s\n' "$edited"
+    else
+      log_and_decode_stdin | jq -c --arg id "${2:-shim-edited}" '. + {id: $id}'
+    fi
     ;;
 
   *)


### PR DESCRIPTION
## Summary

- namespace Bitwarden convention item titles by project and profile
- make the existing folder option customize that title prefix while leaving explicit refs unchanged
- preserve legacy bare items as explicit refs during discovery and document the 0.20 migration
- add a stateful regression test proving same-named secrets in different projects do not overwrite each other

Closes #369

## Verification

- cargo test --all
- cargo test -p secretspec --features bw provider::bw::tests (165 passed)
- npm --prefix docs run build
- cargo fmt --all -- --check
- git diff --check
- bash -n tests/fixtures/bw-shim.sh

The local pre-commit Clippy hook was skipped because its shell environment could not find PHP; Rustfmt passed and CI remains enabled for the PR.