### PR TITLE
Add EJSON provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
     - name: Check each provider feature standalone
       run: |
         set -euo pipefail
-        for feature in cli keyring keeper gcsm awssm vault openbao infisical bws akv aac sops bw kubernetes cloudflare; do
+        for feature in cli keyring keeper gcsm awssm vault openbao infisical bws akv aac ejson sops bw kubernetes cloudflare; do
           echo "::group::$feature"
           cargo check --package secretspec --no-default-features --features "$feature"
           echo "::endgroup::"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Kubernetes provider** (`k8s+<configmap|secret>://`, 0.20+): store and read
   values from a Kubernetes ConfigMap or Secret using the current cluster.
+
+- **EJSON provider** (`ejson:`, 0.20+): read string values from an encrypted
+  EJSON file with RFC 6901 JSON Pointer references. The private key comes from
+  an explicit `private_key` provider credential, so an existing provider such
+  as Google Cloud Secret Manager can supply an exact key without putting it in
+  the URI, environment, process arguments, or a local key file. Batch
+  resolution decrypts each file once, and the initial provider is intentionally
+  read-only.
+
 - **Azure App Configuration provider** (`aac://`, 0.20+): select direct
   values and Azure Key Vault references by label, prefix, and tags, with Entra
   ID or connection-string authentication and guarded writes, deletion, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5574,7 +5574,9 @@ dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
  "url",
  "uuid",
+ "wait-timeout",
  "whoami",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ same-file = "1.0"
 http = "1.0"
 url = "2.5.4"
 percent-encoding = "2.3"
+wait-timeout = "0.2"
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
 whoami = "2.0"
 syn = "2.0"
 quote = "1.0"

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -127,7 +127,7 @@ $ secretspec import dotenv://.env.production
 
 ## Providers
 
-Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Azure App Configuration (0.20+), Infisical (0.16+), age (0.17+), SOPS (0.17+), or Kubernetes (0.20+). Fly.io application secrets and Cloudflare Secrets Store entries can be published through the write-only fly and cloudflare providers (0.20+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
+Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv files, plaintext file directories (0.19+), EJSON files (0.20+, read-only), environment variables, systemd service credentials (0.17+), 1Password, Gopass (0.15+), LastPass, Dashlane (0.18+, read-only), Pass, Proton Pass, Passbolt (0.19+), Keeper Secrets Manager (0.18+), Google Cloud Secret Manager, AWS Secrets Manager, AWS Systems Manager Parameter Store (0.18+), Scaleway Secret Manager (0.17+), HashiCorp Vault, OpenBao (0.17+), Bitwarden Password Manager (0.18+), Bitwarden Secrets Manager, Azure Key Vault, Azure App Configuration (0.20+), Infisical (0.16+), age (0.17+), SOPS (0.17+), or Kubernetes (0.20+). Fly.io application secrets and Cloudflare Secrets Store entries can be published through the write-only fly and cloudflare providers (0.20+). The null provider (0.19+) uses manifest defaults, ephemeral generation, or ephemeral run prompts without storage.`,
         }),
       ],
       title: "SecretSpec",
@@ -277,6 +277,11 @@ Values can be resolved from: keyring (default), KeePass KDBX (0.17+), dotenv fil
               badge: { text: "0.19+", variant: "note" },
             },
             { label: "Environment Variables", slug: "providers/env" },
+            {
+              label: "EJSON",
+              slug: "providers/ejson",
+              badge: { text: "0.20+", variant: "note" },
+            },
             {
               label: "Null",
               slug: "providers/null",

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -44,6 +44,7 @@ DATABASE_URL = { description = "Production database", providers = ["prod_vault"]
 | [dotenv](/providers/dotenv/) | A `.env` file | ✓ | ✓ | ✗ | — |
 | [file](/providers/file/) (0.19+) | One plaintext UTF-8 file per secret | ✓ | ✓ | ✗ | — |
 | [env](/providers/env/) | Current process environment | ✓ | ✗ | ✗ | — |
+| [ejson](/providers/ejson/) (0.20+) | EJSON encrypted file (requires the `ejson` build feature and EJSON CLI) | ✓ | ✗ | ✓ | — |
 | [null](/providers/null/) (0.19+) | No storage; uses a manifest default, ephemeral generation, or an ephemeral run prompt | ✗ | ✗ | N/A | — |
 | [systemd-credential](/providers/systemd-credential/) (0.17+) | Credentials passed to the current systemd service | ✓ | ✗ | Depends on the unit's credential source | [Via systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) |
 | [fly](/providers/fly/) (0.20+) | Fly.io application secrets through `flyctl` | ✗ | ✓ | ✓ | — |

--- a/docs/src/content/docs/providers/ejson.mdx
+++ b/docs/src/content/docs/providers/ejson.mdx
@@ -1,0 +1,164 @@
+---
+title: EJSON Provider
+description: Read secrets from EJSON encrypted files
+tableOfContents:
+  maxHeadingLevel: 3
+---
+
+import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+The `ejson` provider reads string values from EJSON encrypted files.
+
+:::note[Version compatibility]
+The EJSON provider is added in SecretSpec 0.20.
+:::
+
+## At a glance
+
+| | |
+| --- | --- |
+| Provider | `ejson` |
+| URI | `ejson:PATH` |
+| Access | Read-only |
+| Best for | Existing EJSON files stored with application source |
+| Authentication | A `private_key` SecretSpec provider credential |
+| Build feature | `ejson` |
+| Default storage | JSON Pointer `/{project}/{profile}/{key}` in one encrypted file |
+
+## Quick start
+
+Configure an existing EJSON file and supply its private key from an exact Google Cloud Secret Manager reference:
+
+```toml title="secretspec.toml"
+[providers.ejson_keys]
+uri = "gcsm://ejson-private-keys"
+
+[providers.app_ejson]
+uri = "ejson:config/secrets.production.ejson"
+
+[providers.app_ejson.credentials.private_key]
+provider = "ejson_keys"
+ref = { item = "EJSON_PRIVATE_KEY", version = "1" }
+
+[profiles.production]
+API_TOKEN = { description = "Application API token", providers = ["app_ejson"], ref = { item = "/api_token" } }
+```
+
+Read the value or resolve it through an SDK:
+
+```bash
+$ secretspec get API_TOKEN --profile production
+```
+
+```bash
+$ secretspec run --profile production -- your-command
+```
+
+## Setup
+
+### Prerequisites
+
+- EJSON 1.1.0 or later available as `ejson` on `PATH`; 1.1.0 introduced `--key-from-stdin`
+- An existing encrypted EJSON file
+- The matching 64-character hexadecimal private key
+- Build SecretSpec with `--features ejson` when the provider is not included by your package
+
+Install the EJSON CLI through your package manager.
+
+Keep the encrypted file in source control if that matches its owning workflow. Keep the private key in a provider such as Google Cloud Secret Manager, keyring, or another store that can supply an exact SecretSpec credential reference.
+
+## Provider credentials
+
+The private key belongs in the provider alias's `credentials` map. It must not appear in the EJSON URI, application environment, or command arguments.
+
+<ProviderCredentials provider="ejson" />
+
+A configured source is authoritative. SecretSpec reads it before constructing the EJSON provider and passes the resulting value only to the EJSON child process through stdin.
+
+## Configuration
+
+### URI format
+
+```text
+ejson:PATH
+```
+
+`PATH` is the encrypted EJSON file. Relative paths resolve from the directory containing `secretspec.toml`, not the shell's current directory. The default path is `secrets.ejson`.
+
+User information, ports, query options, and fragments are rejected. In particular, the private key cannot be added to the URI.
+
+### URI examples
+
+```text
+ejson:secrets.ejson
+ejson:config/secrets.production.ejson
+ejson:///var/run/application/secrets.ejson
+```
+
+### Project configuration
+
+Use one alias for the key source and one for the EJSON file:
+
+```toml title="secretspec.toml"
+[providers.keys]
+uri = "gcsm://my-key-project"
+
+[providers.encrypted]
+uri = "ejson:config/secrets.production.ejson"
+
+[providers.encrypted.credentials.private_key]
+provider = "keys"
+ref = { item = "EJSON_PRIVATE_KEY", version = "1" }
+```
+
+The public key remains embedded in the EJSON file. The credential reference names the Google Cloud Secret Manager secret and version that store its matching private key. No public-key URI option is needed.
+
+## Storage model
+
+Convention-addressed secrets use an RFC 6901 JSON Pointer with project and profile isolation:
+
+```text
+/{project}/{profile}/{key}
+```
+
+For project `my-app`, profile `production`, and secret `API_TOKEN`, the decrypted JSON shape is:
+
+```json
+{
+  "my-app": {
+    "production": {
+      "API_TOKEN": "secret-value"
+    }
+  }
+}
+```
+
+`~` and `/` inside a component are escaped as `~0` and `~1`. The selected value must be a JSON string. Missing pointers are treated as missing secrets; numbers, booleans, objects, arrays, and null are rejected as secret values.
+
+## Use existing secrets
+
+Use `ref.item` to name any existing string with an RFC 6901 JSON Pointer:
+
+```toml
+[profiles.production]
+DATABASE_PASSWORD = { description = "Existing EJSON database password", providers = ["app_ejson"], ref = { item = "/database/password" } }
+```
+
+The provider supports only `item`. Extra coordinates such as `field` and `version` are rejected. The provider is read-only, so `secretspec set`, generated-value persistence, and import destinations are unavailable.
+
+## Private-key source
+
+The private key can come from any SecretSpec provider that can read the configured reference. The Google Cloud Secret Manager example uses Application Default Credentials; configure those credentials for the runtime environment and grant access only to the referenced private-key secret.
+
+## Security considerations and limitations
+
+- The current EJSON CLI decrypts the complete document before SecretSpec selects requested JSON Pointers. Each nonempty `get_many` call decrypts once for its complete batch; later calls decrypt again.
+- Encrypted input and decrypted output are each limited to 16 MiB. Full-document buffering creates multiple transient copies, so use smaller, trusted files.
+- The private key and decrypted document exist transiently in process memory. The provider does not write a decrypted file or export values to the environment itself.
+- Treat the `ejson` executable and the process `PATH` as trusted. The executable receives the private key on stdin and writes the complete decrypted document to stdout.
+- On Unix, the configured final path is opened with no-follow and nonblocking semantics. SecretSpec copies the ciphertext into an anonymous file descriptor inherited by EJSON, so later path or temporary-name replacement cannot change the document. Other platforms use a private named ciphertext snapshot. Parent-directory resolution still requires a trusted path.
+- Private-key delivery, EJSON execution, and output collection share one 30-second deadline. On Unix, cleanup stops the CLI process group on every exit.
+- EJSON leaves string properties whose names begin with `_` unencrypted. Treat them as public metadata, never secrets.
+- A SecretSpec scope limits returned values but is not an authorization boundary. Anyone with the private key can decrypt the complete EJSON file.
+- Use separate EJSON files and keypairs when workloads have different trust boundaries or rotation requirements.
+- SecretSpec does not watch the file or reload application clients automatically. A caller must perform another resolution and replace its own credential consumers.

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -169,6 +169,7 @@ $ secretspec config global init  # 0.17+
   akv: Azure Key Vault
   aac: Azure App Configuration (0.20+)
   infisical: Infisical secret management (0.16+)
+  ejson: EJSON encrypted files, read-only (0.20+)
   age: age-encrypted file (0.17+)
   sops: SOPS encrypted files (0.17+)
   kubernetes: Kubernetes (0.20+)

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -880,6 +880,7 @@ entry declares neither, it inherits whichever form `[profiles.default]` uses.
 | [dotenv](/providers/dotenv/#use-existing-secrets) | `.env` key | Rejected | Reads the key | ✅ |
 | [file (0.19+)](/providers/file/#use-existing-files) | Relative file path beneath the configured root | Rejected | Reads the complete UTF-8 file | ✅ |
 | [env](/providers/env/#use-existing-secrets) | Variable name | Rejected | Reads the variable | — (read-only) |
+| [EJSON (0.20+)](/providers/ejson/#use-existing-secrets) | RFC 6901 JSON Pointer | Rejected | Reads the selected JSON string | — (read-only) |
 | [systemd credentials (0.17+)](/providers/systemd-credential/#use-an-existing-credential-name) | Credential filename | Rejected | Reads the credential | — (read-only) |
 | [Fly.io secrets (0.20+)](/providers/fly/#use-existing-secrets) | Fly app secret name | Rejected | Error: Fly.io does not expose plaintext values | ✅ write-only via `flyctl secrets set` |
 | [Cloudflare Secrets Store (0.20+)](/providers/cloudflare/#use-existing-secrets-020) | Account-secret name in the selected store | Rejected | Error: Cloudflare's management API does not expose plaintext values | ✅ write-only via the Cloudflare API |

--- a/docs/src/content/docs/reference/providers.md
+++ b/docs/src/content/docs/reference/providers.md
@@ -651,6 +651,29 @@ folders remain unset so provider fallback continues.
 Values are read with Infisical's secret references expanded, matching its own CLI, so a value of
 `postgres://${DB_USER}@host` arrives resolved.
 
+## EJSON Provider (0.20+)
+
+:::note[Version compatibility]
+The `ejson` provider is added in SecretSpec 0.20.
+:::
+
+**URI**: `ejson:PATH` - Reads string values from one EJSON encrypted file
+
+```text
+ejson:secrets.ejson
+ejson:config/secrets.production.ejson
+ejson:///var/run/application/secrets.ejson
+```
+
+**Features (0.20+)**: Read-only, RFC 6901 JSON Pointer references, project/profile convention pointers, exact provider-credential key sources, and one decryption per batch
+**Prerequisites (0.20+)**: EJSON 1.1.0 or later, an encrypted EJSON file, and its matching private key; build with `--features ejson`
+**Authentication (0.20+)**: The `private_key` provider credential. It has no environment or URI fallback; source it from an exact provider reference such as a Google Cloud Secret Manager secret and version.
+**Storage (0.20+)**: Convention reads use `/{project}/{profile}/{key}` in the decrypted JSON document. A native `ref.item` is any RFC 6901 JSON Pointer selecting a string.
+
+The provider decrypts the complete EJSON document in memory through the current official CLI, then returns only requested values. Encrypted input and decrypted output are each limited to 16 MiB. It writes no decrypted value to a file itself. On Unix, SecretSpec opens the configured path with no-follow and nonblocking semantics, copies ciphertext into an anonymous inherited descriptor, and stops the CLI process group after a 30-second timeout. Other platforms use a private named ciphertext snapshot. Parent-directory resolution still requires a trusted path. The provider rejects writes, non-string selected values, URI credentials, ports, query options, fragments, and native coordinates other than `item`. EJSON properties beginning with `_` are plaintext metadata and must not contain secrets.
+
+See the [EJSON provider guide](/providers/ejson/) for exact Google Cloud Secret Manager credential configuration and security limitations.
+
 ## age Provider (0.17+)
 
 > **Version compatibility:** The age provider is added in SecretSpec 0.17.
@@ -778,6 +801,7 @@ $ export SECRETSPEC_PROVIDER="dotenv:///config/.env"
 | AKV | ✅ Azure-managed | Cloud (Azure) | ✅ Yes |
 | Azure App Configuration (0.20+) | ✅ Azure-managed | Cloud (Azure) | ✅ Yes |
 | Infisical | ✅ Infisical-managed | Cloud (Infisical) or self-hosted | ✅ Yes |
+| EJSON (0.20+) | ✅ EJSON encryption | Local encrypted file; private key from configured provider | Depends on private-key provider |
 | age (0.17+) | ✅ age encryption | Local filesystem | ❌ No |
 | SOPS (0.17+) | ✅ Configured SOPS encryption | Local filesystem | Depends on configured key service |
 | Kubernetes (0.20+) | ❌ ConfigMap ✅ Secret if configured | Kubernetes server | ✅ Yes |

--- a/docs/src/data/provider-credentials.json
+++ b/docs/src/data/provider-credentials.json
@@ -94,6 +94,17 @@
     ]
   },
   {
+    "provider": "ejson",
+    "implementationSources": ["secretspec/src/provider/ejson.rs"],
+    "credentials": [
+      {
+        "name": "private_key",
+        "environmentFallbacks": [],
+        "since": "0.20"
+      }
+    ]
+  },
+  {
     "provider": "fly",
     "implementationSources": ["secretspec/src/provider/fly.rs"],
     "credentials": [

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -58,6 +58,7 @@ const providerMetadata: ProviderMetadata[] = [
   { icon: 'microsoftazure', slug: 'akv', label: 'Azure Key Vault' },
   { icon: 'microsoftazure', slug: 'aac', label: 'Azure App Configuration (0.20+)' },
   { slug: 'infisical', label: 'Infisical' },
+  { slug: 'ejson', label: 'EJSON (0.20+)' },
   { slug: 'age', label: 'age (0.17+)' },
   { slug: 'gopass', label: 'Gopass' },
   { slug: 'protonpass', label: 'Proton Pass' },
@@ -154,6 +155,7 @@ const providerColors: Record<string, SyntaxColorName> = {
   akv: 'blue',
   aac: 'blue',
   infisical: 'cyan',
+  ejson: 'yellow',
   age: 'yellow',
   gopass: 'green',
   protonpass: 'magenta',
@@ -572,6 +574,7 @@ const reelScriptData = {
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/aac/"><span class="provider-name">aac</span>: Azure App Configuration (0.20+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/infisical/"><span class="provider-name">infisical</span>: Infisical secret management</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/openbao/"><span class="provider-name">openbao</span>: OpenBao secret management (0.17+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/ejson/"><span class="provider-name">ejson</span>: EJSON encrypted files, read-only (0.20+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/age/"><span class="provider-name">age</span>: age-encrypted file (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/sops/"><span class="provider-name">sops</span>: SOPS encrypted files (0.17+)</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/systemd-credential/"><span class="provider-name">systemd-credential</span>: Read-only systemd service credentials (0.17+)</a>

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -51,6 +51,7 @@ same-file.workspace = true
 url.workspace = true
 percent-encoding.workspace = true
 whoami = { workspace = true, optional = true }
+wait-timeout = { workspace = true, optional = true }
 linkme.workspace = true
 jiff.workspace = true
 secrecy.workspace = true
@@ -79,8 +80,11 @@ json-patch = { workspace = true, optional = true }
 libc.workspace = true
 signal-hook.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, optional = true }
+
 [features]
-default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "scaleway", "sops", "kubernetes", "cloudflare"]
+default = ["cli", "keyring", "kdbx", "keeper", "gcsm", "awssm", "awsps", "vault", "openbao", "bws", "akv", "aac", "infisical", "bw", "age", "ejson", "scaleway", "sops", "kubernetes", "cloudflare"]
 cli = ["dep:clap_complete", "dep:clap_complete_nushell", "dep:is_executable", "dep:dunce"]
 keyring = ["dep:keyring", "dep:whoami"]
 kdbx = ["dep:keepass"]
@@ -105,6 +109,7 @@ akv = ["dep:azure_core", "dep:azure_identity", "dep:azure_security_keyvault_secr
 # implementation, avoiding a second cryptography dependency.
 aac = ["akv", "dep:reqwest", "azure_core/hmac_rust"]
 age = ["dep:age"]
+ejson = ["dep:wait-timeout", "dep:windows-sys"]
 sops = []
 kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:base64", "dep:json-patch"]
 

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -53,6 +53,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [Azure Key Vault](https://secretspec.dev/providers/akv)
   - [Azure App Configuration](https://secretspec.dev/providers/aac) (0.20+)
   - [Infisical](https://secretspec.dev/providers/infisical) (0.16+)
+  - [EJSON](https://secretspec.dev/providers/ejson) (0.20+, read-only)
   - [age](https://secretspec.dev/providers/age) (0.17+)
   - [SOPS](https://secretspec.dev/providers/sops) (0.17+)
   - [Kubernetes](https://secretspec.dev/providers/kubernetes) (0.20+)
@@ -111,6 +112,7 @@ $ secretspec config global init  # 0.17+
   akv: Azure Key Vault
   aac: Azure App Configuration (0.20+)
   infisical: Infisical secret management (0.16+)
+  ejson: EJSON encrypted files, read-only (0.20+)
   age: age-encrypted file (0.17+)
   sops: SOPS encrypted files (0.17+)
   kubernetes: Kubernetes (0.20+)
@@ -238,6 +240,7 @@ SecretSpec supports multiple storage backends for secrets:
 - **[Azure Key Vault](https://secretspec.dev/providers/akv)** - Azure secret management
 - **[Azure App Configuration](https://secretspec.dev/providers/aac)** (0.20+) - Azure key-value management with Key Vault reference resolution
 - **[Infisical](https://secretspec.dev/providers/infisical)** (0.16+) - Infisical secret management
+- **[EJSON](https://secretspec.dev/providers/ejson)** (0.20+) - Read-only EJSON encrypted files with an explicit private-key provider credential
 - **[age](https://secretspec.dev/providers/age)** (0.17+) - age-encrypted file
 - **[SOPS](https://secretspec.dev/providers/sops)** (0.17+) - SOPS-encrypted files
 - **[Kubernetes](https://secretspec.dev/providers/kubernetes)** (0.20+) - Kubernetes

--- a/secretspec/src/provider/ejson.rs
+++ b/secretspec/src/provider/ejson.rs
@@ -1,0 +1,1864 @@
+//! Provider that reads secrets from an EJSON file.
+//!
+//! The encrypted file path comes from the provider URI. The matching private
+//! key is an injected `private_key` provider credential, so its source can be
+//! any existing SecretSpec provider and native reference. Reads invoke the
+//! official `ejson` CLI with the key on stdin, parse its JSON output, and select
+//! one value with an RFC 6901 JSON Pointer.
+//!
+//! # URI format
+//!
+//! - `ejson:config/secrets.production.ejson`
+//! - `ejson:///absolute/path/secrets.ejson`
+//!
+//! # Private key
+//!
+//! Configure the `private_key` provider credential on an alias. Its provider
+//! reference names the stored private key and may pin an exact version. The key
+//! never belongs in the URI or environment.
+
+use super::{Address, Provider, ProviderCredentials, ProviderUrl};
+use crate::config::NativeAddress;
+use crate::{Result, SecretSpecError};
+use percent_encoding::{AsciiSet, CONTROLS, percent_encode};
+use secrecy::zeroize::Zeroizing;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+#[cfg(windows)]
+use std::os::windows::{io::AsRawHandle, process::CommandExt};
+#[cfg(unix)]
+use std::os::{fd::AsRawFd, fd::FromRawFd, unix::process::CommandExt};
+#[cfg(not(unix))]
+use wait_timeout::ChildExt;
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+#[cfg(windows)]
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+};
+#[cfg(windows)]
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, TerminateJobObject,
+};
+#[cfg(windows)]
+use windows_sys::Win32::System::Threading::{
+    CREATE_SUSPENDED, OpenThread, ResumeThread, THREAD_SUSPEND_RESUME,
+};
+
+const PRIVATE_KEY: &str = "private_key";
+const MAX_EJSON_BYTES: u64 = 16 * 1024 * 1024;
+const DEFAULT_CLI_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// URI structural delimiters and path characters that must round-trip as data.
+/// Path separators stay literal, while Windows separators and drive colons are
+/// encoded into the opaque `ejson:` path form.
+const EJSON_PATH_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'%')
+    .add(b'@')
+    .add(b'#')
+    .add(b'?')
+    .add(b'<')
+    .add(b'>')
+    .add(b'[')
+    .add(b']')
+    .add(b'|')
+    .add(b'^')
+    .add(b'\\')
+    .add(b':');
+
+fn provider_err(message: impl Into<String>) -> SecretSpecError {
+    SecretSpecError::ProviderOperationFailed(message.into())
+}
+
+/// An opened ciphertext snapshot. On Unix it is anonymous and inherited by the
+/// child through a descriptor path; other platforms use a private named file.
+struct EncryptedSnapshot {
+    #[cfg(unix)]
+    file: File,
+    #[cfg(not(unix))]
+    file: tempfile::NamedTempFile,
+}
+
+impl EncryptedSnapshot {
+    fn new() -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            let file = tempfile::tempfile()?;
+            let fd = file.as_raw_fd();
+            if fd >= 3 {
+                return Ok(Self { file });
+            }
+            // Keep the inherited snapshot out of stdin/stdout/stderr slots,
+            // which `Command` replaces while constructing the child.
+            // SAFETY: `fd` belongs to `file`; F_DUPFD_CLOEXEC returns a new
+            // independently owned descriptor at or above the requested floor.
+            let duplicate = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) };
+            if duplicate == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            // SAFETY: `duplicate` is a fresh owned descriptor returned above.
+            let file = unsafe { File::from_raw_fd(duplicate) };
+            Ok(Self { file })
+        }
+        #[cfg(not(unix))]
+        {
+            tempfile::NamedTempFile::new().map(|file| Self { file })
+        }
+    }
+
+    fn file_mut(&mut self) -> &mut File {
+        #[cfg(unix)]
+        {
+            &mut self.file
+        }
+        #[cfg(not(unix))]
+        {
+            self.file.as_file_mut()
+        }
+    }
+
+    fn rewind(&mut self) -> std::io::Result<()> {
+        self.file_mut().seek(SeekFrom::Start(0)).map(|_| ())
+    }
+
+    #[cfg(unix)]
+    fn command_path(&self) -> PathBuf {
+        let fd = self.file.as_raw_fd();
+        if cfg!(target_os = "linux") {
+            PathBuf::from(format!("/proc/self/fd/{fd}"))
+        } else {
+            PathBuf::from(format!("/dev/fd/{fd}"))
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn command_path(&self) -> PathBuf {
+        self.file.path().to_path_buf()
+    }
+
+    #[cfg(unix)]
+    fn configure_command(&self, command: &mut Command) {
+        let fd = self.file.as_raw_fd();
+        // SAFETY: `pre_exec` runs after fork and before exec. The closure uses
+        // only async-signal-safe `fcntl` calls and changes only the child's
+        // descriptor table, leaving the parent's close-on-exec flag unchanged.
+        unsafe {
+            command.pre_exec(move || {
+                let flags = libc::fcntl(fd, libc::F_GETFD);
+                if flags == -1 || libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn configure_command(&self, _command: &mut Command) {}
+}
+
+#[cfg(windows)]
+struct OwnedWindowsHandle {
+    handle: HANDLE,
+}
+
+#[cfg(windows)]
+impl Drop for OwnedWindowsHandle {
+    fn drop(&mut self) {
+        // SAFETY: this type owns the live handle and closes it exactly once.
+        let _ = unsafe { CloseHandle(self.handle) };
+    }
+}
+
+#[cfg(windows)]
+fn resume_suspended_process(process_id: u32) -> std::io::Result<()> {
+    // SAFETY: this requests a read-only system snapshot handle.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+    let snapshot = OwnedWindowsHandle { handle: snapshot };
+    let mut entry = THREADENTRY32 {
+        dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+        ..Default::default()
+    };
+
+    // SAFETY: `entry` advertises its exact size and remains writable while the
+    // owned snapshot handle is live.
+    let mut found = unsafe { Thread32First(snapshot.handle, &mut entry) };
+    while found != 0 {
+        if entry.th32OwnerProcessID == process_id {
+            // SAFETY: the thread ID belongs to the newly created suspended
+            // process, and the requested access permits only suspend/resume.
+            let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID) };
+            if thread.is_null() {
+                return Err(std::io::Error::last_os_error());
+            }
+            let thread = OwnedWindowsHandle { handle: thread };
+            // SAFETY: CREATE_SUSPENDED created this initial thread with a
+            // suspend count of one. `u32::MAX` reports failure.
+            if unsafe { ResumeThread(thread.handle) } == u32::MAX {
+                return Err(std::io::Error::last_os_error());
+            }
+            return Ok(());
+        }
+        // SAFETY: same initialized entry and live snapshot as Thread32First.
+        found = unsafe { Thread32Next(snapshot.handle, &mut entry) };
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "failed to find the suspended EJSON CLI thread",
+    ))
+}
+
+#[cfg(windows)]
+struct WindowsJob {
+    handle: HANDLE,
+}
+
+#[cfg(windows)]
+impl WindowsJob {
+    fn assign(child: &Child) -> std::io::Result<Self> {
+        // SAFETY: null attributes and name create a private job object. Every
+        // returned handle is closed on error or by `Drop`.
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if handle.is_null() {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        // SAFETY: `limits` has the exact layout and size required by this job
+        // information class, and `handle` remains live for the call.
+        if unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                std::ptr::from_ref(&limits).cast(),
+                std::mem::size_of_val(&limits) as u32,
+            )
+        } == 0
+        {
+            let error = std::io::Error::last_os_error();
+            // SAFETY: `handle` is live and owned by this function.
+            let _ = unsafe { CloseHandle(handle) };
+            return Err(error);
+        }
+
+        // SAFETY: the child process handle stays live while `child` is live,
+        // and the job handle is valid. Descendants join the same job unless the
+        // job explicitly permits breakaway, which this job does not.
+        if unsafe { AssignProcessToJobObject(handle, child.as_raw_handle() as HANDLE) } == 0 {
+            let error = std::io::Error::last_os_error();
+            // SAFETY: `handle` is live and owned by this function.
+            let _ = unsafe { CloseHandle(handle) };
+            return Err(error);
+        }
+
+        Ok(Self { handle })
+    }
+
+    fn terminate(&self) -> std::io::Result<()> {
+        // SAFETY: `self.handle` remains valid until `Drop`.
+        if unsafe { TerminateJobObject(self.handle, 1) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsJob {
+    fn drop(&mut self) {
+        // Closing a kill-on-close job stops any descendant that still holds an
+        // inherited stdout handle after the direct EJSON process exits.
+        // SAFETY: this type owns the live handle and closes it exactly once.
+        let _ = unsafe { CloseHandle(self.handle) };
+    }
+}
+
+struct ManagedChild {
+    child: Child,
+    child_reaped: bool,
+    cleanup_complete: bool,
+    exit_observed: bool,
+    exit_status: Option<ExitStatus>,
+    #[cfg(windows)]
+    job: WindowsJob,
+}
+
+impl ManagedChild {
+    fn new(child: Child) -> std::io::Result<Self> {
+        #[cfg(windows)]
+        {
+            let mut child = child;
+            let job = match WindowsJob::assign(&child) {
+                Ok(job) => job,
+                Err(error) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(error);
+                }
+            };
+            if let Err(error) = resume_suspended_process(child.id()) {
+                let _ = job.terminate();
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+            Ok(Self {
+                child,
+                child_reaped: false,
+                cleanup_complete: false,
+                exit_observed: false,
+                exit_status: None,
+                job,
+            })
+        }
+        #[cfg(not(windows))]
+        {
+            Ok(Self {
+                child,
+                child_reaped: false,
+                cleanup_complete: false,
+                exit_observed: false,
+                exit_status: None,
+            })
+        }
+    }
+
+    #[cfg(unix)]
+    fn wait_for_exit(&mut self, timeout: Duration) -> std::io::Result<bool> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::zeroed();
+            // `WNOWAIT` observes exit without reaping the group leader. Its PID
+            // therefore cannot be reused before process-group cleanup.
+            // SAFETY: `info` points to writable storage for one `siginfo_t`, and
+            // this call observes only the child PID owned by `self.child`.
+            let result = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    self.child.id() as libc::id_t,
+                    info.as_mut_ptr(),
+                    libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+                )
+            };
+            if result == -1 {
+                let error = std::io::Error::last_os_error();
+                if error.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error);
+            }
+            // SAFETY: a successful `waitid` initialized `info`; `si_pid == 0`
+            // means the nonblocking observation found no exited child yet.
+            if unsafe { info.assume_init().si_pid() } != 0 {
+                self.exit_observed = true;
+                return Ok(true);
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(false);
+            }
+            std::thread::sleep(remaining.min(Duration::from_millis(10)));
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn wait_for_exit(&mut self, timeout: Duration) -> std::io::Result<bool> {
+        match self.child.wait_timeout(timeout)? {
+            Some(status) => {
+                self.child_reaped = true;
+                self.exit_observed = true;
+                self.exit_status = Some(status);
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn terminate_tree(&self) -> std::io::Result<()> {
+        #[cfg(unix)]
+        {
+            let process_group = -(self.child.id() as libc::pid_t);
+            // SAFETY: the child starts as leader of its own process group and
+            // remains unreaped until this signal succeeds or reports no group.
+            // macOS reports EPERM when only the unsignalable zombie leader
+            // remains; after exit observation that also means no live member
+            // owned by this process remains to stop.
+            if unsafe { libc::kill(process_group, libc::SIGKILL) } == -1 {
+                let error = std::io::Error::last_os_error();
+                let no_signalable_descendant =
+                    self.exit_observed && error.raw_os_error() == Some(libc::EPERM);
+                if error.raw_os_error() != Some(libc::ESRCH) && !no_signalable_descendant {
+                    return Err(error);
+                }
+            }
+        }
+        #[cfg(windows)]
+        self.job.terminate()?;
+        Ok(())
+    }
+
+    fn finish_after_exit(&mut self) -> std::io::Result<ExitStatus> {
+        self.terminate_tree()?;
+        let status = match self.exit_status.take() {
+            Some(status) => status,
+            None => self.child.wait()?,
+        };
+        self.child_reaped = true;
+        self.cleanup_complete = true;
+        Ok(status)
+    }
+
+    fn stop(&mut self) -> std::io::Result<()> {
+        if self.cleanup_complete {
+            return Ok(());
+        }
+        self.terminate_tree()?;
+        if !self.child_reaped {
+            let _ = self.child.kill();
+            self.child.wait()?;
+            self.child_reaped = true;
+        }
+        self.cleanup_complete = true;
+        Ok(())
+    }
+}
+
+impl Drop for ManagedChild {
+    fn drop(&mut self) {
+        // Explicit error paths call `stop` first. A failed attempt leaves the
+        // state incomplete so this final attempt can retry before handles drop.
+        let _ = self.stop();
+    }
+}
+
+/// Configuration for one encrypted EJSON file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EjsonConfig {
+    /// Path to the encrypted EJSON document.
+    pub path: PathBuf,
+}
+
+impl Default for EjsonConfig {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::from("secrets.ejson"),
+        }
+    }
+}
+
+impl TryFrom<&ProviderUrl> for EjsonConfig {
+    type Error = SecretSpecError;
+
+    fn try_from(url: &ProviderUrl) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "ejson" {
+            return Err(provider_err(format!(
+                "Invalid scheme '{}' for ejson provider",
+                url.scheme()
+            )));
+        }
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || url.has_port()
+            || url.has_query()
+            || url.has_fragment()
+        {
+            return Err(provider_err(
+                "ejson provider URIs take only an encrypted file path; user information, ports, query options, and fragments are not supported",
+            ));
+        }
+
+        let path_str = url.path();
+        #[cfg(windows)]
+        let path_str = if path_str.as_bytes().first() == Some(&b'/')
+            && path_str.as_bytes().get(2) == Some(&b':')
+            && path_str
+                .as_bytes()
+                .get(1)
+                .is_some_and(u8::is_ascii_alphabetic)
+        {
+            path_str[1..].to_string()
+        } else {
+            path_str
+        };
+        let path = if !path_str.is_empty() && path_str != "/" {
+            match url.host() {
+                Some(host) => PathBuf::from(format!("{}{}", host, path_str)),
+                None => PathBuf::from(path_str),
+            }
+        } else if let Some(host) = url.host() {
+            PathBuf::from(host)
+        } else {
+            PathBuf::from("secrets.ejson")
+        };
+
+        Ok(Self { path })
+    }
+}
+
+/// Reads string values from one EJSON document.
+pub struct EjsonProvider {
+    config: EjsonConfig,
+    credentials: ProviderCredentials,
+    cli_binary_path: PathBuf,
+    cli_timeout: Duration,
+}
+
+crate::register_provider! {
+    struct: EjsonProvider,
+    config: EjsonConfig,
+    name: "ejson",
+    description: "EJSON encrypted files (0.20+)",
+    schemes: ["ejson"],
+    examples: ["ejson:config/secrets.production.ejson"],
+    credential_names: [PRIVATE_KEY],
+}
+
+impl EjsonProvider {
+    pub fn new(config: EjsonConfig) -> Self {
+        Self {
+            config,
+            credentials: ProviderCredentials::new(),
+            cli_binary_path: PathBuf::from("ejson"),
+            cli_timeout: DEFAULT_CLI_TIMEOUT,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_cli_binary(mut self, path: PathBuf) -> Self {
+        self.cli_binary_path = path;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_cli_timeout(mut self, timeout: Duration) -> Self {
+        self.cli_timeout = timeout;
+        self
+    }
+
+    fn pointer_segment(value: &str) -> String {
+        value.replace('~', "~0").replace('/', "~1")
+    }
+
+    fn validate_pointer(pointer: &str) -> Result<()> {
+        if !pointer.is_empty() && !pointer.starts_with('/') {
+            return Err(provider_err(format!(
+                "invalid ejson item '{pointer}': expected an RFC 6901 JSON Pointer beginning with '/'"
+            )));
+        }
+
+        let bytes = pointer.as_bytes();
+        let mut index = 0;
+        while index < bytes.len() {
+            if bytes[index] == b'~' {
+                let escape = bytes.get(index + 1).copied();
+                if !matches!(escape, Some(b'0' | b'1')) {
+                    return Err(provider_err(format!(
+                        "invalid ejson item '{pointer}': JSON Pointer '~' escapes must be '~0' or '~1'"
+                    )));
+                }
+                index += 2;
+            } else {
+                index += 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn pointer<'a>(&self, addr: Address<'a>) -> Result<Cow<'a, str>> {
+        match self.resolve_coords(addr)? {
+            Cow::Borrowed(native) => {
+                Self::validate_pointer(&native.item)?;
+                Ok(Cow::Borrowed(native.item.as_str()))
+            }
+            Cow::Owned(native) => {
+                Self::validate_pointer(&native.item)?;
+                Ok(Cow::Owned(native.item))
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn open_source(path: &Path) -> std::io::Result<File> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(path)
+    }
+
+    #[cfg(not(unix))]
+    fn open_source(path: &Path) -> std::io::Result<File> {
+        OpenOptions::new().read(true).open(path)
+    }
+
+    #[cfg(unix)]
+    fn is_symlink_open_error(error: &std::io::Error) -> bool {
+        error.raw_os_error() == Some(libc::ELOOP)
+    }
+
+    #[cfg(not(unix))]
+    fn is_symlink_open_error(_error: &std::io::Error) -> bool {
+        false
+    }
+
+    /// Opens the configured source and copies its ciphertext into a private
+    /// temporary file. The CLI receives only this immutable snapshot, so a
+    /// replacement of the configured pathname cannot change the decrypted data.
+    fn encrypted_snapshot(&self) -> Result<Option<EncryptedSnapshot>> {
+        let source = match Self::open_source(&self.config.path) {
+            Ok(source) => source,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) if Self::is_symlink_open_error(&error) => {
+                return Err(provider_err(format!(
+                    "ejson file '{}' is a symbolic link; symbolic links are not followed",
+                    self.config.path.display()
+                )));
+            }
+            Err(error) => {
+                return Err(provider_err(format!(
+                    "failed to open ejson file '{}': {error}",
+                    self.config.path.display()
+                )));
+            }
+        };
+        let metadata = source.metadata().map_err(|error| {
+            provider_err(format!(
+                "failed to inspect opened ejson file '{}': {error}",
+                self.config.path.display()
+            ))
+        })?;
+        if !metadata.is_file() {
+            return Err(provider_err(format!(
+                "ejson path '{}' is not a regular file",
+                self.config.path.display()
+            )));
+        }
+        if metadata.len() > MAX_EJSON_BYTES {
+            return Err(provider_err(format!(
+                "ejson file '{}' is {} bytes; the maximum supported size is {} bytes",
+                self.config.path.display(),
+                metadata.len(),
+                MAX_EJSON_BYTES
+            )));
+        }
+
+        let mut snapshot = EncryptedSnapshot::new().map_err(|error| {
+            provider_err(format!(
+                "failed to create a temporary EJSON ciphertext snapshot: {error}"
+            ))
+        })?;
+        let mut limited = source.take(MAX_EJSON_BYTES + 1);
+        let copied = std::io::copy(&mut limited, snapshot.file_mut()).map_err(|error| {
+            provider_err(format!(
+                "failed to copy EJSON ciphertext into a temporary snapshot: {error}"
+            ))
+        })?;
+        if copied as u64 > MAX_EJSON_BYTES {
+            return Err(provider_err(format!(
+                "ejson file '{}' exceeds the maximum supported size of {MAX_EJSON_BYTES} bytes",
+                self.config.path.display()
+            )));
+        }
+        snapshot.file_mut().flush().map_err(|error| {
+            provider_err(format!(
+                "failed to flush the temporary EJSON ciphertext snapshot: {error}"
+            ))
+        })?;
+        snapshot.rewind().map_err(|error| {
+            provider_err(format!(
+                "failed to rewind the temporary EJSON ciphertext snapshot: {error}"
+            ))
+        })?;
+        Ok(Some(snapshot))
+    }
+
+    fn private_key(&self) -> Result<Zeroizing<String>> {
+        let value = self.credentials.get(PRIVATE_KEY).ok_or_else(|| {
+            provider_err(
+                "No EJSON private key configured. Add the `private_key` provider credential to this provider alias.",
+            )
+        })?;
+        let value = value.expose_secret().trim();
+        if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(provider_err(
+                "Invalid EJSON `private_key` credential: expected exactly 64 hexadecimal characters.",
+            ));
+        }
+        Ok(Zeroizing::new(value.to_string()))
+    }
+
+    fn stop_child(child: &mut ManagedChild) {
+        let _ = child.stop();
+    }
+
+    /// Decrypts the file once. The official CLI currently emits the complete
+    /// document; callers select only declared pointers from the parsed value.
+    fn decrypt(&self) -> Result<Option<serde_json::Value>> {
+        let Some(snapshot) = self.encrypted_snapshot()? else {
+            return Ok(None);
+        };
+        let private_key = self.private_key()?;
+        let deadline = Instant::now() + self.cli_timeout;
+
+        let mut command = Command::new(&self.cli_binary_path);
+        command
+            .arg("decrypt")
+            .arg("--key-from-stdin")
+            .arg(snapshot.command_path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // Child diagnostics are not trusted: a substituted executable sees
+            // the private key on stdin and could echo it. Return a generic error.
+            .stderr(Stdio::null());
+        snapshot.configure_command(&mut command);
+        #[cfg(unix)]
+        command.process_group(0);
+        #[cfg(windows)]
+        command.creation_flags(CREATE_SUSPENDED);
+
+        let spawn_result = command.spawn();
+        let child = match spawn_result {
+            Ok(child) => child,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(provider_err(
+                    "The 'ejson' CLI is not installed. Install it through your package manager.",
+                ));
+            }
+            Err(error) => {
+                return Err(provider_err(format!(
+                    "failed to start the EJSON CLI: {error}"
+                )));
+            }
+        };
+        let mut child = ManagedChild::new(child).map_err(|error| {
+            provider_err(format!(
+                "failed to secure the EJSON CLI process lifetime: {error}"
+            ))
+        })?;
+
+        let Some(stdout) = child.child.stdout.take() else {
+            Self::stop_child(&mut child);
+            return Err(provider_err("failed to open stdout for the EJSON CLI"));
+        };
+        let (output_sender, output_receiver) = mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let mut plaintext = Vec::new();
+            let result = stdout
+                .take(MAX_EJSON_BYTES + 1)
+                .read_to_end(&mut plaintext)
+                .map(|_| plaintext);
+            let _ = output_sender.send(result);
+        });
+
+        let Some(mut stdin) = child.child.stdin.take() else {
+            Self::stop_child(&mut child);
+            drop(output_receiver);
+            return Err(provider_err("failed to open stdin for the EJSON CLI"));
+        };
+        let (input_sender, input_receiver) = mpsc::sync_channel(1);
+        let key_terminator: &'static [u8] = if cfg!(windows) { b"\r\n" } else { b"\n" };
+        std::thread::spawn(move || {
+            let result = stdin
+                .write_all(private_key.as_bytes())
+                .and_then(|()| stdin.write_all(key_terminator));
+            let _ = input_sender.send(result);
+        });
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match input_receiver.recv_timeout(remaining) {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                Self::stop_child(&mut child);
+                drop(output_receiver);
+                return Err(provider_err(format!(
+                    "failed to send the private key to the EJSON CLI: {error}"
+                )));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                Self::stop_child(&mut child);
+                drop(output_receiver);
+                return Err(provider_err(format!(
+                    "EJSON private-key delivery timed out after {} seconds",
+                    self.cli_timeout.as_secs_f64()
+                )));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                Self::stop_child(&mut child);
+                drop(output_receiver);
+                return Err(provider_err(
+                    "EJSON private-key writer stopped unexpectedly",
+                ));
+            }
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match child.wait_for_exit(remaining) {
+            Ok(true) => {}
+            Ok(false) => {
+                Self::stop_child(&mut child);
+                drop(output_receiver);
+                return Err(provider_err(format!(
+                    "EJSON decryption timed out after {} seconds",
+                    self.cli_timeout.as_secs_f64()
+                )));
+            }
+            Err(error) => {
+                Self::stop_child(&mut child);
+                drop(output_receiver);
+                return Err(provider_err(format!(
+                    "failed to wait for the EJSON CLI: {error}"
+                )));
+            }
+        }
+        let status = child.finish_after_exit().map_err(|error| {
+            provider_err(format!(
+                "failed to clean up the EJSON CLI process tree: {error}"
+            ))
+        })?;
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let plaintext = match output_receiver.recv_timeout(remaining) {
+            Ok(Ok(plaintext)) => plaintext,
+            Ok(Err(error)) => {
+                return Err(provider_err(format!(
+                    "failed to read output from the EJSON CLI: {error}"
+                )));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                Self::stop_child(&mut child);
+                return Err(provider_err(format!(
+                    "EJSON output did not close within {} seconds",
+                    self.cli_timeout.as_secs_f64()
+                )));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(provider_err("EJSON output reader stopped unexpectedly"));
+            }
+        };
+        if plaintext.len() as u64 > MAX_EJSON_BYTES {
+            return Err(provider_err(format!(
+                "EJSON decrypted output exceeds the maximum supported size of {MAX_EJSON_BYTES} bytes"
+            )));
+        }
+        if !status.success() {
+            return Err(provider_err(format!(
+                "EJSON decryption failed ({status}). Check the encrypted file, EJSON CLI compatibility, and `private_key` credential."
+            )));
+        }
+
+        serde_json::from_slice(&plaintext)
+            .map(Some)
+            .map_err(|error| {
+                provider_err(format!("failed to parse JSON emitted by EJSON: {error}"))
+            })
+    }
+
+    fn select(document: &serde_json::Value, pointer: &str) -> Result<Option<SecretString>> {
+        match document.pointer(pointer) {
+            None => Ok(None),
+            Some(serde_json::Value::String(value)) => {
+                Ok(Some(SecretString::new(value.clone().into())))
+            }
+            Some(_) => Err(provider_err(format!(
+                "ejson item '{pointer}' does not select a string value"
+            ))),
+        }
+    }
+}
+
+impl Provider for EjsonProvider {
+    fn convention_address(&self, project: &str, profile: &str, key: &str) -> Result<NativeAddress> {
+        Ok(NativeAddress {
+            item: format!(
+                "/{}/{}/{}",
+                Self::pointer_segment(project),
+                Self::pointer_segment(profile),
+                Self::pointer_segment(key)
+            ),
+            ..Default::default()
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        Self::PROVIDER_NAME
+    }
+
+    fn uri(&self) -> String {
+        let path = self.config.path.display().to_string();
+        format!(
+            "ejson:{}",
+            percent_encode(path.as_bytes(), EJSON_PATH_ENCODE_SET)
+        )
+    }
+
+    fn with_base_dir(&mut self, base_dir: &Path) {
+        if self.config.path.is_relative() {
+            self.config.path = base_dir.join(&self.config.path);
+        }
+    }
+
+    fn with_credentials(&mut self, credentials: ProviderCredentials) {
+        self.credentials = credentials;
+    }
+
+    fn physical_store_path(&self) -> Option<&Path> {
+        Some(&self.config.path)
+    }
+
+    fn get(&self, addr: Address<'_>) -> Result<Option<SecretString>> {
+        let pointer = self.pointer(addr)?;
+        let Some(document) = self.decrypt()? else {
+            return Ok(None);
+        };
+        Self::select(&document, &pointer)
+    }
+
+    fn get_many(&self, requests: &[(&str, Address<'_>)]) -> Result<HashMap<String, SecretString>> {
+        let pointers = requests
+            .iter()
+            .map(|(name, addr)| Ok((name.to_string(), self.pointer(*addr)?.into_owned())))
+            .collect::<Result<Vec<_>>>()?;
+        if pointers.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let Some(document) = self.decrypt()? else {
+            return Ok(HashMap::new());
+        };
+
+        let mut values = HashMap::new();
+        for (name, pointer) in pointers {
+            if let Some(value) = Self::select(&document, &pointer)? {
+                values.insert(name, value);
+            }
+        }
+        Ok(values)
+    }
+
+    fn check_writable(&self, _addr: Address<'_>) -> Result<()> {
+        Err(provider_err(
+            "the ejson provider is read-only; edit and encrypt the EJSON file through its owning workflow",
+        ))
+    }
+
+    fn set(&self, addr: Address<'_>, _value: &SecretString) -> Result<()> {
+        self.check_writable(addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+    use std::fs;
+    use url::Url;
+
+    const TEST_PRIVATE_KEY: &str =
+        "1111111111111111111111111111111111111111111111111111111111111111";
+
+    fn config_from(uri: &str) -> EjsonConfig {
+        let url = ProviderUrl::new(Url::parse(uri).unwrap());
+        (&url).try_into().unwrap()
+    }
+
+    #[test]
+    fn registration_advertises_private_key_credential() {
+        assert_eq!(
+            crate::provider::credential_names_for_spec("ejson:secrets.ejson"),
+            &[PRIVATE_KEY]
+        );
+    }
+
+    #[test]
+    fn parses_relative_absolute_and_default_paths() {
+        assert_eq!(
+            config_from("ejson:config/secrets.ejson").path,
+            Path::new("config/secrets.ejson")
+        );
+        assert_eq!(
+            config_from("ejson://config/secrets.ejson").path,
+            Path::new("config/secrets.ejson")
+        );
+        assert_eq!(
+            config_from("ejson:///var/run/secrets.ejson").path,
+            Path::new("/var/run/secrets.ejson")
+        );
+        assert_eq!(config_from("ejson:").path, Path::new("secrets.ejson"));
+    }
+
+    #[test]
+    fn rejects_non_path_uri_components() {
+        for spec in [
+            "ejson:config/secrets.ejson?private_key=nope",
+            "ejson:secrets#prod.ejson",
+            "ejson:dir:123/file.ejson",
+        ] {
+            let Err(error) = Box::<dyn Provider>::try_from(spec) else {
+                panic!("{spec} unexpectedly built an EJSON provider");
+            };
+            assert!(
+                error.to_string().contains("only an encrypted file path"),
+                "{spec}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn convention_address_uses_escaped_json_pointer() {
+        let provider = EjsonProvider::new(EjsonConfig::default());
+        let address = provider
+            .convention_address("my/app", "prod~blue", "API/TOKEN")
+            .unwrap();
+        assert_eq!(address.item, "/my~1app/prod~0blue/API~1TOKEN");
+    }
+
+    #[test]
+    fn uri_round_trips_structural_path_characters() {
+        for path in [
+            "config/secrets #1?.ejson",
+            "config/100% secrets.ejson",
+            "config/name@host.ejson",
+            r"C:\\Users\\app\\secrets.ejson",
+        ] {
+            let provider = EjsonProvider::new(EjsonConfig {
+                path: PathBuf::from(path),
+            });
+            let reparsed = Box::<dyn Provider>::try_from(provider.uri().as_str()).unwrap();
+            assert_eq!(reparsed.physical_store_path(), Some(Path::new(path)));
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_paths_round_trip_through_provider_factory() {
+        for spec in [
+            r"ejson://C:\Users\app\secrets.ejson",
+            "ejson:///C:/Users/app/secrets.ejson",
+        ] {
+            let provider = Box::<dyn Provider>::try_from(spec).unwrap();
+            assert_eq!(provider.name(), "ejson");
+            assert_eq!(
+                provider.physical_store_path(),
+                Some(Path::new(r"C:\Users\app\secrets.ejson"))
+            );
+            let reparsed = Box::<dyn Provider>::try_from(provider.uri().as_str()).unwrap();
+            assert_eq!(
+                reparsed.physical_store_path(),
+                provider.physical_store_path()
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_decrypts_through_a_named_snapshot() {
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let cli = directory.path().join("ejson.cmd");
+        fs::write(
+            &cli,
+            format!(
+                "@echo off\r\nset /p private_key=\r\nif not \"%private_key%\" == \"{TEST_PRIVATE_KEY}\" exit /b 3\r\nif not exist \"%~3\" exit /b 4\r\necho {{\"TOKEN\":\"value\"}}\r\n"
+            ),
+        )
+        .unwrap();
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted })
+            .with_cli_binary(cli)
+            .with_cli_timeout(Duration::from_secs(5));
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let value = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap()
+            .unwrap();
+        assert_eq!(value.expose_secret(), "value");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_suspended_job_stops_a_descendant_holding_stdout() {
+        use std::os::windows::process::CommandExt as _;
+        use windows_sys::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, PROCESS_SYNCHRONIZE, WaitForSingleObject,
+        };
+
+        let directory = tempfile::tempdir().unwrap();
+        let descendant_pid = directory.path().join("descendant-pid");
+        let pid_path = descendant_pid.display().to_string().replace('\'', "''");
+        let script = format!(
+            "$child = Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 60') -NoNewWindow -PassThru; $child.Id | Set-Content -NoNewline -Encoding Ascii -LiteralPath '{pid_path}'; Wait-Process -Id $child.Id"
+        );
+        let mut command = Command::new("powershell.exe");
+        command
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &script,
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .creation_flags(CREATE_SUSPENDED);
+        let child = command.spawn().unwrap();
+        let mut child = ManagedChild::new(child).unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !descendant_pid.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        if !descendant_pid.exists() {
+            let _ = child.stop();
+            panic!("suspended Windows helper did not record its descendant");
+        }
+        let pid: u32 = fs::read_to_string(descendant_pid)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        child.stop().unwrap();
+
+        // SAFETY: this opens only the test descendant for synchronization. The
+        // returned handle is closed below and grants no mutation rights.
+        let handle = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, 0, pid) };
+        if !handle.is_null() {
+            // SAFETY: `handle` is live for this bounded wait.
+            let wait = unsafe { WaitForSingleObject(handle, 2_000) };
+            // SAFETY: this test owns the live process handle.
+            let _ = unsafe { CloseHandle(handle) };
+            assert_eq!(wait, WAIT_OBJECT_0, "EJSON descendant {pid} survived");
+        }
+    }
+
+    #[test]
+    fn validates_json_pointer_escapes() {
+        for valid in ["", "/API_KEY", "/nested/key", "/a~0b/c~1d"] {
+            EjsonProvider::validate_pointer(valid).unwrap();
+        }
+        for invalid in ["API_KEY", "/bad~", "/bad~2escape"] {
+            assert!(
+                EjsonProvider::validate_pointer(invalid).is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn rebases_relative_file_path() {
+        let mut provider = EjsonProvider::new(EjsonConfig {
+            path: PathBuf::from("config/secrets.ejson"),
+        });
+        provider.with_base_dir(Path::new("/project"));
+        assert_eq!(
+            provider.config.path,
+            Path::new("/project/config/secrets.ejson")
+        );
+    }
+
+    #[test]
+    fn missing_file_is_an_absent_value_without_key_access() {
+        let directory = tempfile::tempdir().unwrap();
+        let provider = EjsonProvider::new(EjsonConfig {
+            path: directory.path().join("missing.ejson"),
+        });
+        assert!(
+            provider
+                .get(Address::convention("app", "default", "MISSING"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn read_only_error_is_consistent() {
+        let provider = EjsonProvider::new(EjsonConfig::default());
+        let addr = Address::convention("app", "default", "TOKEN");
+        let preflight = provider.check_writable(addr).unwrap_err().to_string();
+        let write = provider
+            .set(addr, &SecretString::new("value".into()))
+            .unwrap_err()
+            .to_string();
+        assert_eq!(preflight, write);
+        assert!(write.contains("read-only"));
+    }
+
+    #[test]
+    fn native_address_rejects_unsupported_coordinates() {
+        let provider = EjsonProvider::new(EjsonConfig::default());
+        let address = NativeAddress {
+            item: "/TOKEN".into(),
+            field: Some("value".into()),
+            ..Default::default()
+        };
+        let error = provider.get(Address::Native(&address)).unwrap_err();
+        assert!(error.to_string().contains("`field`"));
+    }
+
+    #[test]
+    fn selects_only_string_values() {
+        let document = serde_json::json!({
+            "string": "value",
+            "number": 42,
+        });
+        assert_eq!(
+            EjsonProvider::select(&document, "/string")
+                .unwrap()
+                .unwrap()
+                .expose_secret(),
+            "value"
+        );
+        assert!(
+            EjsonProvider::select(&document, "/missing")
+                .unwrap()
+                .is_none()
+        );
+        assert!(EjsonProvider::select(&document, "/number").is_err());
+        assert!(EjsonProvider::select(&document, "").is_err());
+    }
+
+    #[cfg(unix)]
+    fn fake_cli(directory: &Path, output: &str, count_file: &Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = directory.join("ejson");
+        let escaped_output = output.replace('\\', "\\\\").replace('\'', "'\\''");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nset -eu\n[ \"$1\" = decrypt ]\n[ \"$2\" = --key-from-stdin ]\n[ -f \"$3\" ]\nkey=$(cat)\n[ \"$key\" = '{}' ]\nprintf x >> '{}'\nprintf '%s' '{}'\n",
+                TEST_PRIVATE_KEY,
+                count_file.display(),
+                escaped_output,
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o700)).unwrap();
+        script
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn decrypts_when_parent_stdio_is_closed() {
+        const CHILD_ENV: &str = "SECRETSPEC_EJSON_CLOSED_STDIO_CHILD";
+        const TEST_NAME: &str = "provider::ejson::tests::decrypts_when_parent_stdio_is_closed";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let directory = tempfile::tempdir().unwrap();
+            let encrypted = directory.path().join("secrets.ejson");
+            let count = directory.path().join("count");
+            fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+            let cli = fake_cli(directory.path(), r#"{"TOKEN":"value"}"#, &count);
+            let mut provider =
+                EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+            provider.credentials.insert(
+                PRIVATE_KEY.to_string(),
+                SecretString::new(TEST_PRIVATE_KEY.into()),
+            );
+            assert_eq!(
+                provider
+                    .get(Address::Native(&NativeAddress {
+                        item: "/TOKEN".into(),
+                        ..Default::default()
+                    }))
+                    .unwrap()
+                    .unwrap()
+                    .expose_secret(),
+                "value"
+            );
+            return;
+        }
+
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .arg("--exact")
+            .arg(TEST_NAME)
+            .env(CHILD_ENV, "1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        // SAFETY: the closure runs in the child after fork and uses only the
+        // async-signal-safe close operation. The parent descriptors are intact.
+        unsafe {
+            command.pre_exec(|| {
+                libc::close(libc::STDIN_FILENO);
+                libc::close(libc::STDOUT_FILENO);
+                libc::close(libc::STDERR_FILENO);
+                Ok(())
+            });
+        }
+        assert!(command.status().unwrap().success());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn decrypts_with_a_low_descriptor_limit() {
+        const CHILD_ENV: &str = "SECRETSPEC_EJSON_LOW_NOFILE_CHILD";
+        const TEST_NAME: &str = "provider::ejson::tests::decrypts_with_a_low_descriptor_limit";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let directory = tempfile::tempdir().unwrap();
+            let encrypted = directory.path().join("secrets.ejson");
+            let count = directory.path().join("count");
+            fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+            let cli = fake_cli(directory.path(), r#"{"TOKEN":"value"}"#, &count);
+            let mut provider =
+                EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+            provider.credentials.insert(
+                PRIVATE_KEY.to_string(),
+                SecretString::new(TEST_PRIVATE_KEY.into()),
+            );
+            assert_eq!(
+                provider
+                    .get(Address::Native(&NativeAddress {
+                        item: "/TOKEN".into(),
+                        ..Default::default()
+                    }))
+                    .unwrap()
+                    .unwrap()
+                    .expose_secret(),
+                "value"
+            );
+            return;
+        }
+
+        let status = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("ulimit -n 64; exec \"$1\" --exact \"$2\" --nocapture")
+            .arg("sh")
+            .arg(std::env::current_exe().unwrap())
+            .arg(TEST_NAME)
+            .env(CHILD_ENV, "1")
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn batch_decrypts_once_and_selects_requested_pointers() {
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let count = directory.path().join("count");
+        let cli = fake_cli(
+            directory.path(),
+            r#"{"app":{"production":{"API_KEY":"one","OTHER":"two"}}}"#,
+            &count,
+        );
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let results = provider
+            .get_many(&[
+                (
+                    "API_KEY",
+                    Address::convention("app", "production", "API_KEY"),
+                ),
+                ("OTHER", Address::convention("app", "production", "OTHER")),
+                (
+                    "MISSING",
+                    Address::convention("app", "production", "MISSING"),
+                ),
+            ])
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results["API_KEY"].expose_secret(), "one");
+        assert_eq!(results["OTHER"].expose_secret(), "two");
+        assert_eq!(fs::read_to_string(count).unwrap(), "x");
+    }
+
+    #[test]
+    fn empty_batch_needs_no_file_or_private_key() {
+        let provider = EjsonProvider::new(EjsonConfig {
+            path: PathBuf::from("does-not-exist.ejson"),
+        });
+        assert!(provider.get_many(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn private_key_requires_exact_hex_and_trims_outer_whitespace() {
+        let mut provider = EjsonProvider::new(EjsonConfig::default());
+        for invalid in [
+            "1".repeat(63),
+            "1".repeat(65),
+            "g".repeat(64),
+            "１".repeat(64),
+        ] {
+            provider
+                .credentials
+                .insert(PRIVATE_KEY.to_string(), SecretString::new(invalid.into()));
+            assert!(provider.private_key().is_err());
+        }
+
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(format!("  {TEST_PRIVATE_KEY}\n").into()),
+        );
+        assert_eq!(provider.private_key().unwrap().as_str(), TEST_PRIVATE_KEY);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_private_key_fails_before_cli_receives_input() {
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let count = directory.path().join("count");
+        let cli = fake_cli(directory.path(), r#"{"TOKEN":"value"}"#, &count);
+        let provider = EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err();
+        assert!(error.to_string().contains("private_key"));
+        assert!(!count.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_or_oversized_private_key_fails_before_cli_starts() {
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let count = directory.path().join("count");
+        let cli = fake_cli(directory.path(), r#"{"TOKEN":"value"}"#, &count);
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new("x".repeat(1024 * 1024).into()),
+        );
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("64 hexadecimal"));
+        assert!(!count.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fifo_source_is_rejected_without_blocking() {
+        let directory = tempfile::tempdir().unwrap();
+        let fifo = directory.path().join("secrets.ejson");
+        let status = Command::new("mkfifo").arg(&fifo).status().unwrap();
+        assert!(status.success());
+        let provider = EjsonProvider::new(EjsonConfig { path: fifo });
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cli_failure_is_generic_and_does_not_expose_key() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let cli = directory.path().join("ejson");
+        fs::write(&cli, "#!/bin/sh\nkey=$(cat)\necho \"$key\" >&2\nexit 1\n").unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("EJSON CLI compatibility"));
+        assert!(!error.contains(TEST_PRIVATE_KEY));
+        assert!(!error.contains("unknown flag"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hung_cli_that_never_reads_stdin_is_stopped_at_timeout() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::Instant;
+
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let cli = directory.path().join("ejson");
+        fs::write(&cli, "#!/bin/sh\nsleep 60\n").unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted })
+            .with_cli_binary(cli)
+            .with_cli_timeout(Duration::from_millis(500));
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let started = Instant::now();
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hung_cli_and_descendants_are_stopped_at_timeout() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::Instant;
+
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let cli = directory.path().join("ejson");
+        let descendant_pid = directory.path().join("descendant-pid");
+        fs::write(
+            &cli,
+            format!(
+                "#!/bin/sh\nsleep 60 &\necho $! > '{}'\ncat >/dev/null\nwait\n",
+                descendant_pid.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted })
+            .with_cli_binary(cli)
+            .with_cli_timeout(Duration::from_secs(2));
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let started = Instant::now();
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(4));
+
+        let pid: libc::pid_t = fs::read_to_string(&descendant_pid)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            // SAFETY: signal 0 only probes a PID recorded by the test child.
+            if unsafe { libc::kill(pid, 0) } == -1 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        // SAFETY: same non-mutating existence probe as above.
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_cli_stops_descendant_holding_stdout_without_waiting_for_deadline() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::Instant;
+
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let cli = directory.path().join("ejson");
+        let descendant_pid = directory.path().join("descendant-pid");
+        fs::write(
+            &cli,
+            format!(
+                "#!/bin/sh\ncat >/dev/null\nsleep 60 &\necho $! > '{}'\nexit 0\n",
+                descendant_pid.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted })
+            .with_cli_binary(cli)
+            .with_cli_timeout(Duration::from_secs(5));
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let started = Instant::now();
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("failed to parse JSON"));
+        assert!(started.elapsed() < Duration::from_secs(2));
+
+        let pid: libc::pid_t = fs::read_to_string(&descendant_pid)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            // SAFETY: signal 0 only probes a PID recorded by the test child.
+            if unsafe { libc::kill(pid, 0) } == -1 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        // SAFETY: same non-mutating existence probe as above.
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_oversized_encrypted_files_before_key_access() {
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("oversized.ejson");
+        File::create(&encrypted)
+            .unwrap()
+            .set_len(MAX_EJSON_BYTES + 1)
+            .unwrap();
+        let provider = EjsonProvider::new(EjsonConfig { path: encrypted });
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("maximum supported size"));
+        assert!(!error.contains("private_key"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_oversized_decrypted_output() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let cli = directory.path().join("ejson");
+        fs::write(
+            &cli,
+            "#!/bin/sh\ncat >/dev/null\nhead -c 16777217 /dev/zero\n",
+        )
+        .unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("decrypted output exceeds"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_malformed_successful_cli_output() {
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let count = directory.path().join("count");
+        let cli = fake_cli(directory.path(), "not-json", &count);
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("failed to parse JSON emitted by EJSON"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn malformed_output_stops_descendants_that_closed_stdout() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, "{\"_public_key\":\"placeholder\"}").unwrap();
+        let descendant_pid = directory.path().join("descendant-pid");
+        let cli = directory.path().join("ejson");
+        fs::write(
+            &cli,
+            format!(
+                "#!/bin/sh\nsleep 60 </dev/null >/dev/null 2>&1 &\necho $! > '{}'\ncat >/dev/null\nprintf not-json\n",
+                descendant_pid.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut provider = EjsonProvider::new(EjsonConfig { path: encrypted }).with_cli_binary(cli);
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("failed to parse JSON"));
+
+        let pid: libc::pid_t = fs::read_to_string(descendant_pid)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            // SAFETY: signal 0 only probes a PID recorded by the test child.
+            if unsafe { libc::kill(pid, 0) } == -1 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        // SAFETY: same non-mutating existence probe as above.
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_file_replacement_does_not_change_open_snapshot() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::{Duration, Instant};
+
+        let directory = tempfile::tempdir().unwrap();
+        let encrypted = directory.path().join("secrets.ejson");
+        fs::write(&encrypted, r#"{"TOKEN":"original"}"#).unwrap();
+        let ready = directory.path().join("ready");
+        let proceed = directory.path().join("proceed");
+        let cli = directory.path().join("ejson");
+        fs::write(
+            &cli,
+            format!(
+                "#!/bin/sh\nset -eu\ncat >/dev/null\ntouch '{}'\nwhile [ ! -f '{}' ]; do sleep 0.01; done\ncat \"$3\"\n",
+                ready.display(),
+                proceed.display(),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o700)).unwrap();
+        let mut provider = EjsonProvider::new(EjsonConfig {
+            path: encrypted.clone(),
+        })
+        .with_cli_binary(cli);
+        provider.credentials.insert(
+            PRIVATE_KEY.to_string(),
+            SecretString::new(TEST_PRIVATE_KEY.into()),
+        );
+
+        let reader = std::thread::spawn(move || {
+            provider.get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+        });
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !ready.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(ready.exists(), "fake EJSON CLI did not start");
+        fs::write(&encrypted, r#"{"TOKEN":"replacement"}"#).unwrap();
+        fs::write(&proceed, "go").unwrap();
+
+        let value = reader.join().unwrap().unwrap().unwrap();
+        assert_eq!(value.expose_secret(), "original");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symbolic_link_files() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target.ejson");
+        let link = directory.path().join("link.ejson");
+        fs::write(&target, "{}").unwrap();
+        symlink(&target, &link).unwrap();
+        let provider = EjsonProvider::new(EjsonConfig { path: link });
+
+        let error = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".into(),
+                ..Default::default()
+            }))
+            .unwrap_err();
+        assert!(error.to_string().contains("symbolic link"));
+    }
+}

--- a/secretspec/src/provider/mod.rs
+++ b/secretspec/src/provider/mod.rs
@@ -20,6 +20,7 @@
 //! - [`keeper::KeeperProvider`]: Keeper Secrets Manager integration (0.18+)
 //! - [`dotenv::DotEnvProvider`]: `.env` file support
 //! - [`env::EnvProvider`]: Environment variables (read-only)
+//! - [`ejson::EjsonProvider`]: EJSON encrypted files (0.20+)
 //! - [`null::NullProvider`]: Defaults, generation, or run prompts without storage (0.19+)
 //! - [`file::FileProvider`]: Plaintext file-per-secret storage (0.19+)
 //! - [`fly::FlyProvider`]: Fly.io application secrets, write-only (0.20+)
@@ -161,6 +162,8 @@ pub mod bws;
 pub mod cloudflare;
 pub mod dashlane;
 pub mod dotenv;
+#[cfg(feature = "ejson")]
+pub mod ejson;
 pub mod env;
 pub mod file;
 pub mod fly;

--- a/secretspec/src/provider/tests.rs
+++ b/secretspec/src/provider/tests.rs
@@ -1163,6 +1163,8 @@ fn test_provider_names_with_special_characters() {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
+    #[cfg(feature = "ejson")]
+    use crate::config::{CredentialSource, NativeAddress};
 
     fn generate_test_project_name() -> String {
         use std::time::{SystemTime, UNIX_EPOCH};
@@ -1183,6 +1185,72 @@ mod integration_tests {
             .collect()
     }
 
+    #[cfg(feature = "ejson")]
+    fn create_ejson_provider() -> (Box<dyn Provider>, Option<TempDir>) {
+        let temp_dir = TempDir::new().expect("Create EJSON integration directory");
+        let keygen = std::process::Command::new("ejson")
+            .arg("keygen")
+            .output()
+            .expect("Testing ejson requires the official CLI on PATH");
+        assert!(keygen.status.success(), "ejson keygen failed");
+        let output = String::from_utf8(keygen.stdout).expect("ejson keygen output must be UTF-8");
+        let keys: Vec<&str> = output
+            .lines()
+            .filter(|line| line.len() == 64 && line.bytes().all(|byte| byte.is_ascii_hexdigit()))
+            .collect();
+        assert_eq!(
+            keys.len(),
+            2,
+            "ejson keygen must print one public and private key"
+        );
+
+        let encrypted = temp_dir.path().join("integration.ejson");
+        std::fs::write(
+            &encrypted,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "_public_key": keys[0],
+                "TOKEN": "official-cli-value",
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let encrypt = std::process::Command::new("ejson")
+            .arg("encrypt")
+            .arg(&encrypted)
+            .output()
+            .expect("run ejson encrypt");
+        assert!(encrypt.status.success(), "ejson encrypt failed");
+
+        let key_file = temp_dir.path().join("keys.env");
+        std::fs::write(&key_file, format!("PRIVATE_KEY={}\n", keys[1])).unwrap();
+        let target =
+            crate::provider::ejson::EjsonProvider::new(crate::provider::ejson::EjsonConfig {
+                path: encrypted,
+            });
+        let target_uri = crate::provider::Provider::uri(&target);
+        let key_source =
+            crate::provider::dotenv::DotEnvProvider::new(crate::provider::dotenv::DotEnvConfig {
+                path: key_file,
+            });
+        let secrets = crate::tests::secrets_with_credential_alias(
+            &target_uri,
+            HashMap::from([(
+                "private_key".to_string(),
+                CredentialSource {
+                    provider: crate::provider::Provider::uri(&key_source),
+                    reference: Some(NativeAddress {
+                        item: "PRIVATE_KEY".to_string(),
+                        ..Default::default()
+                    }),
+                },
+            )]),
+        );
+        let provider = secrets
+            .get_provider(Some("target"), Some("default"))
+            .expect("the sourced private key should build the EJSON provider");
+        (provider, Some(temp_dir))
+    }
+
     fn create_provider_with_temp_path(provider_name: &str) -> (Box<dyn Provider>, Option<TempDir>) {
         match provider_name {
             "dotenv" => {
@@ -1200,6 +1268,8 @@ mod integration_tests {
                     .expect("Should create file provider with path");
                 (provider, Some(temp_dir))
             }
+            #[cfg(feature = "ejson")]
+            "ejson" => create_ejson_provider(),
             "pass" => {
                 let provider =
                     Box::<dyn Provider>::try_from("pass").expect("Should create pass provider");
@@ -1426,6 +1496,27 @@ mod integration_tests {
                 "[{provider_name}] unexpected delete failure: {error}"
             ),
         }
+    }
+
+    #[cfg(feature = "ejson")]
+    #[test]
+    fn test_ejson_official_cli_and_sourced_credential() {
+        if !get_test_providers()
+            .iter()
+            .any(|provider| provider == "ejson")
+        {
+            eprintln!("skipping: SECRETSPEC_TEST_PROVIDERS does not name ejson");
+            return;
+        }
+        let (provider, _temp_dir) = create_ejson_provider();
+        let value = provider
+            .get(Address::Native(&NativeAddress {
+                item: "/TOKEN".to_string(),
+                ..Default::default()
+            }))
+            .expect("official EJSON decrypt should succeed")
+            .expect("the encrypted TOKEN should exist");
+        assert_eq!(value.expose_secret(), "official-cli-value");
     }
 
     #[test]

--- a/secretspec/src/provider/url.rs
+++ b/secretspec/src/provider/url.rs
@@ -117,6 +117,14 @@ impl ProviderUrl {
         self.0.query().is_some()
     }
 
+    pub(crate) fn has_fragment(&self) -> bool {
+        self.0.fragment().is_some()
+    }
+
+    pub(crate) fn has_port(&self) -> bool {
+        self.0.port().is_some()
+    }
+
     /// Percent-encode a value for use in a URI path or host component (e.g., in
     /// `uri()` methods).
     pub fn encode(value: &str) -> String {

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -8369,7 +8369,7 @@ fn test_resolve_profile_unknown_returns_invalid_profile() {
 
 /// Builds a `Secrets` whose only project provider alias is `target`, carrying
 /// the given semantic credential-source map.
-fn secrets_with_credential_alias(
+pub(crate) fn secrets_with_credential_alias(
     target_uri: &str,
     credentials: HashMap<String, CredentialSource>,
 ) -> Secrets {


### PR DESCRIPTION
This PR adds a read-only `ejson` provider that reads string values from an encrypted EJSON file through RFC 6901 JSON Pointers. The matching private key comes from an explicit provider credential.

## Why

We want SecretSpec to provide one place to manage EJSON-backed values alongside values from other providers. This provider makes EJSON available through the same manifests, profiles, fallback chains, audit trail, and SDK interfaces.

## Design choices

The private key uses SecretSpec's existing provider-credential mechanism. SecretSpec resolves the configured credential first, then gives the EJSON provider the resulting key. Projects can source it from any configured provider, including a pinned Google Cloud Secret Manager version.

The provider invokes the official `ejson` CLI rather than embedding the upstream Go package. Embedding Go would add another native and FFI build path across SecretSpec's supported targets and SDK artifacts, and no official Rust library exists. `std::process::Command` starts the binary directly without a shell interpreter.

The public key remains embedded in the EJSON document. There is no public-key or digest URI option because duplicating that identity in configuration would create another source of truth that can drift.

## Configuration

One alias names the private-key source, and another names the encrypted file:

```toml
[providers.keys]
uri = "gcsm://my-key-project"

[providers.encrypted]
uri = "ejson:config/secrets.production.ejson"

[providers.encrypted.credentials.private_key]
provider = "keys"
ref = { item = "EJSON_PRIVATE_KEY", version = "1" }

[profiles.production]
API_TOKEN = { description = "Application API token", providers = ["encrypted"], ref = { item = "/api_token" } }
```

## Provider behavior

- `ejson:PATH` identifies one encrypted file, with relative paths resolved from the directory containing `secretspec.toml`
- URI parsing rejects user information, passwords, ports, query options, and fragments while preserving path data such as `@`
- Native `ref.item` values use RFC 6901 JSON Pointers; convention addresses use `/{project}/{profile}/{key}` with `~0` and `~1` escaping
- Each nonempty `get_many` call decrypts once for its complete batch; later calls decrypt again, and no plaintext document is cached across calls
- Only JSON strings are returned; missing pointers remain missing, non-string selections fail, and writes are rejected

Encryption, rotation, file updates, backup, and recovery remain with the workflow that owns the EJSON file and key.

## Process and file safety

The official CLI decrypts the complete document, so SecretSpec bounds encrypted input and decrypted output at 16 MiB, parses the document in memory, and returns only the requested values.

- The private key is validated as exactly 64 ASCII hexadecimal characters, held in zeroizing storage, and delivered only through stdin
- Child stderr is suppressed because an executable could echo the key; failures remain generic and value-free
- Unix opens the source with `CLOEXEC`, `NOFOLLOW`, and `NONBLOCK`, checks that it is a regular file, and copies it into a bounded anonymous snapshot
- Unix keeps the snapshot outside stdio descriptors, clears close-on-exec only in the child, anchors the process group until cleanup, stops descendants, then reaps the leader
- Windows uses a private named snapshot, starts the child suspended, assigns a kill-on-close Job Object, then resumes its initial thread

Key delivery, process spawn and execution, and output collection share one 30-second deadline. Snapshot I/O happens before that deadline and is bounded by size.

The `ejson` executable and process `PATH` are trusted, matching CLI-backed providers such as SOPS, because the child receives the private key and complete decrypted document.

## Validation

- [Exact-head fork CI](https://github.com/shane-lawrence/secretspec/actions/runs/33131441614) passed documentation, standalone features, package checks, Ubuntu tests/Clippy/formatting, macOS tests, and Windows tests
- `cargo test --workspace --exclude secretspec-php-native`, `cargo clippy --workspace --exclude secretspec-php-native`, `cargo fmt --all -- --check`, and `git diff --check`
- Standalone `ejson` feature compilation and 29 focused tests covering URI parsing, pointers, key handling, batching, limits, filesystem races, deadlines, descriptors, and cross-platform process cleanup
- Opt-in integration against checksum-verified EJSON 1.5.5 with real key generation, encryption, decryption, and a provider-sourced private key
- Clean npm documentation build, provider-credential checks, terminal-copy tests, Astro and Pagefind generation, plus package-content verification

`secretspec-php-native` remains excluded from the native Rust suite because that environment lacks PHP headers, matching the repository's existing CI configuration.

## Documentation

The provider guide, provider and configuration references, security table, sidebar, generated summary, landing page, quick start, README, credential catalog, and changelog are updated and labeled for SecretSpec 0.20.
