### PR TITLE
feat(config): add project default provider chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Projects can select a default provider chain in 0.21+ with
+  `[defaults].providers`. Secret and profile provider chains retain precedence,
+  and the project default can name a user-global alias whose `ref` template
+  expands `{project}`, `{profile}`, and `{key}` for the active project. Native
+  SDK inline declarations expose the same setting through inline schema v2.
+
 - The age provider supports deleting secrets in 0.20+: `secretspec delete`,
   `secretspec import --delete-source`, and cache invalidation now work with it,
   so an age-encrypted file can serve as the local store of a cached provider

--- a/docs/src/content/docs/concepts/profiles.mdx
+++ b/docs/src/content/docs/concepts/profiles.mdx
@@ -172,9 +172,10 @@ make a non-default profile standalone; unlike `required`, `default`, and
 than supplying a value to each secret. The precedence order is:
 
 1. **Secret-level configuration** (highest priority) -- explicit settings in the secret definition
-2. **Profile defaults** -- from `profiles.<name>.defaults`
-3. **Profile inheritance** -- inherited from default profile
-4. **Global defaults** (lowest priority) -- from CLI, environment, or global config
+2. **Profile inheritance** -- inherited from the default profile when the active profile omits a field
+3. **Profile defaults** -- from `profiles.<name>.defaults`
+4. **Project provider defaults** -- from `[defaults].providers` in 0.21+
+5. **Global defaults** (lowest priority) -- from CLI, environment, or global config
 
 This is particularly useful for setting common [provider fallback routes](/concepts/providers/fallback/#ordered-fallback-routes), requirements, or defaults across all secrets in a profile.
 

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -151,6 +151,34 @@ $ secretspec run --provider "onepassword://Development" -- npm start
 $ secretspec run --provider "dotenv:/home/user/work/.env" -- npm test
 ```
 
+## Configure a project default provider chain (0.21+)
+
+<VersionCompatibility version="0.21" />
+
+Use project `[defaults].providers` when every profile should use the same
+provider chain unless a profile or secret overrides it. The chain can name a
+user-global alias, allowing each developer to supply personal provider-native
+coordinates while the committed manifest stays the same:
+
+```toml title="secretspec.toml"
+[defaults]
+providers = ["developer"]
+
+[profiles.staging]
+DATABASE_PASSWORD = { description = "Personal staging database password" }
+```
+
+```toml title="~/.config/secretspec/config.toml"
+[defaults.providers.developer]
+uri = "awsps://developer@us-east-1"
+ref = { item = "/{project}/{profile}/developers/alice/{key}" }
+```
+
+The alias's existing `{project}`, `{profile}`, and `{key}` placeholders expand
+in the project that selects it. Only `alice` is user-specific. Do not also
+declare `developer` in the project's `[providers]` table, because a project
+alias with the same name takes precedence over the user-global alias.
+
 ## Configure provider aliases
 
 Provider aliases can be declared at either project or user scope:

--- a/docs/src/content/docs/concepts/providers/caching.mdx
+++ b/docs/src/content/docs/concepts/providers/caching.mdx
@@ -178,6 +178,7 @@ An inline cached provider alias or cached fallback alias works anywhere a
 complete route is selected:
 
 - a secret or profile-default `providers` list;
+- a project `[defaults].providers` list (0.21+);
 - the user-global default provider;
 - `SECRETSPEC_PROVIDER`;
 - `--provider`.

--- a/docs/src/content/docs/concepts/providers/fallback.md
+++ b/docs/src/content/docs/concepts/providers/fallback.md
@@ -15,11 +15,12 @@ SecretSpec selects each secret's route in this order:
 2. The `SECRETSPEC_PROVIDER` environment variable.
 3. The secret's effective `providers` list after profile inheritance and
    `[profiles.<name>.defaults]` are applied.
-4. The default provider in the user configuration.
+4. Project `[defaults].providers` (0.21+).
+5. The default provider in the user configuration.
 
 `--provider` and `SECRETSPEC_PROVIDER` replace the configured route for every
-secret. Without an override or effective `providers` list, SecretSpec uses the
-user-level default.
+secret. Without an override, effective `providers` list, or project default
+chain (0.21+), SecretSpec uses the user-level default.
 
 ## Ordered fallback routes
 
@@ -31,6 +32,9 @@ from left to right:
 prod_vault = "onepassword://Production"
 local = "keyring://"
 
+[defaults] # 0.21+
+providers = ["local"]
+
 [profiles.production.defaults]
 providers = ["prod_vault", "local"]
 
@@ -40,6 +44,10 @@ DATABASE_URL = { description = "Production database" }
 
 # Overrides the profile default and reads only from the environment.
 DEPLOY_TOKEN = { description = "Deployment token", providers = ["env"] }
+
+[profiles.development]
+# Uses the project default provider chain in SecretSpec 0.21+.
+DATABASE_URL = { description = "Development database" }
 ```
 
 Reads stop at the first value. Writes and generated values go only to the first

--- a/docs/src/content/docs/concepts/references.mdx
+++ b/docs/src/content/docs/concepts/references.mdx
@@ -60,7 +60,8 @@ exactly how each provider maps the coordinates.
 A `ref` supplies naming only. It does not pin the secret to a particular store.
 Which provider actually resolves the coordinates follows the ordinary
 [provider resolution order](/concepts/providers/fallback/): a `--provider` override, then
-the secret's `providers` chain, then the profile and global defaults.
+the secret's `providers` chain, then profile defaults, project
+`[defaults].providers` in 0.21+, and the user-global default.
 
 This is the difference from pasting a store URL into your config. Because the
 store is not baked into the reference, the same `ref` works across providers.

--- a/docs/src/content/docs/development/sdks.mdx
+++ b/docs/src/content/docs/development/sdks.mdx
@@ -119,7 +119,7 @@ carries a logical `base_dir`, used for relative provider paths as
 `Secrets::from_spec_at` does.
 
 The inline specification is strict JSON, not the private Rust `Config` or a
-serialized compiled manifest. Its v1 shape contains `project`, `profiles`, and
+serialized compiled manifest. Its v2 shape contains `project`, `profiles`, and
 a `secrets` object per profile, with optional provider aliases, scopes, and
 the normal secret declaration fields. `project.extends` uses paths relative to
 the inline declaration's `base_dir`, so the full configuration model—including
@@ -128,6 +128,8 @@ versions, and unsupported operations are rejected. SDKs bind `secretspec_call`
 only when using inline specs: an older library therefore reports the missing
 capability instead of silently ignoring an unknown field and loading a
 filesystem manifest.
+
+Inline schema v2 adds project-level `defaults.providers` in SecretSpec 0.21+.
 
 `scripts/build-swift-xcframework.sh` changes Cargo's target-local dylib install
 name to `@rpath`, merges the native slices into a universal dylib, adds the C

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -81,6 +81,29 @@ The reason is recorded in secretspec's own [audit log](/concepts/audit/) and is
 also forwarded to providers that support auditing (e.g. the
 [Proton Pass](/providers/protonpass/) provider records it in the agent audit log).
 
+### [defaults] Section (0.21+)
+
+<VersionCompatibility version="0.21" />
+
+Set one project-wide provider chain for provider-backed secrets that do not
+choose providers themselves or through their active profile:
+
+```toml title="secretspec.toml"
+[defaults]
+providers = ["developer"]
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `providers` | array[string] | Yes | Non-empty default provider chain for every profile. Entries may be aliases, provider names, or provider URIs. |
+
+Project defaults deliberately accept only `providers`: a literal fallback value
+or requiredness policy rarely makes sense for every secret in every profile.
+The chain may name an alias defined in the project `[providers]` table or only
+in the current user's `[defaults.providers]` table. A secret-level chain wins,
+followed by `[profiles.<name>.defaults].providers`, this project default, and
+finally the user-global default provider.
+
 ### [profiles.*] Section
 
 Defines secret variables for different environments. At least one profile is
@@ -107,7 +130,7 @@ profile:
 | `inherit` (0.19+) | boolean | No | For a non-default profile, whether to inherit declarations and omitted fields from `[profiles.default]` (default: true) |
 | `required` | boolean | No | Default requiredness for secrets declared in this profile |
 | `default` | string | No | Default value for secrets declared in this profile |
-| `providers` | array[string] | No | Default provider chain for secrets declared in this profile |
+| `providers` | array[string] | No | Default provider chain for secrets declared in this profile. Overrides project `[defaults].providers` in 0.21+. |
 
 In SecretSpec 0.19+, set `inherit = false` for a standalone profile:
 

--- a/libsecretspec/include/secretspec.h
+++ b/libsecretspec/include/secretspec.h
@@ -72,7 +72,7 @@ char *secretspec_resolve(const char *request_json);
  *   "request_version": 1,
  *   "operation": "resolve",
  *   "source": {
- *     "kind": "inline", "spec_version": 1, "base_dir": "/project",
+ *     "kind": "inline", "spec_version": 2, "base_dir": "/project",
  *     "spec": {
  *       "project": { "name": "my-app" },
  *       "profiles": {
@@ -86,7 +86,7 @@ char *secretspec_resolve(const char *request_json);
  * }
  *
  * source.kind is exactly one of "search", "path" (with path), or "inline".
- * Inline spec v1 is strict JSON: profile declarations use a `secrets` object,
+ * Inline spec v2 is strict JSON: profile declarations use a `secrets` object,
  * and unknown declaration fields are rejected. Its base_dir resolves relative
  * provider paths like Secrets::from_spec_at. project.extends is supported and
  * resolves parent manifests relative to base_dir, like a file-backed Spec.

--- a/libsecretspec/src/tests.rs
+++ b/libsecretspec/src/tests.rs
@@ -73,7 +73,7 @@ fn abi_version_is_nonempty() {
 }
 
 #[test]
-fn call_resolves_a_strict_inline_spec_at_its_logical_base_directory() {
+fn call_resolves_inline_project_defaults_at_its_logical_base_directory() {
     let dir = TempDir::new().unwrap();
     let env_path = dir.path().join("inline.env");
     fs::write(&env_path, "TOKEN=from-inline\n").unwrap();
@@ -82,15 +82,16 @@ fn call_resolves_a_strict_inline_spec_at_its_logical_base_directory() {
         "operation": "resolve",
         "source": {
             "kind": "inline",
-            "spec_version": 1,
+            "spec_version": 2,
             "base_dir": dir.path(),
             "spec": {
                 "project": { "name": "inline-ffi" },
+                "defaults": { "providers": ["env"] },
                 "providers": { "env": "dotenv://inline.env" },
                 "profiles": {
                     "default": {
                         "secrets": {
-                            "TOKEN": { "description": "inline token", "providers": ["env"] }
+                            "TOKEN": { "description": "inline token" }
                         }
                     }
                 }
@@ -131,7 +132,7 @@ TOKEN = { description = "inherited token", providers = ["env"] }
         "operation": "resolve",
         "source": {
             "kind": "inline",
-            "spec_version": 1,
+            "spec_version": 2,
             "base_dir": dir.path(),
             "spec": {
                 "project": { "name": "child", "extends": ["parent"] },
@@ -158,7 +159,7 @@ fn call_rejects_unknown_versions_operations_and_source_combinations() {
         }),
         serde_json::json!({
             "request_version": 1, "operation": "resolve",
-            "source": { "kind": "inline", "spec_version": 2, "base_dir": ".", "spec": {} }
+            "source": { "kind": "inline", "spec_version": 3, "base_dir": ".", "spec": {} }
         }),
         serde_json::json!({
             "request_version": 1, "operation": "resolve",
@@ -180,7 +181,7 @@ fn call_rejects_unknown_inline_declaration_fields() {
         "request_version": 1,
         "operation": "resolve",
         "source": {
-            "kind": "inline", "spec_version": 1, "base_dir": ".",
+            "kind": "inline", "spec_version": 2, "base_dir": ".",
             "spec": {
                 "project": { "name": "inline" },
                 "profiles": { "default": { "secrets": {
@@ -204,7 +205,7 @@ fn call_accepts_scalar_required_group_names() {
         "request_version": 1,
         "operation": "resolve",
         "source": {
-            "kind": "inline", "spec_version": 1, "base_dir": ".",
+            "kind": "inline", "spec_version": 2, "base_dir": ".",
             "spec": {
                 "project": { "name": "inline-groups" },
                 "profiles": { "default": { "secrets": {
@@ -236,7 +237,7 @@ fn call_rejects_empty_required_groups() {
         "request_version": 1,
         "operation": "resolve",
         "source": {
-            "kind": "inline", "spec_version": 1, "base_dir": ".",
+            "kind": "inline", "spec_version": 2, "base_dir": ".",
             "spec": {
                 "project": { "name": "inline-groups" },
                 "profiles": { "default": { "secrets": {

--- a/secretspec-derive/src/tests.rs
+++ b/secretspec-derive/src/tests.rs
@@ -251,6 +251,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         );
 
         let valid_config = Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -299,6 +300,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         );
 
         let invalid_config = Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -380,6 +382,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         );
 
         let keyword_config = Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -460,6 +463,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         );
 
         let duplicate_config = Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -515,6 +519,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         );
 
         let valid_config = Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -548,6 +553,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         );
 
         let invalid_config = Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -679,6 +685,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         );
 
         let valid_config = Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -724,6 +731,7 @@ HAS_DEFAULT = { description = "Secret with default", required = false, default =
         );
 
         let invalid_config = Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()

--- a/secretspec-dotnet/src/SecretSpec/SecretSpecBuilder.cs
+++ b/secretspec-dotnet/src/SecretSpec/SecretSpecBuilder.cs
@@ -179,7 +179,7 @@ public sealed class SecretSpecBuilder
             writer.WritePropertyName("source");
             writer.WriteStartObject();
             writer.WriteString("kind", "inline");
-            writer.WriteNumber("spec_version", 1);
+            writer.WriteNumber("spec_version", 2);
             writer.WriteString("base_dir", _inlineBaseDir);
             writer.WritePropertyName("spec");
             _inlineSpec.WriteTo(writer);

--- a/secretspec-go/secretspec.go
+++ b/secretspec-go/secretspec.go
@@ -433,7 +433,7 @@ func (b *Builder) execute(mode string) (string, error) {
 		"request_version": 1,
 		"operation":       "resolve",
 		"source": map[string]any{
-			"kind": "inline", "spec_version": 1,
+			"kind": "inline", "spec_version": 2,
 			"base_dir": b.inline.baseDir, "spec": b.inline.spec,
 		},
 		"options": options,

--- a/secretspec-hs/src/SecretSpec.hs
+++ b/secretspec-hs/src/SecretSpec.hs
@@ -329,7 +329,7 @@ requestBytes b mode =
       , "operation" .= ("resolve" :: Text)
       , "source" .= object
           [ "kind" .= ("inline" :: Text)
-          , "spec_version" .= (1 :: Int)
+          , "spec_version" .= (2 :: Int)
           , "base_dir" .= baseDir
           , "spec" .= spec
           ]

--- a/secretspec-jvm/gradle.properties
+++ b/secretspec-jvm/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=false
-org.gradle.java.installations.fromEnv=SECRETSPEC_JVM_TARGET_JDK,JAVA_HOME_11_X64,JAVA_HOME_11_ARM64
+org.gradle.java.installations.fromEnv=SECRETSPEC_JVM_TARGET_JDK,JAVA_HOME_11_X64,JAVA_HOME_11_ARM64,JAVA_HOME_11_AARCH64
 secretspec.version=0.20.0-SNAPSHOT

--- a/secretspec-jvm/library/src/main/java/org/cachix/secretspec/SecretSpec.java
+++ b/secretspec-jvm/library/src/main/java/org/cachix/secretspec/SecretSpec.java
@@ -247,7 +247,7 @@ public class SecretSpec {
 
             var source = root.putObject("source");
             source.put("kind", "inline");
-            source.put("spec_version", 1);
+            source.put("spec_version", 2);
             source.put("base_dir", inlineBaseDir);
             source.set("spec", inlineSpec);
 

--- a/secretspec-node/index.js
+++ b/secretspec-node/index.js
@@ -323,7 +323,7 @@ class Builder {
     return {
       request_version: 1,
       operation: 'resolve',
-      source: { kind: 'inline', spec_version: 1, base_dir: this._inline.baseDir, spec: this._inline.spec },
+      source: { kind: 'inline', spec_version: 2, base_dir: this._inline.baseDir, spec: this._inline.spec },
       options,
     };
   }

--- a/secretspec-php/src/Builder.php
+++ b/secretspec-php/src/Builder.php
@@ -222,7 +222,7 @@ final class Builder
             'request_version' => 1,
             'operation' => 'resolve',
             'source' => [
-                'kind' => 'inline', 'spec_version' => 1,
+                'kind' => 'inline', 'spec_version' => 2,
                 'base_dir' => $this->inline['base_dir'], 'spec' => $this->inline['spec'],
             ],
             'options' => $options,

--- a/secretspec-py/secretspec/__init__.py
+++ b/secretspec-py/secretspec/__init__.py
@@ -415,7 +415,7 @@ class _Builder:
         return ({
             "request_version": 1,
             "operation": "resolve",
-            "source": {"kind": "inline", "spec_version": 1,
+            "source": {"kind": "inline", "spec_version": 2,
                        "base_dir": base_dir, "spec": spec},
             "options": options,
         }, True)

--- a/secretspec-rb/lib/secretspec.rb
+++ b/secretspec-rb/lib/secretspec.rb
@@ -293,7 +293,7 @@ module Secretspec
       return [options, false] unless @inline
 
       [{ "request_version" => 1, "operation" => "resolve",
-         "source" => { "kind" => "inline", "spec_version" => 1,
+         "source" => { "kind" => "inline", "spec_version" => 2,
                        "base_dir" => @inline["base_dir"], "spec" => @inline["spec"] },
          "options" => options }, true]
     end

--- a/secretspec-swift/Sources/SecretSpec/SecretSpec.swift
+++ b/secretspec-swift/Sources/SecretSpec/SecretSpec.swift
@@ -216,7 +216,7 @@ public struct SecretSpecBuilder: Sendable {
                     "request_version": 1,
                     "operation": "resolve",
                     "source": [
-                        "kind": "inline", "spec_version": 1,
+                        "kind": "inline", "spec_version": 2,
                         "base_dir": inline.baseDir, "spec": declaration,
                     ],
                     "options": try JSONSerialization.jsonObject(with: JSONEncoder().encode(configured)),

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -156,6 +156,10 @@ revision = "1.0"
 # Optional: extend other configuration files
 extends = ["../shared/common", "../shared/auth"]
 
+# SecretSpec 0.21+: use one provider chain unless a profile or secret overrides it.
+[defaults]
+providers = ["developer"]
+
 [profiles.default]
 DATABASE_URL = { description = "PostgreSQL connection string" }
 REDIS_URL = { description = "Redis connection string" }

--- a/secretspec/src/cli/mod.rs
+++ b/secretspec/src/cli/mod.rs
@@ -1024,6 +1024,7 @@ pub fn main() -> Result<()> {
                     ..Default::default()
                 },
                 profiles,
+                defaults: None,
                 providers: None,
                 scopes: None,
             };
@@ -1828,6 +1829,7 @@ mod tests {
         let mut secrets = HashMap::new();
         secrets.insert("S".to_string(), secret);
         Config {
+            defaults: None,
             project: Project {
                 name: "myproj".to_string(),
                 ..Default::default()
@@ -2066,6 +2068,7 @@ mod tests {
         // project name contains a quote. Before escaping was added these produced
         // malformed TOML that failed to parse back.
         let config = Config {
+            defaults: None,
             project: Project {
                 name: "weird \"name\"".to_string(),
                 ..Default::default()

--- a/secretspec/src/codegen.rs
+++ b/secretspec/src/codegen.rs
@@ -292,6 +292,7 @@ mod tests {
             );
         }
         Config {
+            defaults: None,
             project: Project {
                 name: "ir-test".to_string(),
                 ..Default::default()

--- a/secretspec/src/compiled_spec.rs
+++ b/secretspec/src/compiled_spec.rs
@@ -180,8 +180,13 @@ impl CompiledSpec {
                 .map(|name| {
                     let current = profile.secrets.get(name);
                     let default = inherited.and_then(|p| p.secrets.get(name));
-                    let effective = Secret::resolved(current, default, profile.defaults.as_ref())
-                        .expect("an effective name comes from current or default");
+                    let effective = Secret::resolved(
+                        current,
+                        default,
+                        profile.defaults.as_ref(),
+                        config.defaults.as_ref(),
+                    )
+                    .expect("an effective name comes from current or default");
                     (name.clone(), effective)
                 })
                 .collect();

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -657,6 +657,9 @@ pub struct Config {
     pub project: Project,
     /// Map of profile names to their configurations (e.g., "default", "production", "staging")
     pub profiles: HashMap<String, Profile>,
+    /// Project-wide defaults applied to every provider-backed secret (0.21+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub defaults: Option<ProjectDefaults>,
     /// Project-level provider aliases that map alias names to provider URIs.
     ///
     /// Take precedence over aliases in the user-global config
@@ -704,6 +707,10 @@ impl Config {
             return Err(ParseError::Validation(
                 "At least one profile must be defined".into(),
             ));
+        }
+
+        if let Some(defaults) = &self.defaults {
+            defaults.validate().map_err(ParseError::Validation)?;
         }
 
         // Raw syntax checks stay on the document model; effective semantic
@@ -840,6 +847,10 @@ impl Config {
                     self.profiles.insert(profile_name, later_profile);
                 }
             }
+        }
+
+        if later.defaults.is_some() {
+            self.defaults = later.defaults;
         }
 
         if let Some(later_providers) = later.providers {
@@ -1360,6 +1371,35 @@ pub struct Profile {
     /// Map of secret names to their configurations, flattened in TOML for cleaner syntax
     #[serde(flatten)]
     pub secrets: HashMap<String, Secret>,
+}
+
+/// Project-wide defaults for provider-backed secrets (0.21+).
+///
+/// This is deliberately narrower than [`ProfileDefaults`]: a project can
+/// select one provider chain without assigning the same fallback value or
+/// requiredness policy to every secret in every profile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectDefaults {
+    /// Provider aliases, names, or URIs used when neither a secret nor its
+    /// profile declares a provider chain.
+    pub providers: Vec<String>,
+}
+
+impl ProjectDefaults {
+    fn validate(&self) -> Result<(), String> {
+        if self.providers.is_empty() {
+            return Err("project defaults must name at least one provider".to_string());
+        }
+        if self
+            .providers
+            .iter()
+            .any(|provider| provider.trim().is_empty())
+        {
+            return Err("project default providers cannot be empty or whitespace".to_string());
+        }
+        Ok(())
+    }
 }
 
 /// A named, membership-only subset of a profile's secrets.
@@ -2159,8 +2199,10 @@ pub struct Secret {
     pub composed: Option<String>,
     /// Optional list of provider aliases for retrieving this secret.
     /// Providers are tried in order until one has the secret.
-    /// If not specified, uses the profile defaults.providers or global provider.
-    /// Each alias is resolved against the providers map in GlobalConfig.
+    /// If not specified, uses the profile defaults, project defaults in 0.21+,
+    /// or the user-global provider.
+    /// Aliases resolve against the project's provider map first, then the
+    /// user-global provider map.
     /// Example: providers = ["keyring", "env"] will try keyring first, then env.
     pub providers: Option<Vec<String>>,
     /// Native coordinates naming one externally managed secret (see
@@ -2655,14 +2697,16 @@ impl Secret {
     /// acts on.
     ///
     /// Precedence (highest to lowest): the current profile's entry, the
-    /// default profile's entry, then the current profile's `[defaults]` table
-    /// (for the fields it can supply). Shared by secret resolution
+    /// default profile's entry, the current profile's `[defaults]` table, then
+    /// project `[defaults].providers` in 0.21+ (for the fields each can supply).
+    /// Shared by secret resolution
     /// (`Secrets::resolve_secret_config`) and `Config::validate` so the two
     /// can never disagree about what a merged secret looks like.
     pub(crate) fn resolved(
         current: Option<&Secret>,
         default: Option<&Secret>,
         defaults: Option<&ProfileDefaults>,
+        project_defaults: Option<&ProjectDefaults>,
     ) -> Option<Secret> {
         if current.is_none() && default.is_none() {
             return None;
@@ -2695,9 +2739,14 @@ impl Secret {
         } else {
             (defaults.and_then(|d| d.required), None, None)
         };
-        // A composed secret's source is its dependency graph, so the
-        // `[defaults]` storage fields (`default`, `providers`) do not apply.
+        // A composed secret's source is its dependency graph, so neither the
+        // profile's storage defaults nor project default providers apply.
         let storage_defaults = if composed.is_some() { None } else { defaults };
+        let project_providers = if composed.is_none() {
+            project_defaults.map(|defaults| defaults.providers.clone())
+        } else {
+            None
+        };
         // `ref` and `refs` are two serialized forms of one address-model
         // setting. Select the pair from one profile entry so an explicit switch
         // in either direction replaces, rather than combines with, the inherited
@@ -2719,7 +2768,8 @@ impl Secret {
                 .or_else(|| storage_defaults.and_then(|d| d.default.clone())),
             composed,
             providers: inherit(current, default, |s| s.providers.clone())
-                .or_else(|| storage_defaults.and_then(|d| d.providers.clone())),
+                .or_else(|| storage_defaults.and_then(|d| d.providers.clone()))
+                .or(project_providers),
             reference,
             refs,
             as_path: inherit(current, default, |s| s.as_path),
@@ -3120,6 +3170,7 @@ mod require_reason_tests {
     fn extends_inherits_parent_require_reason_when_unspecified() {
         use std::collections::HashMap;
         let cfg = |rr: Option<RequireReason>| Config {
+            defaults: None,
             project: Project {
                 name: "t".to_string(),
                 require_reason: rr,
@@ -3324,6 +3375,7 @@ mod validation_tests {
             })
             .collect();
         Config {
+            defaults: None,
             project: Project {
                 name: name.to_string(),
                 ..Default::default()
@@ -3776,6 +3828,122 @@ providers = ["keyring"]
     }
 
     #[test]
+    fn project_default_providers_apply_with_narrow_precedence() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "payments"
+revision = "1.0"
+
+[defaults]
+providers = ["project"]
+
+[profiles.default]
+SHARED = { description = "Shared secret" }
+
+[profiles.production.defaults]
+providers = ["profile"]
+
+[profiles.production]
+DIRECT = { description = "Direct secret", providers = ["secret"] }
+"#,
+        )
+        .unwrap();
+
+        let compiled = config.validate_and_compile().unwrap();
+        let default = compiled.profile("default").unwrap();
+        assert_eq!(
+            default.secrets["SHARED"].config.providers.as_deref(),
+            Some(["project".to_string()].as_slice())
+        );
+
+        let production = compiled.profile("production").unwrap();
+        assert_eq!(
+            production.secrets["SHARED"].config.providers.as_deref(),
+            Some(["profile".to_string()].as_slice())
+        );
+        assert_eq!(
+            production.secrets["DIRECT"].config.providers.as_deref(),
+            Some(["secret".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn project_defaults_accept_only_a_nonempty_provider_chain() {
+        for body in [
+            "[defaults]\nproviders = []",
+            "[defaults]\nproviders = [\"  \"]",
+        ] {
+            let source = format!(
+                r#"
+[project]
+name = "payments"
+revision = "1.0"
+
+{body}
+
+[profiles.default]
+TOKEN = {{ description = "Token" }}
+"#
+            );
+            let config: Config = toml::from_str(&source).unwrap();
+            assert!(config.validate().is_err(), "{source}");
+        }
+
+        let error = toml::from_str::<Config>(
+            r#"
+[project]
+name = "payments"
+revision = "1.0"
+
+[defaults]
+default = "same value for every secret"
+
+[profiles.default]
+TOKEN = { description = "Token" }
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("unknown field `default`"), "{error}");
+    }
+
+    #[test]
+    fn later_documents_override_project_defaults_only_when_present() {
+        let parse = |providers: Option<&str>| {
+            let defaults = providers
+                .map(|provider| format!("[defaults]\nproviders = [\"{provider}\"]\n"))
+                .unwrap_or_default();
+            toml::from_str::<Config>(&format!(
+                r#"
+[project]
+name = "payments"
+revision = "1.0"
+
+{defaults}
+[profiles.default]
+TOKEN = {{ description = "Token" }}
+"#
+            ))
+            .unwrap()
+        };
+
+        let mut inherited = parse(Some("parent"));
+        inherited.overlay_with(parse(None));
+        assert_eq!(
+            inherited.defaults.unwrap().providers,
+            vec!["parent".to_string()]
+        );
+
+        let mut overridden = parse(Some("parent"));
+        overridden.overlay_with(parse(Some("child")));
+        assert_eq!(
+            overridden.defaults.unwrap().providers,
+            vec!["child".to_string()]
+        );
+    }
+
+    #[test]
     fn config_validate_allows_profile_override_to_inherit_description() {
         // required = true in the default profile plus a default value from
         // the override is also fine: only that combination within a single
@@ -3969,7 +4137,7 @@ default = "placeholder"
         let rendered = toml::to_string(&parsed).unwrap();
         assert!(rendered.contains("prompt = true"), "{rendered}");
 
-        let inherited = Secret::resolved(None, Some(&parsed), None).unwrap();
+        let inherited = Secret::resolved(None, Some(&parsed), None, None).unwrap();
         assert_eq!(inherited.prompt, Some(true));
         let disabled = Secret::resolved(
             Some(&Secret {
@@ -3977,6 +4145,7 @@ default = "placeholder"
                 ..Default::default()
             }),
             Some(&parsed),
+            None,
             None,
         )
         .unwrap();
@@ -4100,7 +4269,7 @@ refs = { remote = { item = "scoped" } }"#,
             ..Default::default()
         };
 
-        let resolved = Secret::resolved(Some(&scoped), Some(&legacy), None).unwrap();
+        let resolved = Secret::resolved(Some(&scoped), Some(&legacy), None, None).unwrap();
         assert!(
             resolved.reference.is_none(),
             "an explicit `refs` override must replace an inherited legacy `ref`"
@@ -4108,7 +4277,7 @@ refs = { remote = { item = "scoped" } }"#,
         assert_eq!(resolved.refs, scoped.refs);
         resolved.validate().unwrap();
 
-        let resolved = Secret::resolved(Some(&legacy), Some(&scoped), None).unwrap();
+        let resolved = Secret::resolved(Some(&legacy), Some(&scoped), None, None).unwrap();
         assert_eq!(resolved.reference, legacy.reference);
         assert!(
             resolved.refs.is_none(),
@@ -4247,6 +4416,7 @@ refs = { remote = { item = "scoped" } }"#,
                 ..Default::default()
             }),
             None,
+            None,
         )
         .unwrap();
         assert_eq!(inherited.encoding, Some(SecretEncoding::Base64));
@@ -4290,6 +4460,7 @@ encoding = "rot13""#,
                 extract: secret.extract.clone(),
                 ..Default::default()
             }),
+            None,
             None,
         )
         .unwrap();

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -92,7 +92,8 @@ pub mod __private {
     }
 
     pub use crate::config::{
-        Config, GenerateConfig, GenerateOptions, Profile, ProfileDefaults, Project, Secret,
+        Config, GenerateConfig, GenerateOptions, Profile, ProfileDefaults, Project,
+        ProjectDefaults, Secret,
     };
     pub use crate::spec::load_for_codegen;
 }

--- a/secretspec/src/native.rs
+++ b/secretspec/src/native.rs
@@ -7,7 +7,8 @@
 
 use crate::config::{
     Config, GenerateConfig, GenerateOptions, Profile as ConfigProfile, ProfileDefaults, Project,
-    ProviderAlias, RequireReason, Scope, Secret as ConfigSecret, SecretEncoding, SecretExtract,
+    ProjectDefaults, ProviderAlias, RequireReason, Scope, Secret as ConfigSecret, SecretEncoding,
+    SecretExtract,
 };
 use crate::{CallerContext, Secrets, Spec};
 use serde::Deserialize;
@@ -17,7 +18,7 @@ use std::path::PathBuf;
 /// The version of the native call envelope understood by this library.
 pub const NATIVE_CALL_REQUEST_VERSION: u32 = 1;
 /// The version of the JSON inline-declaration document understood by this library.
-pub const INLINE_SPEC_SCHEMA_VERSION: u32 = 1;
+pub const INLINE_SPEC_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -111,9 +112,17 @@ struct InlineSpec {
     project: InlineProject,
     profiles: BTreeMap<String, InlineProfile>,
     #[serde(default)]
+    defaults: Option<InlineProjectDefaults>,
+    #[serde(default)]
     providers: Option<HashMap<String, ProviderAlias>>,
     #[serde(default)]
     scopes: Option<HashMap<String, InlineScope>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InlineProjectDefaults {
+    providers: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -285,6 +294,9 @@ impl InlineSpec {
                     ))
                 })
                 .collect::<std::result::Result<_, _>>()?,
+            defaults: self.defaults.map(|defaults| ProjectDefaults {
+                providers: defaults.providers,
+            }),
             providers: self.providers,
             scopes: self.scopes.map(|scopes| {
                 scopes
@@ -501,7 +513,7 @@ mod tests {
     fn inline_declaration_rejects_unknown_secret_fields() {
         let response: serde_json::Value = serde_json::from_str(&call_json(r#"{
           "request_version": 1, "operation": "resolve",
-          "source": { "kind": "inline", "spec_version": 1, "base_dir": ".", "spec": {
+          "source": { "kind": "inline", "spec_version": 2, "base_dir": ".", "spec": {
             "project": { "name": "inline" },
             "profiles": { "default": { "secrets": { "TOKEN": { "description": "token", "typo": true } } } }
           }}

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -784,7 +784,7 @@ fn coordinate_fingerprint<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{NativeAddressTemplate, ProviderAlias, ProviderCache};
+    use crate::config::{NativeAddressTemplate, ProjectDefaults, ProviderAlias, ProviderCache};
     use crate::error::SecretSpecError;
     use crate::tests::{global_config_with_aliases, scrub_resolution_env};
     use std::collections::HashMap;
@@ -1074,6 +1074,41 @@ mod tests {
             spec.address_for_spec(planned, Some("dotenv://other.env"), "app", "prod")
                 .unwrap(),
             OwnedAddress::convention("app", "prod", "API_KEY")
+        );
+    }
+
+    #[test]
+    fn project_default_uses_a_global_alias_template_with_logical_placeholders() {
+        let _env = scrub_resolution_env();
+        let mut config = crate::tests::resolve_test_config(HashMap::from([(
+            "API_KEY".to_string(),
+            secret(None),
+        )]));
+        config.project.name = "payments".to_string();
+        config.defaults = Some(ProjectDefaults {
+            providers: vec!["developer".to_string()],
+        });
+
+        let developer = ProviderAlias::from("env://")
+            .with_reference_template(NativeAddressTemplate {
+                item: "/{project}/{profile}/developers/alice/{key}".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let mut global = global_config_with_aliases(&[]);
+        global.defaults.providers = Some(HashMap::from([("developer".to_string(), developer)]));
+        let spec = Secrets::new(config, Some(global), None, None);
+
+        let plan = spec.build_plan(None).unwrap();
+        let planned = find(&plan, "API_KEY");
+        assert_eq!(route(planned).group_key(), Some("developer"));
+        assert_eq!(
+            spec.address_for_spec(planned, route(planned).group_key(), "payments", "default")
+                .unwrap(),
+            OwnedAddress::Native(NativeAddress {
+                item: "/payments/default/developers/alice/API_KEY".to_string(),
+                ..Default::default()
+            })
         );
     }
 

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -7313,6 +7313,7 @@ mod report_provider_tests {
     fn report_provider_uri_redacts_credentials() {
         let spec = Secrets::new(
             Config {
+                defaults: None,
                 project: crate::config::Project {
                     name: "redact-test".to_string(),
                     ..Default::default()
@@ -7493,6 +7494,7 @@ mod reference_routing_tests {
     fn spec_with_provider(provider: Option<&str>) -> Secrets {
         Secrets::new(
             Config {
+                defaults: None,
                 project: crate::config::Project {
                     name: "ref-test".to_string(),
                     ..Default::default()

--- a/secretspec/src/spec.rs
+++ b/secretspec/src/spec.rs
@@ -8,8 +8,8 @@
 use crate::compiled_spec::CompiledSpec;
 use crate::config::{
     Config, GenerateConfig, GenerateOptions, NativeAddress, Profile as ConfigProfile,
-    ProfileDefaults, Project, ProviderAlias, RequireReason, Scope, Secret as ConfigSecret,
-    SecretEncoding, SecretExtract,
+    ProfileDefaults, Project, ProjectDefaults, ProviderAlias, RequireReason, Scope,
+    Secret as ConfigSecret, SecretEncoding, SecretExtract,
 };
 use crate::error::{Result, SecretSpecError};
 use std::collections::{HashMap, HashSet};
@@ -227,6 +227,7 @@ impl SpecBuilder {
                     ..Project::default()
                 },
                 profiles: HashMap::new(),
+                defaults: None,
                 providers: None,
                 scopes: None,
             },
@@ -440,6 +441,23 @@ impl SpecBuilder {
             self.errors
                 .push(format!("duplicate provider alias '{name}'"));
         }
+        self.refresh_effective_config();
+        self
+    }
+
+    /// Set the provider chain used across profiles when neither a profile nor
+    /// a secret selects one. Available starting with SecretSpec 0.21.
+    ///
+    /// This semantic edit clears any retained source document.
+    pub fn default_providers<I, S>(mut self, providers: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.source = None;
+        self.declarations_mut().defaults = Some(ProjectDefaults {
+            providers: providers.into_iter().map(Into::into).collect(),
+        });
         self.refresh_effective_config();
         self
     }
@@ -1085,6 +1103,7 @@ mod tests {
     #[test]
     fn rust_builder_and_toml_compile_to_the_same_shape() {
         let rust = Spec::builder("embedded")
+            .default_providers(["keyring"])
             .secret("TOKEN", Secret::required("API token").providers(["env"]))
             .secret("OPTIONAL", Secret::optional("Optional value"))
             .profile(
@@ -1100,6 +1119,9 @@ mod tests {
                 [project]
                 name = "embedded"
                 revision = "1.0"
+
+                [defaults]
+                providers = ["keyring"]
 
                 [profiles.default]
                 TOKEN = { description = "API token", required = true, providers = ["env"] }
@@ -1125,6 +1147,16 @@ mod tests {
                 toml.secrets(profile).unwrap().collect::<Vec<_>>()
             );
         }
+        assert_eq!(
+            rust.config
+                .defaults
+                .as_ref()
+                .map(|defaults| &defaults.providers),
+            toml.config
+                .defaults
+                .as_ref()
+                .map(|defaults| &defaults.providers)
+        );
     }
 
     #[test]

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -45,6 +45,7 @@ fn parse_spec_from_str(content: &str, _base_path: Option<&Path>) -> Result<Confi
 #[test]
 fn test_new_with_project_config() {
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test-project".to_string(),
             ..Default::default()
@@ -208,6 +209,7 @@ require_reason = false
 #[test]
 fn test_new_with_default_overrides() {
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test-project".to_string(),
             ..Default::default()
@@ -395,6 +397,7 @@ fn test_resolution_report_provenance() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "report-test".to_string(),
             ..Default::default()
@@ -480,6 +483,7 @@ fn profile_presence_constraints_validate_resolved_values() {
             ..Default::default()
         };
         let config = Config {
+            defaults: None,
             project: Project {
                 name: "constraint-test".to_string(),
                 ..Default::default()
@@ -581,6 +585,7 @@ pub(crate) fn resolve_test_config(secrets: HashMap<String, Secret>) -> Config {
         },
     );
     Config {
+        defaults: None,
         project: Project {
             name: "resolve-test".to_string(),
             ..Default::default()
@@ -1475,6 +1480,7 @@ fn test_chain_primary_error_surfaces_instead_of_missing() {
 #[test]
 fn test_secretspec_new() {
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test".to_string(),
             ..Default::default()
@@ -1518,6 +1524,7 @@ fn test_resolve_profile() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -1540,6 +1547,7 @@ fn test_resolve_profile() {
     // Test without global config
     let spec_no_global = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -1612,6 +1620,7 @@ fn test_resolve_secret_config() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -1653,6 +1662,7 @@ fn test_resolve_secret_config() {
 fn test_get_provider_error_cases() {
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -1684,6 +1694,7 @@ fn test_get_provider_with_global_config() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -2817,6 +2828,7 @@ NEW_SECRET = { description = "New secret", required = true }
 #[test]
 fn test_set_with_undefined_secret() {
     let project_config = Config {
+        defaults: None,
         project: Project {
             name: "test_project".to_string(),
             ..Default::default()
@@ -2889,6 +2901,7 @@ fn test_set_with_defined_secret() {
     env::set_current_dir(&temp_dir).unwrap();
 
     let project_config = Config {
+        defaults: None,
         project: Project {
             name: "test_project".to_string(),
             ..Default::default()
@@ -2944,6 +2957,7 @@ fn test_set_with_defined_secret() {
 #[test]
 fn test_set_with_readonly_provider() {
     let project_config = Config {
+        defaults: None,
         project: Project {
             name: "test_project".to_string(),
             ..Default::default()
@@ -3006,6 +3020,7 @@ fn test_import_between_dotenv_files() {
 
     // Create project config
     let project_config = Config {
+        defaults: None,
         project: Project {
             name: "test_import_project".to_string(),
             ..Default::default()
@@ -3138,6 +3153,7 @@ fn test_import_edge_cases() {
 
     // Create project config
     let project_config = Config {
+        defaults: None,
         project: Project {
             name: "test_edge_cases".to_string(),
             ..Default::default()
@@ -3375,6 +3391,7 @@ fn test_import_with_profiles() {
 
     // Create project config with multiple profiles
     let project_config = Config {
+        defaults: None,
         project: Project {
             name: "test_profiles".to_string(),
             ..Default::default()
@@ -3509,6 +3526,7 @@ fn test_run_with_empty_command() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -3572,6 +3590,7 @@ fn test_run_with_missing_required_secrets() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -3633,6 +3652,7 @@ fn test_get_existing_secret() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -3688,6 +3708,7 @@ fn test_get_secret_with_default() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -3742,6 +3763,7 @@ fn test_get_nonexistent_secret() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -3913,6 +3935,7 @@ fn test_per_secret_provider_configuration() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test_per_secret_provider".to_string(),
             ..Default::default()
@@ -3967,6 +3990,7 @@ fn test_provider_alias_resolution() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -4008,6 +4032,7 @@ fn test_provider_alias_not_found() {
 
     let spec = Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -4082,6 +4107,7 @@ fn test_per_secret_provider_with_fallback_chain() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test_fallback".to_string(),
             ..Default::default()
@@ -4176,6 +4202,7 @@ fn test_get_secret_with_fallback_chain() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test_fallback_integration".to_string(),
             ..Default::default()
@@ -4260,6 +4287,7 @@ fn fallback_chains_resolve_concurrently_under_the_provider_cap() {
         })
         .collect();
     let config = Config {
+        defaults: None,
         project: Project {
             name: PROJECT.to_string(),
             ..Default::default()
@@ -4302,6 +4330,7 @@ fn fallback_chains_resolve_concurrently_under_the_provider_cap() {
 
 fn stateful_fallback_spec(project: &str, secret_name: &str, primary_file: &Path) -> Secrets {
     let config = Config {
+        defaults: None,
         project: Project {
             name: project.to_string(),
             ..Default::default()
@@ -4477,6 +4506,7 @@ fn test_validate_falls_back_on_primary_provider_error() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test_error_fallback".to_string(),
             ..Default::default()
@@ -4547,6 +4577,7 @@ fn test_validate_surfaces_error_when_all_providers_fail() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test_all_fail".to_string(),
             ..Default::default()
@@ -4642,6 +4673,7 @@ fn test_validate_with_per_secret_providers() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test_multi_provider".to_string(),
             ..Default::default()
@@ -4771,6 +4803,7 @@ fn test_secret_config_merges_providers_from_default() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test_merge".to_string(),
             ..Default::default()
@@ -6349,6 +6382,7 @@ fn test_resolve_secret_config_merges_type_and_generate() {
     );
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test".to_string(),
             ..Default::default()
@@ -6383,6 +6417,7 @@ fn build_chain_scenario(
     fs::write(&team_path, "").unwrap();
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "test_project".to_string(),
             ..Default::default()
@@ -6904,6 +6939,7 @@ pub(crate) fn aliases_map(aliases: &[(&str, &str)]) -> HashMap<String, ProviderA
 
 fn config_with_project_aliases(aliases: &[(&str, &str)]) -> Config {
     Config {
+        defaults: None,
         project: Project {
             name: "alias-test".to_string(),
             ..Default::default()
@@ -6951,6 +6987,7 @@ fn config_with_project_alias_secret(
     );
 
     Config {
+        defaults: None,
         project: Project {
             name: "alias-validation".to_string(),
             ..Default::default()
@@ -7887,6 +7924,7 @@ fn dotenv_spec(
     fs::write(&env_file, env_contents).unwrap();
     Secrets::new(
         Config {
+            defaults: None,
             project: Project {
                 name: "test".to_string(),
                 ..Default::default()
@@ -8350,6 +8388,7 @@ fn audit_set_provider_construction_failure_records_error() {
 #[test]
 fn audit_set_readonly_provider_records_error() {
     let project_config = Config {
+        defaults: None,
         project: Project {
             name: "test".to_string(),
             ..Default::default()
@@ -11091,6 +11130,7 @@ fn a_built_provider_carries_the_operation_profile() {
     use crate::provider::Address;
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "myapp".to_string(),
             ..Default::default()
@@ -11133,6 +11173,7 @@ fn a_credential_source_provider_gets_no_profile() {
     use crate::provider::Address;
 
     let config = Config {
+        defaults: None,
         project: Project {
             name: "myapp".to_string(),
             ..Default::default()


### PR DESCRIPTION
## Summary

- add a project-level `[defaults].providers` chain for provider-backed secrets
- keep project defaults deliberately narrow: only `providers` is accepted
- allow the chain to select project or user-global aliases, including aliases whose `ref` templates use `{project}`, `{profile}`, and `{key}`
- preserve the existing precedence of CLI/environment overrides, secret chains, and profile defaults

This provides a deterministic version of the developer-specific workflow discussed in #409 without adding ambient environment-variable interpolation to provider references:

```toml
# secretspec.toml (0.21+)
[defaults]
providers = ["developer"]
```

```toml
# ~/.config/secretspec/config.toml
[defaults.providers.developer]
uri = "awsps://developer@us-east-1"
ref = { item = "/{project}/{profile}/developers/alice/{key}" }
```

Each developer can define `developer` differently while the project manifest remains shared.

## Resolution order

1. `--provider`
2. `SECRETSPEC_PROVIDER`
3. secret provider chain, including inherited default-profile declarations
4. active profile defaults
5. project `[defaults].providers`
6. user-global default provider

## Validation

- `cargo test -p secretspec --lib`: 1497 passed, 4 ignored
- focused project-default and alias-template tests
- derive unit tests
- `cargo fmt --all -- --check`
- repository clippy hook
- `npm --prefix docs run build`

The new syntax and all documentation references are marked as SecretSpec 0.21+.
