### PR TITLE
fix(run): forward signals to child process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   [#369]: https://github.com/cachix/secretspec/issues/369
 
+- On Unix, `secretspec run` now forwards `SIGTERM`, `SIGINT`, and `SIGHUP` to
+  the command it started, allowing graceful container shutdown even when
+  SecretSpec is PID 1. Commands terminated by a signal now produce the
+  conventional `128 + signal` exit status instead of always exiting 1
+  ([#382]).
+
+  [#382]: https://github.com/cachix/secretspec/issues/382
+
 - Format-preserving `Spec` edits now keep inherited declarations separate after
   semantic builder changes, resolve parent specs independently of later working
   directory changes, remove synthesized profile tables when additions are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5346,6 +5346,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "signal-hook",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ keyring = "4.1.6"
 keepass = { version = "0.13.17", features = ["save_kdbx4"] }
 keeper-secrets-manager-core = { version = "17.3.0", default-features = false, features = ["blocking"] }
 libc = "0.2"
+signal-hook = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9"
 toml_edit = { version = "0.23", features = ["serde"] }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -511,6 +511,12 @@ terminal exists, `run` fails before starting the child. Only declarations with
 `prompt = true` opt into this behavior; ordinary missing secrets still fail
 without a prompt.
 
+On Unix, SecretSpec 0.20+ forwards `SIGTERM`, `SIGINT`, and `SIGHUP` to the
+started command. This lets applications run their graceful-shutdown handlers
+when `secretspec run` is a container entrypoint, including when SecretSpec is
+PID 1. If the command is terminated by a signal, `run` exits with the
+conventional `128 + signal` status (for example, 143 for `SIGTERM`).
+
 The `--provider` override applies to every secret, including those with a
 [`ref`](/reference/configuration/#secret-references) field: refs are redirected
 to the overriding provider just like convention secrets. This makes it easy to

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -61,6 +61,7 @@ age = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
+signal-hook.workspace = true
 
 [features]
 default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "scaleway", "sops"]

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -25,13 +25,84 @@ use data_encoding::{
     BASE64, BASE64_NOPAD, BASE64URL, BASE64URL_NOPAD, Encoding, HEXLOWER, HEXLOWER_PERMISSIVE,
 };
 use secrecy::{ExposeSecret, SecretSlice, SecretString};
+#[cfg(unix)]
+use signal_hook::consts::signal::{SIGHUP, SIGINT, SIGTERM};
+#[cfg(unix)]
+use signal_hook::iterator::{Handle as SignalHandle, Signals};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 use std::sync::{Arc, Mutex};
+#[cfg(unix)]
+use std::thread::JoinHandle;
 use std::time::Duration;
+
+#[cfg(unix)]
+struct ChildSignalForwarder {
+    signals: Option<Signals>,
+    handle: SignalHandle,
+    thread: Option<JoinHandle<()>>,
+}
+
+#[cfg(unix)]
+impl ChildSignalForwarder {
+    /// Install handlers before spawning the child so a signal cannot slip
+    /// through while SecretSpec is becoming the child's supervisor.
+    fn prepare() -> io::Result<Self> {
+        let signals = Signals::new([SIGTERM, SIGINT, SIGHUP])?;
+        let handle = signals.handle();
+        Ok(Self {
+            signals: Some(signals),
+            handle,
+            thread: None,
+        })
+    }
+
+    fn start(&mut self, child_pid: u32) {
+        let mut signals = self
+            .signals
+            .take()
+            .expect("signal forwarder can only be started once");
+        self.thread = Some(std::thread::spawn(move || {
+            for signal in signals.forever() {
+                // `kill` is async-signal-safe, and this call runs on an ordinary
+                // thread rather than inside the installed signal handler. The
+                // child may already have exited, in which case ESRCH is benign.
+                unsafe {
+                    libc::kill(child_pid as libc::pid_t, signal);
+                }
+            }
+        }));
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ChildSignalForwarder {
+    fn drop(&mut self) {
+        self.handle.close();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn command_exit_code(status: ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return 128 + signal;
+        }
+    }
+
+    1
+}
 
 /// Format the human-facing name and optional description used by status output.
 ///
@@ -6095,6 +6166,12 @@ impl Secrets {
             cmd.env_remove(key);
         }
 
+        // Set up Unix signal handling before `spawn`: when SecretSpec is PID 1,
+        // the kernel ignores terminating signals with their default disposition,
+        // and any signal received in a post-spawn setup window would be lost.
+        #[cfg(unix)]
+        let mut signal_forwarder = ChildSignalForwarder::prepare()?;
+
         // Spawn (rather than `status`) so the Run event is recorded the moment the
         // child starts, before the potentially long-running wait. A long-lived
         // command (e.g. a dev server) would otherwise not be logged until it exits,
@@ -6121,8 +6198,12 @@ impl Secrets {
             },
         );
 
-        let status = child?.wait()?;
-        Ok(status.code().unwrap_or(1))
+        let mut child = child?;
+        #[cfg(unix)]
+        signal_forwarder.start(child.id());
+
+        let status = child.wait()?;
+        Ok(command_exit_code(status))
     }
 
     /// Resolves every secret for the active profile and emits them in `format`,

--- a/secretspec/tests/run_signals.rs
+++ b/secretspec/tests/run_signals.rs
@@ -1,0 +1,132 @@
+//! Unix process-supervision behavior for `secretspec run`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const START_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn project() -> tempfile::TempDir {
+    let project = tempfile::tempdir().unwrap();
+    fs::write(
+        project.path().join("secretspec.toml"),
+        r#"[project]
+name = "run-signals-test"
+revision = "1.0"
+require_reason = false
+
+[providers]
+env = "env://"
+
+[profiles.default]
+UNUSED = { description = "unused optional value", required = false, providers = ["env"] }
+"#,
+    )
+    .unwrap();
+    project
+}
+
+fn command(project: &tempfile::TempDir) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_secretspec"));
+    command
+        .args([
+            "--file",
+            project.path().join("secretspec.toml").to_str().unwrap(),
+            "run",
+            "--",
+        ])
+        .current_dir(project.path())
+        .env("HOME", project.path())
+        .env("XDG_CONFIG_HOME", project.path().join("config"))
+        .env("XDG_STATE_HOME", project.path().join("state"))
+        .env("APPDATA", project.path().join("config"))
+        .env("LOCALAPPDATA", project.path().join("state"))
+        .env_remove("SECRETSPEC_PROVIDER")
+        .env_remove("SECRETSPEC_PROFILE")
+        .env_remove("SECRETSPEC_SCOPE")
+        .env_remove("SECRETSPEC_REASON")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    command
+}
+
+fn wait_until_started(child: &mut Child, ready: &std::path::Path) {
+    let deadline = Instant::now() + START_TIMEOUT;
+    while Instant::now() < deadline {
+        if ready.exists() {
+            return;
+        }
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!("secretspec exited before its child was ready: {status}");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    unsafe {
+        libc::kill(child.id() as libc::pid_t, libc::SIGKILL);
+    }
+    let _ = child.wait();
+    panic!("timed out waiting for the child command to start");
+}
+
+#[test]
+fn forwards_termination_signals_to_the_child() {
+    for (name, signal) in [
+        ("TERM", libc::SIGTERM),
+        ("INT", libc::SIGINT),
+        ("HUP", libc::SIGHUP),
+    ] {
+        let project = project();
+        let ready = project.path().join(format!("ready-{name}"));
+        let received = project.path().join(format!("received-{name}"));
+        let script = format!("trap ': > \"$2\"; exit 0' {name}; : > \"$1\"; while :; do :; done");
+        let mut child = command(&project)
+            .args([
+                "sh",
+                "-c",
+                &script,
+                "sh",
+                ready.to_str().unwrap(),
+                received.to_str().unwrap(),
+            ])
+            .spawn()
+            .unwrap();
+
+        wait_until_started(&mut child, &ready);
+        assert_eq!(unsafe { libc::kill(child.id() as libc::pid_t, signal) }, 0);
+
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "forwarding {name} failed with {}:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            received.exists(),
+            "the child did not receive forwarded SIG{name}"
+        );
+    }
+}
+
+#[test]
+fn maps_child_signal_deaths_to_conventional_exit_codes() {
+    for (name, expected) in [("TERM", 143), ("KILL", 137)] {
+        let project = project();
+        let output = command(&project)
+            .args(["sh", "-c", &format!("kill -{name} $$")])
+            .output()
+            .unwrap();
+
+        assert_eq!(
+            output.status.code(),
+            Some(expected),
+            "child killed by SIG{name} produced {}:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- forward SIGTERM, SIGINT, and SIGHUP from secretspec run to its child on Unix
- return conventional 128 + signal exit codes for signal-terminated children
- document the SecretSpec 0.20+ behavior and add end-to-end regression coverage

## Testing

- devenv shell cargo test -p secretspec
- pre-commit hooks: clippy, rustfmt

Closes #382