### PR TITLE
Add Cloudflare Secrets Store provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
     - name: Check each provider feature standalone
       run: |
         set -euo pipefail
-        for feature in cli keyring keeper gcsm awssm vault openbao infisical bws akv aac sops bw kubernetes; do
+        for feature in cli keyring keeper gcsm awssm vault openbao infisical bws akv aac sops bw kubernetes cloudflare; do
           echo "::group::$feature"
           cargo check --package secretspec --no-default-features --features "$feature"
           echo "::endgroup::"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `flyctl secrets set` over stdin, refuse boundary whitespace that `flyctl`
   would silently trim, and scrub ambient Fly token variables before injecting
   the token selected through the provider credential mechanism.
+- The Cloudflare `cloudflare` provider (0.20+) publishes, replaces, deletes,
+  and discovers account-level Secrets Store entries through Cloudflare's API.
+  Cloudflare never returns plaintext values through its management API, so the
+  provider clearly reports its write-only behavior. Authentication can use a
+  SecretSpec `api_token` credential, `CLOUDFLARE_API_TOKEN`, or the current
+  Wrangler OAuth, API-token, or legacy API-key session; secret values are sent
+  only in HTTPS request bodies ([#84]).
+
+  [#84]: https://github.com/cachix/secretspec/issues/84
 - `secretspec completions <shell>` generates completion scripts for Bash,
   Elvish, Fish, Nushell, PowerShell, and Zsh directly from the CLI definition,
   including descriptions and contextual suggestions for profiles, scopes,

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -127,7 +127,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Azure App Configuration (0.20+), Infisical (0.16+), age (0.17+), SOPS (0.17+), or Kubernetes (0.20+). Fly.io application secrets can be published through the write-only fly provider (0.20+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
+Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Azure App Configuration (0.20+), Infisical (0.16+), age (0.17+), SOPS (0.17+), or Kubernetes (0.20+). Fly.io application secrets and Cloudflare Secrets Store entries can be published through the write-only fly and cloudflare providers (0.20+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
         }),
       ],
       title: "SecretSpec",
@@ -290,6 +290,11 @@ Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv fil
             {
               label: "Fly.io Secrets",
               slug: "providers/fly",
+              badge: { text: "0.20+", variant: "note" },
+            },
+            {
+              label: "Cloudflare Secrets Store",
+              slug: "providers/cloudflare",
               badge: { text: "0.20+", variant: "note" },
             },
             { label: "Pass", slug: "providers/pass" },

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -47,6 +47,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [null](/providers/null/) (0.19+) | No storage; uses a manifest default, ephemeral generation, or an ephemeral run prompt | ✗ | ✗ | N/A | — |
 | [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |
 | [fly](/providers/fly/) (0.20+) | Fly.io application secrets through `flyctl` | ✗ | ✓ | ✓ | — |
+| [cloudflare](/providers/cloudflare/) (0.20+) | Cloudflare account-level Secrets Store through its REST API | ✗ | ✓ | ✓ | — |
 | [pass](/providers/pass/) | Unix `pass` password store | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [gopass](/providers/gopass/) (0.15+) | `gopass` password store (git-synced, GPG-encrypted) | ✓ | ✓ | ✓ | [Via GnuPG](https://gnupg.org/blog/20210315-using-tpm-with-gnupg-2.3.html) |
 | [protonpass](/providers/protonpass/) | Proton Pass | ✓ | ✓ | ✓ | — |

--- a/docs/src/content/docs/providers/cloudflare.mdx
+++ b/docs/src/content/docs/providers/cloudflare.mdx
@@ -1,0 +1,240 @@
+---
+title: Cloudflare Secrets Store provider
+description: Publish SecretSpec values to Cloudflare account-level Secrets Store
+---
+
+import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+The Cloudflare provider publishes declared values to an account-level
+[Cloudflare Secrets Store](https://developers.cloudflare.com/secrets-store/)
+through the Cloudflare REST API.
+
+:::note[Version compatibility]
+The Cloudflare `cloudflare` provider is added in SecretSpec 0.20.
+:::
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `cloudflare` (0.20+) |
+| URI | `cloudflare://STORE_ID[?account_id=ACCOUNT_ID][&OPTIONS]` |
+| Access | Write, delete, and discover names; plaintext values cannot be read back |
+| Best for | Publishing secrets to Workers and other Cloudflare services from a separate source of truth |
+| Authentication | API token or credentials from `wrangler auth token --json` |
+| Availability | SecretSpec 0.20+; included in official and default builds (`cloudflare` feature for custom minimal builds) |
+| Default storage | Account secret named `{key}` in the selected store |
+
+## Quick start
+
+Find the account ID and Secrets Store ID in the Cloudflare dashboard or with
+Wrangler, then authenticate and configure an alias:
+
+```bash
+$ wrangler login
+$ wrangler secrets-store store list --remote
+```
+
+```toml title="secretspec.toml"
+[providers]
+cloudflare_prod = "cloudflare://0123456789abcdef0123456789abcdef?account_id=abcdef0123456789abcdef0123456789&auth=wrangler"
+
+[profiles.production]
+DATABASE_URL = { description = "Production database URL" }
+```
+
+```bash
+# Publish or replace the account secret
+$ secretspec set DATABASE_URL --profile production --provider cloudflare_prod
+
+# Remove it
+$ secretspec delete DATABASE_URL --profile production --provider cloudflare_prod
+```
+
+Cloudflare never returns plaintext through its management API, so
+`secretspec get`, `check`, and `run` cannot resolve a value from this provider.
+Keep the authoritative value in a readable provider and select
+`cloudflare_prod` explicitly when publishing it.
+
+## Setup
+
+### Prerequisites (0.20+)
+
+- SecretSpec 0.20 or newer
+- A Cloudflare account with a Secrets Store
+- Account **Secrets Store Write** permission for publishing and deletion
+- The account ID and Secrets Store ID
+
+The official SecretSpec CLI includes this provider. Custom minimal Rust builds
+enable it with `--features cloudflare`.
+
+### Wrangler authentication (0.20+)
+
+With `auth=wrangler`, SecretSpec runs:
+
+```bash
+$ wrangler auth token --json
+```
+
+Wrangler can return an API token, a refreshed OAuth token from `wrangler
+login`, or legacy API-key/email credentials. SecretSpec uses the returned
+credential only in HTTPS request headers. It never passes the account secret
+value to Wrangler.
+
+Wrangler supports named authentication profiles:
+
+```text
+cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=wrangler&wrangler_profile=production
+```
+
+If the executable has another name or location, set
+`SECRETSPEC_WRANGLER_PATH`. SecretSpec never invokes `npx` automatically.
+
+### Authentication with provider credentials (0.20+)
+
+For CI or a machine identity, declare the `api_token`
+[provider credential](/reference/provider-credentials/):
+
+```toml title="secretspec.toml"
+[providers]
+bootstrap = "keyring://"
+
+[providers.cloudflare_prod]
+uri = "cloudflare://0123456789abcdef0123456789abcdef?account_id=abcdef0123456789abcdef0123456789&auth=token"
+credentials = { api_token = "bootstrap" }
+```
+
+Store it once:
+
+```bash
+$ secretspec config provider login cloudflare_prod
+Enter api_token for provider 'cloudflare_prod' (source: bootstrap): ****
+```
+
+Use a scoped user or account API token with **Secrets Store Write** on only the
+required account. Do not use the full-access Global API Key for new setups.
+
+### Environment fallback (0.20+)
+
+`CLOUDFLARE_API_TOKEN` supplies the `api_token` credential when no explicit
+provider credential exists. `CLOUDFLARE_ACCOUNT_ID` supplies the account ID
+when the URI omits `account_id`.
+
+The default `auth=auto` uses the provider credential or
+`CLOUDFLARE_API_TOKEN` first, then falls back to Wrangler. Use `auth=token` to
+require a token or `auth=wrangler` to require Wrangler credentials.
+
+## Provider credentials
+
+<ProviderCredentials provider="cloudflare" />
+
+## Configuration
+
+### URI format (0.20+)
+
+```text
+cloudflare://STORE_ID[?account_id=ACCOUNT_ID][&scopes=LIST][&auth=MODE][&wrangler_profile=NAME]
+```
+
+- `STORE_ID` is required and selects the account-level Secrets Store.
+- `account_id` selects the Cloudflare account and falls back to
+  `CLOUDFLARE_ACCOUNT_ID`.
+- `scopes` is a comma-separated list applied when a secret is created or
+  replaced. It defaults to `workers`. Supported values are `workers`,
+  `ai_gateway`, `dex`, `access`, `containers`, and `websearch`.
+- `auth` is `auto` (default), `token`, or `wrangler`.
+- `wrangler_profile` selects a named Wrangler auth profile and requires
+  `auth=wrangler`.
+
+### URI examples (0.20+)
+
+```text
+cloudflare://STORE_ID?account_id=ACCOUNT_ID
+cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=token
+cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=wrangler
+cloudflare://STORE_ID?account_id=ACCOUNT_ID&scopes=workers,containers
+cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=wrangler&wrangler_profile=production
+```
+
+## Storage model (0.20+)
+
+The provider maps a declaration key directly to an account-secret name. For
+example, `DATABASE_URL` maps to:
+
+```text
+account: ACCOUNT_ID
+store:   STORE_ID
+secret:  DATABASE_URL
+```
+
+Project and profile names are not added to the secret name. The store selected
+by the provider alias supplies isolation. Use a different alias and store when
+two profiles must hold different values for the same key.
+
+Cloudflare Workers can bind that account secret to any binding name; the
+SecretSpec key does not need to match the Worker's binding variable.
+
+## Use existing secrets (0.20+)
+
+A [`ref`](/reference/configuration/#secret-references) changes the Cloudflare
+secret name updated or deleted by SecretSpec:
+
+```toml title="secretspec.toml"
+[profiles.production]
+DATABASE_URL = {
+  description = "Production database URL",
+  ref = { item = "PRIMARY_DATABASE_URL" }
+}
+```
+
+The reference remains write-only: it can select an existing name but cannot
+retrieve its plaintext value.
+
+## Discover secret names (0.20+)
+
+Cloudflare's list API exposes names, IDs, scopes, comments, and status without
+returning values. SecretSpec uses that metadata for declaration discovery:
+
+```bash
+$ secretspec init \
+    --from 'cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=wrangler' \
+    --project my-app --profile production
+```
+
+The generated manifest contains required declarations for active or pending
+secret names, not defaults or values.
+
+## CI/CD (0.20+)
+
+Use a short-lived or account-owned token scoped to Secrets Store Write:
+
+```yaml
+- run: secretspec set DATABASE_URL --profile production --provider cloudflare_prod
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+```
+
+The account ID and store ID are attribution, not credentials, and can stay in
+the checked-in provider URI.
+
+## Security considerations and limitations (0.20+)
+
+- Cloudflare's management API accepts values for creation and replacement but
+  never returns them. Plaintext access exists only inside a Cloudflare service
+  with a Secrets Store binding. This provider therefore cannot support `get`,
+  `check`, `run`, fallback reads, generation-on-miss, prompting-on-miss, or
+  value comparisons.
+- Secret values are serialized directly into an HTTPS request body. They do
+  not appear in the provider URI, command arguments, Wrangler input, or
+  SecretSpec diagnostics.
+- HTTP redirects are rejected so credentials and secret-bearing request bodies
+  remain confined to Cloudflare's API origin.
+- `secretspec set` lists metadata to resolve an existing name to the secret ID,
+  then creates or patches it. `secretspec delete` uses the same metadata lookup
+  and remains idempotent when the name is absent.
+- A replacement applies the `scopes` configured in the provider URI. Review
+  those scopes because changing them affects which Cloudflare services may bind
+  the secret.
+- Secret values cannot exceed Cloudflare's 65,536-byte limit.
+- Cloudflare Secrets Store is currently a beta service; API behavior and scope
+  availability may change upstream.

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -151,6 +151,7 @@ $ secretspec config global init  # 0.17+
   null: Use defaults, generation, or run prompts without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
   fly: Fly.io application secrets via flyctl, write-only (0.20+)
+  cloudflare: Cloudflare Secrets Store, write-only (0.20+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
   protonpass: Proton Pass via official pass-cli

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -882,6 +882,7 @@ entry declares neither, it inherits whichever form `[profiles.default]` uses.
 | [env](/providers/env/#use-existing-secrets) | Variable name | Rejected | Reads the variable | — (read-only) |
 | [systemd credentials (0.17+)](/providers/systemd-credential/#use-an-existing-credential-name) | Credential filename | Rejected | Reads the credential | — (read-only) |
 | [Fly.io secrets (0.20+)](/providers/fly/#use-existing-secrets) | Fly app secret name | Rejected | Error: Fly.io does not expose plaintext values | ✅ write-only via `flyctl secrets set` |
+| [Cloudflare Secrets Store (0.20+)](/providers/cloudflare/#use-existing-secrets-020) | Account-secret name in the selected store | Rejected | Error: Cloudflare's management API does not expose plaintext values | ✅ write-only via the Cloudflare API |
 | [pass](/providers/pass/#use-existing-secrets) | Entry path | Rejected | Reads the entry | ✅ |
 | [Gopass (0.15+)](/providers/gopass/#use-existing-secrets) | Entry path, including any mount-point prefix | Rejected | Reads the entry | ✅ |
 | [LastPass](/providers/lastpass/#use-existing-secrets) | Item name | Rejected | Reads the item | ✅ |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -336,6 +336,42 @@ and prompting-on-miss cannot use this write-only provider. See the
 rejects leading or trailing whitespace rather than silently publishing a
 different value.
 
+## Cloudflare Secrets Store provider (0.20+)
+
+**Availability**: Added in SecretSpec 0.20 and included in default builds; use
+the `cloudflare` feature for a custom minimal build.
+
+**URI**: `cloudflare://STORE_ID[?account_id=ACCOUNT_ID][&scopes=LIST][&auth=MODE][&wrangler_profile=NAME]`
+- Publishes account-level secrets through Cloudflare's REST API
+
+```text
+cloudflare://STORE_ID?account_id=ACCOUNT_ID
+cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=token
+cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=wrangler&wrangler_profile=production
+cloudflare://STORE_ID?account_id=ACCOUNT_ID&scopes=workers,containers
+```
+
+**Features (0.20+)**: Write, replace, delete, provider credentials, and
+name-only discovery through `init --from`; values are sent only in HTTPS
+request bodies
+
+**Prerequisites (0.20+)**: A Cloudflare account and Secrets Store, account
+**Secrets Store Write** permission, the account and store IDs, and either an
+`api_token` provider credential, `CLOUDFLARE_API_TOKEN`, or credentials from
+`wrangler auth token --json`. `CLOUDFLARE_ACCOUNT_ID` is the fallback when the
+URI omits `account_id`.
+
+**Storage (0.20+)**: Account secret `{key}` in the selected store. The store
+URI, rather than the SecretSpec project or profile name, supplies isolation.
+New and replaced entries receive the configured scopes, defaulting to
+`workers`.
+
+**Read limitation (0.20+)**: Cloudflare's management API exposes metadata but
+never plaintext secret values. `get`, `check`, `run`, fallback reads,
+generation-on-miss, and prompting-on-miss cannot use this write-only provider.
+Plaintext is available only inside a bound Cloudflare service. See the
+[Cloudflare provider guide](/providers/cloudflare/).
+
 ## Google Cloud Secret Manager Provider
 
 **URI**: `gcsm://PROJECT_ID` - Stores secrets in Google Cloud Secret Manager
@@ -726,6 +762,7 @@ $ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | Proton Pass | ✅ End-to-end | Cloud (Proton) | ✅ Yes |
 | Passbolt (0.19+) | ✅ End-to-end | Self-hosted (Passbolt server) | ✅ Yes |
 | Fly.io secrets (0.20+) | ✅ Fly.io-managed | Cloud (Fly.io app vault) | ✅ Yes |
+| Cloudflare Secrets Store (0.20+) | ✅ Cloudflare-managed | Cloud (account-level store) | ✅ Yes |
 | LastPass | ✅ End-to-end | Cloud (LastPass) | ✅ Yes |
 | Dashlane (0.18+) | ✅ End-to-end | Cloud (Dashlane), synced locally | Yes — `dcli` auto-syncs hourly |
 | 1Password | ✅ End-to-end | Cloud (1Password) | ✅ Yes |

--- a/docs/src/data/provider-credentials.json
+++ b/docs/src/data/provider-credentials.json
@@ -72,6 +72,17 @@
     ]
   },
   {
+    "provider": "cloudflare",
+    "implementationSources": ["secretspec/src/provider/cloudflare.rs"],
+    "credentials": [
+      {
+        "name": "api_token",
+        "environmentFallbacks": ["CLOUDFLARE_API_TOKEN"],
+        "since": "0.20"
+      }
+    ]
+  },
+  {
     "provider": "dashlane",
     "implementationSources": ["secretspec/src/provider/dashlane.rs"],
     "credentials": [

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -69,6 +69,7 @@ const providerMetadata: ProviderMetadata[] = [
   { slug: 'null', label: 'Defaults / ephemeral values (null, 0.19+)' },
   { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials (0.17+)' },
   { slug: 'fly', label: 'Fly.io secrets (write-only, 0.20+)' },
+  { icon: 'cloudflare', slug: 'cloudflare', label: 'Cloudflare Secrets Store (write-only, 0.20+)' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden Secrets Manager' },
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
   { slug: 'keyring', label: 'Credential Manager' },
@@ -160,6 +161,7 @@ const providerColors: Record<string, SyntaxColorName> = {
   env: 'comment',
   'systemd-credential': 'blue',
   fly: 'magenta',
+  cloudflare: 'orange',
   sops: 'magenta',
   kubernetes: 'blue',
 };
@@ -557,6 +559,7 @@ const reelScriptData = {
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/sops/"><span class="provider-name">sops</span>: SOPS encrypted files (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/systemd-credential/"><span class="provider-name">systemd-credential</span>: Read-only systemd service credentials (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/fly/"><span class="provider-name">fly</span>: Fly.io application secrets, write-only (0.20+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-orange)" href="/providers/cloudflare/"><span class="provider-name">cloudflare</span>: Cloudflare Secrets Store, write-only (0.20+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-orange)" href="/providers/awsps/"><span class="provider-name">awsps</span>: AWS Systems Manager Parameter Store (0.18+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/scaleway/"><span class="provider-name">scaleway</span>: Scaleway Secret Manager (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/dashlane/"><span class="provider-name">dashlane</span>: Dashlane password manager, read-only (0.18+)</a>

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -80,7 +80,7 @@ libc.workspace = true
 signal-hook.workspace = true
 
 [features]
-default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "scaleway", "sops", "kubernetes"]
+default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "scaleway", "sops", "kubernetes", "cloudflare"]
 cli = ["dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable", "dep:dunce"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
@@ -92,6 +92,7 @@ vault = ["dep:reqwest", "tokio/sync"]
 # Scaleway Secret Manager talks to the v1beta1 REST API directly; base64
 # payloads use data-encoding, which is already a non-optional dependency.
 scaleway = ["dep:reqwest"]
+cloudflare = ["dep:reqwest"]
 openbao = ["dep:reqwest", "tokio/sync"]
 # `tokio/sync` for the async `OnceCell` that serializes the Universal Auth
 # exchange. It is already on transitively via reqwest, but a provider should

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -41,6 +41,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [null](https://secretspec.dev/providers/null) (0.19+)
   - [systemd credentials](https://secretspec.dev/providers/systemd-credential) (0.17+)
   - [Fly.io application secrets](https://secretspec.dev/providers/fly) (0.20+, write-only)
+  - [Cloudflare Secrets Store](https://secretspec.dev/providers/cloudflare) (0.20+, write-only)
   - [Google Cloud Secret Manager](https://secretspec.dev/providers/gcsm)
   - [AWS Secrets Manager](https://secretspec.dev/providers/awssm)
   - [AWS Systems Manager Parameter Store](https://secretspec.dev/providers/awsps) (0.18+)
@@ -92,6 +93,7 @@ $ secretspec config global init  # 0.17+
   null: Use defaults, generation, or run prompts without storage (0.19+)
   systemd-credential: Read-only systemd service credentials (0.17+)
   fly: Fly.io application secrets via flyctl, write-only (0.20+)
+  cloudflare: Cloudflare Secrets Store, write-only (0.20+)
   pass: Unix password manager with GPG encryption
   gopass: Gopass CLI password manager with GPG encryption (0.15+)
   protonpass: Proton Pass via official pass-cli
@@ -216,6 +218,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Null](https://secretspec.dev/providers/null)** (0.19+) - Use committed defaults, ephemeral generation, or ephemeral run prompts without secret storage
 - **[systemd credentials](https://secretspec.dev/providers/systemd-credential)** (0.17+) - Read-only credentials passed to the current service
 - **[Fly.io application secrets](https://secretspec.dev/providers/fly)** (0.20+) - Write and delete app secrets through `flyctl`; Fly.io does not expose plaintext values
+- **[Cloudflare Secrets Store](https://secretspec.dev/providers/cloudflare)** (0.20+) - Publish and delete account secrets through Cloudflare's API; plaintext is available only to bound Cloudflare services
 - **[Pass](https://secretspec.dev/providers/pass)** - Unix password manager with GPG encryption
 - **[Gopass](https://secretspec.dev/providers/gopass)** (0.15+) - GPG-based password manager with git-synced password store
 - **[Proton Pass](https://secretspec.dev/providers/protonpass)** - End-to-end encrypted via Proton's official pass-cli

--- a/secretspec/src/provider/cloudflare.rs
+++ b/secretspec/src/provider/cloudflare.rs
@@ -1,0 +1,1011 @@
+//! Cloudflare Secrets Store provider.
+//!
+//! Cloudflare's management API deliberately never returns stored plaintext, so
+//! this provider is write-only. It publishes, replaces, deletes, and discovers
+//! account-level secret names through the REST API. Authentication comes from
+//! an `api_token` provider credential, `CLOUDFLARE_API_TOKEN`, or Wrangler's
+//! current OAuth/API credentials via `wrangler auth token --json`.
+
+use super::{Address, DiscoveryContext, Provider, ProviderCredentials, ProviderUrl};
+use crate::config::NativeAddress;
+use crate::{Result, Secret, SecretSpecError};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::io;
+use std::process::Command;
+
+const API_TOKEN: &str = "api_token";
+const API_TOKEN_ENV: &str = "CLOUDFLARE_API_TOKEN";
+const ACCOUNT_ID_ENV: &str = "CLOUDFLARE_ACCOUNT_ID";
+const WRANGLER_PATH_ENV: &str = "SECRETSPEC_WRANGLER_PATH";
+const API_BASE: &str = "https://api.cloudflare.com/client/v4";
+const MAX_SECRET_BYTES: usize = 65_536;
+const DEFAULT_SCOPE: &str = "workers";
+const KNOWN_SCOPES: &[&str] = &[
+    "workers",
+    "ai_gateway",
+    "dex",
+    "access",
+    "containers",
+    "websearch",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudflareAuth {
+    Auto,
+    Token,
+    Wrangler,
+}
+
+/// Configuration for one account-level Cloudflare Secrets Store.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudflareConfig {
+    pub store_id: String,
+    pub account_id: Option<String>,
+    pub scopes: Vec<String>,
+    pub auth: CloudflareAuth,
+    pub wrangler_profile: Option<String>,
+}
+
+impl TryFrom<&ProviderUrl> for CloudflareConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "cloudflare" {
+            return Err(operation_error(format!(
+                "Invalid scheme '{}' for cloudflare provider",
+                url.scheme()
+            )));
+        }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(operation_error(
+                "cloudflare:// does not accept credentials in URI userinfo; use the api_token provider credential",
+            ));
+        }
+        let store_id = url.host().filter(|value| !value.is_empty()).ok_or_else(|| {
+            operation_error(
+                "cloudflare provider requires a Secrets Store ID, for example cloudflare://0123456789abcdef0123456789abcdef",
+            )
+        })?;
+        validate_cloudflare_id("Secrets Store ID", &store_id)?;
+        if !url.path().trim_matches('/').is_empty() {
+            return Err(operation_error(
+                "cloudflare:// takes no path; put the Secrets Store ID in the URI authority",
+            ));
+        }
+
+        let mut account_id = None;
+        let mut scopes = None;
+        let mut auth = None;
+        let mut wrangler_profile = None;
+        for (key, value) in url.query_pairs() {
+            let value = value.into_owned();
+            let duplicate = match key.as_ref() {
+                "account_id" => set_once(&mut account_id, value),
+                "scopes" => set_once(&mut scopes, value),
+                "auth" => set_once(&mut auth, value),
+                "wrangler_profile" => set_once(&mut wrangler_profile, value),
+                unknown => {
+                    return Err(operation_error(format!(
+                        "unknown cloudflare query parameter '{unknown}'; supported parameters are `account_id`, `scopes`, `auth`, and `wrangler_profile`"
+                    )));
+                }
+            };
+            if duplicate {
+                return Err(operation_error(format!(
+                    "duplicate cloudflare query parameter '{key}'"
+                )));
+            }
+        }
+
+        let account_id = account_id.filter(|value| !value.is_empty());
+        if let Some(account_id) = &account_id {
+            validate_cloudflare_id("account ID", account_id)?;
+        }
+        let scopes = parse_scopes(scopes.as_deref().unwrap_or(DEFAULT_SCOPE))?;
+        let auth = match auth.as_deref().unwrap_or("auto") {
+            "auto" => CloudflareAuth::Auto,
+            "token" => CloudflareAuth::Token,
+            "wrangler" => CloudflareAuth::Wrangler,
+            value => {
+                return Err(operation_error(format!(
+                    "cloudflare auth must be `auto`, `token`, or `wrangler`, not '{value}'"
+                )));
+            }
+        };
+        let wrangler_profile = wrangler_profile.filter(|value| !value.is_empty());
+        if wrangler_profile.is_some() && auth != CloudflareAuth::Wrangler {
+            return Err(operation_error(
+                "cloudflare `wrangler_profile` requires `auth=wrangler`",
+            ));
+        }
+
+        Ok(Self {
+            store_id,
+            account_id,
+            scopes,
+            auth,
+            wrangler_profile,
+        })
+    }
+}
+
+fn set_once(slot: &mut Option<String>, value: String) -> bool {
+    if slot.is_some() {
+        true
+    } else {
+        *slot = Some(value);
+        false
+    }
+}
+
+fn parse_scopes(value: &str) -> Result<Vec<String>> {
+    let mut scopes = Vec::new();
+    for scope in value.split(',') {
+        let scope = scope.trim();
+        if scope.is_empty() {
+            return Err(operation_error(
+                "cloudflare scopes cannot contain an empty name",
+            ));
+        }
+        if !KNOWN_SCOPES.contains(&scope) {
+            return Err(operation_error(format!(
+                "unknown Cloudflare Secrets Store scope '{scope}'; supported scopes are {}",
+                KNOWN_SCOPES.join(", ")
+            )));
+        }
+        if !scopes.iter().any(|existing| existing == scope) {
+            scopes.push(scope.to_string());
+        }
+    }
+    Ok(scopes)
+}
+
+fn validate_cloudflare_id(label: &str, value: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > 32
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(operation_error(format!(
+            "Cloudflare {label} must be at most 32 ASCII letters, digits, hyphens, or underscores"
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct ListedSecret {
+    id: String,
+    name: String,
+    status: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResultInfo {
+    total_pages: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiMessage {
+    code: Option<u64>,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiEnvelope<T> {
+    success: bool,
+    result: Option<T>,
+    #[serde(default)]
+    errors: Vec<ApiMessage>,
+    result_info: Option<ResultInfo>,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateSecret<'a> {
+    name: &'a str,
+    scopes: &'a [String],
+    value: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateSecret<'a> {
+    scopes: &'a [String],
+    value: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum WranglerCredentials {
+    ApiToken { token: String },
+    Oauth { token: String },
+    ApiKey { key: String, email: String },
+}
+
+/// A write-only Cloudflare account Secrets Store provider.
+pub struct CloudflareProvider {
+    config: CloudflareConfig,
+    credentials: ProviderCredentials,
+    api_base: String,
+    wrangler_binary_path: String,
+}
+
+crate::register_provider! {
+    struct: CloudflareProvider,
+    config: CloudflareConfig,
+    name: "cloudflare",
+    description: "Cloudflare Secrets Store, write-only (0.20+)",
+    schemes: ["cloudflare"],
+    examples: ["cloudflare://STORE_ID?account_id=ACCOUNT_ID", "cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=wrangler"],
+    credential_names: [API_TOKEN],
+    reads: false,
+    deletes: true,
+}
+
+impl CloudflareProvider {
+    pub fn new(config: CloudflareConfig) -> Self {
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+            api_base: API_BASE.to_string(),
+            wrangler_binary_path: std::env::var(WRANGLER_PATH_ENV)
+                .unwrap_or_else(|_| "wrangler".to_string()),
+        }
+    }
+
+    fn account_id(&self) -> Result<String> {
+        let account_id = self
+            .config
+            .account_id
+            .clone()
+            .or_else(|| super::preferred_env(&[ACCOUNT_ID_ENV]))
+            .ok_or_else(|| {
+                operation_error(format!(
+                    "No Cloudflare account ID found. Add `?account_id=...` to the provider URI or set {ACCOUNT_ID_ENV}."
+                ))
+            })?;
+        validate_cloudflare_id("account ID", &account_id)?;
+        Ok(account_id)
+    }
+
+    fn api_token(&self) -> Option<String> {
+        super::credential_or_env(&self.credentials, API_TOKEN, API_TOKEN_ENV)
+    }
+
+    fn wrangler_credentials(&self) -> Result<WranglerCredentials> {
+        let mut command = Command::new(&self.wrangler_binary_path);
+        command.args(["auth", "token", "--json"]);
+        if let Some(profile) = &self.config.wrangler_profile {
+            command.args(["--profile", profile]);
+        }
+        let output = command
+            .output()
+            .map_err(|error| self.wrangler_spawn_error(error))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(operation_error(format!(
+                "wrangler could not resolve Cloudflare credentials: {}",
+                if stderr.trim().is_empty() {
+                    "command exited unsuccessfully"
+                } else {
+                    stderr.trim()
+                }
+            )));
+        }
+        serde_json::from_slice(&output.stdout).map_err(|error| {
+            operation_error(format!(
+                "wrangler auth token --json returned invalid credentials JSON: {error}"
+            ))
+        })
+    }
+
+    fn wrangler_spawn_error(&self, error: io::Error) -> SecretSpecError {
+        if error.kind() == io::ErrorKind::NotFound {
+            operation_error(format!(
+                "wrangler executable '{}' was not found; configure the `{API_TOKEN}` provider credential, set {API_TOKEN_ENV}, install Wrangler, or select it with {WRANGLER_PATH_ENV}",
+                self.wrangler_binary_path
+            ))
+        } else {
+            operation_error(format!(
+                "failed to execute '{}': {error}",
+                self.wrangler_binary_path
+            ))
+        }
+    }
+
+    fn auth_headers(&self) -> Result<HeaderMap> {
+        let credentials = match self.config.auth {
+            CloudflareAuth::Auto => self.api_token().map_or_else(
+                || self.wrangler_credentials(),
+                |token| Ok(WranglerCredentials::ApiToken { token }),
+            )?,
+            CloudflareAuth::Token => WranglerCredentials::ApiToken {
+                token: self.api_token().ok_or_else(|| {
+                    operation_error(format!(
+                        "Cloudflare auth=token requires the `{API_TOKEN}` provider credential or {API_TOKEN_ENV}"
+                    ))
+                })?,
+            },
+            CloudflareAuth::Wrangler => self.wrangler_credentials()?,
+        };
+
+        let mut headers = HeaderMap::new();
+        match credentials {
+            WranglerCredentials::ApiToken { token } | WranglerCredentials::Oauth { token } => {
+                let mut value =
+                    HeaderValue::from_str(&format!("Bearer {token}")).map_err(|error| {
+                        operation_error(format!("invalid Cloudflare token: {error}"))
+                    })?;
+                value.set_sensitive(true);
+                headers.insert(AUTHORIZATION, value);
+            }
+            WranglerCredentials::ApiKey { key, email } => {
+                let mut key = HeaderValue::from_str(&key).map_err(|error| {
+                    operation_error(format!("invalid Cloudflare API key: {error}"))
+                })?;
+                key.set_sensitive(true);
+                let email = HeaderValue::from_str(&email).map_err(|error| {
+                    operation_error(format!("invalid Cloudflare account email: {error}"))
+                })?;
+                headers.insert(HeaderName::from_static("x-auth-key"), key);
+                headers.insert(HeaderName::from_static("x-auth-email"), email);
+            }
+        }
+        Ok(headers)
+    }
+
+    fn client(&self) -> Result<reqwest::Client> {
+        reqwest::Client::builder()
+            .default_headers(self.auth_headers()?)
+            // Account-secret values must remain confined to Cloudflare's fixed
+            // API origin. In particular, never replay a PATCH/POST body after
+            // a 307/308 redirect to an origin selected by a response.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| {
+                operation_error(format!(
+                    "failed to build Cloudflare HTTP client: {}",
+                    crate::error::display_error_chain(&error)
+                ))
+            })
+    }
+
+    fn secrets_url(&self, account_id: &str) -> String {
+        format!(
+            "{}/accounts/{account_id}/secrets_store/stores/{}/secrets",
+            self.api_base.trim_end_matches('/'),
+            self.config.store_id
+        )
+    }
+
+    fn secret_name<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, str>> {
+        let name = super::flat_item(self, addr)?;
+        if name.is_empty() || name.chars().any(char::is_whitespace) || name.contains('\0') {
+            return Err(operation_error(format!(
+                "'{name}' is not a valid Cloudflare secret name: names must be non-empty and cannot contain whitespace or NUL"
+            )));
+        }
+        Ok(name)
+    }
+
+    async fn list_secrets(
+        &self,
+        client: &reqwest::Client,
+        account_id: &str,
+        search: Option<&str>,
+    ) -> Result<Vec<ListedSecret>> {
+        let url = self.secrets_url(account_id);
+        let mut page = 1_u64;
+        let mut listed = Vec::new();
+        loop {
+            let page_string = page.to_string();
+            let mut query = vec![("page", page_string.as_str()), ("per_page", "100")];
+            if let Some(search) = search {
+                query.push(("search", search));
+            }
+            let response = client
+                .get(&url)
+                .query(&query)
+                .send()
+                .await
+                .map_err(|error| reach_error("listing secrets", error))?;
+            let envelope: ApiEnvelope<Vec<ListedSecret>> =
+                parse_envelope(response, "listing secrets").await?;
+            let page_results = envelope.result.ok_or_else(|| {
+                operation_error("Cloudflare returned no result while listing secrets")
+            })?;
+            let result_count = page_results.len();
+            listed.extend(
+                page_results
+                    .into_iter()
+                    .filter(|secret| secret.status != "deleted"),
+            );
+            let total_pages = envelope
+                .result_info
+                .and_then(|info| info.total_pages)
+                .unwrap_or_else(|| if result_count < 100 { page } else { page + 1 });
+            if page >= total_pages || result_count == 0 {
+                break;
+            }
+            page += 1;
+        }
+        Ok(listed)
+    }
+
+    async fn lookup_secret(
+        &self,
+        client: &reqwest::Client,
+        account_id: &str,
+        name: &str,
+    ) -> Result<Option<ListedSecret>> {
+        let mut exact = self
+            .list_secrets(client, account_id, Some(name))
+            .await?
+            .into_iter()
+            .filter(|secret| secret.name == name);
+        let found = exact.next();
+        if exact.next().is_some() {
+            return Err(operation_error(format!(
+                "Cloudflare returned more than one active secret named '{name}'"
+            )));
+        }
+        Ok(found)
+    }
+
+    async fn update_secret(
+        &self,
+        client: &reqwest::Client,
+        account_id: &str,
+        secret_id: &str,
+        value: &str,
+    ) -> Result<()> {
+        validate_cloudflare_id("secret ID", secret_id)?;
+        let url = format!("{}/{}", self.secrets_url(account_id), secret_id);
+        let response = client
+            .patch(url)
+            .json(&UpdateSecret {
+                scopes: &self.config.scopes,
+                value,
+            })
+            .send()
+            .await
+            .map_err(|error| reach_error("updating secret", error))?;
+        let _: ApiEnvelope<serde_json::Value> = parse_envelope(response, "updating secret").await?;
+        Ok(())
+    }
+
+    async fn set_async(&self, name: &str, value: &SecretString) -> Result<()> {
+        let account_id = self.account_id()?;
+        let client = self.client()?;
+        if let Some(existing) = self.lookup_secret(&client, &account_id, name).await? {
+            return self
+                .update_secret(&client, &account_id, &existing.id, value.expose_secret())
+                .await;
+        }
+
+        let response = client
+            .post(self.secrets_url(&account_id))
+            .json(&[CreateSecret {
+                name,
+                scopes: &self.config.scopes,
+                value: value.expose_secret(),
+            }])
+            .send()
+            .await
+            .map_err(|error| reach_error("creating secret", error))?;
+        if response.status() == reqwest::StatusCode::CONFLICT {
+            if let Some(existing) = self.lookup_secret(&client, &account_id, name).await? {
+                return self
+                    .update_secret(&client, &account_id, &existing.id, value.expose_secret())
+                    .await;
+            }
+            return Err(operation_error(format!(
+                "Cloudflare reported a conflict creating secret '{name}', but the secret could not be found for an update"
+            )));
+        }
+        let _: ApiEnvelope<Vec<ListedSecret>> = parse_envelope(response, "creating secret").await?;
+        Ok(())
+    }
+
+    async fn delete_async(&self, name: &str) -> Result<bool> {
+        let account_id = self.account_id()?;
+        let client = self.client()?;
+        let Some(existing) = self.lookup_secret(&client, &account_id, name).await? else {
+            return Ok(false);
+        };
+        validate_cloudflare_id("secret ID", &existing.id)?;
+        let url = format!("{}/{}", self.secrets_url(&account_id), existing.id);
+        let response = client
+            .delete(url)
+            .send()
+            .await
+            .map_err(|error| reach_error("deleting secret", error))?;
+        let _: ApiEnvelope<serde_json::Value> = parse_envelope(response, "deleting secret").await?;
+        Ok(true)
+    }
+}
+
+impl Provider for CloudflareProvider {
+    /// The selected store supplies project/environment isolation; convention
+    /// writes use the SecretSpec key directly as the account-secret name.
+    fn convention_address(
+        &self,
+        _project: &str,
+        _profile: &str,
+        key: &str,
+    ) -> Result<NativeAddress> {
+        Ok(NativeAddress {
+            item: key.to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let mut query = Vec::new();
+        if let Some(account_id) = &self.config.account_id {
+            query.push(format!(
+                "account_id={}",
+                ProviderUrl::encode_query(account_id)
+            ));
+        }
+        if self.config.scopes != [DEFAULT_SCOPE] {
+            query.push(format!(
+                "scopes={}",
+                ProviderUrl::encode_query(&self.config.scopes.join(","))
+            ));
+        }
+        match self.config.auth {
+            CloudflareAuth::Auto => {}
+            CloudflareAuth::Token => query.push("auth=token".to_string()),
+            CloudflareAuth::Wrangler => query.push("auth=wrangler".to_string()),
+        }
+        if let Some(profile) = &self.config.wrangler_profile {
+            query.push(format!(
+                "wrangler_profile={}",
+                ProviderUrl::encode_query(profile)
+            ));
+        }
+        let base = format!("cloudflare://{}", self.config.store_id);
+        if query.is_empty() {
+            base
+        } else {
+            format!("{base}?{}", query.join("&"))
+        }
+    }
+
+    fn storage_identity(&self) -> String {
+        let account_id = self
+            .config
+            .account_id
+            .clone()
+            .or_else(|| super::preferred_env(&[ACCOUNT_ID_ENV]))
+            .unwrap_or_default();
+        format!("cloudflare://{account_id}/{}", self.config.store_id)
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let _ = self.secret_name(addr)?;
+        Err(operation_error(
+            "Cloudflare Secrets Store is write-only at the management API: plaintext values can only be read by bound Cloudflare services; use this provider with `secretspec set`, `secretspec delete`, or `secretspec init --from`",
+        ))
+    }
+
+    fn check_writable(&self, addr: Address<'_>) -> Result<()> {
+        self.secret_name(addr).map(|_| ())
+    }
+
+    fn set(&self, addr: Address<'_>, value: &SecretString) -> Result<()> {
+        self.check_writable(addr)?;
+        if value.expose_secret().len() > MAX_SECRET_BYTES {
+            return Err(operation_error(format!(
+                "Cloudflare secret values cannot exceed {MAX_SECRET_BYTES} bytes"
+            )));
+        }
+        let name = self.secret_name(addr)?;
+        super::block_on(self.set_async(&name, value))
+    }
+
+    fn supports_delete(&self) -> bool {
+        true
+    }
+
+    fn check_deletable(&self, addr: Address<'_>) -> Result<()> {
+        self.secret_name(addr).map(|_| ())
+    }
+
+    fn delete(&self, addr: Address<'_>) -> Result<bool> {
+        self.check_deletable(addr)?;
+        let name = self.secret_name(addr)?;
+        super::block_on(self.delete_async(&name))
+    }
+
+    fn describe_write_target(&self, addr: Address<'_>) -> Result<String> {
+        let name = self.secret_name(addr)?;
+        Ok(format!(
+            "Cloudflare account '{}' Secrets Store '{}' secret '{}' with scopes [{}]",
+            self.account_id()?,
+            self.config.store_id,
+            name,
+            self.config.scopes.join(", ")
+        ))
+    }
+
+    fn reflect(&self, _context: DiscoveryContext<'_>) -> Result<HashMap<String, Secret>> {
+        let account_id = self.account_id()?;
+        let client = self.client()?;
+        Ok(
+            super::block_on(self.list_secrets(&client, &account_id, None))?
+                .into_iter()
+                .map(|listed| {
+                    let name = listed.name;
+                    let secret =
+                        Secret::required(format!("{name} Cloudflare Secrets Store secret"));
+                    (name, secret)
+                })
+                .collect(),
+        )
+    }
+}
+
+async fn parse_envelope<T: DeserializeOwned>(
+    response: reqwest::Response,
+    action: &str,
+) -> Result<ApiEnvelope<T>> {
+    let status = response.status();
+    let envelope: ApiEnvelope<T> = response.json().await.map_err(|error| {
+        operation_error(format!(
+            "Cloudflare returned invalid JSON while {action} (HTTP {}): {}",
+            status.as_u16(),
+            crate::error::display_error_chain(&error)
+        ))
+    })?;
+    if status.is_success() && envelope.success {
+        return Ok(envelope);
+    }
+    let details = if envelope.errors.is_empty() {
+        "request failed without an API error message".to_string()
+    } else {
+        envelope
+            .errors
+            .iter()
+            .map(|error| match error.code {
+                Some(code) => format!("{code}: {}", error.message),
+                None => error.message.clone(),
+            })
+            .collect::<Vec<_>>()
+            .join("; ")
+    };
+    Err(operation_error(format!(
+        "Cloudflare returned HTTP {} while {action}: {details}",
+        status.as_u16()
+    )))
+}
+
+fn reach_error(action: &str, error: reqwest::Error) -> SecretSpecError {
+    operation_error(format!(
+        "failed to reach Cloudflare while {action}: {}",
+        crate::error::display_error_chain(&error)
+    ))
+}
+
+fn operation_error(message: impl Into<String>) -> SecretSpecError {
+    SecretSpecError::ProviderOperationFailed(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{SocketAddr, TcpListener};
+    use url::Url;
+
+    const STORE: &str = "0123456789abcdef0123456789abcdef";
+    const ACCOUNT: &str = "abcdef0123456789abcdef0123456789";
+
+    #[derive(Debug)]
+    struct RecordedRequest {
+        line: String,
+        headers: HashMap<String, String>,
+        body: String,
+    }
+
+    fn config(spec: &str) -> CloudflareConfig {
+        CloudflareConfig::try_from(&ProviderUrl::new(Url::parse(spec).unwrap())).unwrap()
+    }
+
+    fn provider_with_token(endpoint: SocketAddr) -> CloudflareProvider {
+        let mut provider = CloudflareProvider::new(config(&format!(
+            "cloudflare://{STORE}?account_id={ACCOUNT}&auth=token"
+        )));
+        provider.api_base = format!("http://{endpoint}");
+        provider.with_credentials(ProviderCredentials::from([(
+            API_TOKEN.to_string(),
+            SecretString::new("test-token".into()),
+        )]));
+        provider
+    }
+
+    fn response_server(
+        responses: Vec<(&'static str, &'static str)>,
+    ) -> (SocketAddr, std::thread::JoinHandle<Vec<RecordedRequest>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let mut recorded = Vec::new();
+            for (status, body) in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(&mut stream);
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                let mut headers = HashMap::new();
+                loop {
+                    let mut header = String::new();
+                    reader.read_line(&mut header).unwrap();
+                    if header == "\r\n" || header.is_empty() {
+                        break;
+                    }
+                    if let Some((name, value)) = header.trim_end().split_once(':') {
+                        headers.insert(name.to_ascii_lowercase(), value.trim().to_string());
+                    }
+                }
+                let content_length = headers
+                    .get("content-length")
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .unwrap_or(0);
+                let mut request_body = vec![0; content_length];
+                reader.read_exact(&mut request_body).unwrap();
+                recorded.push(RecordedRequest {
+                    line: line.trim_end().to_string(),
+                    headers,
+                    body: String::from_utf8(request_body).unwrap(),
+                });
+                write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .unwrap();
+            }
+            recorded
+        });
+        (endpoint, server)
+    }
+
+    fn list_body(secrets: &str, total_pages: u64) -> String {
+        format!(
+            r#"{{"success":true,"result":{secrets},"errors":[],"result_info":{{"total_pages":{total_pages}}}}}"#
+        )
+    }
+
+    #[test]
+    fn parses_and_round_trips_configuration() {
+        let encoded = format!(
+            "cloudflare://{STORE}?account_id={ACCOUNT}&scopes=workers%2Ccontainers&auth=wrangler&wrangler_profile=production"
+        );
+        let canonical = format!(
+            "cloudflare://{STORE}?account_id={ACCOUNT}&scopes=workers,containers&auth=wrangler&wrangler_profile=production"
+        );
+        let provider = CloudflareProvider::new(config(&encoded));
+        assert_eq!(provider.uri(), canonical);
+        assert_eq!(config(&provider.uri()), provider.config);
+        assert_eq!(provider.config.scopes, ["workers", "containers"]);
+    }
+
+    #[test]
+    fn rejects_invalid_configuration() {
+        for spec in [
+            "cloudflare://",
+            &format!("cloudflare://{STORE}/path"),
+            &format!("cloudflare://{STORE}?unknown=true"),
+            &format!("cloudflare://{STORE}?scopes=unknown"),
+            &format!("cloudflare://{STORE}?auth=bad"),
+            &format!("cloudflare://{STORE}?wrangler_profile=prod"),
+            &format!("cloudflare://{STORE}?auth=token&auth=auto"),
+        ] {
+            assert!(
+                CloudflareConfig::try_from(&ProviderUrl::new(Url::parse(spec).unwrap())).is_err(),
+                "{spec}"
+            );
+        }
+    }
+
+    #[test]
+    fn convention_is_flat_and_reads_explain_the_limitation() {
+        let provider = CloudflareProvider::new(config(&format!("cloudflare://{STORE}")));
+        let address = provider
+            .convention_address("project", "production", "DATABASE_URL")
+            .unwrap();
+        assert_eq!(address.item, "DATABASE_URL");
+        let error = provider
+            .get(Address::convention("project", "production", "DATABASE_URL"))
+            .unwrap_err();
+        assert!(error.to_string().contains("write-only"), "{error}");
+        assert!(
+            error.to_string().contains("bound Cloudflare services"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn registration_declares_write_only_delete_and_credentials() {
+        let registration = crate::provider::PROVIDER_REGISTRY
+            .iter()
+            .find(|registration| registration.info.name == "cloudflare")
+            .unwrap();
+        assert_eq!(registration.credential_names, &[API_TOKEN]);
+        assert!(!registration.reads);
+        assert!(registration.deletes);
+    }
+
+    #[test]
+    fn rejects_values_larger_than_cloudflares_limit_before_authentication() {
+        let provider = CloudflareProvider::new(config(&format!("cloudflare://{STORE}")));
+        let oversized = SecretString::new("x".repeat(MAX_SECRET_BYTES + 1).into());
+        let error = provider
+            .set(
+                Address::convention("project", "production", "API_KEY"),
+                &oversized,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("65536 bytes"), "{error}");
+    }
+
+    #[test]
+    fn creates_a_missing_secret_with_bearer_auth_and_scopes() {
+        let empty = Box::leak(list_body("[]", 1).into_boxed_str());
+        let created = r#"{"success":true,"result":[{"id":"secret-id","name":"API_KEY","status":"pending"}],"errors":[]}"#;
+        let (endpoint, server) = response_server(vec![("200 OK", empty), ("200 OK", created)]);
+        let provider = provider_with_token(endpoint);
+
+        provider
+            .set(
+                Address::convention("project", "production", "API_KEY"),
+                &SecretString::new("super-secret".into()),
+            )
+            .unwrap();
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].line.starts_with("GET /accounts/"));
+        assert_eq!(
+            requests[0].headers.get("authorization").map(String::as_str),
+            Some("Bearer test-token")
+        );
+        assert!(requests[1].line.starts_with("POST /accounts/"));
+        let body: serde_json::Value = serde_json::from_str(&requests[1].body).unwrap();
+        assert_eq!(body[0]["name"], "API_KEY");
+        assert_eq!(body[0]["value"], "super-secret");
+        assert_eq!(body[0]["scopes"], serde_json::json!(["workers"]));
+    }
+
+    #[test]
+    fn updates_an_existing_secret_by_id() {
+        let listed = Box::leak(
+            list_body(
+                r#"[{"id":"existing-id","name":"API_KEY","status":"active"}]"#,
+                1,
+            )
+            .into_boxed_str(),
+        );
+        let updated = r#"{"success":true,"result":{"id":"existing-id","name":"API_KEY","status":"pending"},"errors":[]}"#;
+        let (endpoint, server) = response_server(vec![("200 OK", listed), ("200 OK", updated)]);
+        let provider = provider_with_token(endpoint);
+
+        provider
+            .set(
+                Address::convention("project", "production", "API_KEY"),
+                &SecretString::new("replacement".into()),
+            )
+            .unwrap();
+
+        let requests = server.join().unwrap();
+        assert!(requests[1].line.contains("PATCH "));
+        assert!(requests[1].line.contains("/secrets/existing-id"));
+        let body: serde_json::Value = serde_json::from_str(&requests[1].body).unwrap();
+        assert_eq!(body["value"], "replacement");
+    }
+
+    #[test]
+    fn deletes_by_id_and_missing_deletion_is_idempotent() {
+        let listed = Box::leak(
+            list_body(
+                r#"[{"id":"existing-id","name":"API_KEY","status":"active"}]"#,
+                1,
+            )
+            .into_boxed_str(),
+        );
+        let deleted = r#"{"success":true,"result":null,"errors":[]}"#;
+        let (endpoint, server) = response_server(vec![("200 OK", listed), ("200 OK", deleted)]);
+        let provider = provider_with_token(endpoint);
+        assert!(
+            provider
+                .delete(Address::convention("project", "production", "API_KEY"))
+                .unwrap()
+        );
+        let requests = server.join().unwrap();
+        assert!(requests[1].line.contains("DELETE "));
+        assert!(requests[1].line.contains("/secrets/existing-id"));
+
+        let empty = Box::leak(list_body("[]", 1).into_boxed_str());
+        let (endpoint, server) = response_server(vec![("200 OK", empty)]);
+        let provider = provider_with_token(endpoint);
+        assert!(
+            !provider
+                .delete(Address::convention("project", "production", "MISSING"))
+                .unwrap()
+        );
+        assert_eq!(server.join().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn reflection_paginates_and_excludes_deleted_entries() {
+        let first = Box::leak(
+            list_body(
+                r#"[{"id":"1","name":"FIRST","status":"active"},{"id":"gone","name":"GONE","status":"deleted"}]"#,
+                2,
+            )
+            .into_boxed_str(),
+        );
+        let second = Box::leak(
+            list_body(r#"[{"id":"2","name":"SECOND","status":"pending"}]"#, 2).into_boxed_str(),
+        );
+        let (endpoint, server) = response_server(vec![("200 OK", first), ("200 OK", second)]);
+        let provider = provider_with_token(endpoint);
+        let reflected = provider
+            .reflect(DiscoveryContext::new("project", "production"))
+            .unwrap();
+        assert!(reflected.contains_key("FIRST"));
+        assert!(reflected.contains_key("SECOND"));
+        assert!(!reflected.contains_key("GONE"));
+        let requests = server.join().unwrap();
+        assert!(requests[0].line.contains("page=1"));
+        assert!(requests[1].line.contains("page=2"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrangler_auth_supports_oauth_and_named_profiles() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let binary = directory.path().join("wrangler");
+        std::fs::write(
+            &binary,
+            r#"#!/bin/sh
+printf '%s' "$*" > "$(dirname "$0")/args"
+printf '%s' '{"type":"oauth","token":"oauth-token"}'
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&binary, permissions).unwrap();
+
+        let mut provider = CloudflareProvider::new(config(&format!(
+            "cloudflare://{STORE}?account_id={ACCOUNT}&auth=wrangler&wrangler_profile=production"
+        )));
+        provider.wrangler_binary_path = binary.to_string_lossy().into_owned();
+        let headers = provider.auth_headers().unwrap();
+        assert_eq!(
+            headers.get(AUTHORIZATION).unwrap().to_str().unwrap(),
+            "Bearer oauth-token"
+        );
+        assert_eq!(
+            std::fs::read_to_string(directory.path().join("args")).unwrap(),
+            "auth token --json --profile production"
+        );
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -23,6 +23,7 @@
 //! - [`null::NullProvider`]: Defaults, generation, or run prompts without storage (0.19+)
 //! - [`file::FileProvider`]: Plaintext file-per-secret storage (0.19+)
 //! - [`fly::FlyProvider`]: Fly.io application secrets, write-only (0.20+)
+//! - [`cloudflare::CloudflareProvider`]: Cloudflare Secrets Store, write-only (0.20+)
 //! - [`pass::PassProvider`]: Pass integration
 //! - [`gopass::GoPassProvider`]: Gopass integration
 //! - [`systemd_credential::SystemdCredentialProvider`]: systemd service credentials (0.17+)
@@ -102,7 +103,12 @@ pub use traits::{DiscoveryContext, ProducedValuePersistence, Provider};
 
 // Shared implementation support used by provider backends and orchestration.
 pub(crate) use address::{OwnedAddress, flat_item};
-#[cfg(any(feature = "openbao", feature = "scaleway", feature = "vault"))]
+#[cfg(any(
+    feature = "cloudflare",
+    feature = "openbao",
+    feature = "scaleway",
+    feature = "vault"
+))]
 pub(crate) use credentials::preferred_env;
 pub(crate) use credentials::{ProviderCredentials, credential_or_env, credential_or_envs};
 pub(crate) use factory::provider_from_spec;
@@ -121,6 +127,7 @@ pub(crate) use registry::{
     feature = "akv",
     feature = "awsps",
     feature = "awssm",
+    feature = "cloudflare",
     feature = "gcsm",
     feature = "infisical",
     feature = "scaleway"
@@ -150,6 +157,8 @@ pub mod awssm;
 pub mod bw;
 #[cfg(feature = "bws")]
 pub mod bws;
+#[cfg(feature = "cloudflare")]
+pub mod cloudflare;
 pub mod dashlane;
 pub mod dotenv;
 pub mod env;


### PR DESCRIPTION
## Summary

- add a write-only `cloudflare://` provider for Cloudflare account-level Secrets Store
- support create, replace, delete, and name discovery through the Cloudflare REST API
- authenticate through SecretSpec `api_token` credentials, `CLOUDFLARE_API_TOKEN`, or `wrangler auth token --json`
- support Wrangler OAuth, API token, API key/email, and named authentication profiles
- document the provider as a SecretSpec 0.20+ feature across the provider guide, references, README, homepage, and credential catalog

## Testing

- `cargo test --all`
- `cargo test --package secretspec --features cloudflare provider::cloudflare::tests`
- `cargo check --package secretspec --no-default-features --features cloudflare`
- `cargo clippy --workspace --exclude secretspec-php-native`
- `cargo fmt --all -- --check`
- `npm --prefix docs run check:provider-credentials`
- `npm --prefix docs run build`
- `git diff --check`

Closes #84