### PR TITLE
Add inline specifications to all SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Native SDKs can resolve a strict, versioned inline secret declaration through
+  the new `secretspec_call` C ABI entry point. Inline declarations use an
+  explicit logical base directory for relative providers, reject unknown fields,
+  and require the new symbol so an older library cannot silently fall back to a
+  filesystem manifest. The Go, Python, Node.js, Ruby, Haskell, PHP, C#, and
+  Swift SDKs expose this as their `WithInlineSpec` / `with_inline_spec` builder
+  method.
+
 - Static musl CLI release binaries for x64 and arm64 Linux are available in
   0.20+, so the standalone installer and `secretspec-update` work on Alpine
   without a glibc compatibility layer.

--- a/docs/src/content/docs/development/sdks.md
+++ b/docs/src/content/docs/development/sdks.md
@@ -88,7 +88,7 @@ Notes:
 
 Swift interoperates with C directly through Clang modules, and SwiftPM
 distributes native Apple binaries as XCFramework binary targets. That fits the
-existing `secretspec-ffi` boundary exactly: three ownership-audited C functions
+existing `secretspec-ffi` boundary exactly: ownership-audited C functions
 carry one already-versioned JSON contract.
 
 [UniFFI](https://mozilla.github.io/uniffi-rs/latest/) is a good default for a
@@ -98,6 +98,26 @@ shared by several SDKs, and introducing UniFFI would create a second exported
 ABI, generated Rust scaffolding, and another schema to version. The hand-written
 Swift layer is limited to `Codable` request/response models and idiomatic errors;
 resolution remains entirely in Rust.
+
+## Versioned native calls (0.20+)
+
+`secretspec_resolve` remains the compatibility request for path and search
+resolution. SDKs that need a declaration held in application code call the new
+`secretspec_call` symbol with request version 1 instead. A separately versioned
+`source` is exactly one of `search`, `path`, or `inline`; an inline source also
+carries a logical `base_dir`, used for relative provider paths as
+`Secrets::from_spec_at` does.
+
+The inline specification is strict JSON, not the private Rust `Config` or a
+serialized compiled manifest. Its v1 shape contains `project`, `profiles`, and
+a `secrets` object per profile, with optional provider aliases, scopes, and
+the normal secret declaration fields. `project.extends` uses paths relative to
+the inline declaration's `base_dir`, so the full configuration model—including
+inheritance—is supported. Unknown request and declaration fields, unsupported
+versions, and unsupported operations are rejected. SDKs bind `secretspec_call`
+only when using inline specs: an older library therefore reports the missing
+capability instead of silently ignoring an unknown field and loading a
+filesystem manifest.
 
 `scripts/build-swift-xcframework.sh` changes Cargo's target-local dylib install
 name to `@rpath`, merges the native slices into a universal dylib, adds the C

--- a/docs/src/content/docs/sdk/csharp.mdx
+++ b/docs/src/content/docs/sdk/csharp.mdx
@@ -69,6 +69,12 @@ var builder = SecretSpec.Builder().WithCaller(new CallerContext
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
+## Inline specifications (0.20+)
+
+Use `WithInlineSpec(spec, baseDir)` to resolve strict inline-spec v1 declarations
+from an object serialized by `System.Text.Json`. `baseDir` resolves relative
+provider paths, and an older native library reports a capability error.
+
 ## Scopes (0.17+)
 
 Use `WithScope("api")` to resolve only a named `[scopes.api]` subset. The

--- a/docs/src/content/docs/sdk/go.mdx
+++ b/docs/src/content/docs/sdk/go.mdx
@@ -34,6 +34,36 @@ builder := secretspec.New().WithCaller(secretspec.CallerContext{
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
+## Inline specifications (0.20+)
+
+Applications that own their declarations in code can resolve a strict JSON
+inline specification without creating a temporary `secretspec.toml` file. Pass
+the wire document to `WithInlineSpec`; `baseDir` resolves relative provider
+paths just as a manifest's directory would.
+
+```go
+spec := map[string]any{
+    "project": map[string]any{"name": "my-app"},
+    "profiles": map[string]any{
+        "default": map[string]any{"secrets": map[string]any{
+            "API_TOKEN": map[string]any{"description": "API token"},
+        }},
+    },
+}
+resolved, err := secretspec.New().
+    WithInlineSpec(spec, "/logical/project").
+    WithReason("application startup").
+    Load()
+```
+
+Inline specification v1 uses `project`, `profiles`, and each profile's
+`secrets` object; optional `providers`, `scopes`, profile `defaults`, and the
+normal secret declaration fields are also supported. Unknown declaration fields
+are rejected. `project.extends` resolves parent manifests relative to `baseDir`.
+The SDK requires the native
+`secretspec_call` capability for inline specs; an older library returns a
+capability error rather than falling back to a filesystem search.
+
 ## Scopes (0.17+)
 
 Use `WithScope("api")` to resolve only a named `[scopes.api]` subset. The

--- a/docs/src/content/docs/sdk/haskell.mdx
+++ b/docs/src/content/docs/sdk/haskell.mdx
@@ -33,6 +33,12 @@ let caller = S.CallerContext
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
+## Inline specifications (0.20+)
+
+Use `withInlineSpec spec baseDir` with an Aeson JSON value to resolve strict
+inline-spec v1 declarations. `baseDir` resolves relative provider paths; an
+older static archive fails to link the versioned call symbol.
+
 ## Scopes (0.17+)
 
 Use `withScope "api"` to resolve only a named `[scopes.api]` subset. The

--- a/docs/src/content/docs/sdk/nodejs.mdx
+++ b/docs/src/content/docs/sdk/nodejs.mdx
@@ -36,6 +36,12 @@ const builder = SecretSpec.builder().withCaller({
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
+## Inline specifications (0.20+)
+
+Use `.withInlineSpec(spec, baseDir)` (or `loadAsync`/`reportAsync`) to resolve a
+strict inline-spec v1 object. `baseDir` resolves relative provider paths; the
+embedded addon submits the versioned native request directly.
+
 ## Scopes (0.17+)
 
 Use `.withScope('api')` to resolve only a named `[scopes.api]` subset. The

--- a/docs/src/content/docs/sdk/php.mdx
+++ b/docs/src/content/docs/sdk/php.mdx
@@ -118,6 +118,12 @@ $builder = SecretSpec::builder()->withCaller(new CallerContext(
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
+## Inline specifications (0.20+)
+
+Use `withInlineSpec($spec, $baseDir)` to resolve a strict inline-spec v1 PHP
+array. The embedded extension or FFI fallback uses the versioned native call;
+an older cdylib raises a capability error instead of searching for a manifest.
+
 ## Scopes (0.17+)
 
 Use `withScope('api')` to resolve only a named `[scopes.api]` subset. The

--- a/docs/src/content/docs/sdk/python.mdx
+++ b/docs/src/content/docs/sdk/python.mdx
@@ -36,6 +36,13 @@ builder = SecretSpec.builder().with_caller(CallerContext(
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
+## Inline specifications (0.20+)
+
+Use `.with_inline_spec(spec, base_dir)` to resolve a strict inline-spec v1
+dictionary without a manifest file. `base_dir` resolves relative provider paths.
+An inline call uses the versioned native entry point, so it cannot fall back to
+a filesystem manifest on an older runtime.
+
 ## Scopes (0.17+)
 
 Use `.with_scope("api")` to resolve only a named `[scopes.api]` subset. The

--- a/docs/src/content/docs/sdk/ruby.mdx
+++ b/docs/src/content/docs/sdk/ruby.mdx
@@ -35,6 +35,12 @@ builder = Secretspec::SecretSpec.builder.with_caller(
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
+## Inline specifications (0.20+)
+
+Use `.with_inline_spec(spec, base_dir)` to resolve a strict inline-spec v1 hash
+at its logical provider-path base directory. The extension links the separate
+native call symbol, so an older archive cannot fall back to a manifest search.
+
 ## Scopes (0.17+)
 
 Use `.with_scope("api")` to resolve only a named `[scopes.api]` subset. The

--- a/docs/src/content/docs/sdk/swift.mdx
+++ b/docs/src/content/docs/sdk/swift.mdx
@@ -81,6 +81,12 @@ let builder = SecretSpec.builder().withCaller(CallerContext(
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
+## Inline specifications (0.20+)
+
+Use `try builder.withInlineSpec(spec, baseDir: ...)` with an `Encodable`
+declaration to resolve strict inline-spec v1 JSON. The base directory resolves
+relative provider paths; an older XCFramework fails to link the versioned call.
+
 ## Scopes
 
 Use `withScope("api")` to resolve only a named `[scopes.api]` subset. The

--- a/secretspec-dotnet/src/SecretSpec/Native.cs
+++ b/secretspec-dotnet/src/SecretSpec/Native.cs
@@ -14,15 +14,29 @@ internal static partial class Native
     }
 
     internal static string Resolve(string requestJson)
+        => Invoke(secretspec_resolve, requestJson, "secretspec_resolve", false);
+
+    internal static string Call(string requestJson)
+        => Invoke(secretspec_call, requestJson, "secretspec_call", true);
+
+    private static string Invoke(
+        Func<string, IntPtr> function,
+        string requestJson,
+        string symbol,
+        bool missingSymbolIsCapability)
     {
         IntPtr response = IntPtr.Zero;
         try
         {
-            response = secretspec_resolve(requestJson);
+            response = function(requestJson);
             if (response == IntPtr.Zero)
-                throw new SecretSpecException("ffi", "secretspec_resolve returned null");
+                throw new SecretSpecException("ffi", $"{symbol} returned null");
             return Marshal.PtrToStringUTF8(response)
                 ?? throw new SecretSpecException("ffi", "secretspec_resolve returned invalid UTF-8");
+        }
+        catch (EntryPointNotFoundException error) when (missingSymbolIsCapability)
+        {
+            throw new SecretSpecException("capability", error.Message, error);
         }
         catch (Exception error) when (
             error is DllNotFoundException or EntryPointNotFoundException or BadImageFormatException)
@@ -107,6 +121,10 @@ internal static partial class Native
     [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial IntPtr secretspec_resolve(string requestJson);
+
+    [LibraryImport(LibraryName, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial IntPtr secretspec_call(string requestJson);
 
     [LibraryImport(LibraryName)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/secretspec-dotnet/src/SecretSpec/SecretSpecBuilder.cs
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpecBuilder.cs
@@ -7,12 +7,48 @@ namespace Cachix.SecretSpec;
 public sealed class SecretSpecBuilder
 {
     private readonly ResolveRequest _request = new();
+    private bool _hasInlineSpec;
+    private JsonElement _inlineSpec;
+    private string? _inlineBaseDir;
 
     public SecretSpecBuilder WithPath(string? path)
     {
+        _inlineSpec = default;
+        _inlineBaseDir = null;
+        _hasInlineSpec = false;
         _request.Path = path;
         return this;
     }
+
+    /// <summary>Resolve strict inline-spec v1 at <paramref name="baseDir"/> (SecretSpec 0.20+).</summary>
+    public SecretSpecBuilder WithInlineSpec(JsonElement spec, string baseDir)
+    {
+        if (spec.ValueKind == JsonValueKind.Undefined)
+            throw new ArgumentException("The inline specification must be a JSON value.", nameof(spec));
+
+        _request.Path = null;
+        _hasInlineSpec = true;
+        _inlineSpec = spec.Clone();
+        _inlineBaseDir = baseDir;
+        return this;
+    }
+
+    /// <summary>
+    /// Resolve a pre-serialized strict inline-spec v1 at <paramref name="baseDir"/>
+    /// (SecretSpec 0.20+).
+    /// </summary>
+    public SecretSpecBuilder WithInlineSpec(string specJson, string baseDir)
+    {
+        using var document = JsonDocument.Parse(specJson);
+        return WithInlineSpec(document.RootElement, baseDir);
+    }
+
+    /// <summary>
+    /// Resolve strict inline-spec v1 using source-generated JSON metadata
+    /// (SecretSpec 0.20+).
+    /// </summary>
+    public SecretSpecBuilder WithInlineSpec<T>(T spec, string baseDir, JsonTypeInfo<T> jsonTypeInfo)
+        => WithInlineSpec(JsonSerializer.SerializeToElement(spec, jsonTypeInfo), baseDir);
 
     public SecretSpecBuilder WithProvider(string? provider)
     {
@@ -94,16 +130,20 @@ public sealed class SecretSpecBuilder
             response.Secrets);
     }
 
-    private static T Call<T>(
+    private T Call<T>(
         ResolveRequest request,
         string kind,
         JsonTypeInfo<Envelope<T>> envelopeTypeInfo)
         where T : class
     {
-        var payload = JsonSerializer.Serialize(
+        var versioned = _hasInlineSpec;
+        var options = JsonSerializer.SerializeToElement(
             request,
             SecretSpecJsonContext.Default.ResolveRequest);
-        var raw = Native.Resolve(payload);
+        var payload = versioned
+            ? SerializeInlineRequest(options)
+            : JsonSerializer.Serialize(request, SecretSpecJsonContext.Default.ResolveRequest);
+        var raw = versioned ? Native.Call(payload) : Native.Resolve(payload);
         Envelope<T>? envelope;
         try
         {
@@ -126,6 +166,29 @@ public sealed class SecretSpecBuilder
             ?? throw new SecretSpecException(
                 "ffi",
                 $"secretspec_resolve reported ok with no {kind} response");
+    }
+
+    private string SerializeInlineRequest(JsonElement options)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("request_version", 1);
+            writer.WriteString("operation", "resolve");
+            writer.WritePropertyName("source");
+            writer.WriteStartObject();
+            writer.WriteString("kind", "inline");
+            writer.WriteNumber("spec_version", 1);
+            writer.WriteString("base_dir", _inlineBaseDir);
+            writer.WritePropertyName("spec");
+            _inlineSpec.WriteTo(writer);
+            writer.WriteEndObject();
+            writer.WritePropertyName("options");
+            options.WriteTo(writer);
+            writer.WriteEndObject();
+        }
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
     }
 
     private static void EnsureSchemaVersion(int actual, int expected, string kind)

--- a/secretspec-dotnet/tests/SecretSpec.Tests/Program.cs
+++ b/secretspec-dotnet/tests/SecretSpec.Tests/Program.cs
@@ -24,6 +24,8 @@ internal static class Program
         ("ABI version", TestAbiVersion),
         ("caller context", TestCallerContext),
         ("load values and provenance", TestLoad),
+        ("inline specification", TestInlineSpec),
+        ("null inline specification does not fall back", TestNullInlineSpec),
         ("scoped resolution", TestScope),
         ("missing required exception", TestMissingRequired),
         ("invalid manifest exception", TestInvalidManifest),
@@ -96,6 +98,48 @@ internal static class Program
 
         var fields = JsonNode.Parse(resolved.FieldsJson());
         Equal("postgres://db", fields?["DATABASE_URL"]?.GetValue<string>());
+    }
+
+    private static void TestInlineSpec()
+    {
+        using var project = Project.Create(Manifest, "");
+        var dir = Path.GetDirectoryName(project.ManifestPath)!;
+        File.WriteAllText(Path.Combine(dir, "inline.env"), "TOKEN=inline-dotnet\n");
+        var spec = """
+            {
+              "project": { "name": "dotnet-inline" },
+              "providers": { "env": "dotenv://inline.env" },
+              "profiles": { "default": { "secrets": {
+                "TOKEN": { "description": "token", "providers": ["env"] }
+              } } }
+            }
+            """;
+        using var resolved = SecretSpecClient.Builder()
+            .WithInlineSpec(spec, dir)
+            .WithReason("C# inline test")
+            .Load();
+        Equal("inline-dotnet", resolved.Secrets["TOKEN"].Get());
+    }
+
+    private static void TestNullInlineSpec()
+    {
+        using var project = Project.Create(Manifest, "DATABASE_URL=postgres://db\n");
+        var directory = Path.GetDirectoryName(project.ManifestPath)!;
+        var before = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(directory);
+            var error = Throws<SecretSpecException>(() =>
+                SecretSpecClient.Builder()
+                    .WithInlineSpec("null", directory)
+                    .WithReason("C# null inline test")
+                    .Load());
+            Equal("invalid_request", error.Kind);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(before);
+        }
     }
 
     private static void TestScope()

--- a/secretspec-dotnet/tests/SecretSpec.Tests/SecretSpec.Tests.csproj
+++ b/secretspec-dotnet/tests/SecretSpec.Tests/SecretSpec.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/secretspec-ffi/include/secretspec.h
+++ b/secretspec-ffi/include/secretspec.h
@@ -2,7 +2,7 @@
  * SecretSpec C ABI.
  *
  * A deliberately narrow, JSON-in / JSON-out boundary. The entire native surface
- * is the three functions below; all richness lives in the versioned JSON
+ * is the functions below; all richness lives in the versioned JSON
  * contract so language bindings stay thin.
  *
  * Request JSON (all fields optional):
@@ -62,7 +62,40 @@ extern "C" {
 char *secretspec_resolve(const char *request_json);
 
 /*
- * Free a string previously returned by secretspec_resolve(). NULL is ignored.
+ * Execute a versioned native operation. This is separate from
+ * secretspec_resolve so SDKs using inline declarations can require this symbol
+ * at load time, rather than risk an old library ignoring an unknown field and
+ * searching for a filesystem manifest.
+ *
+ * Request v1:
+ * {
+ *   "request_version": 1,
+ *   "operation": "resolve",
+ *   "source": {
+ *     "kind": "inline", "spec_version": 1, "base_dir": "/project",
+ *     "spec": {
+ *       "project": { "name": "my-app" },
+ *       "profiles": {
+ *         "default": { "secrets": {
+ *           "TOKEN": { "description": "API token", "required": true }
+ *         }}
+ *       }
+ *     }
+ *   },
+ *   "options": { "provider": "dotenv://.env", "reason": "startup" }
+ * }
+ *
+ * source.kind is exactly one of "search", "path" (with path), or "inline".
+ * Inline spec v1 is strict JSON: profile declarations use a `secrets` object,
+ * and unknown declaration fields are rejected. Its base_dir resolves relative
+ * provider paths like Secrets::from_spec_at. project.extends is supported and
+ * resolves parent manifests relative to base_dir, like a file-backed Spec.
+ */
+char *secretspec_call(const char *request_json);
+
+/*
+ * Free a string previously returned by secretspec_resolve() or secretspec_call().
+ * NULL is ignored.
  * Must not be called twice on the same pointer.
  */
 void secretspec_free(char *ptr);

--- a/secretspec-ffi/src/lib.rs
+++ b/secretspec-ffi/src/lib.rs
@@ -1,6 +1,6 @@
 //! The SecretSpec C ABI: a deliberately narrow, JSON-in/JSON-out boundary.
 //!
-//! The entire native surface is three functions. Richness lives in the
+//! The native surface is four functions. Richness lives in the
 //! versioned JSON contract, not in a wide C API, so that every consumer of
 //! this ABI (Go via purego, Ruby via ffi, Haskell via the GHC FFI) stays a
 //! thin shell: marshal a request string in, get a response string out, free it.
@@ -15,6 +15,8 @@
 //!   returns a heap-allocated, NUL-terminated JSON **response envelope**. The
 //!   caller owns the returned pointer and must free it with [`secretspec_free`].
 //! - [`secretspec_abi_version`] returns a static version string (do not free).
+//! - [`secretspec_call`] accepts the versioned operation envelope used by SDKs
+//!   that need an inline declaration source.
 //!
 //! ## Request JSON
 //!
@@ -98,7 +100,7 @@ pub extern "C" fn secretspec_abi_version() -> *const c_char {
     ABI_VERSION.as_ptr().cast()
 }
 
-/// Frees a string previously returned by [`secretspec_resolve`].
+/// Frees a string previously returned by [`secretspec_resolve`] or [`secretspec_call`].
 ///
 /// # Safety
 /// `ptr` must be either null or a pointer returned by [`secretspec_resolve`]
@@ -136,7 +138,39 @@ pub unsafe extern "C" fn secretspec_resolve(request_json: *const c_char) -> *mut
     }
 }
 
+/// Executes a versioned native operation described by a JSON request.
+///
+/// This is intentionally a separate symbol from [`secretspec_resolve`]. SDKs
+/// that require inline declarations can use its presence as a capability check:
+/// an older library fails while binding the symbol instead of silently ignoring
+/// an inline declaration and searching the filesystem.
+///
+/// # Safety
+/// `request_json` must be null or a valid pointer to a NUL-terminated C string.
+/// The returned pointer is owned by the caller and must be freed with
+/// [`secretspec_free`]. Returns null only on catastrophic allocation failure.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn secretspec_call(request_json: *const c_char) -> *mut c_char {
+    let json = match catch_unwind(AssertUnwindSafe(|| call_inner(request_json))) {
+        Ok(json) => json,
+        Err(_) => input_error("internal panic during native call"),
+    };
+
+    match CString::new(json) {
+        Ok(c) => c.into_raw(),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
 fn resolve_inner(request_json: *const c_char) -> String {
+    decode_input(request_json, secretspec::resolve_json)
+}
+
+fn call_inner(request_json: *const c_char) -> String {
+    decode_input(request_json, secretspec::call_json)
+}
+
+fn decode_input(request_json: *const c_char, dispatch: impl FnOnce(&str) -> String) -> String {
     if request_json.is_null() {
         return input_error("request_json was null");
     }
@@ -144,7 +178,7 @@ fn resolve_inner(request_json: *const c_char) -> String {
     // Safety: caller contract guarantees a NUL-terminated string when non-null.
     let raw = unsafe { CStr::from_ptr(request_json) };
     match raw.to_str() {
-        Ok(text) => secretspec::resolve_json(text),
+        Ok(text) => dispatch(text),
         Err(_) => input_error("request_json was not valid UTF-8"),
     }
 }

--- a/secretspec-ffi/tests/c_abi.rs
+++ b/secretspec-ffi/tests/c_abi.rs
@@ -5,7 +5,9 @@
 use std::ffi::{CStr, CString, c_char};
 use std::fs;
 
-use secretspec_ffi::{secretspec_abi_version, secretspec_free, secretspec_resolve};
+use secretspec_ffi::{
+    secretspec_abi_version, secretspec_call, secretspec_free, secretspec_resolve,
+};
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -15,6 +17,16 @@ fn resolve(request: &str) -> Value {
     let c_request = CString::new(request).unwrap();
     let ptr: *mut c_char = unsafe { secretspec_resolve(c_request.as_ptr()) };
     assert!(!ptr.is_null(), "resolve returned null");
+    let json = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_string();
+    unsafe { secretspec_free(ptr) };
+    serde_json::from_str(&json).unwrap()
+}
+
+/// Call the versioned operation API through its real exported C symbol.
+fn call(request: &str) -> Value {
+    let c_request = CString::new(request).unwrap();
+    let ptr: *mut c_char = unsafe { secretspec_call(c_request.as_ptr()) };
+    assert!(!ptr.is_null(), "call returned null");
     let json = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_string();
     unsafe { secretspec_free(ptr) };
     serde_json::from_str(&json).unwrap()
@@ -60,6 +72,180 @@ fn abi_version_is_nonempty() {
     let version = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();
     assert!(!version.is_empty());
     // Static string: no free.
+}
+
+#[test]
+fn call_resolves_a_strict_inline_spec_at_its_logical_base_directory() {
+    let dir = TempDir::new().unwrap();
+    let env_path = dir.path().join("inline.env");
+    fs::write(&env_path, "TOKEN=from-inline\n").unwrap();
+    let request = serde_json::json!({
+        "request_version": 1,
+        "operation": "resolve",
+        "source": {
+            "kind": "inline",
+            "spec_version": 1,
+            "base_dir": dir.path(),
+            "spec": {
+                "project": { "name": "inline-ffi" },
+                "providers": { "env": "dotenv://inline.env" },
+                "profiles": {
+                    "default": {
+                        "secrets": {
+                            "TOKEN": { "description": "inline token", "providers": ["env"] }
+                        }
+                    }
+                }
+            }
+        },
+        "options": { "reason": "ffi inline test" }
+    })
+    .to_string();
+
+    let env = call(&request);
+    assert_eq!(env["ok"], true, "envelope: {env}");
+    assert_eq!(env["response"]["secrets"]["TOKEN"]["value"], "from-inline");
+}
+
+#[test]
+fn call_inline_spec_resolves_extends_relative_to_base_directory() {
+    let dir = TempDir::new().unwrap();
+    let parent = dir.path().join("parent");
+    fs::create_dir(&parent).unwrap();
+    fs::write(parent.join("parent.env"), "TOKEN=from-parent\n").unwrap();
+    fs::write(
+        parent.join("secretspec.toml"),
+        r#"
+[project]
+name = "parent"
+revision = "1.0"
+
+[providers]
+env = "dotenv://parent/parent.env"
+
+[profiles.default]
+TOKEN = { description = "inherited token", providers = ["env"] }
+"#,
+    )
+    .unwrap();
+    let request = serde_json::json!({
+        "request_version": 1,
+        "operation": "resolve",
+        "source": {
+            "kind": "inline",
+            "spec_version": 1,
+            "base_dir": dir.path(),
+            "spec": {
+                "project": { "name": "child", "extends": ["parent"] },
+                "profiles": {}
+            }
+        },
+        "options": { "reason": "ffi inline inheritance test" }
+    })
+    .to_string();
+
+    let env = call(&request);
+    assert_eq!(env["ok"], true, "envelope: {env}");
+    assert_eq!(env["response"]["secrets"]["TOKEN"]["value"], "from-parent");
+}
+
+#[test]
+fn call_rejects_unknown_versions_operations_and_source_combinations() {
+    let cases = [
+        serde_json::json!({
+            "request_version": 2, "operation": "resolve", "source": { "kind": "search" }
+        }),
+        serde_json::json!({
+            "request_version": 1, "operation": "inspect", "source": { "kind": "search" }
+        }),
+        serde_json::json!({
+            "request_version": 1, "operation": "resolve",
+            "source": { "kind": "inline", "spec_version": 2, "base_dir": ".", "spec": {} }
+        }),
+        serde_json::json!({
+            "request_version": 1, "operation": "resolve",
+            "source": { "kind": "path", "path": "secretspec.toml", "spec": {} }
+        }),
+    ];
+    for request in cases {
+        let env = call(&request.to_string());
+        assert_eq!(
+            env["ok"], false,
+            "request unexpectedly succeeded: {request}"
+        );
+    }
+}
+
+#[test]
+fn call_rejects_unknown_inline_declaration_fields() {
+    let request = serde_json::json!({
+        "request_version": 1,
+        "operation": "resolve",
+        "source": {
+            "kind": "inline", "spec_version": 1, "base_dir": ".",
+            "spec": {
+                "project": { "name": "inline" },
+                "profiles": { "default": { "secrets": {
+                    "TOKEN": { "description": "token", "required": true, "unknown": true }
+                }}}
+            }
+        }
+    })
+    .to_string();
+    let env = call(&request);
+    assert_eq!(env["ok"], false);
+    assert_eq!(env["error"]["kind"], "invalid_request");
+}
+
+#[test]
+fn call_accepts_scalar_required_group_names() {
+    let request = serde_json::json!({
+        "request_version": 1,
+        "operation": "resolve",
+        "source": {
+            "kind": "inline", "spec_version": 1, "base_dir": ".",
+            "spec": {
+                "project": { "name": "inline-groups" },
+                "profiles": { "default": { "secrets": {
+                    "USERNAME": {
+                        "description": "username", "required": { "at_least_one": "account_auth" },
+                        "default": "alice"
+                    },
+                    "PASSWORD": {
+                        "description": "password", "required": { "at_least_one": "account_auth" },
+                        "default": "secret"
+                    }
+                }}}
+            }
+        },
+        "options": { "reason": "ffi inline groups test" }
+    })
+    .to_string();
+
+    let env = call(&request);
+    assert_eq!(env["ok"], true, "envelope: {env}");
+}
+
+#[test]
+fn call_rejects_empty_required_groups() {
+    let request = serde_json::json!({
+        "request_version": 1,
+        "operation": "resolve",
+        "source": {
+            "kind": "inline", "spec_version": 1, "base_dir": ".",
+            "spec": {
+                "project": { "name": "inline-groups" },
+                "profiles": { "default": { "secrets": {
+                    "TOKEN": { "description": "token", "required": {} }
+                }}}
+            }
+        }
+    })
+    .to_string();
+
+    let env = call(&request);
+    assert_eq!(env["ok"], false, "envelope: {env}");
+    assert_eq!(env["error"]["kind"], "invalid_request");
 }
 
 #[test]

--- a/secretspec-ffi/tests/c_abi.rs
+++ b/secretspec-ffi/tests/c_abi.rs
@@ -199,6 +199,9 @@ fn call_rejects_unknown_inline_declaration_fields() {
 
 #[test]
 fn call_accepts_scalar_required_group_names() {
+    let dir = TempDir::new().unwrap();
+    let env_path = dir.path().join("inline-groups.env");
+    fs::write(&env_path, "").unwrap();
     let request = serde_json::json!({
         "request_version": 1,
         "operation": "resolve",
@@ -218,7 +221,10 @@ fn call_accepts_scalar_required_group_names() {
                 }}}
             }
         },
-        "options": { "reason": "ffi inline groups test" }
+        "options": {
+            "provider": format!("dotenv://{}", env_path.display()),
+            "reason": "ffi inline groups test"
+        }
     })
     .to_string();
 

--- a/secretspec-go/README.md
+++ b/secretspec-go/README.md
@@ -38,6 +38,27 @@ func main() {
 A missing required secret returns `*MissingRequiredError`; any other failure
 returns `*Error` (with a stable `.Kind`).
 
+## Inline specifications (0.20+)
+
+Use `WithInlineSpec(spec, baseDir)` to resolve a strict JSON declaration held
+in application code. `baseDir` resolves relative provider paths, and an older
+native library fails with a capability error rather than searching for a
+filesystem manifest. The inline v1 document uses `project`, `profiles`, and a
+`secrets` object in each profile. `project.extends` resolves parent manifests
+relative to the supplied logical base directory.
+
+```go
+spec := map[string]any{
+	"project": map[string]any{"name": "my-app"},
+	"profiles": map[string]any{"default": map[string]any{
+		"secrets": map[string]any{
+			"API_TOKEN": map[string]any{"description": "API token"},
+		},
+	}},
+}
+resolved, err := secretspec.New().WithInlineSpec(spec, "/logical/project").Load()
+```
+
 ## Scopes (0.17+)
 
 Use `WithScope("api")` to resolve only a named `[scopes.api]` subset. Both

--- a/secretspec-go/binding_cgo.go
+++ b/secretspec-go/binding_cgo.go
@@ -16,7 +16,8 @@ import "C"
 import "unsafe"
 
 // ensureLoaded is a no-op: the platform linker loads the resolver.
-func ensureLoaded() error { return nil }
+func ensureLoaded() error     { return nil }
+func ensureCallLoaded() error { return nil }
 
 // nativeResolve calls secretspec_resolve and returns the owned response, freeing
 // both the C request copy and the returned allocation.
@@ -27,6 +28,19 @@ func nativeResolve(payload string) (string, error) {
 	res := C.secretspec_resolve(req)
 	if res == nil {
 		return "", &Error{Kind: "ffi", Message: "secretspec_resolve returned null"}
+	}
+	out := C.GoString(res)
+	C.secretspec_free(res)
+	return out, nil
+}
+
+func nativeCall(payload string) (string, error) {
+	req := C.CString(payload)
+	defer C.free(unsafe.Pointer(req))
+
+	res := C.secretspec_call(req)
+	if res == nil {
+		return "", &Error{Kind: "ffi", Message: "secretspec_call returned null"}
 	}
 	out := C.GoString(res)
 	C.secretspec_free(res)

--- a/secretspec-go/binding_purego.go
+++ b/secretspec-go/binding_purego.go
@@ -19,11 +19,15 @@ import (
 )
 
 var (
-	loadOnce sync.Once
-	loadErr  error
-	cResolve func(string) uintptr
-	cFree    func(uintptr)
-	cABI     func() uintptr
+	loadOnce  sync.Once
+	loadErr   error
+	callOnce  sync.Once
+	callErr   error
+	libHandle uintptr
+	cResolve  func(string) uintptr
+	cCall     func(string) uintptr
+	cFree     func(uintptr)
+	cABI      func() uintptr
 )
 
 func libNames() []string {
@@ -106,11 +110,31 @@ func ensureLoaded() error {
 			loadErr = err
 			return
 		}
+		libHandle = handle
 		purego.RegisterLibFunc(&cResolve, handle, "secretspec_resolve")
 		purego.RegisterLibFunc(&cFree, handle, "secretspec_free")
 		purego.RegisterLibFunc(&cABI, handle, "secretspec_abi_version")
 	})
 	return loadErr
+}
+
+// ensureCallLoaded binds the capability-gated call symbol only for SDKs that
+// request an inline declaration. Keeping it out of ensureLoaded preserves the
+// legacy path/search API for an older runtime that predates secretspec_call.
+func ensureCallLoaded() error {
+	if err := ensureLoaded(); err != nil {
+		return err
+	}
+	callOnce.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				callErr = &Error{Kind: "capability", Message: fmt.Sprintf(
+					"loaded secretspec-ffi does not support inline specs (missing secretspec_call): %v", r)}
+			}
+		}()
+		purego.RegisterLibFunc(&cCall, libHandle, "secretspec_call")
+	})
+	return callErr
 }
 
 // nativeResolve calls secretspec_resolve and returns the owned response, freeing
@@ -119,6 +143,16 @@ func nativeResolve(payload string) (string, error) {
 	ptr := cResolve(payload)
 	if ptr == 0 {
 		return "", &Error{Kind: "ffi", Message: "secretspec_resolve returned null"}
+	}
+	raw := goString(ptr)
+	cFree(ptr)
+	return raw, nil
+}
+
+func nativeCall(payload string) (string, error) {
+	ptr := cCall(payload)
+	if ptr == 0 {
+		return "", &Error{Kind: "ffi", Message: "secretspec_call returned null"}
 	}
 	raw := goString(ptr)
 	cFree(ptr)

--- a/secretspec-go/conformance_test.go
+++ b/secretspec-go/conformance_test.go
@@ -70,6 +70,36 @@ func TestConformance(t *testing.T) {
 	}
 }
 
+// TestInlineSpecConformance exercises the purego/dlopen-capable SDK through
+// the versioned `secretspec_call` symbol. It deliberately has no manifest: a
+// successful result proves the inline declaration did not fall back to a file
+// search and that its logical base directory resolves relative providers.
+func TestInlineSpecConformance(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "inline.env"), []byte("TOKEN=inline\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	spec := map[string]any{
+		"project":   map[string]any{"name": "go-inline"},
+		"providers": map[string]any{"env": "dotenv://inline.env"},
+		"profiles": map[string]any{
+			"default": map[string]any{
+				"secrets": map[string]any{
+					"TOKEN": map[string]any{"description": "inline token", "providers": []string{"env"}},
+				},
+			},
+		},
+	}
+	resolved, err := New().WithInlineSpec(spec, dir).WithReason("conformance").Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resolved.Close()
+	if got := resolved.Secrets["TOKEN"].Get(); got != "inline" {
+		t.Fatalf("TOKEN = %q, want inline", got)
+	}
+}
+
 func canonical(t *testing.T, resolved *Resolved) map[string]any {
 	t.Helper()
 	secrets := map[string]any{}

--- a/secretspec-go/secretspec.go
+++ b/secretspec-go/secretspec.go
@@ -171,7 +171,13 @@ func ABIVersion() (string, error) {
 
 // Builder configures a resolution, mirroring the derive crate's SecretSpec::builder().
 type Builder struct {
-	req map[string]any
+	req    map[string]any
+	inline *inlineSource
+}
+
+type inlineSource struct {
+	baseDir string
+	spec    any
 }
 
 // New starts a resolution builder.
@@ -190,7 +196,13 @@ func (b *Builder) set(key string, value any) *Builder {
 	return b
 }
 
-func (b *Builder) WithPath(path string) *Builder  { return b.set("path", path) }
+func (b *Builder) WithPath(path string) *Builder {
+	// Sources are a tagged union in the native request. Choosing a path after
+	// an inline source deliberately selects the legacy path source instead of
+	// serializing an ambiguous request.
+	b.inline = nil
+	return b.set("path", path)
+}
 func (b *Builder) WithProvider(p string) *Builder { return b.set("provider", p) }
 func (b *Builder) WithProfile(p string) *Builder  { return b.set("profile", p) }
 
@@ -201,6 +213,21 @@ func (b *Builder) WithCaller(caller CallerContext) *Builder {
 	return b.set("caller", caller)
 }
 func (b *Builder) WithNoValues(v bool) *Builder { return b.set("no_values", v) }
+
+// WithInlineSpec resolves a strict, versioned inline declaration instead of a
+// filesystem manifest. `spec` is serialized as the native inline-spec v1
+// document (project/profiles/secrets); `baseDir` resolves relative provider
+// paths just like the directory of a manifest. Available since SecretSpec 0.20.
+//
+// The native library must export `secretspec_call`. If it is older, Load and
+// Report return a capability error rather than falling back to a manifest search.
+func (b *Builder) WithInlineSpec(spec any, baseDir string) *Builder {
+	if b.req != nil {
+		delete(b.req, "path")
+	}
+	b.inline = &inlineSource{baseDir: baseDir, spec: spec}
+	return b
+}
 
 // envelope is the response wrapper shared by the resolve and report paths,
 // generic over its inner response type R.
@@ -264,21 +291,13 @@ func parseEnvelope[R any](raw, kind string, expected int, schemaOf func(*R) int)
 // Load resolves the secrets. It returns *MissingRequiredError if a required
 // secret is missing, and *Error for any other failure.
 func (b *Builder) Load() (*Resolved, error) {
-	if err := ensureLoaded(); err != nil {
-		return nil, err
-	}
 	// A zero-value Builder (var b Builder; b.Load()) has a nil req, which marshals
 	// to the literal `null` that serde rejects as an invalid JsonRequest. The WithX
 	// setters lazily allocate req, but Load may run before any of them.
 	if b.req == nil {
 		b.req = map[string]any{}
 	}
-	payload, err := json.Marshal(b.req)
-	if err != nil {
-		return nil, err
-	}
-
-	raw, err := nativeResolve(string(payload))
+	raw, err := b.execute("")
 	if err != nil {
 		return nil, err
 	}
@@ -361,20 +380,7 @@ type reportResponseJSON struct {
 // *MissingRequiredError: a missing required secret appears as a SecretReport
 // with Status "missing_required". It returns *Error for a genuine failure.
 func (b *Builder) Report() (*Report, error) {
-	if err := ensureLoaded(); err != nil {
-		return nil, err
-	}
-	req := make(map[string]any, len(b.req)+1)
-	for k, v := range b.req {
-		req[k] = v
-	}
-	req["mode"] = "report"
-	payload, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-
-	raw, err := nativeResolve(string(payload))
+	raw, err := b.execute("report")
 	if err != nil {
 		return nil, err
 	}
@@ -394,4 +400,46 @@ func (b *Builder) Report() (*Report, error) {
 		Scope:    resp.Scope,
 		Secrets:  secrets,
 	}, nil
+}
+
+// execute keeps the legacy request exactly as it was for path/search callers.
+// Inline callers use the separate C symbol, making an old runtime's missing
+// capability an explicit load error instead of a filesystem fallback.
+func (b *Builder) execute(mode string) (string, error) {
+	if b.req == nil {
+		b.req = map[string]any{}
+	}
+	options := make(map[string]any, len(b.req)+1)
+	for k, v := range b.req {
+		options[k] = v
+	}
+	if mode != "" {
+		options["mode"] = mode
+	}
+	if b.inline == nil {
+		if err := ensureLoaded(); err != nil {
+			return "", err
+		}
+		payload, err := json.Marshal(options)
+		if err != nil {
+			return "", err
+		}
+		return nativeResolve(string(payload))
+	}
+	if err := ensureCallLoaded(); err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(map[string]any{
+		"request_version": 1,
+		"operation":       "resolve",
+		"source": map[string]any{
+			"kind": "inline", "spec_version": 1,
+			"base_dir": b.inline.baseDir, "spec": b.inline.spec,
+		},
+		"options": options,
+	})
+	if err != nil {
+		return "", err
+	}
+	return nativeCall(string(payload))
 }

--- a/secretspec-hs/src/SecretSpec.hs
+++ b/secretspec-hs/src/SecretSpec.hs
@@ -22,6 +22,7 @@ module SecretSpec
   , CallerContext(..)
   , builder
   , withPath
+  , withInlineSpec
   , withProvider
   , withProfile
   , withScope
@@ -71,6 +72,9 @@ import qualified System.Environment.Blank as Env
 -- (1Password, LastPass), and a @safe@ call lets other Haskell threads run.
 foreign import ccall safe "secretspec_resolve"
   c_secretspec_resolve :: CString -> IO CString
+
+foreign import ccall safe "secretspec_call"
+  c_secretspec_call :: CString -> IO CString
 
 foreign import ccall safe "secretspec_free"
   c_secretspec_free :: CString -> IO ()
@@ -177,6 +181,7 @@ data Builder = Builder
   , bReason   :: Maybe Text
   , bCaller   :: Maybe CallerContext
   , bNoValues :: Bool
+  , bInline   :: Maybe (Value, Text)
   }
 
 -- | Caller-asserted software-integration context (SecretSpec 0.20+). It is
@@ -190,12 +195,18 @@ data CallerContext = CallerContext
 
 -- | A builder with no options set.
 builder :: Builder
-builder = Builder Nothing Nothing Nothing Nothing Nothing Nothing False
+builder = Builder Nothing Nothing Nothing Nothing Nothing Nothing False Nothing
 
 -- | Resolve from a manifest at this path instead of walking up from the working
 -- directory.
 withPath :: Text -> Builder -> Builder
-withPath v b = b { bPath = Just v }
+withPath v b = b { bPath = Just v, bInline = Nothing }
+
+-- | Resolve strict inline-spec v1 at its logical base directory (0.20+).
+-- The static linker requires @secretspec_call@, so an older native archive
+-- fails at link time instead of falling back to a filesystem manifest.
+withInlineSpec :: Value -> Text -> Builder -> Builder
+withInlineSpec spec baseDir b = b { bPath = Nothing, bInline = Just (spec, baseDir) }
 
 -- | Override the provider (a @keyring:\/\/@-style URI or a configured alias).
 withProvider :: Text -> Builder -> Builder
@@ -273,7 +284,7 @@ abiVersion = do
 -- missing, and 'SecretSpecError' for any other failure.
 load :: Builder -> IO Resolved
 load b = do
-  resp <- callNative (requestBytes b Nothing)
+  resp <- callNative (isInline b) (requestBytes b Nothing)
   value <- responseValue resp resolveSchemaVersion "resolve"
   (prov, prof, scope, secs, mreq, mopt) <- fromResult (parseEither pResolve value)
   case mreq of
@@ -295,7 +306,7 @@ load b = do
 -- status @"missing_required"@.
 report :: Builder -> IO Report
 report b = do
-  resp <- callNative (requestBytes b (Just "report"))
+  resp <- callNative (isInline b) (requestBytes b (Just "report"))
   value <- responseValue resp reportSchemaVersion "report"
   (prov, prof, scope, secs) <- fromResult (parseEither pReport value)
   pure (Report prov prof scope secs)
@@ -311,18 +322,31 @@ report b = do
 -- (@mode = Just "report"@), omitting unset options.
 requestBytes :: Builder -> Maybe Text -> BL.ByteString
 requestBytes b mode =
-  encode . object $
-    catMaybes
-      [ ("path" .=) <$> bPath b
-      , ("provider" .=) <$> bProvider b
-      , ("profile" .=) <$> bProfile b
-      , ("scope" .=) <$> bScope b
-      , ("reason" .=) <$> bReason b
-      , ("caller" .=) . callerValue <$> bCaller b
+  case bInline b of
+    Nothing -> encode options
+    Just (spec, baseDir) -> encode $ object
+      [ "request_version" .= (1 :: Int)
+      , "operation" .= ("resolve" :: Text)
+      , "source" .= object
+          [ "kind" .= ("inline" :: Text)
+          , "spec_version" .= (1 :: Int)
+          , "base_dir" .= baseDir
+          , "spec" .= spec
+          ]
+      , "options" .= options
       ]
-      ++ ["no_values" .= True | bNoValues b]
-      ++ ["mode" .= m | Just m <- [mode]]
   where
+    options = object $
+      catMaybes
+        [ ("path" .=) <$> bPath b
+        , ("provider" .=) <$> bProvider b
+        , ("profile" .=) <$> bProfile b
+        , ("scope" .=) <$> bScope b
+        , ("reason" .=) <$> bReason b
+        , ("caller" .=) . callerValue <$> bCaller b
+        ]
+        ++ ["no_values" .= True | bNoValues b]
+        ++ ["mode" .= m | Just m <- [mode]]
     callerValue caller = object . catMaybes $
       [ Just ("name" .= callerName caller)
       , ("version" .=) <$> callerVersion caller
@@ -338,13 +362,16 @@ requestBytes b mode =
 -- around 'load') from landing between the call returning and the free being
 -- installed, and @finally@ guarantees the free runs whether @packCString@
 -- succeeds, throws, or is interrupted — so the secret-bearing buffer never leaks.
-callNative :: BL.ByteString -> IO BS.ByteString
-callNative reqLazy =
+isInline :: Builder -> Bool
+isInline = maybe False (const True) . bInline
+
+callNative :: Bool -> BL.ByteString -> IO BS.ByteString
+callNative versioned reqLazy =
   BS.useAsCString (BL.toStrict reqLazy) $ \creq ->
     mask $ \restore -> do
-      cresp <- c_secretspec_resolve creq
+      cresp <- (if versioned then c_secretspec_call else c_secretspec_resolve) creq
       if cresp == nullPtr
-        then throwIO (SecretSpecError "ffi" "secretspec_resolve returned null")
+        then throwIO (SecretSpecError "ffi" (if versioned then "secretspec_call returned null" else "secretspec_resolve returned null"))
         else restore (BS.packCString cresp) `finally` c_secretspec_free cresp
 
 -- Decode the envelope, unwrap @ok@/@error@, and check the schema version,

--- a/secretspec-hs/test/Main.hs
+++ b/secretspec-hs/test/Main.hs
@@ -41,6 +41,7 @@ main = do
   let tests =
         [ ("abi_version_nonempty", testAbiVersion)
         , ("caller_context_builder", testCallerContextBuilder)
+        , ("inline_spec", testInlineSpec)
         , ("missing_required_throws", testMissingRequired)
         , ("scoped_resolution", testScope)
         , ("codegen", testCodegen)
@@ -79,6 +80,30 @@ testCallerContextBuilder = do
         (Just "credential_get") (Just "github.com")
       configured = S.builder & S.withCaller caller
   configured `seq` pure ()
+
+testInlineSpec :: IO ()
+testInlineSpec = do
+  tmp <- getTemporaryDirectory
+  let dir = tmp </> "secretspec-hs-inline"
+  createDirectoryIfMissing True dir
+  writeFile (dir </> "inline.env") "TOKEN=inline-haskell\n"
+  let spec = object
+        [ "project" .= object ["name" .= ("haskell-inline" :: Text)]
+        , "providers" .= object ["env" .= ("dotenv://inline.env" :: Text)]
+        , "profiles" .= object
+            [ "default" .= object
+                [ "secrets" .= object
+                    [ "TOKEN" .= object
+                        [ "description" .= ("token" :: Text)
+                        , "providers" .= (["env"] :: [Text])
+                        ]
+                    ]
+                ]
+            ]
+        ]
+  resolved <- S.load (S.builder & S.withInlineSpec spec (T.pack dir) & S.withReason "inline test")
+  let token = Map.lookup "TOKEN" (S.resolvedSecrets resolved) >>= S.get
+  expect (token == Just "inline-haskell") "inline spec did not resolve TOKEN"
 
 testMissingRequired :: IO ()
 testMissingRequired = do

--- a/secretspec-node/index.d.ts
+++ b/secretspec-node/index.d.ts
@@ -73,6 +73,8 @@ export interface CallerContext {
 
 export class Builder {
   withPath(path: string): this;
+  /** Resolve strict inline-spec v1 at `baseDir` (0.20+). */
+  withInlineSpec(spec: Record<string, unknown>, baseDir: string): this;
   withProvider(provider: string): this;
   withProfile(profile: string): this;
   /** Limit resolution to a named manifest scope (SecretSpec 0.17+). */

--- a/secretspec-node/index.js
+++ b/secretspec-node/index.js
@@ -207,9 +207,16 @@ class Report {
 class Builder {
   constructor() {
     this._request = {};
+    this._inline = null;
   }
 
-  withPath(p) { if (p != null) this._request.path = p; return this; }
+  withPath(p) { this._inline = null; if (p != null) this._request.path = p; return this; }
+  /** Resolve inline-spec v1 at baseDir (SecretSpec 0.20+). */
+  withInlineSpec(spec, baseDir) {
+    delete this._request.path;
+    this._inline = { spec, baseDir };
+    return this;
+  }
   withProvider(p) { if (p != null) this._request.provider = p; return this; }
   withProfile(p) { if (p != null) this._request.profile = p; return this; }
   /** Limit resolution to a named manifest scope (SecretSpec 0.17+). */
@@ -227,7 +234,7 @@ class Builder {
    * loadAsync() when a provider may do network I/O (1Password, LastPass).
    */
   load() {
-    return this._parse(native.resolve(JSON.stringify(this._request)));
+    return this._parse(this._nativeCall());
   }
 
   /**
@@ -236,13 +243,14 @@ class Builder {
    * and rejects with the same error types load() throws.
    */
   async loadAsync() {
-    if (typeof native.resolveAsync !== 'function') {
+    const method = this._inline ? 'callAsync' : 'resolveAsync';
+    if (typeof native[method] !== 'function') {
       throw new SecretSpecError(
         'addon',
-        'the loaded native addon predates resolveAsync; rebuild it with scripts/build-addon.sh',
+        `the loaded native addon predates ${method}; rebuild it with scripts/build-addon.sh`,
       );
     }
-    return this._parse(await native.resolveAsync(JSON.stringify(this._request)));
+    return this._parse(await this._nativeCallAsync());
   }
 
   /**
@@ -288,27 +296,52 @@ class Builder {
    * network-backed providers.
    */
   report() {
-    return this._parseReport(
-      native.resolve(JSON.stringify({ ...this._request, mode: 'report' })),
-    );
+    return this._parseReport(this._nativeCall('report'));
   }
 
   /** Like report(), but resolves on the libuv threadpool. */
   async reportAsync() {
-    if (typeof native.resolveAsync !== 'function') {
+    const method = this._inline ? 'callAsync' : 'resolveAsync';
+    if (typeof native[method] !== 'function') {
       throw new SecretSpecError(
         'addon',
-        'the loaded native addon predates resolveAsync; rebuild it with scripts/build-addon.sh',
+        `the loaded native addon predates ${method}; rebuild it with scripts/build-addon.sh`,
       );
     }
-    return this._parseReport(
-      await native.resolveAsync(JSON.stringify({ ...this._request, mode: 'report' })),
-    );
+    return this._parseReport(await this._nativeCallAsync('report'));
   }
 
   /** Parse a JSON report envelope string into a Report (or throw). */
   _parseReport(raw) {
     return new Report(this._parseEnvelope(raw, 'report', REPORT_SCHEMA_VERSION));
+  }
+
+  _nativeRequest(mode) {
+    const options = { ...this._request };
+    if (mode) options.mode = mode;
+    if (!this._inline) return options;
+    return {
+      request_version: 1,
+      operation: 'resolve',
+      source: { kind: 'inline', spec_version: 1, base_dir: this._inline.baseDir, spec: this._inline.spec },
+      options,
+    };
+  }
+
+  _nativeCall(mode) {
+    const payload = JSON.stringify(this._nativeRequest(mode));
+    if (this._inline && typeof native.call !== 'function') {
+      throw new SecretSpecError(
+        'capability',
+        'the loaded native addon predates inline specifications; rebuild it with scripts/build-addon.sh',
+      );
+    }
+    return this._inline ? native.call(payload) : native.resolve(payload);
+  }
+
+  _nativeCallAsync(mode) {
+    const payload = JSON.stringify(this._nativeRequest(mode));
+    return this._inline ? native.callAsync(payload) : native.resolveAsync(payload);
   }
 }
 

--- a/secretspec-node/src/lib.rs
+++ b/secretspec-node/src/lib.rs
@@ -18,11 +18,18 @@ pub fn resolve(request_json: String) -> String {
     secretspec::resolve_json(&request_json)
 }
 
+/// Process a versioned native operation request, including inline specs.
+#[napi]
+pub fn call(request_json: String) -> String {
+    secretspec::call_json(&request_json)
+}
+
 /// Dispatches `resolve_json` from the libuv threadpool to one short-lived Rust
 /// thread, so it never runs on the JS thread and provider runtime/TLS state is
 /// torn down before the libuv worker is returned to Node.
 pub struct ResolveTask {
     request_json: String,
+    versioned_call: bool,
 }
 
 impl Task for ResolveTask {
@@ -40,7 +47,13 @@ impl Task for ResolveTask {
         std::thread::scope(|scope| {
             let resolver = std::thread::Builder::new()
                 .name("secretspec-resolve".to_string())
-                .spawn_scoped(scope, || secretspec::resolve_json(&self.request_json))
+                .spawn_scoped(scope, || {
+                    if self.versioned_call {
+                        secretspec::call_json(&self.request_json)
+                    } else {
+                        secretspec::resolve_json(&self.request_json)
+                    }
+                })
                 .map_err(|error| {
                     napi::Error::from_reason(format!(
                         "failed to start the SecretSpec resolver thread: {error}"
@@ -63,7 +76,19 @@ impl Task for ResolveTask {
 /// worker. Returns a Promise of the same JSON response envelope string.
 #[napi]
 pub fn resolve_async(request_json: String) -> AsyncTask<ResolveTask> {
-    AsyncTask::new(ResolveTask { request_json })
+    AsyncTask::new(ResolveTask {
+        request_json,
+        versioned_call: false,
+    })
+}
+
+/// Async variant of [`call`].
+#[napi]
+pub fn call_async(request_json: String) -> AsyncTask<ResolveTask> {
+    AsyncTask::new(ResolveTask {
+        request_json,
+        versioned_call: true,
+    })
 }
 
 /// The addon (ABI) version.

--- a/secretspec-node/test/resolve.test.js
+++ b/secretspec-node/test/resolve.test.js
@@ -90,6 +90,19 @@ test('load returns values and provenance', () => {
   assert.ok(!('SENTRY_DSN' in resolved.secrets));
 });
 
+test('withInlineSpec resolves at its logical base directory', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ss-node-inline-'));
+  fs.writeFileSync(path.join(dir, 'inline.env'), 'TOKEN=inline-node\n');
+  const resolved = SecretSpec.builder().withInlineSpec({
+    project: { name: 'node-inline' },
+    providers: { env: 'dotenv://inline.env' },
+    profiles: { default: { secrets: {
+      TOKEN: { description: 'token', providers: ['env'] },
+    } } },
+  }, dir).withReason('node inline test').load();
+  assert.equal(resolved.secrets.TOKEN.get(), 'inline-node');
+});
+
 test('scope is selected and returned', () => {
   const { manifestPath, provider } = project(
     'DATABASE_URL=postgres://db\nSENTRY_DSN=https://sentry\n',

--- a/secretspec-php/native/lib.rs
+++ b/secretspec-php/native/lib.rs
@@ -28,6 +28,13 @@ pub fn secretspec_native_resolve(request_json: &str) -> String {
     secretspec::resolve_json(request_json)
 }
 
+/// Process a versioned native operation request. Exposed as
+/// `secretspec_native_call()` for inline-spec resolution.
+#[php_function]
+pub fn secretspec_native_call(request_json: &str) -> String {
+    secretspec::call_json(request_json)
+}
+
 /// The extension's version (tracks the crate version). Exposed to PHP as
 /// `secretspec_native_abi_version()`.
 #[php_function]
@@ -39,5 +46,6 @@ pub fn secretspec_native_abi_version() -> String {
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
         .function(wrap_function!(secretspec_native_resolve))
+        .function(wrap_function!(secretspec_native_call))
         .function(wrap_function!(secretspec_native_abi_version))
 }

--- a/secretspec-php/src/Builder.php
+++ b/secretspec-php/src/Builder.php
@@ -26,10 +26,23 @@ final class Builder
     /** @var array<string, mixed> */
     private array $request = [];
 
+    /** @var array{spec: array<string, mixed>, base_dir: string}|null */
+    private ?array $inline = null;
+
     /** Path to a `secretspec.toml`; omit to walk up from the working directory. */
     public function withPath(?string $path): self
     {
+        $this->inline = null;
         return $this->set('path', $path);
+    }
+
+    /** Resolve strict inline-spec v1 at its logical base directory (0.20+). */
+    public function withInlineSpec(array $spec, string $baseDir): self
+    {
+        unset($this->request['path']);
+        $this->inline = ['spec' => $spec, 'base_dir' => $baseDir];
+
+        return $this;
     }
 
     /** Provider address, e.g. `keyring://` or `dotenv://.env.production`. */
@@ -92,7 +105,8 @@ final class Builder
      */
     public function load(): Resolved
     {
-        $response = $this->checkedResponse($this->request, 'resolve', self::RESOLVE_SCHEMA_VERSION);
+        [$request, $versioned] = $this->nativeRequest();
+        $response = $this->checkedResponse($request, $versioned, 'resolve', self::RESOLVE_SCHEMA_VERSION);
 
         $missing = $response['missing_required'] ?? [];
         if (!empty($missing)) {
@@ -129,9 +143,8 @@ final class Builder
      */
     public function report(): Report
     {
-        $request = $this->request;
-        $request['mode'] = 'report';
-        $response = $this->checkedResponse($request, 'report', self::REPORT_SCHEMA_VERSION);
+        [$request, $versioned] = $this->nativeRequest('report');
+        $response = $this->checkedResponse($request, $versioned, 'report', self::REPORT_SCHEMA_VERSION);
 
         $secrets = [];
         foreach ($response['secrets'] ?? [] as $s) {
@@ -163,12 +176,13 @@ final class Builder
      *
      * @return array<string, mixed>
      */
-    private function checkedResponse(array $request, string $kind, int $expectedVersion): array
+    private function checkedResponse(array $request, bool $versioned, string $kind, int $expectedVersion): array
     {
         // An empty request must serialize as a JSON object `{}`, not an array
         // `[]`; cast to object so the resolver parses it either way.
         $payload = \json_encode((object) $request, \JSON_THROW_ON_ERROR);
-        $envelope = \json_decode(Native::resolve($payload), true, 512, \JSON_THROW_ON_ERROR);
+        $raw = $versioned ? Native::call($payload) : Native::resolve($payload);
+        $envelope = \json_decode($raw, true, 512, \JSON_THROW_ON_ERROR);
 
         if (empty($envelope['ok'])) {
             $err = $envelope['error'] ?? [];
@@ -191,5 +205,27 @@ final class Builder
         }
 
         return $response;
+    }
+
+    /** @return array{0: array<string, mixed>, 1: bool} */
+    private function nativeRequest(?string $mode = null): array
+    {
+        $options = $this->request;
+        if ($mode !== null) {
+            $options['mode'] = $mode;
+        }
+        if ($this->inline === null) {
+            return [$options, false];
+        }
+
+        return [[
+            'request_version' => 1,
+            'operation' => 'resolve',
+            'source' => [
+                'kind' => 'inline', 'spec_version' => 1,
+                'base_dir' => $this->inline['base_dir'], 'spec' => $this->inline['spec'],
+            ],
+            'options' => $options,
+        ], true];
     }
 }

--- a/secretspec-php/src/Native.php
+++ b/secretspec-php/src/Native.php
@@ -16,7 +16,8 @@ namespace Secretspec;
  *     production path: it needs no `ffi.enable` and works under FPM/web like any
  *     other PHP extension. Preferred whenever it is loaded.
  *  2. A runtime `ext-ffi` fallback that dlopens the `secretspec-ffi` cdylib and
- *     calls the three C entry points from `secretspec-ffi/include/secretspec.h`.
+ *     calls the stable C entry points from `secretspec-ffi/include/secretspec.h`
+ *     and binds the optional versioned-call entry point only when needed.
  *     Zero-config for CLI and local dev; requires the FFI extension.
  *
  * Both call `secretspec::resolve_json` and return the identical envelope.
@@ -25,17 +26,21 @@ namespace Secretspec;
  */
 final class Native
 {
-    /**
-     * C declarations for the three-function ABI. Kept in lock-step with
-     * `secretspec-ffi/include/secretspec.h`.
-     */
+    /** The legacy ABI, which remains usable with pre-0.20 native libraries. */
     private const CDEF = <<<'C'
         char *secretspec_resolve(const char *request_json);
         void secretspec_free(char *ptr);
         const char *secretspec_abi_version(void);
         C;
 
+    /** The optional 0.20+ entry point, bound only when an inline call needs it. */
+    private const CALL_CDEF = <<<'C'
+        char *secretspec_call(const char *request_json);
+        void secretspec_free(char *ptr);
+        C;
+
     private static ?\FFI $ffi = null;
+    private static ?\FFI $callFfi = null;
 
     private function __construct()
     {
@@ -54,6 +59,16 @@ final class Native
         }
 
         return self::resolveViaFfi($requestJson);
+    }
+
+    /** Execute a versioned native operation, including inline specs. */
+    public static function call(string $requestJson): string
+    {
+        if (\function_exists('secretspec_native_call')) {
+            return \secretspec_native_call($requestJson);
+        }
+
+        return self::callViaFfi($requestJson);
     }
 
     /** The ABI version reported by the active backend. */
@@ -78,11 +93,48 @@ final class Native
      */
     private static function resolveViaFfi(string $requestJson): string
     {
-        $ffi = self::ffi();
-        $ptr = $ffi->secretspec_resolve($requestJson);
+        return self::ffiCall('secretspec_resolve', $requestJson);
+    }
+
+    private static function callViaFfi(string $requestJson): string
+    {
+        try {
+            return self::ffiCallWith(self::callFfi(), 'secretspec_call', $requestJson);
+        } catch (SecretSpecException $error) {
+            // Keep backend-load and native-call failures distinguishable from an
+            // older library that merely lacks the versioned entry point.
+            throw $error;
+        } catch (\FFI\Exception $error) {
+            if (!self::isMissingCallSymbol($error)) {
+                throw new SecretSpecException('ffi', $error->getMessage());
+            }
+            throw new SecretSpecException(
+                'capability',
+                'the loaded secretspec-ffi library does not support inline specs (missing secretspec_call): '
+                . $error->getMessage(),
+            );
+        }
+    }
+
+    private static function isMissingCallSymbol(\FFI\Exception $error): bool
+    {
+        return \preg_match(
+            "/(?:undefined|unknown|resolv(?:e|ing)|function).*secretspec_call/i",
+            $error->getMessage(),
+        ) === 1;
+    }
+
+    private static function ffiCall(string $symbol, string $requestJson): string
+    {
+        return self::ffiCallWith(self::ffi(), $symbol, $requestJson);
+    }
+
+    private static function ffiCallWith(\FFI $ffi, string $symbol, string $requestJson): string
+    {
+        $ptr = $ffi->$symbol($requestJson);
         // secretspec_resolve returns null only on catastrophic allocation failure.
         if ($ptr === null || \FFI::isNull($ptr)) {
-            throw new SecretSpecException('ffi', 'secretspec_resolve returned null');
+            throw new SecretSpecException('ffi', $symbol . ' returned null');
         }
 
         try {
@@ -105,10 +157,31 @@ final class Native
                     . 'to use the SecretSpec SDK',
                 );
             }
-            self::$ffi = \FFI::cdef(self::CDEF, self::locateLibrary());
+            try {
+                self::$ffi = \FFI::cdef(self::CDEF, self::locateLibrary());
+            } catch (\FFI\Exception $error) {
+                throw new SecretSpecException('load', $error->getMessage());
+            }
         }
 
         return self::$ffi;
+    }
+
+    /** Lazily bind the optional versioned-call ABI without affecting legacy calls. */
+    private static function callFfi(): \FFI
+    {
+        if (self::$callFfi === null) {
+            if (!\extension_loaded('ffi')) {
+                throw new SecretSpecException(
+                    'load',
+                    'the PHP FFI extension is required; enable ext-ffi (and set ffi.enable) '
+                    . 'to use the SecretSpec SDK',
+                );
+            }
+            self::$callFfi = \FFI::cdef(self::CALL_CDEF, self::locateLibrary());
+        }
+
+        return self::$callFfi;
     }
 
     /**

--- a/secretspec-php/tests/ResolveTest.php
+++ b/secretspec-php/tests/ResolveTest.php
@@ -7,6 +7,7 @@ namespace Secretspec\Tests;
 use PHPUnit\Framework\TestCase;
 use Secretspec\CallerContext;
 use Secretspec\MissingRequiredException;
+use Secretspec\Native;
 use Secretspec\SecretReport;
 use Secretspec\SecretSpec;
 use Secretspec\SecretSpecException;
@@ -62,6 +63,20 @@ final class ResolveTest extends TestCase
         self::assertNotEmpty(SecretSpec::abiVersion());
     }
 
+    public function testLegacyFfiBindingDoesNotRequireInlineCallSymbol(): void
+    {
+        $reflection = new \ReflectionClass(Native::class);
+
+        self::assertStringNotContainsString(
+            'secretspec_call',
+            $reflection->getConstant('CDEF'),
+        );
+        self::assertStringContainsString(
+            'secretspec_call',
+            $reflection->getConstant('CALL_CDEF'),
+        );
+    }
+
     public function testCallerContextCanAccompanyASeparateReason(): void
     {
         [$manifest, $provider] = $this->project("DATABASE_URL=postgres://db\n");
@@ -103,6 +118,26 @@ final class ResolveTest extends TestCase
 
         self::assertSame(['SENTRY_DSN'], $resolved->missingOptional);
         self::assertArrayNotHasKey('SENTRY_DSN', $resolved->secrets);
+    }
+
+    public function testInlineSpecResolvesAtItsLogicalBaseDir(): void
+    {
+        [$manifest] = $this->project('');
+        $dir = \dirname($manifest);
+        \file_put_contents($dir . \DIRECTORY_SEPARATOR . 'inline.env', "TOKEN=inline-php\n");
+        $spec = [
+            'project' => ['name' => 'php-inline'],
+            'providers' => ['env' => 'dotenv://inline.env'],
+            'profiles' => ['default' => ['secrets' => [
+                'TOKEN' => ['description' => 'token', 'providers' => ['env']],
+            ]]],
+        ];
+        $resolved = SecretSpec::builder()
+            ->withInlineSpec($spec, $dir)
+            ->withReason('php inline test')
+            ->load();
+
+        self::assertSame('inline-php', $resolved->secrets['TOKEN']->get());
     }
 
     public function testSetAsEnv(): void

--- a/secretspec-py/secretspec/__init__.py
+++ b/secretspec-py/secretspec/__init__.py
@@ -201,13 +201,23 @@ def _resolve_envelope(request: dict) -> dict:
     return json.loads(raw)
 
 
-def _checked_response(request: dict, kind: str, expected_version: int) -> dict:
+def _call_envelope(request: dict) -> dict:
+    if not hasattr(_native, "call"):
+        raise SecretSpecError(
+            "capability",
+            "the loaded native extension predates inline specifications; reinstall SecretSpec 0.20+",
+        )
+    raw = _native.call(json.dumps(request))
+    return json.loads(raw)
+
+
+def _checked_response(request: dict, kind: str, expected_version: int, *, versioned: bool = False) -> dict:
     """Resolve ``request`` and return the validated ``response`` envelope.
 
     ``kind`` is ``"resolve"`` or ``"report"``; it selects the schema version to
     enforce and labels the version-mismatch message.
     """
-    envelope = _resolve_envelope(request)
+    envelope = _call_envelope(request) if versioned else _resolve_envelope(request)
     if not envelope.get("ok", False):
         err = envelope.get("error", {})
         raise SecretSpecError(err.get("kind", "unknown"), err.get("message", ""))
@@ -289,10 +299,22 @@ class SecretSpec:
 class _Builder:
     def __init__(self) -> None:
         self._request: dict = {}
+        self._inline: Optional[tuple[dict, str]] = None
 
     def with_path(self, path: Optional[str]) -> "_Builder":
+        self._inline = None
         if path is not None:
             self._request["path"] = path
+        return self
+
+    def with_inline_spec(self, spec: dict, base_dir: str) -> "_Builder":
+        """Resolve inline-spec v1 at ``base_dir`` (SecretSpec 0.20+).
+
+        Inline resolution uses the versioned native call entry point, so an
+        older runtime cannot fall back to a filesystem manifest.
+        """
+        self._request.pop("path", None)
+        self._inline = (spec, base_dir)
         return self
 
     def with_provider(self, provider: Optional[str]) -> "_Builder":
@@ -328,7 +350,10 @@ class _Builder:
         return self
 
     def load(self) -> Resolved:
-        response = _checked_response(self._request, "resolve", _RESOLVE_SCHEMA_VERSION)
+        request, versioned = self._native_request()
+        response = _checked_response(
+            request, "resolve", _RESOLVE_SCHEMA_VERSION, versioned=versioned
+        )
 
         missing_required = response.get("missing_required", [])
         if missing_required:
@@ -359,9 +384,8 @@ class _Builder:
         required secret appears as a :class:`SecretReport` with status
         ``"missing_required"``.
         """
-        request = dict(self._request)
-        request["mode"] = "report"
-        response = _checked_response(request, "report", _REPORT_SCHEMA_VERSION)
+        request, versioned = self._native_request("report")
+        response = _checked_response(request, "report", _REPORT_SCHEMA_VERSION, versioned=versioned)
         secrets = [
             SecretReport(
                 name=s["name"],
@@ -380,3 +404,18 @@ class _Builder:
             secrets=secrets,
             scope=response.get("scope"),
         )
+
+    def _native_request(self, mode: Optional[str] = None) -> tuple[dict, bool]:
+        options = dict(self._request)
+        if mode is not None:
+            options["mode"] = mode
+        if self._inline is None:
+            return options, False
+        spec, base_dir = self._inline
+        return ({
+            "request_version": 1,
+            "operation": "resolve",
+            "source": {"kind": "inline", "spec_version": 1,
+                       "base_dir": base_dir, "spec": spec},
+            "options": options,
+        }, True)

--- a/secretspec-py/src/lib.rs
+++ b/secretspec-py/src/lib.rs
@@ -14,6 +14,12 @@ fn resolve(request_json: &str) -> String {
     secretspec::resolve_json(request_json)
 }
 
+/// Process a versioned native operation request, including inline specs.
+#[pyfunction]
+fn call(request_json: &str) -> String {
+    secretspec::call_json(request_json)
+}
+
 /// The extension's version (tracks the crate version).
 #[pyfunction]
 fn abi_version() -> String {
@@ -23,6 +29,7 @@ fn abi_version() -> String {
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(resolve, m)?)?;
+    m.add_function(wrap_pyfunction!(call, m)?)?;
     m.add_function(wrap_pyfunction!(abi_version, m)?)?;
     Ok(())
 }

--- a/secretspec-py/tests/test_resolve.py
+++ b/secretspec-py/tests/test_resolve.py
@@ -83,6 +83,22 @@ def test_load_returns_values_and_provenance(tmp_path):
     assert "SENTRY_DSN" not in resolved.secrets
 
 
+def test_inline_spec_resolves_at_its_logical_base_dir(tmp_path):
+    env_path = tmp_path / "inline.env"
+    env_path.write_text("TOKEN=inline-python\n")
+    spec = {
+        "project": {"name": "python-inline"},
+        "providers": {"env": "dotenv://inline.env"},
+        "profiles": {"default": {"secrets": {
+            "TOKEN": {"description": "token", "providers": ["env"]},
+        }}},
+    }
+    resolved = SecretSpec.builder().with_inline_spec(spec, str(tmp_path)).with_reason(
+        "python inline test"
+    ).load()
+    assert resolved.secrets["TOKEN"].get == "inline-python"
+
+
 def test_scope_is_selected_and_returned(tmp_path):
     manifest, provider = _project(
         tmp_path,

--- a/secretspec-rb/ext/secretspec/secretspec_ext.c
+++ b/secretspec-rb/ext/secretspec/secretspec_ext.c
@@ -17,6 +17,14 @@ resolve_nogvl(void *arg)
     return secretspec_resolve((const char *)arg);
 }
 
+static void *
+call_nogvl(void *arg)
+{
+    return secretspec_call((const char *)arg);
+}
+
+static VALUE native_dispatch(VALUE request_json, void *(*dispatch)(void *));
+
 /*
  * Secretspec::Native.c_resolve(request_json) -> String or nil
  *
@@ -32,12 +40,24 @@ resolve_nogvl(void *arg)
 static VALUE
 native_resolve(VALUE self, VALUE request_json)
 {
+    return native_dispatch(request_json, resolve_nogvl);
+}
+
+static VALUE
+native_call(VALUE self, VALUE request_json)
+{
+    return native_dispatch(request_json, call_nogvl);
+}
+
+static VALUE
+native_dispatch(VALUE request_json, void *(*dispatch)(void *))
+{
     char *request = strdup(StringValueCStr(request_json));
     if (request == NULL) {
         return Qnil;
     }
     char *result = rb_thread_call_without_gvl(
-        resolve_nogvl, request, RUBY_UBF_IO, NULL);
+        dispatch, request, RUBY_UBF_IO, NULL);
     free(request);
     if (result == NULL) {
         return Qnil;
@@ -60,5 +80,6 @@ Init_secretspec_ext(void)
     VALUE mod = rb_define_module("Secretspec");
     VALUE native = rb_define_module_under(mod, "Native");
     rb_define_singleton_method(native, "c_resolve", native_resolve, 1);
+    rb_define_singleton_method(native, "c_call", native_call, 1);
     rb_define_singleton_method(native, "c_abi_version", native_abi_version, 0);
 }

--- a/secretspec-rb/lib/secretspec.rb
+++ b/secretspec-rb/lib/secretspec.rb
@@ -134,6 +134,17 @@ module Secretspec
         result
       end
 
+      def call(request_json)
+        unless respond_to?(:c_call, true)
+          raise Error.new("capability", "the loaded native extension predates inline specifications; rebuild the secretspec gem")
+        end
+
+        result = c_call(request_json)
+        raise Error.new("ffi", "secretspec_call returned null") if result.nil?
+
+        result
+      end
+
       def abi_version
         c_abi_version
       end
@@ -151,10 +162,19 @@ module Secretspec
   class Builder
     def initialize
       @request = {}
+      @inline = nil
     end
 
     def with_path(path)
+      @inline = nil
       @request["path"] = path if path
+      self
+    end
+
+    # Resolve strict inline-spec v1 at its logical base directory (0.20+).
+    def with_inline_spec(spec, base_dir)
+      @request.delete("path")
+      @inline = { "spec" => spec, "base_dir" => base_dir }
       self
     end
 
@@ -198,7 +218,7 @@ module Secretspec
     # done to clean up any as_path temp files). With a block, yields the Resolved
     # and closes it afterwards, returning the block's value.
     def load
-      response = parse_response(JSON.generate(@request), "resolve", RESOLVE_SCHEMA_VERSION)
+      response = parse_response(*native_request, "resolve", RESOLVE_SCHEMA_VERSION)
 
       missing = response["missing_required"] || []
       raise MissingRequiredError.new(missing) unless missing.empty?
@@ -229,8 +249,7 @@ module Secretspec
     # MissingRequiredError: a missing required secret appears as a SecretReport
     # with status "missing_required".
     def report
-      request = @request.merge("mode" => "report")
-      response = parse_response(JSON.generate(request), "report", REPORT_SCHEMA_VERSION)
+      response = parse_response(*native_request("report"), "report", REPORT_SCHEMA_VERSION)
 
       secrets = (response["secrets"] || []).map do |s|
         SecretReport.new(s["name"], s["status"], s["required"],
@@ -245,8 +264,9 @@ module Secretspec
     # Resolve a JSON request payload and return the validated "response" hash, or
     # raise. +kind+ is "resolve" or "report"; it selects the schema version to
     # enforce and labels the version-mismatch message.
-    def parse_response(payload, kind, expected_version)
-      envelope = JSON.parse(Native.resolve(payload))
+    def parse_response(request, versioned, kind, expected_version)
+      payload = JSON.generate(request)
+      envelope = JSON.parse(versioned ? Native.call(payload) : Native.resolve(payload))
 
       unless envelope["ok"]
         err = envelope["error"] || {}
@@ -265,6 +285,17 @@ module Secretspec
       end
 
       response
+    end
+
+    def native_request(mode = nil)
+      options = @request.dup
+      options["mode"] = mode if mode
+      return [options, false] unless @inline
+
+      [{ "request_version" => 1, "operation" => "resolve",
+         "source" => { "kind" => "inline", "spec_version" => 1,
+                       "base_dir" => @inline["base_dir"], "spec" => @inline["spec"] },
+         "options" => options }, true]
     end
   end
 

--- a/secretspec-rb/test/test_resolve.rb
+++ b/secretspec-rb/test/test_resolve.rb
@@ -83,6 +83,24 @@ class ResolveTest < Minitest::Test
     end
   end
 
+  def test_inline_spec_resolves_at_its_logical_base_dir
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "inline.env"), "TOKEN=inline-ruby\n")
+      spec = {
+        "project" => { "name" => "ruby-inline" },
+        "providers" => { "env" => "dotenv://inline.env" },
+        "profiles" => { "default" => { "secrets" => {
+          "TOKEN" => { "description" => "token", "providers" => ["env"] }
+        } } }
+      }
+      resolved = Secretspec::SecretSpec.builder
+                                        .with_inline_spec(spec, dir)
+                                        .with_reason("ruby inline test")
+                                        .load
+      assert_equal "inline-ruby", resolved.secrets.fetch("TOKEN").get
+    end
+  end
+
   def test_set_as_env
     Dir.mktmpdir do |dir|
       manifest, provider = project(dir, "DATABASE_URL=postgres://db\n")

--- a/secretspec-swift/Sources/SecretSpec/Native.swift
+++ b/secretspec-swift/Sources/SecretSpec/Native.swift
@@ -1,23 +1,42 @@
 import CSecretSpec
+import Darwin
 import Foundation
 
 enum Native {
     static func resolve(_ requestJSON: String) throws -> String {
         guard let response = requestJSON.withCString({ secretspec_resolve($0) }) else {
+            throw SecretSpecError(kind: "ffi", message: "secretspec_resolve returned null")
+        }
+        defer { secretspec_free(response) }
+        guard let result = String(validatingUTF8: response) else {
+            throw SecretSpecError(kind: "ffi", message: "secretspec_resolve returned invalid UTF-8")
+        }
+        return result
+    }
+
+    static func call(_ requestJSON: String) throws -> String {
+        typealias CallFunction = @convention(c) (UnsafePointer<CChar>?)
+            -> UnsafeMutablePointer<CChar>?
+
+        // The checked-in package still downloads the 0.19.1 XCFramework. Look
+        // up the 0.20+ entry point only when inline specs are used, so ordinary
+        // calls continue to compile and run against that older binary.
+        guard let symbol = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "secretspec_call") else {
             throw SecretSpecError(
-                kind: "ffi",
-                message: "secretspec_resolve returned null"
+                kind: "capability",
+                message: "the loaded secretspec-ffi library does not support inline specs "
+                    + "(missing secretspec_call)"
             )
+        }
+        let call = unsafeBitCast(symbol, to: CallFunction.self)
+        guard let response = requestJSON.withCString({ call($0) }) else {
+            throw SecretSpecError(kind: "ffi", message: "secretspec_call returned null")
         }
         defer {
             secretspec_free(response)
         }
-
         guard let result = String(validatingUTF8: response) else {
-            throw SecretSpecError(
-                kind: "ffi",
-                message: "secretspec_resolve returned invalid UTF-8"
-            )
+            throw SecretSpecError(kind: "ffi", message: "secretspec_call returned invalid UTF-8")
         }
         return result
     }

--- a/secretspec-swift/Sources/SecretSpec/SecretSpec.swift
+++ b/secretspec-swift/Sources/SecretSpec/SecretSpec.swift
@@ -95,11 +95,36 @@ private struct ReportResponse: Decodable {
 /// Configures a SecretSpec resolution.
 public struct SecretSpecBuilder: Sendable {
     private var request = ResolveRequest()
+    private var inline: InlineSpec? = nil
+
+    private struct InlineSpec: Sendable {
+        let declaration: Data
+        let baseDir: String
+    }
 
     public init() {}
 
     public func withPath(_ path: String?) -> Self {
-        setting(\.path, to: path)
+        var copy = setting(\.path, to: path)
+        copy.inline = nil
+        return copy
+    }
+
+    /// Resolves strict inline-spec v1 at `baseDir` (SecretSpec 0.20+).
+    ///
+    /// The declaration is encoded once into the dedicated native wire format.
+    /// An older native library reports a capability error rather than searching
+    /// for a filesystem manifest.
+    public func withInlineSpec<Declaration: Encodable & Sendable>(
+        _ declaration: Declaration,
+        baseDir: String
+    ) throws -> Self {
+        var copy = self
+        copy.request.path = nil
+        copy.inline = InlineSpec(
+            declaration: try JSONEncoder().encode(declaration), baseDir: baseDir
+        )
+        return copy
     }
 
     public func withProvider(_ provider: String?) -> Self {
@@ -185,7 +210,20 @@ public struct SecretSpecBuilder: Sendable {
 
         let requestData: Data
         do {
-            requestData = try JSONEncoder().encode(configured)
+            if let inline {
+                let declaration = try JSONSerialization.jsonObject(with: inline.declaration)
+                requestData = try JSONSerialization.data(withJSONObject: [
+                    "request_version": 1,
+                    "operation": "resolve",
+                    "source": [
+                        "kind": "inline", "spec_version": 1,
+                        "base_dir": inline.baseDir, "spec": declaration,
+                    ],
+                    "options": try JSONSerialization.jsonObject(with: JSONEncoder().encode(configured)),
+                ])
+            } else {
+                requestData = try JSONEncoder().encode(configured)
+            }
         } catch {
             throw SecretSpecError(kind: "encode", message: error.localizedDescription)
         }
@@ -196,7 +234,12 @@ public struct SecretSpecBuilder: Sendable {
             )
         }
 
-        let responseJSON = try Native.resolve(requestJSON)
+        let responseJSON: String
+        if inline == nil {
+            responseJSON = try Native.resolve(requestJSON)
+        } else {
+            responseJSON = try Native.call(requestJSON)
+        }
         let envelope: Envelope<Response>
         do {
             envelope = try JSONDecoder().decode(

--- a/secretspec-swift/Tests/SecretSpecTests/SecretSpecTests.swift
+++ b/secretspec-swift/Tests/SecretSpecTests/SecretSpecTests.swift
@@ -10,6 +10,19 @@ import Glibc
 @testable import SecretSpec
 
 final class SecretSpecTests: XCTestCase {
+    private struct InlineSpec: Encodable, Sendable {
+        struct Project: Encodable, Sendable { let name: String }
+        struct Secret: Encodable, Sendable {
+            let description: String
+            let providers: [String]
+        }
+        struct Profile: Encodable, Sendable { let secrets: [String: Secret] }
+
+        let project: Project
+        let providers: [String: String]
+        let profiles: [String: Profile]
+    }
+
     private static let manifest = """
     [project]
     name = "swift-test"
@@ -69,6 +82,29 @@ final class SecretSpecTests: XCTestCase {
         let fields = try JSONSerialization.jsonObject(with: resolved.fieldsJSON())
         let object = try XCTUnwrap(fields as? [String: Any])
         XCTAssertEqual(object["DATABASE_URL"] as? String, "postgres://db")
+    }
+
+    func testInlineSpecResolvesAtItsLogicalBaseDirectory() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try "TOKEN=inline-swift\n".write(
+            to: directory.appendingPathComponent("inline.env"), atomically: true, encoding: .utf8
+        )
+        let spec = InlineSpec(
+            project: .init(name: "swift-inline"),
+            providers: ["env": "dotenv://inline.env"],
+            profiles: ["default": .init(secrets: [
+                "TOKEN": .init(description: "token", providers: ["env"]),
+            ])]
+        )
+        let resolved = try SecretSpec.builder()
+            .withInlineSpec(spec, baseDir: directory.path)
+            .withReason("Swift inline test")
+            .load()
+        defer { try? resolved.close() }
+        XCTAssertEqual(resolved.secrets["TOKEN"]?.get(), "inline-swift")
     }
 
     func testScopedResolveAndReport() throws {

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -53,6 +53,7 @@ mod error;
 pub(crate) mod generator;
 pub(crate) mod ini_field;
 pub(crate) mod json_field;
+mod native;
 mod plan;
 mod report;
 mod resolve;
@@ -102,6 +103,7 @@ pub use config::{
     ProviderCache, RequireReason, SecretEncoding, SecretExtract,
 };
 pub use error::{Result, SecretSpecError};
+pub use native::{INLINE_SPEC_SCHEMA_VERSION, NATIVE_CALL_REQUEST_VERSION, call_json};
 pub use provider::{DiscoveryContext, ProducedValuePersistence, Provider};
 pub use report::{
     RESOLUTION_REPORT_SCHEMA_VERSION, ResolutionReport, ResolutionStatus, SecretResolution,

--- a/secretspec/src/native.rs
+++ b/secretspec/src/native.rs
@@ -1,0 +1,500 @@
+//! Versioned requests for the extensible native SDK boundary.
+//!
+//! This is deliberately separate from the legacy [`crate::resolve_json`]
+//! request.  A new SDK must call the new C symbol to use this format: sending
+//! an inline declaration to an old `secretspec_resolve` would otherwise let an
+//! old library ignore that unknown field and search for an unrelated manifest.
+
+use crate::config::{
+    Config, GenerateConfig, GenerateOptions, Profile as ConfigProfile, ProfileDefaults, Project,
+    ProviderAlias, RequireReason, Scope, Secret as ConfigSecret, SecretEncoding, SecretExtract,
+};
+use crate::{CallerContext, Secrets, Spec};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+
+/// The version of the native call envelope understood by this library.
+pub const NATIVE_CALL_REQUEST_VERSION: u32 = 1;
+/// The version of the JSON inline-declaration document understood by this library.
+pub const INLINE_SPEC_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CallRequest {
+    request_version: u32,
+    operation: Operation,
+    source: serde_json::Value,
+    #[serde(default)]
+    options: Options,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Operation {
+    Resolve,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    profile: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    caller: Option<CallerContext>,
+    #[serde(default)]
+    no_values: bool,
+    #[serde(default)]
+    mode: Mode,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Mode {
+    #[default]
+    Resolve,
+    Report,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SearchSource {
+    #[serde(rename = "kind")]
+    _kind: SearchKind,
+}
+
+#[derive(Debug, Deserialize)]
+enum SearchKind {
+    #[serde(rename = "search")]
+    Search,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PathSource {
+    #[serde(rename = "kind")]
+    _kind: PathKind,
+    path: String,
+}
+
+#[derive(Debug, Deserialize)]
+enum PathKind {
+    #[serde(rename = "path")]
+    Path,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineSource {
+    #[serde(rename = "kind")]
+    _kind: InlineKind,
+    spec_version: u32,
+    base_dir: String,
+    spec: InlineSpec,
+}
+
+#[derive(Debug, Deserialize)]
+enum InlineKind {
+    #[serde(rename = "inline")]
+    Inline,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineSpec {
+    project: InlineProject,
+    profiles: BTreeMap<String, InlineProfile>,
+    #[serde(default)]
+    providers: Option<HashMap<String, ProviderAlias>>,
+    #[serde(default)]
+    scopes: Option<HashMap<String, InlineScope>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineProject {
+    name: String,
+    #[serde(default)]
+    revision: Option<String>,
+    #[serde(default)]
+    extends: Option<Vec<String>>,
+    #[serde(default)]
+    require_reason: Option<RequireReason>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineProfile {
+    #[serde(default)]
+    defaults: Option<InlineProfileDefaults>,
+    secrets: BTreeMap<String, InlineSecret>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineProfileDefaults {
+    #[serde(default)]
+    inherit: Option<bool>,
+    #[serde(default)]
+    required: Option<bool>,
+    #[serde(default)]
+    default: Option<String>,
+    #[serde(default)]
+    providers: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineScope {
+    secrets: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineSecret {
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    required: Option<InlineRequired>,
+    #[serde(default)]
+    default: Option<String>,
+    #[serde(default)]
+    composed: Option<String>,
+    #[serde(default)]
+    providers: Option<Vec<String>>,
+    #[serde(default, rename = "ref")]
+    reference: Option<crate::NativeAddress>,
+    #[serde(default)]
+    refs: Option<HashMap<String, crate::NativeAddress>>,
+    #[serde(default)]
+    as_path: Option<bool>,
+    #[serde(default)]
+    encoding: Option<SecretEncoding>,
+    #[serde(default)]
+    extract: Option<SecretExtract>,
+    #[serde(default, rename = "type")]
+    secret_type: Option<String>,
+    #[serde(default)]
+    generate: Option<InlineGenerate>,
+    #[serde(default)]
+    prompt: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum InlineRequired {
+    Bool(bool),
+    Groups(InlineRequiredGroups),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineRequiredGroups {
+    #[serde(default, deserialize_with = "deserialize_group_names")]
+    at_least_one: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_group_names")]
+    exactly_one: Option<Vec<String>>,
+}
+
+/// Deserialize a presence-group membership as either one name or an array,
+/// matching the file-backed configuration syntax.
+fn deserialize_group_names<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    Ok(Some(match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(name) => vec![name],
+        OneOrMany::Many(names) => names,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum InlineGenerate {
+    Bool(bool),
+    Options(InlineGenerateOptions),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineGenerateOptions {
+    #[serde(default)]
+    length: Option<usize>,
+    #[serde(default)]
+    bytes: Option<usize>,
+    #[serde(default)]
+    charset: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    bits: Option<usize>,
+}
+
+impl InlineSpec {
+    fn into_config(self) -> std::result::Result<Config, String> {
+        Ok(Config {
+            project: Project {
+                name: self.project.name,
+                revision: self.project.revision.unwrap_or_else(|| "1.0".to_string()),
+                extends: self.project.extends,
+                require_reason: self.project.require_reason,
+            },
+            profiles: self
+                .profiles
+                .into_iter()
+                .map(|(name, profile)| -> std::result::Result<_, String> {
+                    let secrets = profile
+                        .secrets
+                        .into_iter()
+                        .map(|(name, secret)| secret.into_config().map(|secret| (name, secret)))
+                        .collect::<std::result::Result<_, _>>()?;
+                    Ok((
+                        name,
+                        ConfigProfile {
+                            defaults: profile.defaults.map(|defaults| ProfileDefaults {
+                                inherit: defaults.inherit,
+                                required: defaults.required,
+                                default: defaults.default,
+                                providers: defaults.providers,
+                            }),
+                            secrets,
+                        },
+                    ))
+                })
+                .collect::<std::result::Result<_, _>>()?,
+            providers: self.providers,
+            scopes: self.scopes.map(|scopes| {
+                scopes
+                    .into_iter()
+                    .map(|(name, scope)| {
+                        (
+                            name,
+                            Scope {
+                                secrets: scope.secrets,
+                            },
+                        )
+                    })
+                    .collect()
+            }),
+        })
+    }
+}
+
+impl InlineSecret {
+    fn into_config(self) -> std::result::Result<ConfigSecret, String> {
+        let (required, at_least_one, exactly_one) = match self.required {
+            Some(InlineRequired::Bool(required)) => (Some(required), None, None),
+            Some(InlineRequired::Groups(groups)) => {
+                if groups.at_least_one.is_none() && groups.exactly_one.is_none() {
+                    return Err("`required` table must set `at_least_one` or `exactly_one`".into());
+                }
+                (None, groups.at_least_one, groups.exactly_one)
+            }
+            None => (None, None, None),
+        };
+        Ok(ConfigSecret {
+            description: self.description,
+            required,
+            at_least_one,
+            exactly_one,
+            default: self.default,
+            composed: self.composed,
+            providers: self.providers,
+            reference: self.reference,
+            refs: self.refs,
+            as_path: self.as_path,
+            encoding: self.encoding,
+            extract: self.extract,
+            secret_type: self.secret_type,
+            generate: self.generate.map(|generate| match generate {
+                InlineGenerate::Bool(enabled) => GenerateConfig::Bool(enabled),
+                InlineGenerate::Options(options) => GenerateConfig::Options(GenerateOptions {
+                    length: options.length,
+                    bytes: options.bytes,
+                    charset: options.charset,
+                    command: options.command,
+                    bits: options.bits,
+                }),
+            }),
+            prompt: self.prompt,
+        })
+    }
+}
+
+fn error_envelope(kind: &str, message: impl Into<String>) -> serde_json::Value {
+    serde_json::json!({ "ok": false, "error": { "kind": kind, "message": message.into() } })
+}
+
+fn ok_envelope(response: impl serde::Serialize) -> serde_json::Value {
+    serde_json::json!({ "ok": true, "response": response })
+}
+
+fn parse_source(value: serde_json::Value) -> Result<Source, String> {
+    let kind = value
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "source.kind must be \"search\", \"path\", or \"inline\"".to_string())?;
+    match kind {
+        "search" => serde_json::from_value::<SearchSource>(value)
+            .map(|_| Source::Search)
+            .map_err(|error| format!("invalid search source: {error}")),
+        "path" => serde_json::from_value::<PathSource>(value)
+            .map(|source| Source::Path(source.path))
+            .map_err(|error| format!("invalid path source: {error}")),
+        "inline" => serde_json::from_value::<InlineSource>(value)
+            .map(|source| Source::Inline {
+                version: source.spec_version,
+                base_dir: source.base_dir,
+                spec: Box::new(source.spec),
+            })
+            .map_err(|error| format!("invalid inline source: {error}")),
+        _ => Err(format!(
+            "unknown source kind '{kind}'; expected search, path, or inline"
+        )),
+    }
+}
+
+enum Source {
+    Search,
+    Path(String),
+    Inline {
+        version: u32,
+        base_dir: String,
+        spec: Box<InlineSpec>,
+    },
+}
+
+fn apply_options(mut app: Secrets, options: Options) -> serde_json::Value {
+    if let Some(provider) = options.provider {
+        app.set_provider(provider);
+    }
+    if let Some(profile) = options.profile {
+        app.set_profile(profile);
+    }
+    if let Some(scope) = options.scope {
+        app.set_scope(scope);
+    }
+    if let Some(reason) = options.reason {
+        app = app.with_reason(reason);
+    }
+    if let Some(caller) = options.caller {
+        app = app.with_caller(caller);
+    }
+    match options.mode {
+        Mode::Report => match app.report() {
+            Ok(report) => ok_envelope(report),
+            Err(error) => error_envelope(error.kind(), crate::error::display_error_chain(&error)),
+        },
+        Mode::Resolve => match if options.no_values {
+            app.resolve_without_values()
+        } else {
+            app.resolve()
+        } {
+            Ok(response) => ok_envelope(response),
+            Err(error) => error_envelope(error.kind(), crate::error::display_error_chain(&error)),
+        },
+    }
+}
+
+fn dispatch(request_json: &str) -> serde_json::Value {
+    let request: CallRequest = match serde_json::from_str(request_json) {
+        Ok(request) => request,
+        Err(error) => {
+            return error_envelope("invalid_request", format!("invalid call JSON: {error}"));
+        }
+    };
+    if request.request_version != NATIVE_CALL_REQUEST_VERSION {
+        return error_envelope(
+            "unsupported_request_version",
+            format!(
+                "unsupported request_version {}; expected {}",
+                request.request_version, NATIVE_CALL_REQUEST_VERSION
+            ),
+        );
+    }
+    match request.operation {
+        Operation::Resolve => {}
+    }
+    let source = match parse_source(request.source) {
+        Ok(source) => source,
+        Err(error) => return error_envelope("invalid_request", error),
+    };
+    let loaded = match source {
+        Source::Search => Secrets::load(),
+        Source::Path(path) => Secrets::load_from(PathBuf::from(path).as_path()),
+        Source::Inline {
+            version,
+            base_dir,
+            spec,
+        } => {
+            if version != INLINE_SPEC_SCHEMA_VERSION {
+                return error_envelope(
+                    "unsupported_spec_version",
+                    format!(
+                        "unsupported inline spec_version {version}; expected {INLINE_SPEC_SCHEMA_VERSION}"
+                    ),
+                );
+            }
+            let base_dir = PathBuf::from(base_dir);
+            let config = match (*spec).into_config() {
+                Ok(config) => config,
+                Err(error) => return error_envelope("invalid_request", error),
+            };
+            Config::from_root_in(config, &base_dir)
+                .map_err(Into::into)
+                .and_then(Spec::from_config_document)
+                .and_then(|spec| Secrets::from_spec_at(spec, base_dir))
+        }
+    };
+    match loaded {
+        Ok(app) => apply_options(app, request.options),
+        Err(error) => error_envelope(error.kind(), crate::error::display_error_chain(&error)),
+    }
+}
+
+/// Process a versioned native request and return its JSON response envelope.
+///
+/// This is used by `secretspec_call` in the C ABI. It is intentionally a
+/// different entry point from [`crate::resolve_json`] so inline declarations
+/// cannot be ignored by an older runtime.
+pub fn call_json(request_json: &str) -> String {
+    let envelope =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| dispatch(request_json)))
+            .unwrap_or_else(|_| error_envelope("internal", "internal panic during native call"));
+    serde_json::to_string(&envelope).unwrap_or_else(|_| {
+        "{\"ok\":false,\"error\":{\"kind\":\"serialize\",\"message\":\"failed to serialize response\"}}".to_string()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_declaration_rejects_unknown_secret_fields() {
+        let response: serde_json::Value = serde_json::from_str(&call_json(r#"{
+          "request_version": 1, "operation": "resolve",
+          "source": { "kind": "inline", "spec_version": 1, "base_dir": ".", "spec": {
+            "project": { "name": "inline" },
+            "profiles": { "default": { "secrets": { "TOKEN": { "description": "token", "typo": true } } } }
+          }}
+        }"#)).unwrap();
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["kind"], "invalid_request");
+    }
+}


### PR DESCRIPTION
## Summary
- add the versioned secretspec_call C ABI for strict inline specifications, including inheritance relative to base_dir
- expose inline-spec builder APIs in Go, Python, Node.js, Ruby, Haskell, PHP, C#, and Swift
- document the 0.20+ capability and add core plus SDK coverage

## Verification
- cargo test -p secretspec-ffi --lib --test c_abi
- cargo test -p secretspec native::tests --lib
- go test ./...
- Node, Ruby, PHP, and .NET SDK inline-spec tests

The pre-commit clippy hook was attempted. Its PHP extension build cannot find the Nix C standard-library headers from this standalone shell; rustfmt completed successfully.