### PR TITLE
docs: standardize version compatibility notices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,10 @@ Providers support URI-based configuration (e.g., `keyring://`, `onepassword://va
 
 When adding a new provider, update **every** location below — provider names appear in several listings that drift out of sync if any are missed:
 
-1. `docs/src/content/docs/providers/<provider>.md` - Create the provider's doc page and add a version compatibility notice if it is unreleased. Use `.mdx` instead when the provider accepts provider credentials, import the shared `ProviderCredentials` component, and add its catalog entry as described below.
+1. `docs/src/content/docs/providers/<provider>.mdx` - Create the provider's doc page and add a version compatibility notice if it is unreleased. Put page-level notices at the very top, after imports, and section-level notices immediately below the section heading. New features use the bodyless `<VersionCompatibility version="0.20" />`, which renders “New in version 0.20”. Changes to existing behavior use `<VersionCompatibility version="0.20" kind="changed">...</VersionCompatibility>`, which renders “Changed in version 0.20” and requires a clarifying body. When the provider accepts provider credentials, also import the shared `ProviderCredentials` component and add its catalog entry as described below.
 2. `docs/astro.config.ts` - Add to sidebar navigation under "Providers" **and** to the providers sentence in the `starlightLlmsTxt` description block
 3. `docs/src/content/docs/concepts/providers.mdx` - Add a row to the "Available Providers" table
-4. `docs/src/content/docs/reference/providers.md` - Add a provider section **and** a row in the "Security Considerations" table
+4. `docs/src/content/docs/reference/providers.mdx` - Add a provider section **and** a row in the "Security Considerations" table
 5. `docs/src/pages/index.astro` - Add to the `providerMetadata` array (top of file) **and** to the `secretspec config init` mini-terminal in the hero
 6. `docs/src/content/docs/quick-start.mdx` - Update the `secretspec config init` example output to include the new provider
 7. `README.md` (symlink to `secretspec/README.md`) - Add to the "Providers" bullet list **and** to the `secretspec config init` example output
@@ -222,8 +222,8 @@ The docs site is an Astro Starlight site deployed to https://secretspec.dev/.
 ### What to update
 
 - **New doc page**: Create the `.md` file and add it to the sidebar in `docs/astro.config.ts`
-- **New CLI command**: Update `docs/src/content/docs/reference/cli.md`
-- **New config option**: Update `docs/src/content/docs/reference/configuration.md`
+- **New CLI command**: Update `docs/src/content/docs/reference/cli.mdx`
+- **New config option**: Update `docs/src/content/docs/reference/configuration.mdx`
 - **New provider**: See [Adding Provider Documentation](#adding-provider-documentation) above
 - **New concept**: Create `docs/src/content/docs/concepts/<name>.md` and add to sidebar
 

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import starlightLlmsTxt from "starlight-llms-txt";
 import starlightBlog from "starlight-blog";
+import { preserveHeadingIdPlugin } from "./src/lib/preserve-heading-id.mjs";
 import { terminalCopyPlugin } from "./src/lib/terminal-copy.mjs";
 
 const rustSdkBasicExample = readFileSync(
@@ -49,6 +50,9 @@ const devGitHubApi: PluginOption = {
 // https://astro.build/config
 export default defineConfig({
   site: "https://secretspec.dev/",
+  markdown: {
+    remarkPlugins: [preserveHeadingIdPlugin],
+  },
   redirects: {
     "/reference/adding-providers": "/development/adding-providers",
     "/ci": "/ci/github-actions",

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,10 +6,11 @@
     "dev": "astro dev",
     "start": "astro dev",
     "clean:astro-cache": "node scripts/clean-astro-cache.mjs",
-    "build": "npm run clean:astro-cache && npm run check:provider-credentials && npm run check:terminal-copy && astro check && astro build",
+    "build": "npm run clean:astro-cache && npm run check:provider-credentials && npm run check:terminal-copy && npm run check:version-compatibility && astro check && astro build",
     "check:links": "lychee --root-dir \"$(pwd)/dist\" --remap \"^https://secretspec\\.dev file://$(pwd)/dist\" \"dist/**/*.html\"",
     "check:provider-credentials": "node --test scripts/provider-credentials.test.mjs && node scripts/check-provider-credentials.mjs",
     "check:terminal-copy": "node --test scripts/terminal-copy.test.mjs",
+    "check:version-compatibility": "node --test scripts/version-compatibility.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/docs/scripts/version-compatibility.test.mjs
+++ b/docs/scripts/version-compatibility.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, extname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { preserveHeadingIdPlugin } from '../src/lib/preserve-heading-id.mjs';
+
+const docsRoot = fileURLToPath(new URL('../src/content/docs/', import.meta.url));
+
+function documentationFiles(directory) {
+	return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+		const path = join(directory, entry.name);
+		if (entry.isDirectory()) return documentationFiles(path);
+		return ['.md', '.mdx'].includes(extname(entry.name)) ? [path] : [];
+	});
+}
+
+const files = documentationFiles(docsRoot);
+
+function withoutCodeFences(source) {
+	return source.replace(/^[ \t]*```[^\n]*\n[\s\S]*?^[ \t]*```[ \t]*$/gm, '');
+}
+
+test('version notices use the shared component', () => {
+	const legacyPatterns = [
+		/:::(?:note|caution)\[Version compatibility\]/,
+		/> \*\*Version compatibility:\*\*/,
+	];
+
+	for (const path of files) {
+		const source = withoutCodeFences(readFileSync(path, 'utf8'));
+		for (const pattern of legacyPatterns) {
+			assert.doesNotMatch(source, pattern, `${path} uses a legacy version notice`);
+		}
+	}
+});
+
+test('component users are MDX files with one resolvable import', () => {
+	let notices = 0;
+
+	for (const path of files) {
+		const source = withoutCodeFences(readFileSync(path, 'utf8'));
+		const openings = source.match(/<VersionCompatibility(?:\s[^>]*)?\s*\/?>/g) ?? [];
+		if (openings.length === 0) continue;
+
+		notices += openings.length;
+		assert.equal(extname(path), '.mdx', `${path} must use the .mdx extension`);
+
+		const imports = [
+			...source.matchAll(
+				/import VersionCompatibility from ['"]([^'"]+VersionCompatibility\.astro)['"];?/g,
+			),
+		];
+		assert.equal(imports.length, 1, `${path} must import VersionCompatibility exactly once`);
+		assert.ok(
+			existsSync(resolve(dirname(path), imports[0][1])),
+			`${path} has an invalid VersionCompatibility import`,
+		);
+		for (const opening of openings) {
+			assert.match(
+				opening,
+				/\sversion="0\.\d+"/,
+				`${path} must give every VersionCompatibility notice a version`,
+			);
+			const changed = opening.includes('kind="changed"');
+			const selfClosing = opening.endsWith('/>');
+			assert.equal(
+				selfClosing,
+				!changed,
+				`${path} must keep new notices bodyless and give changed notices a body`,
+			);
+		}
+		const expandedOpenings = openings.filter((opening) => !opening.endsWith('/>'));
+		assert.equal(
+			expandedOpenings.length,
+			(source.match(/<\/VersionCompatibility>/g) ?? []).length,
+			`${path} has an unclosed VersionCompatibility component`,
+		);
+
+		const firstNotice = source.search(/<VersionCompatibility/);
+		const firstSection = source.search(/^## /m);
+		if (firstNotice >= 0 && (firstSection < 0 || firstNotice < firstSection)) {
+			const contentBeforeNotice = source
+				.slice(0, firstNotice)
+				.replace(/^---\n[\s\S]*?\n---\n/, '')
+				.replace(/^import .*;\s*$/gm, '')
+				.trim();
+			assert.equal(
+				contentBeforeNotice,
+				'',
+				`${path} must put its page-level version notice at the very top`,
+			);
+		}
+	}
+
+	assert.ok(notices > 0, 'expected documentation to contain version notices');
+});
+
+test('versioned headings keep their historical URL and put the notice below the heading', () => {
+	let versionedHeadings = 0;
+	const markerPattern = /^(#{2,6}) (.*?) \{\/\* #([A-Za-z][\w:.-]*) \*\/\}$/gm;
+	const versionInTitle = /\(0\.\d+\+\)|\bSecretSpec 0\.\d+\b|\bstored by 0\.\d+\b/i;
+
+	for (const path of files) {
+		const source = withoutCodeFences(readFileSync(path, 'utf8'));
+		const headingIds = new Set();
+		for (const match of source.matchAll(markerPattern)) {
+			versionedHeadings += 1;
+			assert.doesNotMatch(match[2], versionInTitle, `${path} exposes a version in a heading`);
+			assert.ok(!headingIds.has(match[3]), `${path} repeats heading ID ${match[3]}`);
+			headingIds.add(match[3]);
+
+			const nextContent = source.slice(match.index + match[0].length).trimStart();
+			assert.match(
+				nextContent,
+				/^<VersionCompatibility\s/,
+				`${path} must put a version notice immediately below ${match[2]}`,
+			);
+		}
+	}
+
+	assert.ok(versionedHeadings > 0, 'expected documentation to contain versioned headings');
+});
+
+test('historical heading IDs are applied without entering the rendered title', () => {
+	const marker = { type: 'mdxTextExpression', value: '/* #feature-name-020 */' };
+	const heading = {
+		type: 'heading',
+		depth: 2,
+		children: [{ type: 'text', value: 'Feature name ' }, marker],
+	};
+	const tree = { type: 'root', children: [heading] };
+
+	preserveHeadingIdPlugin()(tree);
+
+	assert.deepEqual(heading.children, [{ type: 'text', value: 'Feature name' }]);
+	assert.equal(heading.data.hProperties.id, 'feature-name-020');
+});

--- a/docs/src/components/VersionCompatibility.astro
+++ b/docs/src/components/VersionCompatibility.astro
@@ -1,0 +1,100 @@
+---
+interface Props {
+	/** The first SecretSpec release that includes the documented feature. */
+	version: string;
+	/** Whether the release introduced the feature or changed existing behavior. */
+	kind?: 'new' | 'changed';
+	/** Accessible label describing the purpose of the callout. */
+	label?: string;
+}
+
+const { version, kind = 'new' } = Astro.props;
+const heading = `${kind === 'changed' ? 'Changed' : 'New'} in version ${version}`;
+const label = Astro.props.label ?? heading;
+const hasDetails = Astro.slots.has('default');
+
+if (kind === 'new' && hasDetails) {
+	throw new Error(`New-in-version notices cannot have body content (${version})`);
+}
+if (kind === 'changed' && !hasDetails) {
+	throw new Error(`Changed-in-version notices require body content (${version})`);
+}
+---
+
+<aside class="version-compatibility" aria-label={label}>
+	<div class="version-compatibility__heading">
+		<svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18">
+			{
+				kind === 'changed' ? (
+					<path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm17.71-10.04a1 1 0 0 0 0-1.42l-2.5-2.5a1 1 0 0 0-1.42 0l-1.96 1.96 3.75 3.75 2.13-1.79Z"></path>
+				) : (
+					<>
+						<path d="m12 3 1.55 4.45L18 9l-4.45 1.55L12 15l-1.55-4.45L6 9l4.45-1.55L12 3Z"></path>
+						<path d="m19 15 .78 2.22L22 18l-2.22.78L19 21l-.78-2.22L16 18l2.22-.78L19 15Z"></path>
+					</>
+				)
+			}
+		</svg>
+		<strong>{heading}</strong>
+	</div>
+	{hasDetails && <div class="version-compatibility__content"><slot /></div>}
+</aside>
+
+<style>
+	.version-compatibility {
+		display: grid;
+		gap: 0.45rem;
+		margin-block: 1rem;
+		padding: 0.65rem 0.8rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.5rem;
+		background: var(--sl-color-bg-inline-code);
+		background: color-mix(in srgb, var(--sl-color-gray-6) 24%, transparent);
+		color: var(--sl-color-gray-2);
+		font-size: var(--sl-text-sm);
+		line-height: 1.5;
+	}
+
+	.version-compatibility__heading {
+		display: flex;
+		align-items: center;
+		gap: 0.45rem;
+		color: var(--sl-color-text-accent);
+	}
+
+	.version-compatibility__heading svg {
+		flex: 0 0 auto;
+		fill: currentColor;
+	}
+
+	.version-compatibility__heading strong {
+		font-weight: 600;
+	}
+
+	.version-compatibility__content {
+		min-width: 0;
+		padding-inline-start: 1.45rem;
+	}
+
+	.version-compatibility__content > :global(:first-child) {
+		margin-block-start: 0;
+	}
+
+	.version-compatibility__content > :global(:last-child) {
+		margin-block-end: 0;
+	}
+
+	.version-compatibility__content :global(p) {
+		color: inherit;
+	}
+
+	.version-compatibility__content :global(code) {
+		font-size: 0.9em;
+	}
+
+	@media (forced-colors: active) {
+		.version-compatibility {
+			border-color: CanvasText;
+		}
+	}
+</style>

--- a/docs/src/content/docs/basic-usage.mdx
+++ b/docs/src/content/docs/basic-usage.mdx
@@ -3,6 +3,8 @@ title: Basic Usage
 description: The SecretSpec commands you will use most often
 ---
 
+import VersionCompatibility from '../../components/VersionCompatibility.astro';
+
 Once your project has a `secretspec.toml` file and you have selected a default
 provider, most day-to-day work uses a small set of commands.
 
@@ -56,11 +58,9 @@ $ secretspec run -- npm start
 The `--` separates SecretSpec's options from the command you want to run.
 SecretSpec stops before starting the command if a required secret is missing.
 
-## Add a declaration (0.18+)
+## Add a declaration {/* #add-a-declaration-018 */}
 
-:::caution[Version compatibility]
-`add` is available starting with SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 Declare a new secret without editing `secretspec.toml` by hand, then store its
 value:
@@ -73,11 +73,9 @@ $ secretspec set API_KEY
 `add` changes only the declaration. It never asks for or stores the secret
 value.
 
-## Delete stored values (0.18+)
+## Delete stored values {/* #delete-stored-values-018 */}
 
-:::caution[Version compatibility]
-`delete` is available starting with SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 Remove a stored value from its provider:
 

--- a/docs/src/content/docs/concepts/composed-secrets.mdx
+++ b/docs/src/content/docs/concepts/composed-secrets.mdx
@@ -3,9 +3,9 @@ title: Composed Secrets
 description: Derive read-only values from other declared secrets with strict templates
 ---
 
-:::caution[Version compatibility]
-Available since SecretSpec 0.16.
-:::
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.16" />
 
 Composed secrets derive one exported value from other secrets in the active
 profile. They are useful for connection strings, command arguments, and other

--- a/docs/src/content/docs/concepts/generation.mdx
+++ b/docs/src/content/docs/concepts/generation.mdx
@@ -3,9 +3,9 @@ title: Secret Generation
 description: Automatically generating passwords, tokens, and keys for missing secrets
 ---
 
-:::note
-Secret generation is available since version 0.7.
-:::
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.7" />
 
 Secrets can be declared with `type` and `generate` to be auto-generated when missing. This is useful for passwords, tokens, and keys that do not need to be shared across developers.
 
@@ -49,12 +49,9 @@ MONGO_KEY = { description = "MongoDB keyfile", type = "command", generate = { co
 - `generate` and `default` cannot both be set on the same secret.
 - Setting `type` without `generate` is informational only and does not trigger auto-generation.
 
-## Ephemeral generation with null (0.19+)
+## Ephemeral generation with null {/* #ephemeral-generation-with-null-019 */}
 
-:::caution[Version compatibility]
-Ephemeral generation through the `null` provider requires SecretSpec 0.19 or
-newer.
-:::
+<VersionCompatibility version="0.19" />
 
 Use `providers = ["null"]` when the value should be generated on demand and
 never written to provider storage:

--- a/docs/src/content/docs/concepts/profiles.mdx
+++ b/docs/src/content/docs/concepts/profiles.mdx
@@ -3,6 +3,8 @@ title: Profiles
 description: Managing environment-specific secret requirements with profiles
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 ## What Are Profiles?
 
 Profiles are named configurations that define how secrets behave in different environments. They specify which secrets are required vs optional, provide safe defaults for development, and enforce strict requirements for production.
@@ -67,11 +69,9 @@ When using profiles, inheritance works as follows:
 3. **Field-level overrides**: Most explicitly set properties replace the corresponding property from `default`, while omitted properties continue to inherit
 4. **Profile-specific secrets**: Secrets not in the default profile can be added to any profile
 
-### Standalone profiles (0.19+)
+### Standalone profiles {/* #standalone-profiles-019 */}
 
-:::caution[Version compatibility]
-Profile-level `inherit` is available starting with SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 Set `inherit = false` in a non-default profile's `defaults` table when its
 secret set is unrelated to `[profiles.default]`:
@@ -98,11 +98,9 @@ field-by-field inheritance for secrets explicitly redeclared in the standalone
 profile. Omitting it preserves the existing inheritance behavior. A standalone
 profile must declare at least one secret.
 
-### Switching reference models (0.19+)
+### Switching reference models {/* #switching-reference-models-019 */}
 
-:::caution[Version compatibility]
-Provider-scoped `refs` are available starting with SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 Legacy `ref` and provider-scoped `refs` are alternative forms of one inherited
 address-model setting. Declaring either one in a profile replaces both forms

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -3,6 +3,8 @@ title: Providers
 description: Choose and configure the storage backends SecretSpec uses for secrets
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 A provider is a storage backend from which SecretSpec reads secrets and, when
 supported, writes them. Providers let one `secretspec.toml` describe the secrets
 an application needs without requiring every environment to use the same secret
@@ -180,12 +182,9 @@ Provider lists may combine aliases, provider names, and inline provider URIs:
 DATABASE_URL = { description = "Production database", providers = ["onepassword://Production", "keyring"] }
 ```
 
-### Alias ref templates (0.19+)
+### Alias ref templates {/* #alias-ref-templates-019 */}
 
-:::caution[Version compatibility]
-Provider-alias `ref` templates and per-secret `refs` are available starting
-with SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 A leaf alias can map the logical `{project}`, `{profile}`, and `{key}` into its
 provider's native coordinates. This lets every link in a fallback chain—and
@@ -220,9 +219,7 @@ top-level `[providers]` table directly to change project aliases.
 
 ## Provider credentials
 
-:::note
-Provider credentials are supported in version 0.15 and later.
-:::
+<VersionCompatibility version="0.15" />
 
 Some providers need credentials before they can retrieve secrets. Examples
 include an access token for Bitwarden Secrets Manager, a Vault token or AppRole

--- a/docs/src/content/docs/concepts/providers/caching.mdx
+++ b/docs/src/content/docs/concepts/providers/caching.mdx
@@ -3,10 +3,9 @@ title: Provider caching
 description: Cache slow provider routes in a local secret store
 ---
 
-:::caution[Version compatibility]
-Provider caching and `secretspec cache clear` are available starting with
-SecretSpec 0.17.
-:::
+import VersionCompatibility from '../../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.17" />
 
 ## The problem
 
@@ -19,17 +18,18 @@ Latency can also scale with the number of distinct secret addresses. SecretSpec
 groups compatible reads and providers can batch or parallelize them, but the
 remote service, proxy, or provider CLI still determines the cost of each read.
 
-## Cache one provider (0.19+)
+## Cache one provider {/* #cache-one-provider-019 */}
 
+<VersionCompatibility version="0.19" kind="changed">
+
+Use a cached fallback alias on SecretSpec 0.17 and 0.18.
+
+</VersionCompatibility>
 Provider caching places a faster local secret store in front of an
 authoritative provider. A fresh cache entry returns without constructing or
 contacting the remote provider; a miss reads the remote value and stores it
 locally for later SecretSpec invocations.
 
-:::caution[Version compatibility]
-Attaching `cache` directly to a provider URI is available starting with
-SecretSpec 0.19. Use a cached fallback alias on SecretSpec 0.17 and 0.18.
-:::
 
 Add `cache` to the remote provider alias and select that same alias normally:
 
@@ -50,7 +50,9 @@ The alias remains the authoritative provider, so its [provider
 credentials](/concepts/providers/#provider-credentials) stay next to `uri` and
 `cache`.
 
-## Cache a fallback route (0.17+)
+## Cache a fallback route {/* #cache-a-fallback-route-017 */}
+
+<VersionCompatibility version="0.17" />
 
 When more than one provider can authoritatively answer, use a route alias.
 `fallback` lists its providers in read order and `cache.provider` selects the
@@ -289,7 +291,9 @@ Do not merge aliases that intentionally use different identities, endpoints,
 namespaces, or other security settings. Those are distinct routes even if they
 use the same provider type.
 
-### Tune per-address concurrency (0.17+)
+### Tune per-address concurrency {/* #tune-per-address-concurrency-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Providers using SecretSpec's default per-address fetch path read up to eight
 unique addresses concurrently. Test a few caps when latency grows with the

--- a/docs/src/content/docs/concepts/references.mdx
+++ b/docs/src/content/docs/concepts/references.mdx
@@ -3,9 +3,9 @@ title: Secret References
 description: Point a secret at one already managed in a provider's store, by the store's own coordinates
 ---
 
-:::note
-Secret references are available since version 0.14.
-:::
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.14" />
 
 By default, SecretSpec owns the naming: it stores each secret under its own
 `{project}/{profile}/{key}` convention. A **secret reference** overrides that for
@@ -80,12 +80,9 @@ file without touching the manifest.
 $ secretspec run --provider dotenv:.env.fixtures -- cargo test
 ```
 
-## Different coordinates per provider (0.19+)
+## Different coordinates per provider {/* #different-coordinates-per-provider-019 */}
 
-:::caution[Version compatibility]
-Provider-scoped `refs` and provider-alias `ref` templates are available
-starting with SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 The original `ref` remains useful when every provider understands one address.
 When endpoints organize the same logical secret differently, attach a template

--- a/docs/src/content/docs/concepts/scopes.mdx
+++ b/docs/src/content/docs/concepts/scopes.mdx
@@ -3,9 +3,9 @@ title: Scopes
 description: Resolve and expose only the secrets a service or task needs
 ---
 
-:::caution[Version compatibility]
-Scopes are available starting with SecretSpec 0.17.
-:::
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.17" />
 
 A profile defines how secrets behave in an environment. A scope selects which
 of those secrets one service, command, or task receives.

--- a/docs/src/content/docs/development/adding-providers.md
+++ b/docs/src/content/docs/development/adding-providers.md
@@ -208,12 +208,28 @@ the two sections do not repeat one another.
 
 When adding a provider for an upcoming release:
 
-1. Add a version notice near the top of the provider page:
+1. Add a version notice at the very top of the provider page, after its imports,
+   with the shared component. A new feature always uses the self-closing form
+   and renders **New in version 0.16** with no body:
 
-   ```md
-   :::note[Version compatibility]
-   The MyBackend provider is added in SecretSpec 0.16.
-   :::
+   ```mdx
+   import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+   <VersionCompatibility version="0.16" />
+   ```
+
+   Place a section-level notice directly after its heading. When a release
+   changes existing behavior, set `kind="changed"` and explain the change in the
+   required body:
+
+   ```mdx
+   ## Advanced authentication
+
+   <VersionCompatibility version="0.16" kind="changed">
+
+   Advanced authentication now requires a token with the `admin` scope.
+
+   </VersionCompatibility>
    ```
 
 2. Mark the provider as `(0.16+)` anywhere it appears in a provider list,
@@ -225,11 +241,10 @@ When adding a provider for an upcoming release:
 
 Update every provider location; names otherwise drift out of sync:
 
-1. `docs/src/content/docs/providers/<provider>.md` (or `.mdx` when it renders
-   the provider credential catalog)
+1. `docs/src/content/docs/providers/<provider>.mdx`
 2. `docs/astro.config.ts` — sidebar and `starlightLlmsTxt` provider summary
 3. `docs/src/content/docs/concepts/providers.mdx` — available providers table
-4. `docs/src/content/docs/reference/providers.md` — provider details and
+4. `docs/src/content/docs/reference/providers.mdx` — provider details and
    security considerations
 5. `docs/src/pages/index.astro` — `providerMetadata` and any provider selector
    examples

--- a/docs/src/content/docs/development/sdks.mdx
+++ b/docs/src/content/docs/development/sdks.mdx
@@ -3,6 +3,8 @@ title: SDK Development
 description: How the language SDKs are built, packaged, and released, and which platforms each one supports
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 SecretSpec ships SDKs for Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell,
 PHP, C#, Swift (0.18+), and JVM languages (0.20+). This page is for
 contributors: how the SDKs are put together, how each one is packaged and
@@ -105,7 +107,9 @@ ABI, generated Rust scaffolding, and another schema to version. The hand-written
 Swift layer is limited to `Codable` request/response models and idiomatic errors;
 resolution remains entirely in Rust.
 
-## Versioned native calls (0.20+)
+## Versioned native calls {/* #versioned-native-calls-020 */}
+
+<VersionCompatibility version="0.20" />
 
 `secretspec_resolve` remains the compatibility request for path and search
 resolution. SDKs that need a declaration held in application code call the new
@@ -160,7 +164,9 @@ crates (`libwindows.*.a` from `windows_x86_64_gnu`, `libwinapi_*.a` from
 the archive — the Ruby gem bundles them in `vendor/`, the Haskell job points
 GHC's linker at them.
 
-## Linking through pkg-config (0.19+)
+## Linking through pkg-config {/* #linking-through-pkg-config-019 */}
+
+<VersionCompatibility version="0.19" />
 
 `libsecretspec/scripts/cinstall.sh PREFIX static|shared` uses
 [cargo-c](https://github.com/lu-zero/cargo-c) to install one library type, the

--- a/docs/src/content/docs/migration.mdx
+++ b/docs/src/content/docs/migration.mdx
@@ -3,6 +3,8 @@ title: Migration
 description: Bring existing secret declarations and values into SecretSpec
 ---
 
+import VersionCompatibility from '../../components/VersionCompatibility.astro';
+
 SecretSpec can discover declarations from supported providers or copy values
 from another provider. Secret values are never written to
 `secretspec.toml`.
@@ -30,12 +32,9 @@ your configured default provider:
 $ secretspec import dotenv://.env
 ```
 
-### From another provider (0.18+)
+### From another provider {/* #from-another-provider-018 */}
 
-:::caution[Version compatibility]
-Declaration discovery from providers other than dotenv is available starting
-with SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 Use `init --from` with any provider that supports declaration discovery. For
 example, you can discover declarations from an AWS Parameter Store hierarchy:

--- a/docs/src/content/docs/providers/aac.mdx
+++ b/docs/src/content/docs/providers/aac.mdx
@@ -3,16 +3,17 @@ title: Azure App Configuration Provider
 description: Azure App Configuration integration
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.20" />
 
 The [Azure App
 Configuration](https://learn.microsoft.com/en-us/azure/azure-app-configuration/)
 provider reads and manages ordinary key-values and resolves canonical Azure
 Key Vault references.
 
-:::caution[Version compatibility]
-The `aac` provider is added in SecretSpec 0.20.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/age.mdx
+++ b/docs/src/content/docs/providers/age.mdx
@@ -3,11 +3,11 @@ title: age Provider
 description: Store secrets in an age-encrypted file committed alongside code
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
 
-:::note[Version compatibility]
-The age provider is added in SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 The [age](https://age-encryption.org) provider keeps secrets in a single
 age-encrypted file that you can commit to your repository. The plaintext inside
@@ -101,7 +101,9 @@ post-quantum protection.
 
 ## Configuration
 
-### Discover declarations (0.18+)
+### Discover declarations {/* #discover-declarations-018 */}
+
+<VersionCompatibility version="0.18" />
 
 SecretSpec 0.18+ can initialize a manifest from the key names already in an
 age file. Reflection decrypts the file in memory to enumerate its keys but

--- a/docs/src/content/docs/providers/akv.mdx
+++ b/docs/src/content/docs/providers/akv.mdx
@@ -3,14 +3,15 @@ title: Azure Key Vault Provider
 description: Azure Key Vault integration
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.15" />
 
 The [Azure Key Vault](https://azure.microsoft.com/en-us/products/key-vault)
 provider integrates with Azure for centralized secret management.
 
-:::note[Version compatibility]
-Available since SecretSpec 0.15.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/awsps.mdx
+++ b/docs/src/content/docs/providers/awsps.mdx
@@ -3,10 +3,9 @@ title: AWS Systems Manager Parameter Store Provider
 description: AWS Systems Manager Parameter Store integration
 ---
 
-:::note
-The AWS Systems Manager Parameter Store provider is available in SecretSpec
-0.18+.
-:::
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.18" />
 
 The [AWS Systems Manager Parameter Store](https://aws.amazon.com/systems-manager/features/#Parameter_Store)
 provider stores secrets as encrypted

--- a/docs/src/content/docs/providers/bw.mdx
+++ b/docs/src/content/docs/providers/bw.mdx
@@ -3,17 +3,13 @@ title: Bitwarden Password Manager Provider
 description: Bitwarden Password Manager secrets management integration
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.18" />
+
 The [Bitwarden Password Manager](https://bitwarden.com/products/)
 (`bw`) provider reads and writes secrets by using the official `bw` CLI.
 
-:::note[Version compatibility]
-The Bitwarden Password Manager provider was added in SecretSpec 0.18.
-
-SecretSpec 0.20+ isolates convention-managed items by project and profile. It
-stores `DATABASE_URL` under an item title such as
-`secretspec/my-project/default/DATABASE_URL`; releases through 0.19 used the
-bare title `DATABASE_URL`. See [Migrating bare item names](#migrating-bare-item-names-020).
-:::
 
 ## At a glance
 
@@ -131,7 +127,9 @@ bw://?folder=team/{project}/{profile} # 0.20+
   configure the CLI — it is a guard that fails with remediation steps when the
   `bw` CLI is pointed somewhere else. See [Self-hosted servers](#self-hosted-servers).
 
-### Organizations and collections (0.18+)
+### Organizations and collections {/* #organizations-and-collections-018 */}
+
+<VersionCompatibility version="0.18" />
 
 Names and IDs are interchangeable: SecretSpec resolves a name to the ID the
 `bw` CLI requires. Names match case-insensitively, and one containing a space
@@ -191,7 +189,9 @@ providers = ["bw"]
 providers = ["bw"]
 ```
 
-### Discover declarations (0.18+)
+### Discover declarations {/* #discover-declarations-018 */}
+
+<VersionCompatibility version="0.18" />
 
 SecretSpec 0.18+ can initialize a manifest from the items visible through a
 Bitwarden provider URI. Scope discovery to a collection, and optionally an
@@ -252,7 +252,16 @@ way as values in the URI. The complete precedence is:
 
 ## Storage model
 
-### Convention item names (0.20+)
+### Convention item names {/* #convention-item-names-020 */}
+
+<VersionCompatibility version="0.20" kind="changed">
+
+Convention-managed items are now isolated by project and profile. SecretSpec
+stores `DATABASE_URL` under an item title such as
+`secretspec/my-project/default/DATABASE_URL`; releases through 0.19 used the
+bare title `DATABASE_URL`. See [Migrating bare item names](#migrating-bare-item-names-020).
+
+</VersionCompatibility>
 
 SecretSpec-managed convention items use the title
 `secretspec/{project}/{profile}/{key}` by default. Project and profile are part
@@ -362,7 +371,9 @@ SecretSpec uses the first custom field whose name contains the requested text,
 also case-insensitively. Use the complete custom-field name to avoid an
 unintended partial match. `field = "notes"` addresses a Secure Note's body.
 
-### How items are matched (0.18+)
+### How items are matched {/* #how-items-are-matched-018 */}
+
+<VersionCompatibility version="0.18" />
 
 Resolved item titles are matched **in full, case-insensitively** — `test database` finds
 `Test Database`, but `API_KEY` never matches `API_KEY_OLD`. The `bw` CLI itself
@@ -396,7 +407,14 @@ DATABASE_URL = { description = "Application database", ref = { item = "MyApp Dat
 
 `ref.item` is matched against the Bitwarden item name, not its item ID.
 
-### Migrating bare item names (0.20+)
+### Migrating bare item names {/* #migrating-bare-item-names-020 */}
+
+<VersionCompatibility version="0.20" kind="changed">
+
+Convention-managed Bitwarden items now use project- and profile-qualified
+titles. Version 0.20 does not fall back to bare item names.
+
+</VersionCompatibility>
 
 Releases through 0.19 wrote convention secrets under their bare keys. Those
 titles contain no project or profile ownership, so SecretSpec cannot safely

--- a/docs/src/content/docs/providers/cloudflare.mdx
+++ b/docs/src/content/docs/providers/cloudflare.mdx
@@ -3,16 +3,17 @@ title: Cloudflare Secrets Store provider
 description: Publish SecretSpec values to Cloudflare account-level Secrets Store
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.20" />
 
 The [Cloudflare](https://www.cloudflare.com/) provider publishes declared
 values to an account-level [Cloudflare Secrets
 Store](https://developers.cloudflare.com/secrets-store/) through the Cloudflare
 REST API.
 
-:::note[Version compatibility]
-The Cloudflare `cloudflare` provider is added in SecretSpec 0.20.
-:::
 
 ## At a glance
 
@@ -59,7 +60,9 @@ Keep the authoritative value in a readable provider and select
 
 ## Setup
 
-### Prerequisites (0.20+)
+### Prerequisites {/* #prerequisites-020 */}
+
+<VersionCompatibility version="0.20" />
 
 - SecretSpec 0.20 or newer
 - A Cloudflare account with a Secrets Store
@@ -69,7 +72,9 @@ Keep the authoritative value in a readable provider and select
 The official SecretSpec CLI includes this provider. Custom minimal Rust builds
 enable it with `--features cloudflare`.
 
-### Wrangler authentication (0.20+)
+### Wrangler authentication {/* #wrangler-authentication-020 */}
+
+<VersionCompatibility version="0.20" />
 
 With `auth=wrangler`, SecretSpec runs:
 
@@ -91,7 +96,9 @@ cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=wrangler&wrangler_profile=produ
 If the executable has another name or location, set
 `SECRETSPEC_WRANGLER_PATH`. SecretSpec never invokes `npx` automatically.
 
-### Authentication with provider credentials (0.20+)
+### Authentication with provider credentials {/* #authentication-with-provider-credentials-020 */}
+
+<VersionCompatibility version="0.20" />
 
 For CI or a machine identity, declare the `api_token`
 [provider credential](/reference/provider-credentials/):
@@ -115,7 +122,9 @@ Enter api_token for provider 'cloudflare_prod' (source: bootstrap): ****
 Use a scoped user or account API token with **Secrets Store Write** on only the
 required account. Do not use the full-access Global API Key for new setups.
 
-### Environment fallback (0.20+)
+### Environment fallback {/* #environment-fallback-020 */}
+
+<VersionCompatibility version="0.20" />
 
 `CLOUDFLARE_API_TOKEN` supplies the `api_token` credential when no explicit
 provider credential exists. `CLOUDFLARE_ACCOUNT_ID` supplies the account ID
@@ -131,7 +140,9 @@ require a token or `auth=wrangler` to require Wrangler credentials.
 
 ## Configuration
 
-### URI format (0.20+)
+### URI format {/* #uri-format-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```text
 cloudflare://STORE_ID[?account_id=ACCOUNT_ID][&scopes=LIST][&auth=MODE][&wrangler_profile=NAME]
@@ -147,7 +158,9 @@ cloudflare://STORE_ID[?account_id=ACCOUNT_ID][&scopes=LIST][&auth=MODE][&wrangle
 - `wrangler_profile` selects a named Wrangler auth profile and requires
   `auth=wrangler`.
 
-### URI examples (0.20+)
+### URI examples {/* #uri-examples-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```text
 cloudflare://STORE_ID?account_id=ACCOUNT_ID
@@ -157,7 +170,9 @@ cloudflare://STORE_ID?account_id=ACCOUNT_ID&scopes=workers,containers
 cloudflare://STORE_ID?account_id=ACCOUNT_ID&auth=wrangler&wrangler_profile=production
 ```
 
-## Storage model (0.20+)
+## Storage model {/* #storage-model-020 */}
+
+<VersionCompatibility version="0.20" />
 
 The provider maps a declaration key directly to an account-secret name. For
 example, `DATABASE_URL` maps to:
@@ -175,7 +190,9 @@ two profiles must hold different values for the same key.
 Cloudflare Workers can bind that account secret to any binding name; the
 SecretSpec key does not need to match the Worker's binding variable.
 
-## Use existing secrets (0.20+)
+## Use existing secrets {/* #use-existing-secrets-020 */}
+
+<VersionCompatibility version="0.20" />
 
 A [`ref`](/reference/configuration/#secret-references) changes the Cloudflare
 secret name updated or deleted by SecretSpec:
@@ -191,7 +208,9 @@ DATABASE_URL = {
 The reference remains write-only: it can select an existing name but cannot
 retrieve its plaintext value.
 
-## Discover secret names (0.20+)
+## Discover secret names {/* #discover-secret-names-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Cloudflare's list API exposes names, IDs, scopes, comments, and status without
 returning values. SecretSpec uses that metadata for declaration discovery:
@@ -205,7 +224,9 @@ $ secretspec init \
 The generated manifest contains required declarations for active or pending
 secret names, not defaults or values.
 
-## CI/CD (0.20+)
+## CI/CD {/* #cicd-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Use a short-lived or account-owned token scoped to Secrets Store Write:
 
@@ -218,7 +239,9 @@ Use a short-lived or account-owned token scoped to Secrets Store Write:
 The account ID and store ID are attribution, not credentials, and can stay in
 the checked-in provider URI.
 
-## Security considerations and limitations (0.20+)
+## Security considerations and limitations {/* #security-considerations-and-limitations-020 */}
+
+<VersionCompatibility version="0.20" />
 
 - Cloudflare's management API accepts values for creation and replacement but
   never returns them. Plaintext access exists only inside a Cloudflare service

--- a/docs/src/content/docs/providers/dashlane.mdx
+++ b/docs/src/content/docs/providers/dashlane.mdx
@@ -3,11 +3,11 @@ title: Dashlane Provider
 description: Read-only access to a Dashlane vault through the Dashlane CLI
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
 
-:::note[Version compatibility]
-The Dashlane provider is added in SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 The [Dashlane](https://www.dashlane.com/) provider reads secrets from a
 Dashlane vault through the [Dashlane CLI](https://cli.dashlane.com/) (`dcli`). It is a

--- a/docs/src/content/docs/providers/dotenv.mdx
+++ b/docs/src/content/docs/providers/dotenv.mdx
@@ -3,6 +3,8 @@ title: Dotenv Provider
 description: Traditional .env file storage for secrets
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 The [Dotenv](https://github.com/cachix/dotenv-ng) provider stores secrets in
 local `.env` files for development setups and compatibility with existing
 tools.
@@ -70,6 +72,16 @@ DATABASE_URL = { description = "Database URL", providers = ["local"] }
 
 ## Storage model
 
+<VersionCompatibility version="0.20" kind="changed">
+
+Dotenv parsing and rendering use dotenv-ng syntax.
+Dollar signs and expressions such as `$TOKEN` and `${TOKEN}` are literal; the
+provider does not substitute them from the process environment. When writing,
+SecretSpec leaves values unquoted when they already round-trip and otherwise
+double-quotes and escapes them. Keys may include hyphens, leading digits,
+leading dots, and Unicode, but not whitespace, `=`, `#`, or control characters.
+
+</VersionCompatibility>
 Dotenv uses standard `KEY=VALUE` pairs:
 
 ```dotenv
@@ -84,14 +96,6 @@ MIIEpAIBAAKCAQEA...
 -----END RSA PRIVATE KEY-----"
 ```
 
-:::note[Dotenv syntax in SecretSpec 0.20+]
-Starting in SecretSpec 0.20+, dotenv parsing and rendering use dotenv-ng syntax.
-Dollar signs and expressions such as `$TOKEN` and `${TOKEN}` are literal; the
-provider does not substitute them from the process environment. When writing,
-SecretSpec leaves values unquoted when they already round-trip and otherwise
-double-quotes and escapes them. Keys may include hyphens, leading digits,
-leading dots, and Unicode, but not whitespace, `=`, `#`, or control characters.
-:::
 
 The file itself provides the namespace. Project and profile names are not
 included in keys; use a different file when environments need separate values:

--- a/docs/src/content/docs/providers/ejson.mdx
+++ b/docs/src/content/docs/providers/ejson.mdx
@@ -5,14 +5,15 @@ tableOfContents:
   maxHeadingLevel: 3
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.20" />
 
 The [`ejson`](https://github.com/Shopify/ejson) provider reads string values
 from EJSON encrypted files.
 
-:::note[Version compatibility]
-The EJSON provider is added in SecretSpec 0.20.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/file.mdx
+++ b/docs/src/content/docs/providers/file.mdx
@@ -3,12 +3,13 @@ title: File Provider
 description: Store each secret in one plaintext file beneath a local directory
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.19" />
+
 The [file](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html)
 provider reads and writes one plaintext UTF-8 file per secret.
 
-:::caution[Version compatibility]
-The `file` provider is added in SecretSpec 0.19.
-:::
 
 ## At a glance
 
@@ -147,12 +148,15 @@ Referenced files are writable when filesystem permissions allow it. Treat
 runtime-managed mounts as read-only unless their owner explicitly permits
 SecretSpec to replace or delete entries.
 
-## Extract from a document (0.19+)
+## Extract from a document {/* #extract-from-a-document-019 */}
 
-:::caution[Version compatibility]
-Structured `extract` is available starting in SecretSpec 0.19.
-INI extraction with `format = "ini"` is available starting in SecretSpec 0.20.
-:::
+<VersionCompatibility version="0.19" />
+
+<VersionCompatibility version="0.20" kind="changed">
+
+Structured extraction now supports INI documents with `format = "ini"`.
+
+</VersionCompatibility>
 
 Several declarations can select values from one JSON file without making JSON
 part of the provider itself:

--- a/docs/src/content/docs/providers/fly.mdx
+++ b/docs/src/content/docs/providers/fly.mdx
@@ -3,15 +3,16 @@ title: Fly.io secrets provider
 description: Publish SecretSpec values to Fly.io application secrets through flyctl
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.20" />
 
 The [Fly.io](https://fly.io/) provider publishes declared values to an
 application's encrypted secret vault through
 [`flyctl`](https://fly.io/docs/flyctl/).
 
-:::note[Version compatibility]
-The Fly.io `fly` provider is added in SecretSpec 0.20.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/flyctl.mdx
+++ b/docs/src/content/docs/providers/flyctl.mdx
@@ -5,11 +5,9 @@ sidebar:
   hidden: true
 ---
 
-# The [Fly.io](https://fly.io/) provider is named `fly`
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
 
-:::note[Version compatibility]
-The Fly.io `fly` provider is added in SecretSpec 0.20.
-:::
+<VersionCompatibility version="0.20" kind="changed">
 
 The pre-release [`flyctl`](https://fly.io/docs/flyctl/) provider name was
 replaced by `fly`. Use the [`fly` provider guide](/providers/fly/) and configure
@@ -17,3 +15,7 @@ Fly.io application secrets with a `fly://APP` URI.
 
 The provider still invokes the `flyctl` executable internally. Only the
 SecretSpec provider name and URI scheme changed.
+
+</VersionCompatibility>
+
+# The [Fly.io](https://fly.io/) provider is named `fly`

--- a/docs/src/content/docs/providers/gcsm.mdx
+++ b/docs/src/content/docs/providers/gcsm.mdx
@@ -3,6 +3,8 @@ title: Google Cloud Secret Manager Provider
 description: Google Cloud Secret Manager integration
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 The [Google Cloud Secret Manager](https://cloud.google.com/security/products/secret-manager)
 provider integrates with GCP for centralized secret management.
 
@@ -78,10 +80,11 @@ DATABASE_URL = { description = "Database URL", providers = ["google"] }
 
 ## Storage model
 
-:::caution[Version compatibility]
-The collision-safe convention below is used starting with SecretSpec 0.20.
+<VersionCompatibility version="0.20" kind="changed">
+
 Releases through 0.19 used `secretspec-{project}-{profile}-{key}`.
-:::
+
+</VersionCompatibility>
 
 SecretSpec joins the project, profile, and key with validated `--` boundaries.
 Distinct logical addresses therefore cannot collapse onto one GCSM secret when
@@ -105,7 +108,14 @@ store the value under the new id, or address the secret with an explicit
 [`ref`](/reference/configuration/#secret-references), which is exempt from the
 convention.
 
-### Reading secrets stored by 0.19
+### Reading legacy secrets {/* #reading-secrets-stored-by-019 */}
+
+<VersionCompatibility version="0.20" kind="changed">
+
+Reads now try the collision-safe ID first, then fall back to the 0.19 ID with a
+warning. Writes use only the collision-safe ID.
+
+</VersionCompatibility>
 
 SecretSpec 0.20 reads the new id first. When that secret holds no value, the
 read falls back to the 0.19 `secretspec-{project}-{profile}-{key}` id and

--- a/docs/src/content/docs/providers/gopass.mdx
+++ b/docs/src/content/docs/providers/gopass.mdx
@@ -3,13 +3,14 @@ title: Gopass Provider
 description: GPG-encrypted, git-synced password store integration
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.15" />
+
 The [Gopass](https://www.gopass.pw/) provider integrates with gopass, a
 multi-user, multi-store abstraction layer on top of `pass` that keeps secrets
 GPG-encrypted and syncs them via git.
 
-:::note[Version compatibility]
-Available since SecretSpec 0.15.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/infisical.mdx
+++ b/docs/src/content/docs/providers/infisical.mdx
@@ -3,14 +3,15 @@ title: Infisical Provider
 description: Infisical integration
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.16" />
 
 The [Infisical](https://infisical.com) provider integrates with Infisical over its REST API, for
 both Infisical Cloud and self-hosted instances.
 
-:::note[Version compatibility]
-Available since SecretSpec 0.16.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/kdbx.mdx
+++ b/docs/src/content/docs/providers/kdbx.mdx
@@ -3,14 +3,15 @@ title: KeePass KDBX Provider
 description: Store SecretSpec values in an encrypted KeePass database
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.17" />
 
 The [KeePass KDBX](https://keepass.info/) provider reads and writes encrypted
 databases directly, without requiring KeePass or KeePassXC to be installed.
 
-:::note[Version compatibility]
-The KDBX provider is added in SecretSpec 0.17.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/keeper.mdx
+++ b/docs/src/content/docs/providers/keeper.mdx
@@ -3,11 +3,11 @@ title: Keeper Secrets Manager Provider
 description: Keeper Secrets Manager integration through Keeper's official Rust SDK
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
 
-:::caution[Version compatibility]
-The `keeper` provider is added in SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 The [Keeper Secrets Manager](https://www.keepersecurity.com/secrets-manager.html)
 provider reads and writes records available to a Keeper Secrets Manager

--- a/docs/src/content/docs/providers/kubernetes.mdx
+++ b/docs/src/content/docs/providers/kubernetes.mdx
@@ -3,12 +3,13 @@ title: Kubernetes Provider
 description: Kubernetes ConfigMap & Secerts
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.20" />
+
 The [Kubernetes](https://kubernetes.io/) provider reads from and writes to
 Kubernetes ConfigMaps or Secrets.
 
-:::caution[Version compatibility]
-The `kubernetes` provider is added in SecretSpec 0.20.
-:::
 
 # At a glance
 | | |

--- a/docs/src/content/docs/providers/null.mdx
+++ b/docs/src/content/docs/providers/null.mdx
@@ -3,9 +3,9 @@ title: Null Provider
 description: Use committed defaults, ephemeral generation, or run-time prompts without storage
 ---
 
-:::caution[Version compatibility]
-The `null` provider is added in SecretSpec 0.19.
-:::
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.19" />
 
 The [null](https://man7.org/linux/man-pages/man4/null.4.html) provider always
 reports that a value is missing. SecretSpec can then
@@ -45,10 +45,7 @@ secrets. The same pattern works for values such as `LOCAL_PORT`.
 
 ## Ephemeral generation
 
-:::note[SecretSpec 0.19+]
-Ephemeral generation through `null://` is available starting in SecretSpec
-0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 Route a generated secret to `null` when each materializing resolution should
 receive a fresh value without storing it in a provider:
@@ -63,11 +60,9 @@ and gives that value to the child process. A later `run`, `get`, `check`, or SDK
 value-carrying resolution generates a new value. Value-free reports mark the
 secret as generated without minting it.
 
-## Ephemeral operator input (0.19+)
+## Ephemeral operator input {/* #ephemeral-operator-input-019 */}
 
-:::note[SecretSpec 0.19+]
-Run-time prompting through `null://` is available starting in SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 Combine `prompt = true` with `null` when the value must always come from the
 operator and must never be stored:

--- a/docs/src/content/docs/providers/openbao.mdx
+++ b/docs/src/content/docs/providers/openbao.mdx
@@ -3,15 +3,16 @@ title: OpenBao Provider
 description: OpenBao integration, available in SecretSpec 0.17+
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.17" />
 
 The [OpenBao](https://openbao.org/) provider integrates with OpenBao's KV
 (Key-Value) secrets engine using OpenBao's own provider identity and
 configuration conventions.
 
-:::caution[Version compatibility]
-The `openbao` provider is added in SecretSpec 0.17.
-:::
 
 ## At a glance
 
@@ -69,6 +70,14 @@ $ export BAO_TOKEN=hvs.your-token-here
 
 ### AppRole authentication
 
+<VersionCompatibility version="0.18" kind="changed">
+
+`BAO_SECRET_ID` (or its `VAULT_SECRET_ID`
+fallback) and the `secret_id` provider credential may be omitted when the
+AppRole is configured with `bind_secret_id=false`. SecretSpec then sends only
+`role_id` and lets OpenBao apply the role's remaining login constraints.
+
+</VersionCompatibility>
 Select AppRole with `?auth=approle`. OpenBao roles bind a SecretID by default,
 so the usual configuration provides both inputs:
 
@@ -91,22 +100,14 @@ role_id = { provider = "onepassword", ref = { vault = "Infra", item = "bao-appro
 secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "bao-approle", field = "secret_id" } }
 ```
 
-:::note[Version compatibility]
-Starting with SecretSpec 0.18, `BAO_SECRET_ID` (or its `VAULT_SECRET_ID`
-fallback) and the `secret_id` provider credential may be omitted when the
-AppRole is configured with `bind_secret_id=false`. SecretSpec then sends only
-`role_id` and lets OpenBao apply the role's remaining login constraints.
-:::
 
 Disabling SecretID binding removes AppRole's usual second credential. Keep the
 server default unless the workload deliberately relies on another trust
 boundary, such as a tightly controlled Agent host and network constraints.
 
-### Custom authentication mounts (0.18+)
+### Custom authentication mounts {/* #custom-authentication-mounts-018 */}
 
-:::note[Version compatibility]
-Custom authentication mounts are available starting with SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 AppRole and JWT methods mounted somewhere other than their defaults can be
 selected with `?auth_mount=`. The value is relative to `/v1/auth`:

--- a/docs/src/content/docs/providers/passbolt.mdx
+++ b/docs/src/content/docs/providers/passbolt.mdx
@@ -3,15 +3,16 @@ title: Passbolt Provider
 description: Store and read SecretSpec values in a self-hosted Passbolt server
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.19" />
 
 The [Passbolt](https://www.passbolt.com/) provider reads and writes resources
 in a self-hosted Passbolt server through the community-maintained
 [`go-passbolt-cli`](https://github.com/passbolt/go-passbolt-cli).
 
-:::note[Version compatibility]
-The Passbolt provider is added in SecretSpec 0.19.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/scaleway.mdx
+++ b/docs/src/content/docs/providers/scaleway.mdx
@@ -3,11 +3,11 @@ title: Scaleway Secret Manager Provider
 description: Scaleway Secret Manager integration
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
 
-:::note
-The Scaleway Secret Manager provider is available in SecretSpec 0.17+.
-:::
+<VersionCompatibility version="0.17" />
 
 The [Scaleway Secret Manager](https://www.scaleway.com/en/secret-manager/)
 provider stores secrets in Scaleway Secret Manager through its `v1beta1` REST

--- a/docs/src/content/docs/providers/sops.mdx
+++ b/docs/src/content/docs/providers/sops.mdx
@@ -5,14 +5,15 @@ tableOfContents:
   maxHeadingLevel: 4
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
+
+<VersionCompatibility version="0.17" />
 
 The [`sops`](https://getsops.io) provider reads and writes secrets in files
 encrypted with SOPS.
 
-:::caution[Version compatibility]
-The `sops` provider was added in SecretSpec 0.17.
-:::
 
 ## At a glance
 

--- a/docs/src/content/docs/providers/systemd-credential.mdx
+++ b/docs/src/content/docs/providers/systemd-credential.mdx
@@ -3,9 +3,9 @@ title: systemd Credential Provider
 description: Read secrets passed to a service through systemd credentials
 ---
 
-:::caution[Version compatibility]
-The `systemd-credential` provider is added in SecretSpec 0.17.
-:::
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
+<VersionCompatibility version="0.17" />
 
 The [systemd](https://systemd.io/) credential provider reads credentials that
 the service manager passed to the current process. It is a read-only delivery

--- a/docs/src/content/docs/providers/vault.mdx
+++ b/docs/src/content/docs/providers/vault.mdx
@@ -3,6 +3,8 @@ title: Vault Provider
 description: HashiCorp Vault integration
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import ProviderCredentials from '../../../components/ProviderCredentials.astro';
 
 The [Vault](https://developer.hashicorp.com/vault) provider integrates with
@@ -50,6 +52,14 @@ $ export VAULT_TOKEN=hvs.your-token-here
 
 ### AppRole authentication
 
+<VersionCompatibility version="0.18" kind="changed">
+
+`VAULT_SECRET_ID` or the `secret_id` provider
+credential may be omitted when the AppRole is configured with
+`bind_secret_id=false`. SecretSpec then sends only `role_id` and lets Vault
+apply the role's remaining login constraints.
+
+</VersionCompatibility>
 Select AppRole with `?auth=approle`. Vault roles bind a SecretID by default, so
 the usual configuration provides both environment variables:
 
@@ -73,22 +83,14 @@ secret_id = { provider = "onepassword", ref = { vault = "Infra", item = "vault-a
 
 SecretSpec 0.14 supports only `VAULT_ROLE_ID` and `VAULT_SECRET_ID`.
 
-:::note[Version compatibility]
-Starting with SecretSpec 0.18, `VAULT_SECRET_ID` or the `secret_id` provider
-credential may be omitted when the AppRole is configured with
-`bind_secret_id=false`. SecretSpec then sends only `role_id` and lets Vault
-apply the role's remaining login constraints.
-:::
 
 Disabling SecretID binding removes AppRole's usual second credential. Keep the
 server default unless the workload deliberately relies on another trust
 boundary, such as a tightly controlled Agent host and network constraints.
 
-### Custom authentication mounts (0.18+)
+### Custom authentication mounts {/* #custom-authentication-mounts-018 */}
 
-:::note[Version compatibility]
-Custom authentication mounts are available starting with SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 AppRole and JWT methods mounted somewhere other than their defaults can be
 selected with `?auth_mount=`. The value is relative to `/v1/auth`:
@@ -102,11 +104,9 @@ The provider logs in at `/v1/auth/platform-approle/login` and
 `/v1/auth/ci-jwt/login`, respectively. The KV mount remains the provider URI
 path (`secret` in these examples).
 
-### JWT / OIDC authentication (0.17+)
+### JWT / OIDC authentication {/* #jwt--oidc-authentication-017 */}
 
-:::note[Version compatibility]
-Added in SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 Select JWT with `?auth=jwt`. The provider performs the `auth/jwt/login`
 exchange itself. The JWT comes from `VAULT_JWT` when set. Otherwise, in a
@@ -188,11 +188,9 @@ configured mount, with its value in a field named `value`.
 For KV v2, `DATABASE_URL` for project `myapp` and profile `production` is read
 from `GET /v1/secret/data/secretspec/myapp/production/DATABASE_URL`.
 
-## Provider caching (0.17+)
+## Provider caching {/* #provider-caching-017 */}
 
-:::caution[Version compatibility]
-Deletion and expiring writes are available starting with SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 A KV v2 mount can hold a [cached provider route's](/concepts/providers/caching/)
 entries. Vault expires them itself: the cache's `max_age` is written to the

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -3,6 +3,8 @@ title: CLI Commands Reference
 description: Complete reference for SecretSpec CLI commands
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 The SecretSpec CLI provides commands for managing secrets across different providers and profiles.
 
 ## Global Options
@@ -135,16 +137,19 @@ Profile:  development
 ```
 
 ### config global provider add
+
+<VersionCompatibility version="0.17" kind="changed">
+
+The explicit `global` namespace replaces the earlier `config provider add`
+spelling, which remains a hidden alias. Adding aliases was introduced in 0.14,
+and `--credential` followed in 0.15.
+
+</VersionCompatibility>
+
 Add a provider alias to your user-level configuration (`~/.config/secretspec/config.toml`).
 
 To share aliases with your team, declare them in a top-level `[providers]` table in `secretspec.toml` instead — they take precedence over user-level aliases on name conflict.
 
-:::note[Version compatibility]
-SecretSpec 0.14 supports adding aliases with `<ALIAS>` and `<URI>`.
-The `--credential` option is available starting with SecretSpec 0.15.
-The explicit `global` namespace is available starting with SecretSpec 0.17;
-the legacy `config provider add` spelling remains a hidden alias.
-:::
 
 ```bash
 $ secretspec config global provider add <ALIAS> <URI> [--credential NAME=PROVIDER]... # 0.17+
@@ -200,13 +205,17 @@ $ secretspec config global provider remove prod_vault  # 0.17+
 ```
 
 ### config provider login
-Store the [credentials](/reference/provider-credentials/) a provider alias declares. Prompts (hidden input) for each credential and writes it to its source provider at the exact location resolution reads it back from. Runs in a project, like `set` and `check`.
 
-:::note[Version compatibility]
-`config provider login` is available starting with SecretSpec 0.15. In
+<VersionCompatibility version="0.15" kind="changed">
+
+In
 SecretSpec 0.14, supply provider credentials through the provider's existing
 environment variables.
-:::
+
+</VersionCompatibility>
+
+Store the [credentials](/reference/provider-credentials/) a provider alias declares. Prompts (hidden input) for each credential and writes it to its source provider at the exact location resolution reads it back from. Runs in a project, like `set` and `check`.
+
 
 ```bash
 $ secretspec config provider login <ALIAS>
@@ -226,7 +235,9 @@ Run 'secretspec check --provider bws' to verify authentication.
 
 A read-only source provider is rejected. An alias that declares no credentials reports that there is nothing to store.
 
-### docker configure (0.20+)
+### docker configure {/* #docker-configure-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Configure Docker to retrieve credentials for one registry through SecretSpec.
 
@@ -254,7 +265,9 @@ and prints the corresponding `secretspec docker login` command. With `--file`,
 registry-specific `credHelpers` entry to Docker's `config.json`, prompts with a
 default of **No**, and refuses to replace an existing helper.
 
-### docker login (0.20+)
+### docker login {/* #docker-login-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Store a password or token in the embedded Docker credential store:
 
@@ -267,7 +280,9 @@ physical Docker configuration pair uses a separate SecretSpec project identity.
 This command rejects `--file`; use `secretspec set` for custom-manifest
 credentials.
 
-### docker logout (0.20+)
+### docker logout {/* #docker-logout-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Remove a password or token from the embedded Docker credential store:
 
@@ -278,7 +293,9 @@ $ secretspec docker logout <REGISTRY> [--provider <PROVIDER>]
 Use the same provider override supplied to `login`. This does not remove the
 Docker helper registration; use `unconfigure` for that.
 
-### docker unconfigure (0.20+)
+### docker unconfigure {/* #docker-unconfigure-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Remove one or all Docker credentials configured by SecretSpec in the active
 Docker configuration.
@@ -294,7 +311,9 @@ registry helpers, stored authentication entries, and unrelated Docker options.
 See [Docker credentials](/integrations/docker/) for complete setup, custom
 manifest, and ownership details.
 
-### git configure (0.20+)
+### git configure {/* #git-configure-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Configure Git to retrieve an HTTP(S) or SMTP password or token through
 SecretSpec. Repository-local configuration is the default.
@@ -327,7 +346,9 @@ Global changes prompt with a default of **No**. Existing helpers and unrelated
 Git configuration are not replaced. See [Git credentials](/integrations/git/)
 for setup examples and the ownership model.
 
-### git login (0.20+)
+### git login {/* #git-login-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Store an embedded Git password or token, prompting securely on a terminal or
 reading it from piped standard input.
@@ -341,7 +362,9 @@ one passed to `configure`, including a path scope. For SMTP, the username is
 read from managed Git configuration unless passed explicitly. `git login`
 rejects `--file`; use `secretspec set` for custom manifest declarations.
 
-### git logout (0.20+)
+### git logout {/* #git-logout-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Remove the embedded username and password or token for one exact target without
 removing its Git helper configuration.
@@ -354,7 +377,9 @@ For SMTP, the username is read from managed Git configuration unless passed
 explicitly. `git logout` rejects `--file`; use `secretspec delete` for custom
 manifest declarations.
 
-### git unconfigure (0.20+)
+### git unconfigure {/* #git-unconfigure-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Remove one or all Git credentials configured by SecretSpec in the selected
 scope.
@@ -503,11 +528,9 @@ The same pattern works in every SDK: Go `UnmarshalSecretSpec(resolved.FieldsJSON
 TypeScript `Convert.toSecretSpec(resolved.fieldsJson())`, Ruby
 `SecretSpec.from_dynamic!(resolved.fields)`.
 
-### add (0.18+)
+### add {/* #add-018 */}
 
-:::caution[Version compatibility]
-`add` is available starting with SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 Add a secret declaration to an existing `secretspec.toml`. This edits only the
 selected profile and preserves the manifest's comments, formatting, and
@@ -567,11 +590,9 @@ missing `--profile` visible before the write.
 `set` rejects composed secrets because their values are derived and read-only.
 Available since SecretSpec 0.16.
 
-### delete (0.18+)
+### delete {/* #delete-018 */}
 
-:::caution[Version compatibility]
-`delete` is available starting with SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 Delete stored provider values without changing their declarations in
 `secretspec.toml`.
@@ -800,11 +821,9 @@ explicitly instead of pretending the migration completed. Source deletion was
 introduced in SecretSpec 0.18; independent endpoint refs and operation-wide
 preflight are available in 0.19+.
 
-### cache clear (0.17+)
+### cache clear {/* #cache-clear-017 */}
 
-:::caution[Version compatibility]
-`cache clear` is available starting with SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 Delete cached provider values for one secret, or for every cached secret in the
 active profile. Authoritative fallback providers are not modified.
@@ -863,11 +882,9 @@ $ secretspec audit --action get -n 5
 $ secretspec audit --json | jq 'select(.outcome == "missing")'
 ```
 
-### completions (0.20+)
+### completions {/* #completions-020 */}
 
-:::caution[Version compatibility]
-`completions` is available starting with SecretSpec 0.20.
-:::
+<VersionCompatibility version="0.20" />
 
 Generate a completion script that asks the same command definition used by
 `secretspec --help` for suggestions. Completion results include every command,

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -3,6 +3,8 @@ title: secretspec.toml Reference
 description: Complete reference for secretspec.toml configuration options
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 ## secretspec.toml Reference
 
 The `secretspec.toml` file defines project-specific secret requirements. This file should be checked into version control.
@@ -122,11 +124,9 @@ redeclared secrets from inheriting omitted fields. The setting has no effect on
 the `default` profile itself. A standalone profile must declare at least one
 secret.
 
-#### Cross-secret presence constraints (0.17+)
+#### Cross-secret presence constraints {/* #cross-secret-presence-constraints-017 */}
 
-:::caution[Version compatibility]
-Added in SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 A profile can require alternative credentials by assigning secrets to a named
 group:
@@ -188,9 +188,7 @@ Field notes:
 
 #### Composed Secrets
 
-:::caution[Version compatibility]
-Available since SecretSpec 0.16.
-:::
+<VersionCompatibility version="0.16" />
 
 A composed secret derives a value from other secrets in the effective profile.
 See [Composed Secrets](/concepts/composed-secrets/) for the dependency model,
@@ -238,11 +236,7 @@ JSON.
 
 ### [scopes] Section
 
-:::note[Version compatibility]
-Scopes are added in **SecretSpec 0.17** and are unavailable in the current 0.16
-release. With 0.16, give each service its own profile, or its own
-`secretspec.toml`.
-:::
+<VersionCompatibility version="0.17" />
 
 See [Scopes](/concepts/scopes/) for the conceptual model and a focused
 guide to narrowing services and tasks. This section specifies the complete
@@ -296,8 +290,8 @@ Behavior:
   fetched, so no provider is contacted for it.
 - A scope does not change a secret's storage address
   (`{project}/{profile}/{key}`); it only narrows the set.
-- **Presence groups are judged over the visible members.** A `required =
-  { at_least_one = … }` or `{ exactly_one = … }` group (see
+- **Presence groups are judged over the visible members.** A
+  `required = { at_least_one = … }` or `{ exactly_one = … }` group (see
   [Cross-secret presence constraints](#cross-secret-presence-constraints-017))
   is evaluated against the members
   the scope actually exposes. A group with no visible member is not that
@@ -421,6 +415,16 @@ REDIS_URL = { description = "Redis cache connection", required = true }
 
 ### Provider Aliases
 
+<VersionCompatibility version="0.15" kind="changed">
+
+SecretSpec 0.14 accepts only bare URI strings; when using
+0.14, configure provider credentials through the provider's existing
+environment variables, such as `BWS_ACCESS_TOKEN`.
+Provider alias `ref` templates are available starting with SecretSpec 0.19.
+Cached alias tables with `fallback` and `cache` are available since SecretSpec
+0.17.
+
+</VersionCompatibility>
 Provider aliases may be declared in two places:
 
 1. **In `secretspec.toml`** — a top-level `[providers]` table. Check this into version control so every team member and CI runner sees the same mapping out of the box.
@@ -428,15 +432,6 @@ Provider aliases may be declared in two places:
 
 On conflict the project-level alias wins, so a stale local config cannot silently shadow the team's mapping.
 
-:::note[Version compatibility]
-Provider alias tables with `uri` and `credentials` are available since
-SecretSpec 0.15. SecretSpec 0.14 accepts only bare URI strings; when using
-0.14, configure provider credentials through the provider's existing
-environment variables, such as `BWS_ACCESS_TOKEN`.
-Provider alias `ref` templates are available starting with SecretSpec 0.19.
-Cached alias tables with `fallback` and `cache` are available since SecretSpec
-0.17.
-:::
 
 ```toml title="secretspec.toml"
 [providers]
@@ -476,7 +471,14 @@ $ secretspec config global provider remove prod_vault
 These explicitly scoped CLI commands operate on the user-global config only —
 edit `secretspec.toml` by hand to change project-level aliases.
 
-#### SecretSpec 0.15 alias values
+#### Credential-aware alias values {/* #secretspec-015-alias-values */}
+
+<VersionCompatibility version="0.15" kind="changed">
+
+Provider aliases now also accept a table with a `uri` and provider credential
+sources; releases through 0.14 accept only a bare provider URI string.
+
+</VersionCompatibility>
 
 In SecretSpec 0.15 and later, an alias value is either a bare provider URI
 string or a table that also declares the credentials the provider needs. Both
@@ -523,12 +525,14 @@ Templates belong on the leaf aliases in a cached route, not on the cached
 alias itself. Bare provider names and literal URIs have no alias identity, so
 they use provider convention naming unless the secret declares legacy `ref`.
 
-#### SecretSpec 0.19 inline provider cache
+#### Inline provider cache {/* #secretspec-019-inline-provider-cache */}
 
-:::caution[Version compatibility]
-Attaching `cache` directly to an alias with `uri` is available starting with
-SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" kind="changed">
+
+Single-provider caches now use `uri` and `cache` on the same alias; versions
+0.17 and 0.18 require a cached fallback alias.
+
+</VersionCompatibility>
 
 Use `uri` and `cache` when one provider is authoritative. `credentials` remains
 optional and configures that same provider:
@@ -557,11 +561,9 @@ providers = ["azure"]
 The alias remains both the selected cached route and the build key for its
 authoritative provider, so its configured credentials apply normally.
 
-#### SecretSpec 0.17 cached fallback alias values
+#### Cached fallback alias values {/* #secretspec-017-cached-fallback-alias-values */}
 
-:::caution[Version compatibility]
-Cached provider aliases are available starting with SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 A cached fallback alias uses `fallback` and `cache` when more than one provider
 can answer:
@@ -597,7 +599,14 @@ cached fallback alias.
 See [Provider caching](/concepts/providers/caching/)
 for freshness, failure, invalidation, and clearing behavior.
 
-#### SecretSpec 0.14 alias values
+#### Legacy bare-URI alias values {/* #secretspec-014-alias-values */}
+
+<VersionCompatibility version="0.15" kind="changed">
+
+Provider aliases gained table-form values in 0.15. Releases through 0.14 require
+every alias value to be a bare provider URI string.
+
+</VersionCompatibility>
 
 In SecretSpec 0.14, every alias value must be a provider URI string:
 
@@ -661,11 +670,9 @@ rather than the stored textual representation. When combined with `extract`
 | Rust SDK | Files cleaned up when `ValidatedSecrets` is dropped; use `keep_temp_files()` to persist |
 | Rust SDK types | `PathBuf` or `Option<PathBuf>` instead of `String` |
 
-### Secret Encoding (0.19+)
+### Secret Encoding {/* #secret-encoding-019 */}
 
-:::caution[Version compatibility]
-Available starting in SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 `encoding` (0.19+) defines the textual representation stored by providers and
 the cache. It is independent of `as_path`: decoded UTF-8 remains an ordinary
@@ -697,12 +704,15 @@ composed results are already logical and are not transformed. The
 `secretspec import` command copies the stored representation verbatim, avoiding
 double encoding.
 
-### Structured Extraction (0.19+)
+### Structured Extraction {/* #structured-extraction-019 */}
 
-:::caution[Version compatibility]
-Available starting in SecretSpec 0.19.
-INI extraction with `format = "ini"` is available starting in SecretSpec 0.20.
-:::
+<VersionCompatibility version="0.19" />
+
+<VersionCompatibility version="0.20" kind="changed">
+
+Structured extraction now supports INI documents with `format = "ini"`.
+
+</VersionCompatibility>
 
 `extract` (0.19+) selects one logical secret from structured text read from a
 provider or cache. It supports JSON (0.19+) and INI (0.20+). JSON `pointer`
@@ -829,12 +839,9 @@ Which provider resolves a `ref` follows the ordinary [provider resolution
 order](/concepts/providers/fallback/); a `ref` composes with the `providers` fallback
 chain, and each provider is asked for the same coordinates.
 
-#### Provider-scoped references (0.19+)
+#### Provider-scoped references {/* #provider-scoped-references-019 */}
 
-:::caution[Version compatibility]
-Provider-scoped `refs` and provider-alias `ref` templates are available
-starting with SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 Use `refs` when one logical secret already has different native coordinates in
 different providers. Keys are leaf provider aliases; they are identity, not a
@@ -931,11 +938,9 @@ vault, and item paths on provider URIs are errors.
 - `check --explain` and `check --json` attribute ref secrets to the store URI
   they resolved from.
 
-### Prompt on missing during run (0.19+)
+### Prompt on missing during run {/* #prompt-on-missing-during-run-019 */}
 
-:::caution[Version compatibility]
-`prompt = true` declarations require SecretSpec 0.19 or newer.
-:::
+<VersionCompatibility version="0.19" />
 
 Use `prompt = true` when `secretspec run` should ask the operator after every
 configured provider has returned missing. Prompting is the value source;
@@ -976,9 +981,7 @@ overrides may set `prompt = false` to return to ordinary missing-value behavior.
 
 ### Secret Generation
 
-:::note
-Secret generation is available since version 0.7.
-:::
+<VersionCompatibility version="0.7" />
 
 When `type` and `generate` are set, missing secrets are automatically generated during `check` or `run` and stored via the configured provider:
 

--- a/docs/src/content/docs/reference/providers.mdx
+++ b/docs/src/content/docs/reference/providers.mdx
@@ -3,6 +3,8 @@ title: Providers Reference
 description: Complete reference for SecretSpec storage providers and their URI configurations
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 SecretSpec supports multiple storage backends for secrets. Each provider has its own URI format and configuration options.
 
 This page is a compact URI reference. For installation, authentication,
@@ -24,11 +26,9 @@ dotenv://~/.config/app/.env  # Home-relative path (0.18+)
 
 **Features**: Read/write, profiles, human-readable, no encryption
 
-## File Provider (0.19+)
+## File Provider {/* #file-provider-019 */}
 
-:::caution[Version compatibility]
-The `file` provider is added in SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 **URI**: `file:ROOT` - Stores one plaintext UTF-8 file per secret beneath an
 explicitly configured local directory
@@ -57,11 +57,9 @@ env://                       # Current process environment
 
 **Features**: Read-only, no setup required, no persistence
 
-## Null Provider (0.19+)
+## Null Provider {/* #null-provider-019 */}
 
-:::caution[Version compatibility]
-The `null` provider is added in SecretSpec 0.19.
-:::
+<VersionCompatibility version="0.19" />
 
 **URI**: `null://` - Always reports a missing value so the declaration's
 committed `default`, configured generator, or `prompt = true` run input (0.19+)
@@ -78,11 +76,9 @@ resolution or child invocation
 or ephemeral generated/operator-supplied values that should be fresh for every
 resolution or run
 
-## systemd Credential Provider (0.17+)
+## systemd Credential Provider {/* #systemd-credential-provider-017 */}
 
-:::caution[Version compatibility]
-The `systemd-credential` provider is added in SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 **URI**: `systemd-credential://` - Reads credentials passed to the current
 service by systemd
@@ -128,11 +124,9 @@ keyring://                   # System default keychain
 **Storage**: Service `secretspec/{project}/{profile}/{key}`, with the current
 operating-system username as the account
 
-## KeePass KDBX Provider (0.17+)
+## KeePass KDBX Provider {/* #keepass-kdbx-provider-017 */}
 
-:::caution[Version compatibility]
-The `kdbx` provider is added in SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 **URI**: `kdbx:PATH[?keyfile=PATH][&prefix=TEMPLATE]` - Stores secrets in a
 KeePass-compatible encrypted database
@@ -170,7 +164,9 @@ lastpass://Work/SecretSpec/{project}/{profile}/{key} # Custom item template
 item template replaces the default and supports `{project}`, `{profile}`, and
 `{key}` placeholders.
 
-## Dashlane Provider (0.18+)
+## Dashlane Provider {/* #dashlane-provider-018 */}
+
+<VersionCompatibility version="0.18" />
 
 **URI**: `dashlane://[item_type]` - Integrates with Dashlane via the `dcli` CLI
 
@@ -222,11 +218,9 @@ write an existing item's field in place, name it with the `ref` field
 (`SECRET = { description = "…", ref = { item = "…", field = "…" } }`); see
 [Secret References](/reference/configuration/#secret-references).
 
-## Keeper Secrets Manager Provider (0.18+)
+## Keeper Secrets Manager Provider {/* #keeper-secrets-manager-provider-018 */}
 
-:::caution[Version compatibility]
-The `keeper` provider is added in SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 **URI**: `keeper://FOLDER_UID[?config_file=PATH]` - Stores records in
 Keeper Secrets Manager through Keeper's official Rust SDK
@@ -282,7 +276,9 @@ select it with
 `SECRETSPEC_PROTONPASS_CLI_PATH`. See
 [`pass-cli` compatibility](/providers/protonpass/#pass-cli-compatibility).
 
-## Passbolt provider (0.19+)
+## Passbolt provider {/* #passbolt-provider-019 */}
+
+<VersionCompatibility version="0.19" />
 
 **Availability**: Added in SecretSpec 0.19.
 
@@ -303,7 +299,9 @@ passbolt://?template=teams/{project}/{profile}/{key}   # Replace the convention 
 
 **Write limitation**: `go-passbolt-cli` accepts created/updated values only as flags, so a value being written is visible in the child process argv until it exits. See the [Passbolt provider security notes](/providers/passbolt/#security-considerations-and-limitations).
 
-## Fly.io secrets provider (0.20+)
+## Fly.io secrets provider {/* #flyio-secrets-provider-020 */}
+
+<VersionCompatibility version="0.20" />
 
 **Availability**: Added in SecretSpec 0.20.
 
@@ -336,7 +334,9 @@ and prompting-on-miss cannot use this write-only provider. See the
 rejects leading or trailing whitespace rather than silently publishing a
 different value.
 
-## Cloudflare Secrets Store provider (0.20+)
+## Cloudflare Secrets Store provider {/* #cloudflare-secrets-store-provider-020 */}
+
+<VersionCompatibility version="0.20" />
 
 **Availability**: Added in SecretSpec 0.20 and included in default builds; use
 the `cloudflare` feature for a custom minimal build.
@@ -398,11 +398,9 @@ awssm://                      # SDK default region and credentials
 **Prerequisites**: AWS credentials configured, build with `--features awssm`
 **Storage**: Secret name `secretspec/{project}/{profile}/{key}`
 
-## AWS Systems Manager Parameter Store Provider (0.18+)
+## AWS Systems Manager Parameter Store Provider {/* #aws-systems-manager-parameter-store-provider-018 */}
 
-:::caution[Version compatibility]
-The `awsps` provider is added in SecretSpec 0.18.
-:::
+<VersionCompatibility version="0.18" />
 
 **URI (0.18+)**:
 `awsps://[profile@]REGION[?prefix=PATH&template=TEMPLATE&kms_key_id=KEY&tier=TIER]`
@@ -430,7 +428,9 @@ complete layout and must end in `/{key}`; `kms_key_id` selects a customer-manage
 key, while `tier` accepts `standard`, `advanced`, or `intelligent-tiering`
 **Discovery (0.18+)**: Bounded declaration discovery through `init --from`
 
-## Scaleway Secret Manager Provider (0.17+)
+## Scaleway Secret Manager Provider {/* #scaleway-secret-manager-provider-017 */}
+
+<VersionCompatibility version="0.17" />
 
 **URI**: `scaleway://[REGION][?project_id=UUID&path=/folder]` - Stores secrets in Scaleway Secret Manager
 
@@ -468,11 +468,9 @@ vault://127.0.0.1:8200/secret?tls=false    # Disable TLS (dev mode)
 **Prerequisites**: Vault server, authentication credentials, build with `--features vault`
 **Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
 
-## OpenBao Provider (0.17+)
+## OpenBao Provider {/* #openbao-provider-017 */}
 
-:::caution[Version compatibility]
-The `openbao` provider is added in SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 **URI**: `openbao://[namespace@]host[:port][/mount][?options]` - Stores secrets in OpenBao's KV engine
 
@@ -492,7 +490,9 @@ openbao://127.0.0.1:8200/secret?kv=1&tls=false
 **Prerequisites**: OpenBao server, authentication credentials, build with `--features openbao` (0.17+)
 **Storage**: KV path `secretspec/{project}/{profile}/{key}` with a `value` field
 
-## Bitwarden Password Manager Provider (0.18+)
+## Bitwarden Password Manager Provider {/* #bitwarden-password-manager-provider-018 */}
+
+<VersionCompatibility version="0.18" />
 
 **URI**: `bw://[COLLECTION]` - Stores secrets in a Bitwarden Password Manager vault via the `bw` CLI
 
@@ -579,11 +579,9 @@ akv://myvault?suffix=vault.azure.cn      # Sovereign cloud (explicit suffix, bar
 **Prerequisites**: An Azure Key Vault instance, authenticated via one of the methods above, build with `--features akv`
 **Storage**: Secret name `secretspec--{base32(project)}--{base32(profile)}--{base32(key)}` (lowercase, unpadded Base32 preserves case and punctuation distinctions within Azure's case-insensitive secret-name namespace)
 
-## Azure App Configuration Provider (0.20+)
+## Azure App Configuration Provider {/* #azure-app-configuration-provider-020 */}
 
-:::caution[Version compatibility]
-The `aac` provider is added in SecretSpec 0.20.
-:::
+<VersionCompatibility version="0.20" />
 
 **URI**:
 `aac://STORE[?auth=METHOD][&label=LABEL][&prefix=PREFIX][&tag=NAME=VALUE]...`
@@ -651,11 +649,9 @@ folders remain unset so provider fallback continues.
 Values are read with Infisical's secret references expanded, matching its own CLI, so a value of
 `postgres://${DB_USER}@host` arrives resolved.
 
-## EJSON Provider (0.20+)
+## EJSON Provider {/* #ejson-provider-020 */}
 
-:::note[Version compatibility]
-The `ejson` provider is added in SecretSpec 0.20.
-:::
+<VersionCompatibility version="0.20" />
 
 **URI**: `ejson:PATH` - Reads string values from one EJSON encrypted file
 
@@ -674,9 +670,9 @@ The provider decrypts the complete EJSON document in memory through the current 
 
 See the [EJSON provider guide](/providers/ejson/) for exact Google Cloud Secret Manager credential configuration and security limitations.
 
-## age Provider (0.17+)
+## age Provider {/* #age-provider-017 */}
 
-> **Version compatibility:** The age provider is added in SecretSpec 0.17.
+<VersionCompatibility version="0.17" />
 
 **URI**: `age://PATH[?identity=FILE][&recipients-file=FILE][&armor=false]` - Stores secrets in a single age-encrypted file committed alongside code
 
@@ -691,11 +687,9 @@ age://secrets.age?recipients-file=secrets.age.recipients # Share with a roster
 **Authentication**: The `identity` credential, `AGE_IDENTITY`, or `?identity=`; recipients from `?recipients-file=` or derived from the identity
 **Storage**: One `KEY=value` entry per secret inside the encrypted blob at PATH
 
-## SOPS Provider (0.17+)
+## SOPS Provider {/* #sops-provider-017 */}
 
-:::caution[Version compatibility]
-The `sops` provider is added in SecretSpec 0.17.
-:::
+<VersionCompatibility version="0.17" />
 
 **URI**: `sops://PATH[?format=yaml|json|dotenv|ini]` - Stores secrets in a
 SOPS-encrypted file or a templated set of files
@@ -720,11 +714,9 @@ as a root key (or a key in `[DEFAULT]` for INI); extra coordinates and refs
 through templated paths are rejected.
 
 
-## Kubernetes Provider (0.20+)
+## Kubernetes Provider {/* #kubernetes-provider-020 */}
 
-:::caution[Version compatibility]
-The `kubernetes` provider is added in SecretSpec 0.20.
-:::
+<VersionCompatibility version="0.20" />
 
 **URI**: `k8s+KIND://NAME[@NAMESPACE]` - Stores secrets in a Kubernetes
 ConfigMap or Secret

--- a/docs/src/content/docs/sdk/csharp.mdx
+++ b/docs/src/content/docs/sdk/csharp.mdx
@@ -3,6 +3,8 @@ title: C# SDK
 description: Resolve SecretSpec secrets from C# and .NET
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-dotnet/examples/quick_start/QuickStart.cs?raw';
 import oneShotExample from '../../../../../secretspec-dotnet/examples/one_shot/OneShot.cs?raw';
@@ -12,9 +14,14 @@ import reportExample from '../../../../../secretspec-dotnet/examples/report/Repo
 import typedAccessExample from '../../../../../secretspec-dotnet/examples/typed_access/TypedAccess.cs?raw';
 import asPathExample from '../../../../../secretspec-dotnet/examples/as_path/AsPath.cs?raw';
 
-> **Version compatibility:** Available since SecretSpec 0.16. The 0.15.0
-> NuGet package is an unsupported bootstrap artifact used to reserve the
-> package ID; use version 0.16 or later for the API below.
+<VersionCompatibility version="0.16" kind="changed">
+
+The 0.15.0 NuGet package is an unsupported
+bootstrap artifact used to reserve the package ID; use version 0.16 or later
+for the API below.
+
+</VersionCompatibility>
+
 
 > **Native library name:** SecretSpec 0.20+ packages the embedded C ABI as
 > `libsecretspec` (`libsecretspec.*`). The runtime loader still accepts the
@@ -24,7 +31,9 @@ The C# SDK (`Cachix.SecretSpec`) is a thin client over the same Rust resolver as
 the CLI. Every provider, fallback chain, profile, generator, reference, and
 `as_path` secret therefore works without C#-side resolution logic.
 
-## Install (0.16+)
+## Install {/* #install-016 */}
+
+<VersionCompatibility version="0.16" />
 
 ```bash
 $ dotnet add package Cachix.SecretSpec
@@ -58,7 +67,9 @@ A one-shot form is also available:
 
 <Code code={oneShotExample} lang="csharp" meta='title="OneShot.cs"' />
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```csharp
 var builder = SecretSpec.Builder().WithCaller(new CallerContext
@@ -73,13 +84,17 @@ var builder = SecretSpec.Builder().WithCaller(new CallerContext
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Inline specifications (0.20+)
+## Inline specifications {/* #inline-specifications-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Use `WithInlineSpec(spec, baseDir)` to resolve strict inline-spec v1 declarations
 from an object serialized by `System.Text.Json`. `baseDir` resolves relative
 provider paths, and an older native library reports a capability error.
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Use `WithScope("api")` to resolve only a named `[scopes.api]` subset. The
 selected name is available as `Resolved.Scope` and `ResolutionReport.Scope`:

--- a/docs/src/content/docs/sdk/go.mdx
+++ b/docs/src/content/docs/sdk/go.mdx
@@ -3,21 +3,26 @@ title: Go SDK
 description: Resolve SecretSpec secrets from Go
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-go/examples/quick_start/main.go?raw';
 import scopesExample from '../../../../../secretspec-go/examples/scopes/main.go?raw';
 import typedAccessExample from '../../../../../secretspec-go/examples/typed_access/main.go?raw';
+
+<VersionCompatibility version="0.20" kind="changed">
+
+`libsecretspec` was named `secretspec-ffi` through SecretSpec 0.19. The current
+Go loader prefers the new artifact name and still accepts pre-0.20 shared
+libraries.
+
+</VersionCompatibility>
 
 The Go SDK (`secretspec-go`) is a thin client over the `libsecretspec` C ABI,
 loaded via [purego](https://github.com/ebitengine/purego) (dlopen, no cgo).
 Resolution happens in the Rust core, so the SDK inherits every provider with no
 Go-side logic.
 
-:::note[SecretSpec 0.20+ library name]
-`libsecretspec` was named `secretspec-ffi` through SecretSpec 0.19. The current
-Go loader prefers the new artifact name and still accepts pre-0.20 shared
-libraries.
-:::
 
 ## Quick start
 
@@ -26,7 +31,9 @@ libraries.
 A missing required secret returns `*MissingRequiredError`; any other failure
 returns `*Error` (with a stable `.Kind`).
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```go
 builder := secretspec.New().WithCaller(secretspec.CallerContext{
@@ -40,7 +47,9 @@ builder := secretspec.New().WithCaller(secretspec.CallerContext{
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Inline specifications (0.20+)
+## Inline specifications {/* #inline-specifications-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Applications that own their declarations in code can resolve a strict JSON
 inline specification without creating a temporary `secretspec.toml` file. Pass
@@ -70,7 +79,9 @@ The SDK requires the native
 `secretspec_call` capability for inline specs; an older library returns a
 capability error rather than falling back to a filesystem search.
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Use `WithScope("api")` to resolve only a named `[scopes.api]` subset. The
 selected name is available as `Resolved.Scope` and `Report.Scope`:
@@ -116,7 +127,9 @@ $ bash scripts/stage-staticlib.sh
 $ CGO_ENABLED=1 go build -tags static ./...
 ```
 
-## Linking with pkg-config (0.19+)
+## Linking with pkg-config {/* #linking-with-pkg-config-019 */}
+
+<VersionCompatibility version="0.19" />
 
 Install one library type with [cargo-c](https://github.com/lu-zero/cargo-c):
 

--- a/docs/src/content/docs/sdk/haskell.mdx
+++ b/docs/src/content/docs/sdk/haskell.mdx
@@ -3,19 +3,24 @@ title: Haskell SDK
 description: Resolve SecretSpec secrets from Haskell
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-hs/examples/QuickStart.hs?raw';
 import scopesExample from '../../../../../secretspec-hs/examples/Scopes.hs?raw';
 import reportExample from '../../../../../secretspec-hs/examples/Report.hs?raw';
 
+<VersionCompatibility version="0.20" kind="changed">
+
+`libsecretspec` was named `secretspec-ffi` through SecretSpec 0.19. New static
+builds and pkg-config metadata use `libsecretspec.a` and `libsecretspec.pc`.
+
+</VersionCompatibility>
+
 The Haskell SDK (`secretspec-hs`) is a thin client over the `libsecretspec` C
 ABI, linked at build time via the Haskell FFI. Resolution happens in the Rust
 core, so the SDK inherits every provider with no Haskell-side logic.
 
-:::note[SecretSpec 0.20+ library name]
-`libsecretspec` was named `secretspec-ffi` through SecretSpec 0.19. New static
-builds and pkg-config metadata use `libsecretspec.a` and `libsecretspec.pc`.
-:::
 
 ## Quick start
 
@@ -27,7 +32,9 @@ throws `SecretSpecError` (with a stable `errorKind`).
 `as_path` secrets are materialized to temp files that outlive the call; call
 `S.close resolved` when done so they do not accumulate in the temp dir.
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```haskell
 let caller = S.CallerContext
@@ -38,13 +45,17 @@ let caller = S.CallerContext
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Inline specifications (0.20+)
+## Inline specifications {/* #inline-specifications-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Use `withInlineSpec spec baseDir` with an Aeson JSON value to resolve strict
 inline-spec v1 declarations. `baseDir` resolves relative provider paths; an
 older static archive fails to link the versioned call symbol.
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Use `withScope "api"` to resolve only a named `[scopes.api]` subset. The
 selected name is available through `resolvedScope` and `reportScope`:
@@ -94,7 +105,9 @@ $ cabal build --extra-lib-dirs="$LIBDIR" --ghc-options="-optl${NATIVE_LIBS// / -
 $ cabal test  --extra-lib-dirs="$LIBDIR" --ghc-options="-optl${NATIVE_LIBS// / -optl}"
 ```
 
-### Linking with pkg-config (0.19+)
+### Linking with pkg-config {/* #linking-with-pkg-config-019 */}
+
+<VersionCompatibility version="0.19" />
 
 Install one library type with [cargo-c](https://github.com/lu-zero/cargo-c):
 

--- a/docs/src/content/docs/sdk/jvm.mdx
+++ b/docs/src/content/docs/sdk/jvm.mdx
@@ -3,6 +3,8 @@ title: JVM SDK
 description: Resolve SecretSpec secrets from Java Virtual Machine languages
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-jvm/examples/src/main/java/org/cachix/examples/QuickStartExample.java?raw';
 import scopesExample from '../../../../../secretspec-jvm/examples/src/main/java/org/cachix/examples/ScopeExample.java?raw';
@@ -11,7 +13,7 @@ import typedAccessExample from '../../../../../secretspec-jvm/examples/src/main/
 import asPathExample from '../../../../../secretspec-jvm/examples/src/main/java/org/cachix/examples/AsPathExample.java?raw';
 import callerExample from '../../../../../secretspec-jvm/examples/src/main/java/org/cachix/examples/CallerExample.java?raw';
 
-> **Version compatibility:** Available since SecretSpec 0.20.
+<VersionCompatibility version="0.20" />
 
 The JVM SDK (`org.cachix.secretspec-jvm`) is a thin client over the same Rust resolver as
 the CLI. Every provider, fallback chain, profile, generator, reference, and
@@ -20,7 +22,9 @@ the CLI. Every provider, fallback chain, profile, generator, reference, and
 The 0.20+ JVM package carries native assets under the `libsecretspec` embedded
 C ABI name.
 
-## Install (0.20+)
+## Install {/* #install-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ### Using gradle
 
@@ -58,7 +62,9 @@ secret. A missing required secret throws `MissingRequiredException`; its
 `missing()` method returns the secret names. Other failures throw
 `SecretSpecException`, whose `kind()` method returns a stable error category.
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Use `withScope("api")` to resolve only a named `[scopes.api]` subset. The
 selected name is available as `Resolved.scope()` and `ResolutionReport.scope()`:
@@ -100,7 +106,9 @@ to remove these files deterministically:
 
 <Code code={asPathExample} lang="java" meta='title="AsPathExample.java"' />
 
-## Caller (0.20+)
+## Caller {/* #caller-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Caller context answers *what* invoked SecretSpec (for example, `git`). It is
 deliberately separate from the user-supplied access reason, which answers

--- a/docs/src/content/docs/sdk/nodejs.mdx
+++ b/docs/src/content/docs/sdk/nodejs.mdx
@@ -3,6 +3,8 @@ title: Node.js SDK
 description: Resolve SecretSpec secrets from Node.js and TypeScript
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-node/examples/quick_start.js?raw';
 import scopesExample from '../../../../../secretspec-node/examples/scopes.js?raw';
@@ -22,7 +24,9 @@ Windows x64. TypeScript declarations ship in `index.d.ts`.
 A missing required secret throws `MissingRequiredError`; any other failure
 throws `SecretSpecError` (with a stable `.kind`).
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```js
 const builder = SecretSpec.builder().withCaller({
@@ -36,13 +40,17 @@ const builder = SecretSpec.builder().withCaller({
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Inline specifications (0.20+)
+## Inline specifications {/* #inline-specifications-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Use `.withInlineSpec(spec, baseDir)` (or `loadAsync`/`reportAsync`) to resolve a
 strict inline-spec v1 object. `baseDir` resolves relative provider paths; the
 embedded addon submits the versioned native request directly.
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Use `.withScope('api')` to resolve only a named `[scopes.api]` subset. The
 selected name is available as `resolved.scope` and `report.scope`:

--- a/docs/src/content/docs/sdk/php.mdx
+++ b/docs/src/content/docs/sdk/php.mdx
@@ -3,6 +3,8 @@ title: PHP SDK
 description: Resolve SecretSpec secrets from PHP, Laravel, and Symfony
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-php/examples/quick_start.php?raw';
 import oneShotExample from '../../../../../secretspec-php/examples/one_shot.php?raw';
@@ -12,6 +14,14 @@ import symfonyExample from '../../../../../secretspec-php/examples/symfony.php?r
 import plainPhpExample from '../../../../../secretspec-php/examples/plain_php.php?raw';
 import typedAccessExample from '../../../../../secretspec-php/examples/typed_access.php?raw';
 import asPathExample from '../../../../../secretspec-php/examples/as_path.php?raw';
+
+<VersionCompatibility version="0.20" kind="changed">
+
+`libsecretspec` was named `secretspec-ffi` through SecretSpec 0.19. The PHP
+loader prefers the new artifact name and still accepts pre-0.20 shared
+libraries.
+
+</VersionCompatibility>
 
 The PHP SDK (`cachix/secretspec`) is a thin client over the same Rust resolver
 every other SecretSpec SDK uses, so it inherits every provider, chain, profile,
@@ -26,11 +36,6 @@ native backends over an identical JSON contract:
   to compile, ideal for CLI tools and local development; requires the FFI
   extension enabled.
 
-:::note[SecretSpec 0.20+ library name]
-`libsecretspec` was named `secretspec-ffi` through SecretSpec 0.19. The PHP
-loader prefers the new artifact name and still accepts pre-0.20 shared
-libraries.
-:::
 
 The SDK prefers the extension whenever it is loaded and transparently falls back
 to `ext-ffi`, so your application code is the same either way.
@@ -107,7 +112,9 @@ There is also a one-shot form using named arguments:
 
 <Code code={oneShotExample} lang="php" meta='title="one_shot.php"' />
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```php
 use Secretspec\CallerContext;
@@ -124,13 +131,17 @@ $builder = SecretSpec::builder()->withCaller(new CallerContext(
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Inline specifications (0.20+)
+## Inline specifications {/* #inline-specifications-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Use `withInlineSpec($spec, $baseDir)` to resolve a strict inline-spec v1 PHP
 array. The embedded extension or FFI fallback uses the versioned native call;
 an older cdylib raises a capability error instead of searching for a manifest.
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Use `withScope('api')` to resolve only a named `[scopes.api]` subset. The
 selected name is available as `$resolved->scope` and `$report->scope`:

--- a/docs/src/content/docs/sdk/python.mdx
+++ b/docs/src/content/docs/sdk/python.mdx
@@ -3,6 +3,8 @@ title: Python SDK
 description: Resolve SecretSpec secrets from Python
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-py/examples/quick_start.py?raw';
 import scopesExample from '../../../../../secretspec-py/examples/scopes.py?raw';
@@ -20,7 +22,9 @@ provider with no Python-side logic.
 A missing required secret raises `MissingRequiredError`; any other failure
 raises `SecretSpecError` (with a stable `.kind`).
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```python
 from secretspec import CallerContext, SecretSpec
@@ -36,14 +40,18 @@ builder = SecretSpec.builder().with_caller(CallerContext(
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Inline specifications (0.20+)
+## Inline specifications {/* #inline-specifications-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Use `.with_inline_spec(spec, base_dir)` to resolve a strict inline-spec v1
 dictionary without a manifest file. `base_dir` resolves relative provider paths.
 An inline call uses the versioned native entry point, so it cannot fall back to
 a filesystem manifest on an older runtime.
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Use `.with_scope("api")` to resolve only a named `[scopes.api]` subset. The
 selected name is available as `resolved.scope` and `report.scope`:

--- a/docs/src/content/docs/sdk/ruby.mdx
+++ b/docs/src/content/docs/sdk/ruby.mdx
@@ -3,20 +3,25 @@ title: Ruby SDK
 description: Resolve SecretSpec secrets from Ruby
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-rb/examples/quick_start.rb?raw';
 import scopesExample from '../../../../../secretspec-rb/examples/scopes.rb?raw';
 import typedAccessExample from '../../../../../secretspec-rb/examples/typed_access.rb?raw';
 
+<VersionCompatibility version="0.20" kind="changed">
+
+`libsecretspec` was named `secretspec-ffi` through SecretSpec 0.19. Upgrade the
+extension source and `libsecretspec.a` together because 0.20 adds the
+`secretspec_call` symbol.
+
+</VersionCompatibility>
+
 The Ruby SDK (`secretspec`) is a thin client over the `libsecretspec` C ABI,
 linked into a native C extension at build time. Resolution happens in the Rust
 core, so the SDK inherits every provider with no Ruby-side logic.
 
-:::note[SecretSpec 0.20+ library name]
-`libsecretspec` was named `secretspec-ffi` through SecretSpec 0.19. Upgrade the
-extension source and `libsecretspec.a` together because 0.20 adds the
-`secretspec_call` symbol.
-:::
 
 ## Quick start
 
@@ -25,7 +30,9 @@ extension source and `libsecretspec.a` together because 0.20 adds the
 A missing required secret raises `Secretspec::MissingRequiredError`; any other
 failure raises `Secretspec::Error` (with a stable `#kind`).
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```ruby
 builder = Secretspec::SecretSpec.builder.with_caller(
@@ -41,13 +48,17 @@ builder = Secretspec::SecretSpec.builder.with_caller(
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Inline specifications (0.20+)
+## Inline specifications {/* #inline-specifications-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Use `.with_inline_spec(spec, base_dir)` to resolve a strict inline-spec v1 hash
 at its logical provider-path base directory. The extension links the separate
 native call symbol, so an older archive cannot fall back to a manifest search.
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 Use `.with_scope("api")` to resolve only a named `[scopes.api]` subset. The
 selected name is available as `resolved.scope` and `report.scope`:
@@ -70,7 +81,9 @@ $ secretspec schema | quicktype -s schema --top-level SecretSpec --lang ruby -o 
 The published platform gems bundle the `libsecretspec` archive and statically
 link it into the mkmf extension at install time.
 
-### Linking with pkg-config (0.19+)
+### Linking with pkg-config {/* #linking-with-pkg-config-019 */}
+
+<VersionCompatibility version="0.19" />
 
 Install one library type with [cargo-c](https://github.com/lu-zero/cargo-c):
 

--- a/docs/src/content/docs/sdk/rust.mdx
+++ b/docs/src/content/docs/sdk/rust.mdx
@@ -3,6 +3,8 @@ title: Rust SDK
 description: Type-safe Rust integration for SecretSpec
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import basicExample from '../../../../../secretspec-derive/examples/basic.rs?raw';
 import profilesExample from '../../../../../secretspec-derive/examples/profiles.rs?raw';
@@ -19,6 +21,13 @@ Rust types for its profiles and secrets.
 
 ## Quick start
 
+<VersionCompatibility version="0.20" kind="changed">
+
+On 0.19 and earlier, also depend on `secrecy = { version =
+"0.10", features = ["serde"] }` and `serde = { version = "1", features =
+["derive"] }`.
+
+</VersionCompatibility>
 Add the runtime and derive macro from the command line:
 
 ```shell
@@ -33,12 +42,6 @@ secretspec = "0.20"
 secretspec-derive = "0.20"
 ```
 
-:::caution[Version compatibility]
-Generated code reaches `serde` and `secrecy` through `secretspec` starting in
-SecretSpec 0.20. On 0.19 and earlier, also depend on `secrecy = { version =
-"0.10", features = ["serde"] }` and `serde = { version = "1", features =
-["derive"] }`.
-:::
 
 The examples on this page are compiled as Cargo examples in
 `secretspec-derive`. They generate their types from this manifest:
@@ -55,7 +58,9 @@ Required and defaulted secrets are generated as `String`; secrets that may be
 absent are `Option<String>`. Field names use Rust snake case, so `DATABASE_URL`
 becomes `database_url`.
 
-## Describing secrets in Rust (0.20+)
+## Describing secrets in Rust {/* #describing-secrets-in-rust-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Starting with SecretSpec 0.20, `Spec` is the format-independent declaration
 API. Build one directly in Rust when an application owns its secret contract
@@ -126,7 +131,9 @@ profile's effective fields, including fields inherited from
 
 <Code code={profilesExample} lang="rust" meta='title="profiles.rs"' />
 
-## Scopes (0.17+)
+## Scopes {/* #scopes-017 */}
+
+<VersionCompatibility version="0.17" />
 
 A [scope](/concepts/scopes/) resolves only a named subset of a profile. Scopes
 are available through the untyped `Secrets` API:
@@ -143,7 +150,9 @@ would leave that field unfillable. `SecretSpec::builder()` therefore has no
 profile. Use a separate manifest or the untyped API when a component needs a
 narrowed set.
 
-## Resolving one secret (0.19+)
+## Resolving one secret {/* #resolving-one-secret-019 */}
+
+<VersionCompatibility version="0.19" />
 
 `resolve()` answers whether the whole profile can be satisfied, so a single
 missing required secret fails it and returns nothing. When a component needs one
@@ -165,7 +174,9 @@ When a wrapper only needs to identify the software integration, use the separate
 caller context below; unlike a default reason, it cannot satisfy
 `require_reason`.
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Software integrations can record what invoked SecretSpec without replacing the
 user-supplied access reason:
@@ -185,7 +196,9 @@ Generated builders expose the same `with_caller()` method. Caller context is
 caller-asserted audit metadata, not an authenticated identity, and never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Interactive prompting (0.20+)
+## Interactive prompting {/* #interactive-prompting-020 */}
+
+<VersionCompatibility version="0.20" />
 
 `Secrets::ensure_secrets` prompts for and stores any missing required secret
 when stdin is a real terminal. Generated builders opt into the same behavior

--- a/docs/src/content/docs/sdk/swift.mdx
+++ b/docs/src/content/docs/sdk/swift.mdx
@@ -3,6 +3,8 @@ title: Swift SDK
 description: Resolve SecretSpec secrets from Swift on macOS
 ---
 
+import VersionCompatibility from '../../../components/VersionCompatibility.astro';
+
 import { Code } from 'astro:components';
 import quickStartExample from '../../../../../secretspec-swift/Examples/QuickStart.swift?raw';
 import errorsExample from '../../../../../secretspec-swift/Examples/Errors.swift?raw';
@@ -11,14 +13,16 @@ import scopesExample from '../../../../../secretspec-swift/Examples/Scopes.swift
 import reportExample from '../../../../../secretspec-swift/Examples/Report.swift?raw';
 import typedAccessExample from '../../../../../secretspec-swift/Examples/TypedAccess.swift?raw';
 
-> **Version compatibility:** The Swift SDK is available in SecretSpec 0.18+.
+<VersionCompatibility version="0.18" />
 
 The Swift SDK is a thin `Codable` wrapper over the same Rust resolver and
 versioned C ABI as the other language SDKs. Every provider, fallback chain,
 profile, scope, generator, reference, and `as_path` secret therefore works
 without Swift-side resolution logic.
 
-## Install (0.18+)
+## Install {/* #install-018 */}
+
+<VersionCompatibility version="0.18" />
 
 In Xcode, choose **File → Add Package Dependencies** and enter:
 
@@ -67,7 +71,9 @@ A one-shot form is also available:
 
 <Code code={oneShotExample} lang="swift" meta='title="OneShot.swift"' />
 
-## Caller context (0.20+)
+## Caller context {/* #caller-context-020 */}
+
+<VersionCompatibility version="0.20" />
 
 ```swift
 let builder = SecretSpec.builder().withCaller(CallerContext(
@@ -81,7 +87,9 @@ let builder = SecretSpec.builder().withCaller(CallerContext(
 Caller context identifies the invoking integration in audit records but never
 satisfies `require_reason`. Do not put credentials or secret values in it.
 
-## Inline specifications (0.20+)
+## Inline specifications {/* #inline-specifications-020 */}
+
+<VersionCompatibility version="0.20" />
 
 Use `try builder.withInlineSpec(spec, baseDir: ...)` with an `Encodable`
 declaration to resolve strict inline-spec v1 JSON. The base directory resolves

--- a/docs/src/lib/preserve-heading-id.mjs
+++ b/docs/src/lib/preserve-heading-id.mjs
@@ -1,0 +1,33 @@
+const explicitHeadingId = /^\s*\/\*\s*#([A-Za-z][\w:.-]*)\s*\*\/\s*$/;
+
+/**
+ * Preserve a historical heading URL while allowing its visible title to change.
+ *
+ * Usage: `## Clean title {/* #historical-heading-id *\/}`
+ */
+export function preserveHeadingIdPlugin() {
+  return (tree) => {
+    walk(tree, (node) => {
+      if (node.type !== "heading") return;
+
+      const marker = node.children.at(-1);
+      if (marker?.type !== "mdxTextExpression") return;
+
+      const match = explicitHeadingId.exec(marker.value);
+      if (!match) return;
+
+      node.children.pop();
+      const titleEnd = node.children.at(-1);
+      if (titleEnd?.type === "text") titleEnd.value = titleEnd.value.trimEnd();
+      node.data ??= {};
+      node.data.hProperties ??= {};
+      node.data.hProperties.id = match[1];
+    });
+  };
+}
+
+function walk(node, visit) {
+  visit(node);
+  if (!Array.isArray(node.children)) return;
+  for (const child of node.children) walk(child, visit);
+}

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -43,39 +43,39 @@ type ProviderMetadata = {
 
 const providerMetadata: ProviderMetadata[] = [
   { icon: 'apple', slug: 'keyring', label: 'macOS Keychain' },
-  { slug: 'kdbx', label: 'KeePass KDBX (0.17+)' },
+  { slug: 'kdbx', label: 'KeePass KDBX' },
   { icon: '1password', slug: 'onepassword', label: '1Password' },
-  { slug: 'keeper', label: 'Keeper Secrets Manager (0.18+)' },
+  { slug: 'keeper', label: 'Keeper Secrets Manager' },
   { icon: 'lastpass', slug: 'lastpass', label: 'LastPass' },
-  { slug: 'dashlane', label: 'Dashlane (0.18+)' },
-  { icon: 'bitwarden', slug: 'bw', label: 'Bitwarden Password Manager (0.18+)' },
+  { slug: 'dashlane', label: 'Dashlane' },
+  { icon: 'bitwarden', slug: 'bw', label: 'Bitwarden Password Manager' },
   { icon: 'vault', slug: 'vault', label: 'Vault' },
-  { slug: 'openbao', label: 'OpenBao (0.17+)' },
+  { slug: 'openbao', label: 'OpenBao' },
   { slug: 'awssm', label: 'AWS Secrets Manager' },
-  { slug: 'awsps', label: 'AWS Parameter Store (0.18+)' },
-  { slug: 'scaleway', label: 'Scaleway Secret Manager (0.17+)' },
+  { slug: 'awsps', label: 'AWS Parameter Store' },
+  { slug: 'scaleway', label: 'Scaleway Secret Manager' },
   { icon: 'googlecloud', slug: 'gcsm', label: 'Google Cloud Secret Manager' },
   { icon: 'microsoftazure', slug: 'akv', label: 'Azure Key Vault' },
-  { icon: 'microsoftazure', slug: 'aac', label: 'Azure App Configuration (0.20+)' },
+  { icon: 'microsoftazure', slug: 'aac', label: 'Azure App Configuration' },
   { slug: 'infisical', label: 'Infisical' },
-  { slug: 'ejson', label: 'EJSON (0.20+)' },
-  { slug: 'age', label: 'age (0.17+)' },
+  { slug: 'ejson', label: 'EJSON' },
+  { slug: 'age', label: 'age' },
   { slug: 'gopass', label: 'Gopass' },
   { slug: 'protonpass', label: 'Proton Pass' },
-  { slug: 'passbolt', label: 'Passbolt (0.19+)' },
+  { slug: 'passbolt', label: 'Passbolt' },
   { icon: 'gnuprivacyguard', slug: 'pass', label: 'Pass (GPG)' },
   { icon: 'dotenv', slug: 'dotenv', label: '.env files' },
-  { slug: 'file', label: 'Plaintext files (0.19+)' },
+  { slug: 'file', label: 'Plaintext files' },
   { slug: 'env', label: 'Environment variables' },
-  { slug: 'null', label: 'Defaults / ephemeral values (null, 0.19+)' },
-  { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials (0.17+)' },
-  { slug: 'fly', label: 'Fly.io secrets (write-only, 0.20+)' },
-  { icon: 'cloudflare', slug: 'cloudflare', label: 'Cloudflare Secrets Store (write-only, 0.20+)' },
+  { slug: 'null', label: 'Defaults / ephemeral values (null)' },
+  { icon: 'systemd', slug: 'systemd-credential', label: 'systemd credentials' },
+  { slug: 'fly', label: 'Fly.io secrets (write-only)' },
+  { icon: 'cloudflare', slug: 'cloudflare', label: 'Cloudflare Secrets Store (write-only)' },
   { icon: 'bitwarden', slug: 'bws', label: 'Bitwarden Secrets Manager' },
   { icon: 'linux', slug: 'keyring', label: 'Secret Service' },
   { slug: 'keyring', label: 'Credential Manager' },
-  { icon: { src: sopsLogo, type: 'bundled' }, slug: 'sops', label: 'SOPS (0.17+)' },
-  { icon: 'kubernetes', slug: 'kubernetes', label: 'Kubernetes (0.20+)' },
+  { icon: { src: sopsLogo, type: 'bundled' }, slug: 'sops', label: 'SOPS' },
+  { icon: 'kubernetes', slug: 'kubernetes', label: 'Kubernetes' },
 ];
 
 type ConsumerMetadata = {
@@ -116,9 +116,9 @@ const consumerMetadata: ConsumerMetadata[] = [
     secrets: ['CONNECTIONSTRINGS__DEFAULT', 'JWT__SECRET', 'API_KEY'] },
   { icon: 'haskell', label: 'Haskell', href: '/sdk/haskell/',
     secrets: ['DATABASE_URL', 'API_KEY', 'SIGNING_KEY'] },
-  { icon: 'swift', label: 'Swift (0.18+)', href: '/sdk/swift/',
+  { icon: 'swift', label: 'Swift', href: '/sdk/swift/',
     secrets: ['DATABASE_URL', 'API_KEY', 'SENTRY_DSN'] },
-  { icon: 'openjdk', label: 'JVM (0.20+)', href: '/sdk/jvm/',
+  { icon: 'openjdk', label: 'JVM', href: '/sdk/jvm/',
     secrets: ['DATABASE_URL', 'API_KEY', 'SENTRY_DSN'] },
   { icon: 'githubactions', label: 'GitHub Actions', href: '/ci/github-actions/',
     secrets: ['NPM_TOKEN', 'AWS_SECRET_ACCESS_KEY', 'CODECOV_TOKEN'] },
@@ -186,8 +186,8 @@ const consumerColors: Record<string, SyntaxColorName> = {
   Symfony: 'comment',
   '.NET / C#': 'blue',
   Haskell: 'magenta',
-  'Swift (0.18+)': 'red',
-  'JVM (0.20+)': 'blue',
+  Swift: 'red',
+  JVM: 'blue',
   'GitHub Actions': 'comment',
   'Forgejo Actions': 'orange',
   'devenv & Nix': 'cyan',
@@ -298,9 +298,9 @@ const languageSdkMetadata = [
   {
     id: 'swift',
     icon: 'swift',
-    label: 'Swift (0.18+)',
+    label: 'Swift',
     href: '/sdk/swift/',
-    color: consumerTone({ label: 'Swift (0.18+)', href: '/sdk/swift/', secrets: [] }),
+    color: consumerTone({ label: 'Swift', href: '/sdk/swift/', secrets: [] }),
     code: `<span class="tok-kw">let</span> <span class="tok-var">s</span> <span class="tok-pun">=</span> <span class="tok-kw">try</span> <span class="tok-var">SecretSpec</span><span class="tok-pun">.</span><span class="tok-fn">builder</span><span class="tok-pun">()</span>
     <span class="tok-pun">.</span><span class="tok-fn">withProvider</span><span class="tok-pun">(</span><span class="tok-str">"keyring://"</span><span class="tok-pun">)</span>
     <span class="tok-pun">.</span><span class="tok-fn">withReason</span><span class="tok-pun">(</span><span class="tok-str">"boot"</span><span class="tok-pun">).</span><span class="tok-fn">load</span><span class="tok-pun">()</span>
@@ -310,9 +310,9 @@ const languageSdkMetadata = [
   {
     id: 'jvm',
     icon: 'openjdk',
-    label: 'JVM (0.20+)',
+    label: 'JVM',
     href: '/sdk/jvm/',
-    color: consumerTone({ label: 'JVM (0.20+)', href: '/sdk/jvm/', secrets: [] }),
+    color: consumerTone({ label: 'JVM', href: '/sdk/jvm/', secrets: [] }),
     code: `<span class="tok-kw">import</span> <span class="tok-var">org</span><span class="tok-pun">.</span><span class="tok-var">cachix</span><span class="tok-pun">.</span><span class="tok-var">secretspec</span><span class="tok-pun">.</span><span class="tok-var">SecretSpec</span><span class="tok-pun">;</span>
 
 <span class="tok-kw">var</span> <span class="tok-var">s</span> <span class="tok-pun">=</span> <span class="tok-var">SecretSpec</span><span class="tok-pun">.</span><span class="tok-fn">builder</span><span class="tok-pun">()</span>
@@ -561,29 +561,29 @@ const reelScriptData = {
 <span class="landing-prompt">$</span> <span class="landing-cmd"><span class="tok-bin">secretspec</span> <span class="landing-arg">init</span> <span class="landing-flag">--from</span> <span class="landing-arg">dotenv</span></span>
 <span class="landing-ok">✓</span> Created secretspec.toml with 5 secrets</span>
 
-<span class="landing-run-step is-provider-list"><span class="tok-com"># 2. Pick a user-global default (0.17+)</span>
+<span class="landing-run-step is-provider-list"><span class="tok-com"># 2. Pick a user-global default</span>
 <span class="landing-prompt">$</span> <span class="landing-cmd"><span class="tok-bin">secretspec</span> <span class="landing-arg">config global init</span></span>
 ? Select your preferred provider backend:
 <span class="landing-provider-cursor" aria-hidden="true">›</span><a class="landing-provider-line is-selected" style="--provider-line-color: var(--syntax-blue)" href="/providers/keyring/"><span class="provider-name">keyring</span>: Uses system keychain (Recommended)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/null/"><span class="provider-name">null</span>: Defaults, generation, or run prompts without storage (0.19+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/file/"><span class="provider-name">file</span>: Plaintext files, one per secret (0.19+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-red)" href="/providers/bw/"><span class="provider-name">bw</span>: Bitwarden Password Manager (0.18+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/kdbx/"><span class="provider-name">kdbx</span>: KeePass KDBX databases (0.17+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/keeper/"><span class="provider-name">keeper</span>: Keeper Secrets Manager (0.18+) via official Rust SDK</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/passbolt/"><span class="provider-name">passbolt</span>: Passbolt self-hosted password manager (0.19+) via go-passbolt-cli</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/aac/"><span class="provider-name">aac</span>: Azure App Configuration (0.20+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/null/"><span class="provider-name">null</span>: Defaults, generation, or run prompts without storage</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/file/"><span class="provider-name">file</span>: Plaintext files, one per secret</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-red)" href="/providers/bw/"><span class="provider-name">bw</span>: Bitwarden Password Manager</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/kdbx/"><span class="provider-name">kdbx</span>: KeePass KDBX databases</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/keeper/"><span class="provider-name">keeper</span>: Keeper Secrets Manager via official Rust SDK</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/passbolt/"><span class="provider-name">passbolt</span>: Passbolt self-hosted password manager via go-passbolt-cli</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/aac/"><span class="provider-name">aac</span>: Azure App Configuration</a>
 <span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/infisical/"><span class="provider-name">infisical</span>: Infisical secret management</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/openbao/"><span class="provider-name">openbao</span>: OpenBao secret management (0.17+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/ejson/"><span class="provider-name">ejson</span>: EJSON encrypted files, read-only (0.20+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/age/"><span class="provider-name">age</span>: age-encrypted file (0.17+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/sops/"><span class="provider-name">sops</span>: SOPS encrypted files (0.17+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/systemd-credential/"><span class="provider-name">systemd-credential</span>: Read-only systemd service credentials (0.17+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/fly/"><span class="provider-name">fly</span>: Fly.io application secrets, write-only (0.20+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-orange)" href="/providers/cloudflare/"><span class="provider-name">cloudflare</span>: Cloudflare Secrets Store, write-only (0.20+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-orange)" href="/providers/awsps/"><span class="provider-name">awsps</span>: AWS Systems Manager Parameter Store (0.18+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/scaleway/"><span class="provider-name">scaleway</span>: Scaleway Secret Manager (0.17+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/dashlane/"><span class="provider-name">dashlane</span>: Dashlane password manager, read-only (0.18+)</a>
-<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/kubernetes/"><span class="provider-name">kubernetes</span>: Kubernetes (0.20+)</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/openbao/"><span class="provider-name">openbao</span>: OpenBao secret management</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/ejson/"><span class="provider-name">ejson</span>: EJSON encrypted files, read-only</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-yellow)" href="/providers/age/"><span class="provider-name">age</span>: age-encrypted file</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/sops/"><span class="provider-name">sops</span>: SOPS encrypted files</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/systemd-credential/"><span class="provider-name">systemd-credential</span>: Read-only systemd service credentials</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/fly/"><span class="provider-name">fly</span>: Fly.io application secrets, write-only</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-orange)" href="/providers/cloudflare/"><span class="provider-name">cloudflare</span>: Cloudflare Secrets Store, write-only</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-orange)" href="/providers/awsps/"><span class="provider-name">awsps</span>: AWS Systems Manager Parameter Store</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-magenta)" href="/providers/scaleway/"><span class="provider-name">scaleway</span>: Scaleway Secret Manager</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-cyan)" href="/providers/dashlane/"><span class="provider-name">dashlane</span>: Dashlane password manager, read-only</a>
+<span class="landing-provider-slot" aria-hidden="true"> </span><a class="landing-provider-line" style="--provider-line-color: var(--syntax-blue)" href="/providers/kubernetes/"><span class="provider-name">kubernetes</span>: Kubernetes</a>
 <span class="landing-ok">✓</span> Saved to ~/.config/secretspec/config.toml</span>
 
 <span class="landing-run-step"><span class="tok-com"># 3. Run your app with secrets injected</span>
@@ -1153,7 +1153,7 @@ const reelScriptData = {
     <div class="landing-section-centered">
       <h2 class="landing-section-title">Make the declaration your source of truth.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        One manifest defines what your app needs. Profiles choose when, providers where, and scopes (0.17+) which consumer receives it.
+        One manifest defines what your app needs. Profiles choose when, providers where, and scopes which consumer receives it.
       </p>
     </div>
 
@@ -1183,14 +1183,14 @@ const reelScriptData = {
       </a>
 
       <a href="/concepts/scopes/" class="landing-bento-card is-link landing-bento-2">
-        <p class="landing-bento-title">Scopes (0.17+)</p>
+        <p class="landing-bento-title">Scopes</p>
         <p class="landing-bento-desc">Resolve and expose only the declared subset of secrets that each service, command, or task needs.</p>
         <pre is:raw class="landing-bento-mini-code"><code><span class="tok-sec">[scopes.api]</span>
 <span class="tok-key">secrets</span> <span class="tok-pun">= [</span><span class="tok-str">"DATABASE_URL"</span><span class="tok-pun">,</span> <span class="tok-str">"API_KEY"</span><span class="tok-pun">]</span></code></pre>
       </a>
 
       <a href="/concepts/providers/caching/" class="landing-bento-card is-link landing-bento-2">
-        <p class="landing-bento-title">Provider caching (0.17+)</p>
+        <p class="landing-bento-title">Provider caching</p>
         <p class="landing-bento-desc">Reuse a fresh local copy of a slow provider route for a configured window, with explicit invalidation.</p>
         <pre is:raw class="landing-bento-mini-code"><code><span class="tok-key">fast_vault</span> <span class="tok-pun">= {</span>
   <span class="tok-key">fallback</span> <span class="tok-pun">= [</span><span class="tok-str">"vault"</span><span class="tok-pun">],</span>
@@ -1202,7 +1202,7 @@ const reelScriptData = {
       </a>
 
       <a href="/reference/configuration/#cross-secret-presence-constraints-017" class="landing-bento-card is-link landing-bento-2">
-        <p class="landing-bento-title">Credential alternatives (0.17+)</p>
+        <p class="landing-bento-title">Credential alternatives</p>
         <p class="landing-bento-desc">Require at least one credential—or exactly one—without treating every alternative as independently required.</p>
         <pre is:raw class="landing-bento-mini-code"><code><span class="tok-key">PASSWORD</span> <span class="tok-pun">= {</span>
   <span class="tok-key">required</span> <span class="tok-pun">= {</span> <span class="tok-key">at_least_one</span> <span class="tok-pun">=</span> <span class="tok-str">"auth"</span> <span class="tok-pun">}</span>
@@ -1392,7 +1392,7 @@ const reelScriptData = {
 <section class="landing-showcase landing-scopes-demo" data-scopes-demo data-active-scope="api">
   <div class="landing-container">
     <div class="landing-showcase-head">
-      <span class="landing-showcase-eyebrow">Scopes · 0.17+</span>
+      <span class="landing-showcase-eyebrow">Scopes</span>
       <h2 class="landing-section-title">Give each service only the secrets it needs.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
         Allowlist secrets for each service, command, or task. Everything else stays out of the child process. <a href="/concepts/scopes/" class="landing-link">Scopes →</a>
@@ -1884,7 +1884,7 @@ Enter access_token for provider 'bws': <span class="tok-str">****</span>
       <div class="landing-terminal">
         <div class="landing-terminal-header">
           <div class="landing-terminal-dots"><span></span><span></span><span></span></div>
-          <span class="landing-terminal-title">GitHub &amp; Forgejo Actions (0.17+)</span>
+          <span class="landing-terminal-title">GitHub &amp; Forgejo Actions</span>
         </div>
         <pre is:raw class="landing-terminal-body"><code><span class="tok-com"># Resolve only the API deployment scope</span>
 - <span class="tok-key">uses</span><span class="tok-pun">:</span> actions/checkout@v7
@@ -1899,7 +1899,7 @@ Enter access_token for provider 'bws': <span class="tok-str">****</span>
     </div>
 
     <p class="landing-chain-result" style="margin-top: 1.5rem;">
-      The 0.17+ action masks every value, fails when a required secret is missing, and exposes the selected scope to later steps. Vault and OpenBao can use the runner's OIDC identity instead of a stored provider credential. <a href="/ci/github-actions/" class="landing-link">Configure Actions →</a>
+      The action masks every value, fails when a required secret is missing, and exposes the selected scope to later steps. Vault and OpenBao can use the runner's OIDC identity instead of a stored provider credential. <a href="/ci/github-actions/" class="landing-link">Configure Actions →</a>
     </p>
   </div>
 </section>
@@ -1911,7 +1911,7 @@ Enter access_token for provider 'bws': <span class="tok-str">****</span>
       <span class="landing-showcase-eyebrow">Language SDKs</span>
       <h2 class="landing-section-title">Resolve secrets directly from your language.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
-        One resolver across {sdkCount} SDKs—Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell, PHP, C#, Swift (0.18+) and JVM (0.20+). Same profiles. Same providers. <a href="/sdk/overview/" class="landing-link">SDKs →</a>
+        One resolver across {sdkCount} SDKs—Rust, Python, Go, Ruby, Node.js/TypeScript, Haskell, PHP, C#, Swift and JVM. Same profiles. Same providers. <a href="/sdk/overview/" class="landing-link">SDKs →</a>
       </p>
     </div>
 
@@ -2065,7 +2065,7 @@ Enter access_token for provider 'bws': <span class="tok-str">****</span>
 <section id="remote-secrets" class="landing-showcase landing-remote-demo" data-flow-demo="cache">
   <div class="landing-container">
     <div class="landing-showcase-head">
-      <span class="landing-showcase-eyebrow">Remote secrets · 0.17+</span>
+      <span class="landing-showcase-eyebrow">Remote secrets</span>
       <h2 class="landing-section-title">Remote secrets, local speed.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
         Fetch from Azure once. Serve reads locally until the cache expires. <a href="/concepts/providers/caching/" class="landing-link">Provider caching →</a>
@@ -2175,7 +2175,7 @@ Enter access_token for provider 'bws': <span class="tok-str">****</span>
 <section id="credential-bootstrapping" class="landing-showcase landing-remote-demo" data-flow-demo="bootstrap">
   <div class="landing-container">
     <div class="landing-showcase-head">
-      <span class="landing-showcase-eyebrow">Credential bootstrapping · 0.15+</span>
+      <span class="landing-showcase-eyebrow">Credential bootstrapping</span>
       <h2 class="landing-section-title">Start local. Unlock remote.</h2>
       <p class="landing-section-lead landing-section-lead-narrow">
         Store credentials locally. Unlock remote providers. Deliver only the secrets your app requests. <a href="/reference/provider-credentials/" class="landing-link">Provider credentials →</a>


### PR DESCRIPTION
## Summary

- add strict `new` and `changed` variants to the shared `VersionCompatibility` component
- render new features as a bodyless “New in version X” notice and behavior changes as “Changed in version X” with required clarification text
- place page-level notices at the very top and section-level notices directly below their headings
- remove version numbers from 112 heading titles while preserving every existing fragment URL
- remove release annotations from the landing page provider, SDK, terminal, feature, and showcase labels
- migrate 161 notices across 48 documentation pages and enforce the placement, body, title, and URL conventions in the docs build

## Testing

- `npm --prefix docs run build`
- rendered-site audit: no version numbers in “On this page” labels
- rendered landing-page audit: no release annotations
- historical-fragment audit: all 112 affected heading URLs preserved

Addresses #406.