### PR TITLE
feat: generate OpenPGP and SSH private keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- OpenPGP and OpenSSH private keys can be generated entirely in Rust (0.21+).
+  OpenPGP generation uses an explicit User ID and signing, encryption, or
+  combined capability profiles; Ed25519/Curve25519 is the default, with
+  configurable RSA available for compatibility. OpenSSH generation likewise
+  defaults to Ed25519 and supports configurable RSA keys and comments.
+
 ## [0.20.0] - 2026-08-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "bytes",
  "crypto-common 0.1.7",
  "generic-array",
 ]
@@ -64,6 +65,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes 0.8.4",
+]
+
+[[package]]
 name = "age"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,7 +102,7 @@ dependencies = [
  "num-traits",
  "p256",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.8",
  "rsa",
  "rust-embed",
  "scrypt",
@@ -119,7 +129,7 @@ dependencies = [
  "hpke",
  "io_tee",
  "nom 8.0.0",
- "rand 0.8.5",
+ "rand 0.8.8",
  "secrecy",
  "sha2 0.10.9",
  "tempfile",
@@ -248,6 +258,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
 ]
 
 [[package]]
@@ -448,7 +471,7 @@ dependencies = [
  "hex",
  "http 1.4.0",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.8",
  "sha1 0.10.6",
  "sha2 0.10.9",
  "time",
@@ -1030,10 +1053,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitfields"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+dependencies = [
+ "bitfields-impl",
+]
+
+[[package]]
+name = "bitfields-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "blake2b_simd"
@@ -1119,6 +1184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "buffer-redux"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1239,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1277,15 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "cast5"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1232,6 +1325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
+]
+
+[[package]]
+name = "cfb-mode"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1392,6 +1494,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher 0.4.4",
+ "dbl",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,6 +1643,15 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
@@ -1595,6 +1717,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc24"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
@@ -1686,6 +1814,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1704,13 +1833,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "cx448"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
+dependencies = [
+ "crypto-bigint",
+ "elliptic-curve",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serdect 0.3.0",
+ "sha3",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1728,11 +1898,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1742,6 +1923,15 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "deflate64"
@@ -1781,6 +1971,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,10 +2016,21 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1868,6 +2100,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96cd2d7607be76b700f707349fe6f48970385220c7c3a59a72e4dcb5e19143ca"
 
 [[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8",
+ "rfc6979",
+ "sha2 0.10.9",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +2126,19 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "eax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+dependencies = [
+ "aead",
+ "cipher 0.4.4",
+ "cmac",
+ "ctr",
+ "subtle",
+]
 
 [[package]]
 name = "ecdsa"
@@ -1894,6 +2155,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +2192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
+ "base64ct",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
@@ -1916,7 +2203,10 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serde_json",
+ "serdect 0.2.0",
  "subtle",
+ "tap",
  "zeroize",
 ]
 
@@ -2094,7 +2384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f57a075f878ad51bcc56745fb21efe601429a509204f8a385bbe526566597320"
 dependencies = [
  "convert_case 0.11.0",
- "darling",
+ "darling 0.23.0",
  "itertools",
  "proc-macro2",
  "quote",
@@ -2124,6 +2414,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2273,6 +2564,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -3174,6 +3471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "idea"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3552,6 +3858,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3601,7 +3921,7 @@ dependencies = [
  "serde",
  "sha2 0.11.0",
  "thiserror 2.0.18",
- "twofish",
+ "twofish 0.8.0",
  "uuid",
  "zeroize",
 ]
@@ -3625,7 +3945,7 @@ dependencies = [
  "log",
  "num-bigint",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.8",
  "regex",
  "reqwest 0.13.4",
  "serde",
@@ -3857,6 +4177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
 dependencies = [
  "sha2 0.11.0",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4099,7 +4429,8 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.8",
+ "serde",
  "smallvec",
  "zeroize",
 ]
@@ -4167,6 +4498,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4191,6 +4543,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher 0.4.4",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -4324,6 +4688,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,6 +4740,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4446,6 +4847,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "pgp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1"
+dependencies = [
+ "aead",
+ "aes 0.8.4",
+ "aes-gcm",
+ "aes-kw",
+ "argon2",
+ "base64",
+ "bitfields",
+ "block-padding 0.3.3",
+ "blowfish",
+ "buffer-redux",
+ "byteorder",
+ "bytes",
+ "camellia",
+ "cast5",
+ "cfb-mode",
+ "cipher 0.4.4",
+ "const-oid 0.9.6",
+ "crc24",
+ "curve25519-dalek",
+ "cx448",
+ "derive_builder",
+ "derive_more",
+ "des",
+ "digest 0.10.7",
+ "dsa",
+ "eax",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "flate2",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "idea",
+ "k256",
+ "log",
+ "md-5",
+ "memchr",
+ "nom 8.0.0",
+ "num-bigint-dig",
+ "num-traits",
+ "num_enum",
+ "ocb3",
+ "p256",
+ "p384",
+ "p521",
+ "rand 0.8.8",
+ "replace_with",
+ "ripemd",
+ "rsa",
+ "sha1 0.10.6",
+ "sha1-checked",
+ "sha2 0.10.9",
+ "sha3",
+ "signature",
+ "smallvec",
+ "snafu",
+ "subtle",
+ "twofish 0.7.1",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -4840,10 +5310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "radium"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5006,6 +5482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5114,6 +5596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5127,6 +5618,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -5445,6 +5937,7 @@ dependencies = [
  "der 0.7.10",
  "generic-array",
  "pkcs8",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -5514,8 +6007,10 @@ dependencies = [
  "linkme",
  "miette",
  "percent-encoding",
+ "pgp",
  "proptest",
  "rand 0.10.2",
+ "rand 0.8.8",
  "reqwest 0.12.28",
  "rsa",
  "rust-ini",
@@ -5525,6 +6020,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "signal-hook",
+ "smallvec",
+ "ssh-key",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5748,10 +6245,30 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -5774,6 +6291,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1 0.10.6",
+ "zeroize",
 ]
 
 [[package]]
@@ -5906,6 +6434,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5939,6 +6488,49 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.10",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "cipher 0.4.4",
+ "ssh-encoding",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468 0.7.0",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "ed25519-dalek",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2 0.10.9",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -6082,6 +6674,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -6513,6 +7111,15 @@ dependencies = [
  "target-triple",
  "termcolor",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "twofish"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -7422,6 +8029,15 @@ name = "wsl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,12 +66,18 @@ secretspec-derive = { version = "0.20.0", path = "./secretspec-derive" }
 secretspec = { version = "0.20.0", path = "./secretspec" }
 secretspec-core = { package = "secretspec", version = "0.20.0", path = "./secretspec" }
 rand = "0.10"
+# rPGP 0.20's public generation API uses Rand 0.8's traits. Keep the older
+# version under an explicit alias until rPGP moves to the current Rand API.
+rand_08 = { package = "rand", version = "0.8.6" }
 rsa = { version = "0.9", features = ["pem"] }
+pgp = { version = "0.20", default-features = false }
+smallvec = "1"
 uuid = { version = "1", features = ["serde", "v4"] }
 data-encoding = "2"
 sha2 = "0.10"
 detect-coding-agent = "0.1"
 age = { version = "0.12", features = ["armor", "plugin", "ssh"] }
+ssh-key = { version = "0.6.7", features = ["crypto"] }
 kube = { version = "4.2", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs", "jsonpatch"] }
 k8s-openapi = { version = "0.28", features = ["v1_36"] }
 json-patch = "4.2.0"

--- a/docs/src/content/docs/concepts/declarative.md
+++ b/docs/src/content/docs/concepts/declarative.md
@@ -36,7 +36,7 @@ SECRET_NAME = {
 - `required`: Whether the secret must be provided (default: `true`)
 - `default`: Fallback value for optional secrets
 - `composed` (0.16+): Derive a read-only value from other declared secrets (see [Composed Secrets](/concepts/composed-secrets/) for the strict template and dependency semantics)
-- `type`: Secret type for auto-generation (`password`, `hex`, `base64`, `uuid`, `command`)
+- `type`: Secret type for auto-generation (`password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key`, and `openpgp_private_key` in 0.21+)
 - `generate`: Enable auto-generation when the secret is missing (`true` or a table with options)
 - `prompt` (0.19+): Securely ask for a missing value during `secretspec run` and
   let the selected provider decide whether to save the answer

--- a/docs/src/content/docs/concepts/generation.mdx
+++ b/docs/src/content/docs/concepts/generation.mdx
@@ -29,6 +29,8 @@ REQUEST_ID = { description = "Request ID prefix", type = "uuid", generate = true
 | `uuid` | UUID v4 (36 chars) | none |
 | `command` | stdout of command | `command` (string, required) |
 | `rsa_private_key` | 2048-bit RSA private key (PKCS1 PEM) | `bits` (int) |
+| `openpgp_private_key` (0.21+) | ASCII-armored OpenPGP transferable secret key | `user_id` (required), `algorithm` (`"ed25519"` or `"rsa"`), `bits` (RSA only), `capabilities` (`["sign"]`, `["encrypt"]`, or both) |
+| `ssh_private_key` (0.21+) | Unencrypted OpenSSH Ed25519 private key | `algorithm` (`"ed25519"` or `"rsa"`), `bits` (RSA only), `comment` (string) |
 
 ### Command type
 
@@ -39,6 +41,63 @@ MONGO_KEY = { description = "MongoDB keyfile", type = "command", generate = { co
 ```
 
 `command` requires `generate = { command = "..." }` rather than just `generate = true`.
+
+### OpenPGP private keys {/* #openpgp-private-keys-021 */}
+
+<VersionCompatibility version="0.21" />
+
+`openpgp_private_key` generates a GnuPG-compatible OpenPGP v4 key entirely in
+process; neither `gpg` nor another executable is required. Its modern default
+uses an Ed25519 certification-only primary key and puts routine operations on
+separate Ed25519 signing and Curve25519 encryption subkeys.
+
+The User ID is required. With no `capabilities`, SecretSpec creates both
+signing and encryption subkeys:
+
+```toml
+[profiles.default]
+GENERAL_KEY = { description = "Service OpenPGP key", type = "openpgp_private_key", generate = { user_id = "Service Bot <service@example.com>" } }
+
+# A signing-only key has no encryption subkey.
+RELEASE_KEY = { description = "Release signing key", type = "openpgp_private_key", generate = { user_id = "Release Bot <releases@example.com>", capabilities = ["sign"] } }
+
+# RSA is available for consumers that require it; 3072 bits is the default.
+LEGACY_KEY = { description = "Legacy-compatible OpenPGP key", type = "openpgp_private_key", generate = { user_id = "Legacy Bot <legacy@example.com>", algorithm = "rsa", bits = 4096 } }
+```
+
+`capabilities` must be a non-empty list containing `"sign"`, `"encrypt"`, or
+both without duplicates. `algorithm` defaults to `"ed25519"`. Selecting
+`"rsa"` uses RSA for the primary key and every requested subkey; `bits`
+defaults to 3072 and accepts values from 2048 through 8192. `bits` is invalid
+with `"ed25519"`.
+
+The result is one `-----BEGIN PGP PRIVATE KEY
+BLOCK-----` value that can be imported by GnuPG and other OpenPGP tools. It has
+no OpenPGP passphrase and no expiration; protect it with an encrypted provider
+and rotate it according to the consuming system's policy. Set `as_path = true`
+when a command needs a temporary key file rather than the armored value in an
+environment variable.
+
+### SSH private keys {/* #ssh-private-keys-021 */}
+
+<VersionCompatibility version="0.21" />
+
+`ssh_private_key` generates an unencrypted OpenSSH private key entirely in
+process. `generate = true` uses Ed25519, the sensible default for new SSH keys:
+
+```toml
+[profiles.default]
+DEPLOY_KEY = { description = "Deployment SSH key", type = "ssh_private_key", generate = true }
+
+# RSA is available for compatibility; 3072 bits is the default.
+LEGACY_DEPLOY_KEY = { description = "Legacy deployment key", type = "ssh_private_key", generate = { algorithm = "rsa", bits = 4096, comment = "deploy@example.com" } }
+```
+
+RSA sizes from 2048 through 8192 bits are accepted. `bits` is invalid with
+Ed25519. `comment` is optional and cannot contain control characters. Generated
+keys are not passphrase-encrypted, so store them in an encrypted provider. Set
+`as_path = true` when a command needs the key in a temporary file rather than in
+an environment variable.
 
 ## How it works
 
@@ -85,6 +144,12 @@ JWT_SIGNING_KEY = { description = "JWT signing key", type = "rsa_private_key", g
 
 # RSA private key with custom key size
 TLS_KEY = { description = "TLS private key", type = "rsa_private_key", generate = { bits = 4096 } }
+
+# OpenPGP signing key (requires SecretSpec 0.21+)
+RELEASE_KEY = { description = "Release signing key", type = "openpgp_private_key", generate = { user_id = "Release Bot <releases@example.com>", capabilities = ["sign"] } }
+
+# OpenSSH Ed25519 private key (requires SecretSpec 0.21+)
+DEPLOY_KEY = { description = "Deployment SSH key", type = "ssh_private_key", generate = true }
 
 # Informational type only, no generation
 EXTERNAL_API_KEY = { description = "Provided by vendor", type = "password" }

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -165,7 +165,7 @@ Each secret variable is defined as a table with the following fields:
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
 | `encoding` (0.19+) | `"base64"`, `"base64url"`, or `"hex"` | No | Encode logical values before storage writes and decode stored values after reads |
 | `extract` (0.19+) | table | No | Select one logical value from stored JSON (0.19+) or INI (0.20+) data with a pointer |
-| `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key` |
+| `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key`, `openpgp_private_key` (0.21+), `ssh_private_key` (0.21+) |
 | `generate` | boolean or table | No | Enable auto-generation when secret is missing |
 | `prompt` (0.19+) | boolean | No | Securely prompt for a missing value during `secretspec run`; the selected provider controls persistence |
 
@@ -1001,6 +1001,12 @@ MONGO_KEY = { description = "MongoDB keyfile", type = "command", generate = { co
 # RSA private key (PKCS1 PEM)
 JWT_SIGNING_KEY = { description = "JWT signing key", type = "rsa_private_key", generate = true }
 
+# OpenPGP signing key (0.21+)
+RELEASE_KEY = { description = "Release signing key", type = "openpgp_private_key", generate = { user_id = "Release Bot <releases@example.com>", capabilities = ["sign"] } }
+
+# OpenSSH Ed25519 private key (0.21+)
+DEPLOY_KEY = { description = "Deployment SSH key", type = "ssh_private_key", generate = true }
+
 # Type without generate: informational only, no auto-generation
 MANUAL_SECRET = { description = "Manually managed", type = "password" }
 ```
@@ -1015,6 +1021,38 @@ MANUAL_SECRET = { description = "Manually managed", type = "password" }
 | `uuid` | UUID v4 (36 chars) | none |
 | `command` | stdout of command | `command` (string, required) |
 | `rsa_private_key` | 2048-bit RSA private key (PKCS1 PEM) | `bits` (int) |
+| `openpgp_private_key` (0.21+) | ASCII-armored OpenPGP v4 transferable secret key | `user_id` (required), `algorithm` (`"ed25519"` or `"rsa"`), `bits` (RSA only), `capabilities` (`["sign"]`, `["encrypt"]`, or both) |
+| `ssh_private_key` (0.21+) | Unencrypted OpenSSH Ed25519 private key | `algorithm` (`"ed25519"` or `"rsa"`), `bits` (RSA only), `comment` (string) |
+
+#### OpenPGP private-key generation {/* #openpgp-private-key-generation-021 */}
+
+<VersionCompatibility version="0.21" />
+
+`openpgp_private_key` is generated entirely in Rust and does not invoke GnuPG.
+The default `algorithm = "ed25519"` creates an Ed25519 certification-only
+primary key plus separate Ed25519 signing and/or Curve25519 encryption subkeys.
+For compatibility with RSA-only consumers, `algorithm = "rsa"` uses RSA for
+the primary key and all requested subkeys. RSA defaults to 3072 bits;
+`bits` accepts 2048 through 8192 and is invalid with `"ed25519"`.
+
+Omitting `capabilities` selects both; the list must otherwise contain `"sign"`,
+`"encrypt"`, or both without duplicates. `generate = true` is invalid because
+every generated certificate requires an explicit `user_id`.
+
+The ASCII-armored transferable secret key has no OpenPGP passphrase and no
+expiration. Store it with an encrypted provider when it needs protection at
+rest. Its public certificate and fingerprint can be derived after import by
+OpenPGP tooling; SecretSpec stores the secret key as one logical value.
+
+#### SSH private-key generation {/* #ssh-private-key-generation-021 */}
+
+<VersionCompatibility version="0.21" />
+
+`ssh_private_key` is generated entirely in Rust. `generate = true` creates an
+unencrypted Ed25519 OpenSSH private key. Select `algorithm = "rsa"` for
+compatibility; RSA defaults to 3072 bits and accepts 2048 through 8192. `bits`
+is invalid with Ed25519. An optional `comment` is embedded in the key and must
+not contain control characters.
 
 #### Behavior
 
@@ -1024,6 +1062,11 @@ MANUAL_SECRET = { description = "Manually managed", type = "password" }
 - Subsequent runs find the stored value and skip generation (idempotent)
 - `generate` and `default` cannot both be set on the same secret
 - `type = "command"` requires `generate = { command = "..." }` (not just `generate = true`)
+- `type = "openpgp_private_key"` (0.21+) requires `generate.user_id`; omitted
+  `algorithm` and `capabilities` default to Ed25519/Curve25519 and both
+  signing and encryption, respectively
+- `type = "ssh_private_key"` (0.21+) defaults to Ed25519; RSA generation is
+  available with `generate = { algorithm = "rsa", bits = 4096 }`
 - The value-free preflights — [`check --json` / `check --explain`](/reference/cli/#resolution-report---json----explain)
   and the SDKs' report/no-values resolutions — never mint a value. Since
   SecretSpec 0.20 a **required** generatable secret that no provider holds is

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -66,10 +66,14 @@ azure_security_keyvault_secrets = { workspace = true, optional = true }
 tokio.workspace = true
 reqwest = { workspace = true, optional = true }
 rand.workspace = true
+rand_08.workspace = true
 rsa.workspace = true
+pgp.workspace = true
+smallvec.workspace = true
 uuid.workspace = true
 data-encoding.workspace = true
 sha2.workspace = true
+ssh-key.workspace = true
 detect-coding-agent.workspace = true
 age = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -59,7 +59,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [Kubernetes](https://secretspec.dev/providers/kubernetes) (0.20+)
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
-- **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — declarative "generate if absent"
+- **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — including pure-Rust OpenPGP and OpenSSH private keys in 0.21+
 - **Run prompts (0.19+)**: Set `prompt = true` to request a hidden missing value; writable providers save it, while `null` keeps it invocation-only
 - **Composed Secrets (0.16+)**: Derive read-only values such as DSNs from declared secrets with strict, order-independent `${UPPERCASE_NAME}` references
 - **[Configuration Inheritance](https://secretspec.dev/concepts/inheritance/)**: Extend and override shared configurations using the `extends` feature

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -1558,10 +1558,29 @@ pub struct GenerateOptions {
     /// Shell command to run (for `command` type)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
-    /// Key size in bits (for `rsa` type, default 2048)
+    /// RSA key size in bits (`rsa_private_key` defaults to 2048; OpenPGP and SSH RSA default to 3072).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bits: Option<usize>,
+    /// OpenPGP or SSH key algorithm (`ed25519` or `rsa`, default `ed25519`; 0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub algorithm: Option<String>,
+    /// OpenPGP User ID bound to a generated certificate (0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    /// OpenPGP subkey capabilities (`sign` and/or `encrypt`, 0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<String>>,
+    /// Comment embedded in a generated OpenSSH private key (0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
 }
+
+pub(crate) const OPENPGP_RSA_DEFAULT_BITS: usize = 3072;
+pub(crate) const OPENPGP_RSA_MIN_BITS: usize = 2048;
+pub(crate) const OPENPGP_RSA_MAX_BITS: usize = 8192;
+pub(crate) const SSH_RSA_DEFAULT_BITS: usize = 3072;
+pub(crate) const SSH_RSA_MIN_BITS: usize = 2048;
+pub(crate) const SSH_RSA_MAX_BITS: usize = 8192;
 
 /// Native coordinates of one externally managed secret: the value of a
 /// secret's `ref` field.
@@ -2182,7 +2201,8 @@ pub struct Secret {
     ///
     /// Available since SecretSpec 0.19.
     pub extract: Option<SecretExtract>,
-    /// The type of secret, used for generation (e.g., "password", "hex", "base64", "uuid", "command", "rsa_private_key")
+    /// The type of secret, used for generation. OpenPGP and OpenSSH private-key
+    /// generation are available in SecretSpec 0.21+.
     pub secret_type: Option<String>,
     /// Auto-generation configuration. Either `true` for defaults or a table with options.
     pub generate: Option<GenerateConfig>,
@@ -2468,10 +2488,139 @@ impl Secret {
                 }
             }
 
+            if self.secret_type.as_deref() == Some("openpgp_private_key") {
+                let opts = match gen_config {
+                    GenerateConfig::Options(opts) => opts,
+                    GenerateConfig::Bool(true) => {
+                        return Err(
+                            "type = \"openpgp_private_key\" requires generate = { user_id = \"Name <email>\" }"
+                                .into(),
+                        );
+                    }
+                    GenerateConfig::Bool(false) => {
+                        unreachable!("disabled generation handled above")
+                    }
+                };
+                let user_id = opts.user_id.as_deref().ok_or_else(|| {
+                    "type = \"openpgp_private_key\" requires generate.user_id".to_string()
+                })?;
+                if user_id.trim().is_empty() {
+                    return Err("generate.user_id cannot be empty or whitespace".into());
+                }
+                if user_id.chars().any(char::is_control) {
+                    return Err("generate.user_id cannot contain control characters".into());
+                }
+                if opts.comment.is_some() {
+                    return Err(
+                        "generate.comment is only valid for type = \"ssh_private_key\"".into(),
+                    );
+                }
+
+                match opts.algorithm.as_deref().unwrap_or("ed25519") {
+                    "ed25519" => {
+                        if opts.bits.is_some() {
+                            return Err(
+                                "generate.bits is only valid when generate.algorithm = \"rsa\""
+                                    .into(),
+                            );
+                        }
+                    }
+                    "rsa" => {
+                        let bits = opts.bits.unwrap_or(OPENPGP_RSA_DEFAULT_BITS);
+                        if !(OPENPGP_RSA_MIN_BITS..=OPENPGP_RSA_MAX_BITS).contains(&bits) {
+                            return Err(
+                                "OpenPGP RSA generate.bits must be between 2048 and 8192".into()
+                            );
+                        }
+                    }
+                    algorithm => {
+                        return Err(format!(
+                            "unknown OpenPGP algorithm '{algorithm}'; expected `ed25519` or `rsa`"
+                        ));
+                    }
+                }
+
+                if let Some(capabilities) = &opts.capabilities {
+                    if capabilities.is_empty() {
+                        return Err(
+                            "generate.capabilities must contain `sign`, `encrypt`, or both".into(),
+                        );
+                    }
+                    let mut seen = HashSet::new();
+                    for capability in capabilities {
+                        if !matches!(capability.as_str(), "sign" | "encrypt") {
+                            return Err(format!(
+                                "unknown OpenPGP capability '{capability}'; expected `sign` or `encrypt`"
+                            ));
+                        }
+                        if !seen.insert(capability) {
+                            return Err(format!(
+                                "generate.capabilities contains duplicate capability '{capability}'"
+                            ));
+                        }
+                    }
+                }
+            }
+
+            if self.secret_type.as_deref() == Some("ssh_private_key") {
+                let opts = match gen_config {
+                    GenerateConfig::Bool(true) => None,
+                    GenerateConfig::Options(opts) => Some(opts),
+                    GenerateConfig::Bool(false) => {
+                        unreachable!("disabled generation handled above")
+                    }
+                };
+                if let Some(opts) = opts {
+                    if opts.user_id.is_some() || opts.capabilities.is_some() {
+                        return Err(
+                            "generate.user_id and generate.capabilities are only valid for type = \"openpgp_private_key\""
+                                .into(),
+                        );
+                    }
+                    if opts
+                        .comment
+                        .as_deref()
+                        .is_some_and(|comment| comment.chars().any(char::is_control))
+                    {
+                        return Err("generate.comment cannot contain control characters".into());
+                    }
+                    match opts.algorithm.as_deref().unwrap_or("ed25519") {
+                        "ed25519" => {
+                            if opts.bits.is_some() {
+                                return Err(
+                                    "generate.bits is only valid when generate.algorithm = \"rsa\""
+                                        .into(),
+                                );
+                            }
+                        }
+                        "rsa" => {
+                            let bits = opts.bits.unwrap_or(SSH_RSA_DEFAULT_BITS);
+                            if !(SSH_RSA_MIN_BITS..=SSH_RSA_MAX_BITS).contains(&bits) {
+                                return Err(
+                                    "SSH RSA generate.bits must be between 2048 and 8192".into()
+                                );
+                            }
+                        }
+                        algorithm => {
+                            return Err(format!(
+                                "unknown SSH algorithm '{algorithm}'; expected `ed25519` or `rsa`"
+                            ));
+                        }
+                    }
+                }
+            }
+
             // Validate known types
             if let Some(ref t) = self.secret_type {
                 match t.as_str() {
-                    "password" | "hex" | "base64" | "uuid" | "command" | "rsa_private_key" => {}
+                    "password"
+                    | "hex"
+                    | "base64"
+                    | "uuid"
+                    | "command"
+                    | "rsa_private_key"
+                    | "openpgp_private_key"
+                    | "ssh_private_key" => {}
                     unknown => {
                         return Err(format!("unknown secret type '{}'", unknown));
                     }
@@ -2485,7 +2634,14 @@ impl Secret {
         {
             // Type is informational when not generating, but still validate known values
             match t.as_str() {
-                "password" | "hex" | "base64" | "uuid" | "command" | "rsa_private_key" => {}
+                "password"
+                | "hex"
+                | "base64"
+                | "uuid"
+                | "command"
+                | "rsa_private_key"
+                | "openpgp_private_key"
+                | "ssh_private_key" => {}
                 unknown => {
                     return Err(format!("unknown secret type '{}'", unknown));
                 }

--- a/secretspec/src/generator.rs
+++ b/secretspec/src/generator.rs
@@ -1,15 +1,30 @@
 //! Secret value generation
 //!
 //! This module provides generation of secret values based on type and configuration.
-//! Supported types: password, hex, base64, uuid, command, rsa_private_key.
+//! Supported types: password, hex, base64, uuid, command, rsa_private_key,
+//! openpgp_private_key, ssh_private_key.
 
 use crate::SecretSpecError;
-use crate::config::GenerateConfig;
+use crate::config::{
+    GenerateConfig, OPENPGP_RSA_DEFAULT_BITS, OPENPGP_RSA_MAX_BITS, OPENPGP_RSA_MIN_BITS,
+    SSH_RSA_DEFAULT_BITS, SSH_RSA_MAX_BITS, SSH_RSA_MIN_BITS,
+};
 use data_encoding::{BASE64, HEXLOWER};
+use pgp::composed::{
+    ArmorOptions, EncryptionCaps, KeyType, SecretKeyParamsBuilder, SubkeyParamsBuilder,
+};
+use pgp::crypto::{ecc_curve::ECCCurve, hash::HashAlgorithm, sym::SymmetricKeyAlgorithm};
+use pgp::types::{CompressionAlgorithm, KeyVersion};
 use rand::RngExt;
+use rand_08::rngs::OsRng as OpenPgpOsRng;
 use rsa::RsaPrivateKey;
 use rsa::pkcs1::EncodeRsaPrivateKey;
 use secrecy::SecretString;
+use smallvec::smallvec;
+use ssh_key::private::{KeypairData as SshKeypairData, RsaKeypair as SshRsaKeypair};
+use ssh_key::{
+    Algorithm as SshAlgorithm, LineEnding as SshLineEnding, PrivateKey as SshPrivateKey,
+};
 
 /// Generate a secret value based on the secret type and generation config.
 pub fn generate(secret_type: &str, config: &GenerateConfig) -> crate::Result<SecretString> {
@@ -20,6 +35,8 @@ pub fn generate(secret_type: &str, config: &GenerateConfig) -> crate::Result<Sec
         "uuid" => generate_uuid(),
         "command" => generate_from_command(config),
         "rsa_private_key" => generate_rsa(config),
+        "openpgp_private_key" => generate_openpgp(config),
+        "ssh_private_key" => generate_ssh(config),
         unknown => Err(SecretSpecError::GenerationFailed(format!(
             "unknown secret type '{}'",
             unknown
@@ -120,6 +137,247 @@ fn generate_rsa(config: &GenerateConfig) -> crate::Result<SecretString> {
     Ok(SecretString::new(pem.to_string().into()))
 }
 
+/// Generates a broadly interoperable OpenPGP v4 transferable secret key.
+///
+/// The certification-only primary key is Ed25519. Requested signing and
+/// encryption capabilities are placed on separate Ed25519 and Curve25519
+/// subkeys, respectively, so routine operations do not use the primary key.
+fn generate_openpgp(config: &GenerateConfig) -> crate::Result<SecretString> {
+    let opts = match config {
+        GenerateConfig::Options(opts) => opts,
+        GenerateConfig::Bool(_) => {
+            return Err(SecretSpecError::GenerationFailed(
+                "type = \"openpgp_private_key\" requires generate = { user_id = \"Name <email>\" }"
+                    .to_string(),
+            ));
+        }
+    };
+
+    let user_id = opts.user_id.as_deref().ok_or_else(|| {
+        SecretSpecError::GenerationFailed(
+            "type = \"openpgp_private_key\" requires generate.user_id".to_string(),
+        )
+    })?;
+    if user_id.trim().is_empty() {
+        return Err(SecretSpecError::GenerationFailed(
+            "generate.user_id cannot be empty or whitespace".to_string(),
+        ));
+    }
+    if user_id.chars().any(char::is_control) {
+        return Err(SecretSpecError::GenerationFailed(
+            "generate.user_id cannot contain control characters".to_string(),
+        ));
+    }
+
+    let (primary_key_type, signing_key_type, encryption_key_type) =
+        match opts.algorithm.as_deref().unwrap_or("ed25519") {
+            "ed25519" => {
+                if opts.bits.is_some() {
+                    return Err(SecretSpecError::GenerationFailed(
+                        "generate.bits is only valid when generate.algorithm = \"rsa\"".to_string(),
+                    ));
+                }
+                (
+                    KeyType::Ed25519Legacy,
+                    KeyType::Ed25519Legacy,
+                    KeyType::ECDH(ECCCurve::Curve25519Legacy),
+                )
+            }
+            "rsa" => {
+                let bits = opts.bits.unwrap_or(OPENPGP_RSA_DEFAULT_BITS);
+                if !(OPENPGP_RSA_MIN_BITS..=OPENPGP_RSA_MAX_BITS).contains(&bits) {
+                    return Err(SecretSpecError::GenerationFailed(
+                        "OpenPGP RSA generate.bits must be between 2048 and 8192".to_string(),
+                    ));
+                }
+                let bits = u32::try_from(bits).map_err(|_| {
+                    SecretSpecError::GenerationFailed(
+                        "OpenPGP RSA generate.bits is too large".to_string(),
+                    )
+                })?;
+                (KeyType::Rsa(bits), KeyType::Rsa(bits), KeyType::Rsa(bits))
+            }
+            algorithm => {
+                return Err(SecretSpecError::GenerationFailed(format!(
+                    "unknown OpenPGP algorithm '{algorithm}'; expected `ed25519` or `rsa`"
+                )));
+            }
+        };
+
+    let (sign, encrypt) = match opts.capabilities.as_deref() {
+        None => (true, true),
+        Some([]) => {
+            return Err(SecretSpecError::GenerationFailed(
+                "generate.capabilities must contain `sign`, `encrypt`, or both".to_string(),
+            ));
+        }
+        Some(capabilities) => {
+            let mut sign = false;
+            let mut encrypt = false;
+            for capability in capabilities {
+                let selected = match capability.as_str() {
+                    "sign" => &mut sign,
+                    "encrypt" => &mut encrypt,
+                    _ => {
+                        return Err(SecretSpecError::GenerationFailed(
+                            "generate.capabilities accepts only `sign` and `encrypt`".to_string(),
+                        ));
+                    }
+                };
+                if *selected {
+                    return Err(SecretSpecError::GenerationFailed(format!(
+                        "generate.capabilities contains duplicate capability '{capability}'"
+                    )));
+                }
+                *selected = true;
+            }
+            (sign, encrypt)
+        }
+    };
+
+    let mut subkeys = Vec::with_capacity(usize::from(sign) + usize::from(encrypt));
+    if sign {
+        subkeys.push(
+            SubkeyParamsBuilder::default()
+                .version(KeyVersion::V4)
+                .key_type(signing_key_type)
+                .can_sign(true)
+                .build()
+                .map_err(|error| {
+                    SecretSpecError::GenerationFailed(format!(
+                        "failed to configure OpenPGP signing subkey: {error}"
+                    ))
+                })?,
+        );
+    }
+    if encrypt {
+        subkeys.push(
+            SubkeyParamsBuilder::default()
+                .version(KeyVersion::V4)
+                .key_type(encryption_key_type)
+                .can_encrypt(EncryptionCaps::All)
+                .build()
+                .map_err(|error| {
+                    SecretSpecError::GenerationFailed(format!(
+                        "failed to configure OpenPGP encryption subkey: {error}"
+                    ))
+                })?,
+        );
+    }
+
+    let mut builder = SecretKeyParamsBuilder::default();
+    builder
+        .version(KeyVersion::V4)
+        .key_type(primary_key_type)
+        .can_certify(true)
+        .can_sign(false)
+        .primary_user_id(user_id.to_string())
+        .preferred_symmetric_algorithms(smallvec![
+            SymmetricKeyAlgorithm::AES256,
+            SymmetricKeyAlgorithm::AES128,
+        ])
+        .preferred_hash_algorithms(smallvec![HashAlgorithm::Sha512, HashAlgorithm::Sha256])
+        .preferred_compression_algorithms(smallvec![
+            CompressionAlgorithm::ZLIB,
+            CompressionAlgorithm::Uncompressed,
+        ])
+        .subkeys(subkeys);
+
+    let key = builder
+        .build()
+        .map_err(|error| {
+            SecretSpecError::GenerationFailed(format!(
+                "failed to configure OpenPGP private key: {error}"
+            ))
+        })?
+        .generate(OpenPgpOsRng)
+        .map_err(|error| {
+            SecretSpecError::GenerationFailed(format!(
+                "failed to generate OpenPGP private key: {error}"
+            ))
+        })?;
+    key.verify_bindings().map_err(|error| {
+        SecretSpecError::GenerationFailed(format!(
+            "generated OpenPGP private key failed self-verification: {error}"
+        ))
+    })?;
+    let armored = key
+        .to_armored_string(ArmorOptions::default())
+        .map_err(|error| {
+            SecretSpecError::GenerationFailed(format!(
+                "failed to armor OpenPGP private key: {error}"
+            ))
+        })?;
+
+    Ok(SecretString::new(armored.into()))
+}
+
+/// Generates an unencrypted OpenSSH private key using a modern Ed25519 default
+/// or a configurable RSA compatibility profile.
+fn generate_ssh(config: &GenerateConfig) -> crate::Result<SecretString> {
+    let opts = match config {
+        GenerateConfig::Bool(_) => None,
+        GenerateConfig::Options(opts) => Some(opts),
+    };
+    let algorithm = opts
+        .and_then(|options| options.algorithm.as_deref())
+        .unwrap_or("ed25519");
+    let comment = opts
+        .and_then(|options| options.comment.as_deref())
+        .unwrap_or_default();
+    if comment.chars().any(char::is_control) {
+        return Err(SecretSpecError::GenerationFailed(
+            "generate.comment cannot contain control characters".to_string(),
+        ));
+    }
+
+    let mut rng = OpenPgpOsRng;
+    let mut key = match algorithm {
+        "ed25519" => {
+            if opts.is_some_and(|options| options.bits.is_some()) {
+                return Err(SecretSpecError::GenerationFailed(
+                    "generate.bits is only valid when generate.algorithm = \"rsa\"".to_string(),
+                ));
+            }
+            SshPrivateKey::random(&mut rng, SshAlgorithm::Ed25519).map_err(|error| {
+                SecretSpecError::GenerationFailed(format!(
+                    "failed to generate Ed25519 SSH private key: {error}"
+                ))
+            })?
+        }
+        "rsa" => {
+            let bits = opts
+                .and_then(|options| options.bits)
+                .unwrap_or(SSH_RSA_DEFAULT_BITS);
+            if !(SSH_RSA_MIN_BITS..=SSH_RSA_MAX_BITS).contains(&bits) {
+                return Err(SecretSpecError::GenerationFailed(
+                    "SSH RSA generate.bits must be between 2048 and 8192".to_string(),
+                ));
+            }
+            let keypair = SshRsaKeypair::random(&mut rng, bits).map_err(|error| {
+                SecretSpecError::GenerationFailed(format!(
+                    "failed to generate RSA SSH private key: {error}"
+                ))
+            })?;
+            SshPrivateKey::new(SshKeypairData::Rsa(keypair), comment).map_err(|error| {
+                SecretSpecError::GenerationFailed(format!(
+                    "failed to assemble RSA SSH private key: {error}"
+                ))
+            })?
+        }
+        algorithm => {
+            return Err(SecretSpecError::GenerationFailed(format!(
+                "unknown SSH algorithm '{algorithm}'; expected `ed25519` or `rsa`"
+            )));
+        }
+    };
+    key.set_comment(comment);
+    let encoded = key.to_openssh(SshLineEnding::LF).map_err(|error| {
+        SecretSpecError::GenerationFailed(format!("failed to encode OpenSSH private key: {error}"))
+    })?;
+    Ok(SecretString::new(encoded.to_string().into()))
+}
+
 fn generate_from_command(config: &GenerateConfig) -> crate::Result<SecretString> {
     let command = match config {
         GenerateConfig::Bool(_) => {
@@ -177,6 +435,9 @@ fn generate_from_command(config: &GenerateConfig) -> crate::Result<SecretString>
 mod tests {
     use super::*;
     use crate::config::GenerateOptions;
+    use pgp::composed::{Deserializable, SignedSecretKey};
+    use pgp::crypto::public_key::PublicKeyAlgorithm;
+    use pgp::types::KeyDetails as _;
     use secrecy::ExposeSecret;
 
     #[test]
@@ -392,6 +653,197 @@ mod tests {
         let v1 = generate("rsa_private_key", &GenerateConfig::Bool(true)).unwrap();
         let v2 = generate("rsa_private_key", &GenerateConfig::Bool(true)).unwrap();
         assert_ne!(v1.expose_secret(), v2.expose_secret());
+    }
+
+    fn openpgp_config(
+        algorithm: Option<&str>,
+        bits: Option<usize>,
+        capabilities: Option<Vec<&str>>,
+    ) -> GenerateConfig {
+        GenerateConfig::Options(GenerateOptions {
+            user_id: Some("SecretSpec Test <test@example.invalid>".to_string()),
+            algorithm: algorithm.map(ToString::to_string),
+            bits,
+            capabilities: capabilities
+                .map(|values| values.into_iter().map(ToString::to_string).collect()),
+            ..Default::default()
+        })
+    }
+
+    fn parse_openpgp(config: &GenerateConfig) -> SignedSecretKey {
+        let value = generate("openpgp_private_key", config).unwrap();
+        assert!(
+            value
+                .expose_secret()
+                .starts_with("-----BEGIN PGP PRIVATE KEY BLOCK-----")
+        );
+        assert!(
+            value
+                .expose_secret()
+                .trim()
+                .ends_with("-----END PGP PRIVATE KEY BLOCK-----")
+        );
+        let (key, _) =
+            SignedSecretKey::from_armor_single(value.expose_secret().as_bytes()).unwrap();
+        key.verify_bindings().unwrap();
+        key
+    }
+
+    #[test]
+    fn test_generate_openpgp_default_profile() {
+        let key = parse_openpgp(&openpgp_config(None, None, None));
+        assert_eq!(key.primary_key.algorithm(), PublicKeyAlgorithm::EdDSALegacy);
+        assert_eq!(key.primary_key.version(), KeyVersion::V4);
+        assert_eq!(key.secret_subkeys.len(), 2);
+        let algorithms = key
+            .secret_subkeys
+            .iter()
+            .map(|subkey| subkey.algorithm())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            algorithms,
+            vec![PublicKeyAlgorithm::EdDSALegacy, PublicKeyAlgorithm::ECDH]
+        );
+
+        let public = key.to_public_key();
+        public.verify_bindings().unwrap();
+        assert_eq!(
+            public.primary_key.fingerprint(),
+            key.primary_key.fingerprint()
+        );
+    }
+
+    #[test]
+    fn test_generate_openpgp_capability_profiles() {
+        let signing = parse_openpgp(&openpgp_config(None, None, Some(vec!["sign"])));
+        assert_eq!(signing.secret_subkeys.len(), 1);
+        assert_eq!(
+            signing.secret_subkeys[0].algorithm(),
+            PublicKeyAlgorithm::EdDSALegacy
+        );
+
+        let encryption = parse_openpgp(&openpgp_config(None, None, Some(vec!["encrypt"])));
+        assert_eq!(encryption.secret_subkeys.len(), 1);
+        assert_eq!(
+            encryption.secret_subkeys[0].algorithm(),
+            PublicKeyAlgorithm::ECDH
+        );
+    }
+
+    #[test]
+    fn test_generate_openpgp_rsa_profile() {
+        let key = parse_openpgp(&openpgp_config(Some("rsa"), Some(2048), Some(vec!["sign"])));
+        assert_eq!(key.primary_key.algorithm(), PublicKeyAlgorithm::RSA);
+        assert_eq!(key.primary_key.version(), KeyVersion::V4);
+        assert_eq!(key.secret_subkeys.len(), 1);
+        assert_eq!(key.secret_subkeys[0].algorithm(), PublicKeyAlgorithm::RSA);
+    }
+
+    #[test]
+    fn test_generate_openpgp_rejects_incomplete_or_invalid_options() {
+        for config in [
+            GenerateConfig::Bool(true),
+            GenerateConfig::Options(GenerateOptions::default()),
+            openpgp_config(None, None, Some(vec![])),
+            openpgp_config(None, None, Some(vec!["authenticate"])),
+            openpgp_config(None, None, Some(vec!["sign", "sign"])),
+            openpgp_config(Some("dsa"), None, None),
+            openpgp_config(Some("ed25519"), Some(3072), None),
+            openpgp_config(Some("rsa"), Some(1024), None),
+            openpgp_config(Some("rsa"), Some(16384), None),
+        ] {
+            assert!(generate("openpgp_private_key", &config).is_err());
+        }
+    }
+
+    #[test]
+    fn test_generate_openpgp_uniqueness() {
+        let config = openpgp_config(None, None, Some(vec!["sign"]));
+        let first = parse_openpgp(&config);
+        let second = parse_openpgp(&config);
+        assert_ne!(
+            first.primary_key.fingerprint(),
+            second.primary_key.fingerprint()
+        );
+    }
+
+    fn parse_ssh(config: &GenerateConfig) -> SshPrivateKey {
+        let value = generate("ssh_private_key", config).unwrap();
+        assert!(
+            value
+                .expose_secret()
+                .starts_with("-----BEGIN OPENSSH PRIVATE KEY-----")
+        );
+        assert!(
+            value
+                .expose_secret()
+                .trim()
+                .ends_with("-----END OPENSSH PRIVATE KEY-----")
+        );
+        SshPrivateKey::from_openssh(value.expose_secret()).unwrap()
+    }
+
+    #[test]
+    fn test_generate_ssh_default_ed25519_profile() {
+        let key = parse_ssh(&GenerateConfig::Bool(true));
+        assert_eq!(key.algorithm(), SshAlgorithm::Ed25519);
+        assert_eq!(key.comment(), "");
+        assert!(!key.is_encrypted());
+    }
+
+    #[test]
+    fn test_generate_ssh_custom_rsa_profile() {
+        let config = GenerateConfig::Options(GenerateOptions {
+            algorithm: Some("rsa".to_string()),
+            bits: Some(2048),
+            comment: Some("deploy@example.com".to_string()),
+            ..Default::default()
+        });
+        let key = parse_ssh(&config);
+        assert!(matches!(key.algorithm(), SshAlgorithm::Rsa { .. }));
+        assert_eq!(key.comment(), "deploy@example.com");
+        let SshKeypairData::Rsa(keypair) = key.key_data() else {
+            panic!("expected RSA keypair");
+        };
+        let bits = keypair
+            .public
+            .n
+            .as_positive_bytes()
+            .map_or(0, |modulus| modulus.len() * 8);
+        assert_eq!(bits, 2048);
+    }
+
+    #[test]
+    fn test_generate_ssh_rejects_invalid_profiles() {
+        for config in [
+            GenerateConfig::Options(GenerateOptions {
+                algorithm: Some("ecdsa".to_string()),
+                ..Default::default()
+            }),
+            GenerateConfig::Options(GenerateOptions {
+                algorithm: Some("ed25519".to_string()),
+                bits: Some(3072),
+                ..Default::default()
+            }),
+            GenerateConfig::Options(GenerateOptions {
+                algorithm: Some("rsa".to_string()),
+                bits: Some(1024),
+                ..Default::default()
+            }),
+            GenerateConfig::Options(GenerateOptions {
+                comment: Some("bad\ncomment".to_string()),
+                ..Default::default()
+            }),
+        ] {
+            assert!(generate("ssh_private_key", &config).is_err());
+        }
+    }
+
+    #[test]
+    fn test_generate_ssh_uniqueness() {
+        let first = parse_ssh(&GenerateConfig::Bool(true));
+        let second = parse_ssh(&GenerateConfig::Bool(true));
+        assert_ne!(first.public_key(), second.public_key());
     }
 
     #[test]

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -114,7 +114,10 @@ pub use resolve::{
 };
 pub use secrets::ExportFormat;
 pub use secrets::Secrets;
-pub use spec::{Generation, PasswordCharset, Profile, Secret, Spec, SpecBuilder};
+pub use spec::{
+    Generation, OpenPgpAlgorithm, OpenPgpCapability, PasswordCharset, Profile, Secret, Spec,
+    SpecBuilder, SshKeyAlgorithm,
+};
 pub use validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
 
 #[cfg(test)]

--- a/secretspec/src/native.rs
+++ b/secretspec/src/native.rs
@@ -243,6 +243,14 @@ struct InlineGenerateOptions {
     command: Option<String>,
     #[serde(default)]
     bits: Option<usize>,
+    #[serde(default)]
+    algorithm: Option<String>,
+    #[serde(default)]
+    user_id: Option<String>,
+    #[serde(default)]
+    capabilities: Option<Vec<String>>,
+    #[serde(default)]
+    comment: Option<String>,
 }
 
 impl InlineSpec {
@@ -329,6 +337,10 @@ impl InlineSecret {
                     charset: options.charset,
                     command: options.command,
                     bits: options.bits,
+                    algorithm: options.algorithm,
+                    user_id: options.user_id,
+                    capabilities: options.capabilities,
+                    comment: options.comment,
                 }),
             }),
             prompt: self.prompt,
@@ -496,5 +508,56 @@ mod tests {
         }"#)).unwrap();
         assert_eq!(response["ok"], false);
         assert_eq!(response["error"]["kind"], "invalid_request");
+    }
+
+    #[test]
+    fn inline_declaration_preserves_openpgp_generation_options() {
+        let secret: InlineSecret = serde_json::from_str(
+            r#"{
+              "description": "Release key",
+              "type": "openpgp_private_key",
+                "generate": {
+                  "user_id": "Release Bot <releases@example.com>",
+                  "algorithm": "rsa",
+                  "bits": 2048,
+                  "capabilities": ["sign"]
+              }
+            }"#,
+        )
+        .unwrap();
+        let secret = secret.into_config().unwrap();
+        let Some(GenerateConfig::Options(options)) = secret.generate else {
+            panic!("expected OpenPGP generation options");
+        };
+        assert_eq!(
+            options.user_id.as_deref(),
+            Some("Release Bot <releases@example.com>")
+        );
+        assert_eq!(options.algorithm.as_deref(), Some("rsa"));
+        assert_eq!(options.bits, Some(2048));
+        assert_eq!(options.capabilities, Some(vec!["sign".to_string()]));
+    }
+
+    #[test]
+    fn inline_declaration_preserves_ssh_generation_options() {
+        let secret: InlineSecret = serde_json::from_str(
+            r#"{
+              "description": "Deployment key",
+              "type": "ssh_private_key",
+              "generate": {
+                "algorithm": "rsa",
+                "bits": 4096,
+                "comment": "deploy@example.com"
+              }
+            }"#,
+        )
+        .unwrap();
+        let secret = secret.into_config().unwrap();
+        let Some(GenerateConfig::Options(options)) = secret.generate else {
+            panic!("expected SSH generation options");
+        };
+        assert_eq!(options.algorithm.as_deref(), Some("rsa"));
+        assert_eq!(options.bits, Some(4096));
+        assert_eq!(options.comment.as_deref(), Some("deploy@example.com"));
     }
 }

--- a/secretspec/src/spec.rs
+++ b/secretspec/src/spec.rs
@@ -840,6 +840,22 @@ pub enum Generation {
         /// Key size in bits; `None` uses SecretSpec's default.
         bits: Option<usize>,
     },
+    /// An ASCII-armored OpenPGP transferable secret key (0.21+).
+    OpenPgpPrivateKey {
+        /// User ID certified by the generated key.
+        user_id: String,
+        /// Cryptographic profile used for the primary key and subkeys.
+        algorithm: OpenPgpAlgorithm,
+        /// Capabilities placed on separate subkeys.
+        capabilities: Vec<OpenPgpCapability>,
+    },
+    /// An unencrypted OpenSSH private key (0.21+).
+    SshPrivateKey {
+        /// Cryptographic algorithm and optional RSA key size.
+        algorithm: SshKeyAlgorithm,
+        /// Optional comment embedded in the OpenSSH key.
+        comment: Option<String>,
+    },
 }
 
 impl Generation {
@@ -874,6 +890,23 @@ impl Generation {
     /// An RSA private key with SecretSpec's default key size.
     pub fn rsa_private_key() -> Self {
         Self::RsaPrivateKey { bits: None }
+    }
+
+    /// An OpenPGP private key with signing and encryption subkeys (0.21+).
+    pub fn openpgp_private_key(user_id: impl Into<String>) -> Self {
+        Self::OpenPgpPrivateKey {
+            user_id: user_id.into(),
+            algorithm: OpenPgpAlgorithm::Ed25519,
+            capabilities: vec![OpenPgpCapability::Sign, OpenPgpCapability::Encrypt],
+        }
+    }
+
+    /// An Ed25519 OpenSSH private key without an embedded comment (0.21+).
+    pub fn ssh_private_key() -> Self {
+        Self::SshPrivateKey {
+            algorithm: SshKeyAlgorithm::Ed25519,
+            comment: None,
+        }
     }
 
     fn into_config(self) -> (&'static str, GenerateConfig) {
@@ -915,6 +948,111 @@ impl Generation {
                     ..GenerateOptions::default()
                 }),
             ),
+            Self::OpenPgpPrivateKey {
+                user_id,
+                algorithm,
+                capabilities,
+            } => (
+                "openpgp_private_key",
+                GenerateConfig::Options(GenerateOptions {
+                    user_id: Some(user_id),
+                    algorithm: Some(algorithm.as_str().to_string()),
+                    bits: algorithm.bits(),
+                    capabilities: Some(
+                        capabilities
+                            .into_iter()
+                            .map(|capability| capability.as_str().to_string())
+                            .collect(),
+                    ),
+                    ..GenerateOptions::default()
+                }),
+            ),
+            Self::SshPrivateKey { algorithm, comment } => (
+                "ssh_private_key",
+                GenerateConfig::Options(GenerateOptions {
+                    algorithm: Some(algorithm.as_str().to_string()),
+                    bits: algorithm.bits(),
+                    comment,
+                    ..GenerateOptions::default()
+                }),
+            ),
+        }
+    }
+}
+
+/// The algorithm for a generated OpenSSH private key.
+///
+/// Available starting with SecretSpec 0.21.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SshKeyAlgorithm {
+    /// Ed25519, the default for new SSH keys.
+    Ed25519,
+    /// RSA for compatibility. `None` uses the 3072-bit default.
+    Rsa { bits: Option<usize> },
+}
+
+impl SshKeyAlgorithm {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ed25519 => "ed25519",
+            Self::Rsa { .. } => "rsa",
+        }
+    }
+
+    fn bits(self) -> Option<usize> {
+        match self {
+            Self::Ed25519 => None,
+            Self::Rsa { bits } => bits,
+        }
+    }
+}
+
+/// The cryptographic profile for a generated OpenPGP key.
+///
+/// Available starting with SecretSpec 0.21.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OpenPgpAlgorithm {
+    /// Ed25519 certification/signing keys and Curve25519 encryption subkeys.
+    Ed25519,
+    /// RSA primary key and subkeys. `None` uses the 3072-bit default.
+    Rsa { bits: Option<usize> },
+}
+
+impl OpenPgpAlgorithm {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ed25519 => "ed25519",
+            Self::Rsa { .. } => "rsa",
+        }
+    }
+
+    fn bits(self) -> Option<usize> {
+        match self {
+            Self::Ed25519 => None,
+            Self::Rsa { bits } => bits,
+        }
+    }
+}
+
+/// A capability assigned to a generated OpenPGP subkey.
+///
+/// Available starting with SecretSpec 0.21.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OpenPgpCapability {
+    /// Generate a signing subkey using the selected algorithm.
+    Sign,
+    /// Generate an encryption subkey using the selected algorithm.
+    Encrypt,
+}
+
+impl OpenPgpCapability {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sign => "sign",
+            Self::Encrypt => "encrypt",
         }
     }
 }
@@ -998,6 +1136,65 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_string().contains("duplicate secret 'TOKEN'"));
+    }
+
+    #[test]
+    fn openpgp_generation_builder_uses_the_interoperable_default_profile() {
+        let (secret_type, config) =
+            Generation::openpgp_private_key("Release Bot <releases@example.com>").into_config();
+        assert_eq!(secret_type, "openpgp_private_key");
+        let GenerateConfig::Options(options) = config else {
+            panic!("OpenPGP generation must use options");
+        };
+        assert_eq!(
+            options.user_id.as_deref(),
+            Some("Release Bot <releases@example.com>")
+        );
+        assert_eq!(options.algorithm.as_deref(), Some("ed25519"));
+        assert_eq!(options.bits, None);
+        assert_eq!(
+            options.capabilities,
+            Some(vec!["sign".to_string(), "encrypt".to_string()])
+        );
+    }
+
+    #[test]
+    fn openpgp_generation_builder_maps_an_explicit_rsa_profile() {
+        let generation = Generation::OpenPgpPrivateKey {
+            user_id: "Legacy Bot <legacy@example.com>".to_string(),
+            algorithm: OpenPgpAlgorithm::Rsa { bits: Some(4096) },
+            capabilities: vec![OpenPgpCapability::Encrypt],
+        };
+        let (_, GenerateConfig::Options(options)) = generation.into_config() else {
+            panic!("OpenPGP generation must use options");
+        };
+        assert_eq!(options.algorithm.as_deref(), Some("rsa"));
+        assert_eq!(options.bits, Some(4096));
+        assert_eq!(options.capabilities, Some(vec!["encrypt".to_string()]));
+    }
+
+    #[test]
+    fn ssh_generation_builder_maps_default_and_rsa_profiles() {
+        let (secret_type, GenerateConfig::Options(default)) =
+            Generation::ssh_private_key().into_config()
+        else {
+            panic!("SSH generation must use options");
+        };
+        assert_eq!(secret_type, "ssh_private_key");
+        assert_eq!(default.algorithm.as_deref(), Some("ed25519"));
+        assert_eq!(default.bits, None);
+        assert_eq!(default.comment, None);
+
+        let generation = Generation::SshPrivateKey {
+            algorithm: SshKeyAlgorithm::Rsa { bits: Some(4096) },
+            comment: Some("deploy@example.com".to_string()),
+        };
+        let (_, GenerateConfig::Options(rsa)) = generation.into_config() else {
+            panic!("SSH generation must use options");
+        };
+        assert_eq!(rsa.algorithm.as_deref(), Some("rsa"));
+        assert_eq!(rsa.bits, Some(4096));
+        assert_eq!(rsa.comment.as_deref(), Some("deploy@example.com"));
     }
 
     #[test]

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::config::{
-    Config, CredentialSource, GlobalConfig, GlobalDefaults, NativeAddress, NativeAddressTemplate,
-    ParseError, Profile, Project, ProviderAlias, ProviderCache, RequireReason, Resolved, Secret,
+    Config, CredentialSource, GenerateConfig, GlobalConfig, GlobalDefaults, NativeAddress,
+    NativeAddressTemplate, ParseError, Profile, Project, ProviderAlias, ProviderCache,
+    RequireReason, Resolved, Secret,
 };
 use crate::error::{Result, SecretSpecError};
 use crate::secrets::Secrets;
@@ -5708,6 +5709,104 @@ MONGO_KEY = { description = "MongoDB keyfile", type = "command", generate = { co
             assert_eq!(opts.command.as_deref(), Some("echo test"));
         }
         other => panic!("Expected Options, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_config_parse_generate_openpgp_private_key() {
+    let toml_content = r#"
+[project]
+name = "test-gen"
+revision = "1.0"
+
+[profiles.default]
+RELEASE_KEY = { description = "Release key", type = "openpgp_private_key", generate = { user_id = "Release Bot <releases@example.com>", algorithm = "rsa", bits = 4096, capabilities = ["sign"] } }
+"#;
+    let config = parse_spec_from_str(toml_content, None).unwrap();
+    let secret = &config.profiles["default"].secrets["RELEASE_KEY"];
+    assert_eq!(secret.secret_type.as_deref(), Some("openpgp_private_key"));
+    match &secret.generate {
+        Some(crate::config::GenerateConfig::Options(opts)) => {
+            assert_eq!(
+                opts.user_id.as_deref(),
+                Some("Release Bot <releases@example.com>")
+            );
+            assert_eq!(opts.algorithm.as_deref(), Some("rsa"));
+            assert_eq!(opts.bits, Some(4096));
+            assert_eq!(
+                opts.capabilities.as_deref(),
+                Some(["sign".to_string()].as_slice())
+            );
+        }
+        other => panic!("Expected Options, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_config_rejects_invalid_openpgp_generation_options() {
+    for declaration in [
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = true }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = {} }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = " " } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", capabilities = [] } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", capabilities = ["authenticate"] } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", capabilities = ["sign", "sign"] } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", algorithm = "dsa" } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", algorithm = "ed25519", bits = 3072 } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", algorithm = "rsa", bits = 1024 } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", algorithm = "rsa", bits = 16384 } }"#,
+    ] {
+        let toml_content = format!(
+            "[project]\nname = \"test-gen\"\nrevision = \"1.0\"\n\n[profiles.default]\n{declaration}\n"
+        );
+        assert!(
+            parse_spec_from_str(&toml_content, None).is_err(),
+            "accepted invalid declaration: {declaration}"
+        );
+    }
+}
+
+#[test]
+fn test_config_parses_ssh_generation_options() {
+    let toml_content = r#"
+[project]
+name = "test-gen"
+revision = "1.0"
+
+[profiles.default]
+DEFAULT_KEY = { description = "Default key", type = "ssh_private_key", generate = true }
+RSA_KEY = { description = "RSA key", type = "ssh_private_key", generate = { algorithm = "rsa", bits = 4096, comment = "deploy@example.com" } }
+"#;
+    let config = parse_spec_from_str(toml_content, None).unwrap();
+    assert!(matches!(
+        config.profiles["default"].secrets["DEFAULT_KEY"].generate,
+        Some(GenerateConfig::Bool(true))
+    ));
+    let Some(GenerateConfig::Options(options)) =
+        &config.profiles["default"].secrets["RSA_KEY"].generate
+    else {
+        panic!("expected SSH generation options");
+    };
+    assert_eq!(options.algorithm.as_deref(), Some("rsa"));
+    assert_eq!(options.bits, Some(4096));
+    assert_eq!(options.comment.as_deref(), Some("deploy@example.com"));
+}
+
+#[test]
+fn test_config_rejects_invalid_ssh_generation_options() {
+    for declaration in [
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { algorithm = "ecdsa" } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { algorithm = "ed25519", bits = 3072 } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { algorithm = "rsa", bits = 1024 } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { algorithm = "rsa", bits = 16384 } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { comment = "bad\ncomment" } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { user_id = "Bot" } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", comment = "ssh-only" } }"#,
+    ] {
+        let toml_content = format!(
+            "[project]\nname = \"test-gen\"\nrevision = \"1.0\"\n\n[profiles.default]\n{declaration}\n"
+        );
+        assert!(parse_spec_from_str(&toml_content, None).is_err());
     }
 }
 


### PR DESCRIPTION
## Summary

- add pure-Rust OpenPGP and OpenSSH private-key generation
- default both key types to modern elliptic-curve profiles: Ed25519/Curve25519 for OpenPGP and Ed25519 for SSH
- allow configurable RSA compatibility profiles with a 3072-bit default and 2048-8192-bit range
- support OpenPGP signing/encryption capabilities plus optional OpenSSH key comments
- add a read-only provider-backed `secretspec ssh-agent` command for SSH and Git, including scopes, auditing, private sockets, child signal forwarding, and cleanup
- expose generation through TOML, inline/native specs, and the typed Rust API
- document all new surfaces as SecretSpec 0.21+ and update the changelog

Generated keys are unencrypted; provider storage remains responsible for protection at rest. Generated SSH agent keys must use a retaining provider rather than `null`, because the agent resolves the key again for each signature.

## Validation

- `devenv shell cargo test --all` (1,526 core tests plus workspace, integration, SDK, and doc tests)
- `cargo test -p secretspec ssh -- --nocapture` (28 focused tests)
- `cargo check -p secretspec --no-default-features`
- `devenv shell prek run -a`
- `devenv shell npm --prefix docs run build`
- `devenv shell npm --prefix docs run check:links` (7,490 links, zero errors)
- `git diff --check`
- manual GnuPG 2.4.9 interoperability check for OpenPGP import, sign/verify, and encrypt/decrypt