### PR TITLE
feat: generate additional credential types and X.509 identities

### DIFF
--- a/.github/workflows/haskell-build.yml
+++ b/.github/workflows/haskell-build.yml
@@ -110,6 +110,10 @@ jobs:
         uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       - name: Install NASM (aws-lc-sys assembly)
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
+      # Build the MSVC CLI before MSYS2 prepends its Cygwin Perl to PATH.
+      # Vendored OpenSSL requires a native Windows Perl for an MSVC target.
+      - name: Build CLI for the test-suite
+        run: cargo build -p secretspec
       # MINGW64 (msvcrt-based) matches the CRT the x86_64-pc-windows-gnu Rust
       # target links, so every object in the archive agrees on one C runtime.
       - name: Install MSYS2 MinGW toolchain (compiles the staticlib's C deps)
@@ -132,9 +136,8 @@ jobs:
           # members that objcopy below refuses to process.
           cargo rustc -p libsecretspec --release --target x86_64-pc-windows-gnu \
             --crate-type staticlib
-          # The CLI (for the test-suite's end-to-end codegen test) builds for
-          # the default MSVC host target, same as the released binaries.
-          cargo build -p secretspec
+          # The CLI for the test-suite's end-to-end codegen test was built for
+          # the default MSVC host before entering MSYS2.
           export SECRETSPEC_BIN="$(cygpath -w "$PWD/target/debug/secretspec.exe")"
           native_libs="$(cargo rustc -q -p libsecretspec --release \
             --target x86_64-pc-windows-gnu --crate-type staticlib -- \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provisioning preserves stored identities while requesting missing passwords
   and canonicalizes encoded PFX input; empty credential maps clear inherited
   bindings, and valid long DNS SANs use a fallback certificate subject.
+  Configuration loading rejects extraction on stored binary identities and
+  generation options that the selected credential type does not support.
 
 ## [0.20.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- OpenPGP and OpenSSH private keys can be generated entirely in Rust (0.21+).
-  OpenPGP generation uses an explicit User ID and signing, encryption, or
-  combined capability profiles; Ed25519/Curve25519 is the default, with
-  configurable RSA available for compatibility. OpenSSH generation likewise
-  defaults to Ed25519 and supports configurable RSA keys and comments.
+- SecretSpec can generate `passphrase`, `mnemonic`, `openpgp_private_key`,
+  `ssh_private_key`, `wireguard_private_key`, `jwk_private_key`, and
+  `age_identity` values entirely in Rust, plus self-signed P-256
+  `x509_identity` values stored as PKCS#12 archives, Base64 by default
+  (0.21+). A secret with `from` derives from another declared secret: with
+  `extract` it selects a JSON or INI field from that secret's text, and with a
+  typed conversion target (`pkcs12`, `pkcs8_private_key`,
+  `x509_certificate`, `x509_certificate_chain`, or `x509_issuer_chain`) it
+  converts an `x509_identity` into a PFX archive, key, certificate, or chain.
+  `format` selects `pem` or `der` where a type offers both. A stored
+  `x509_identity` may be a password protected archive: `credentials =
+  { password = "PFX_PASSWORD" }` names the declared secret that opens it, and
+  the same binding on a `pkcs12` target protects the produced archive with
+  PBES2/AES-256-CBC and HMAC-SHA-256. Derived secrets join composed secrets'
+  dependency graph, so declaration order does not matter, scopes fetch hidden
+  sources and passwords without exposing them, and cycles are rejected when
+  the manifest loads. Binary values are delivered as owner-only `.pfx`, `.pem`,
+  or `.der` files with `as_path`, or inline in their encoding otherwise, and
+  `check --explain` labels them `converted from` or `selected from`. OpenPGP
+  generation uses an explicit User ID and signing, encryption, or combined
+  capability profiles; Ed25519/Curve25519 is the default, with configurable
+  RSA available for compatibility. OpenSSH generation likewise defaults to
+  Ed25519 and supports configurable RSA keys and comments. JWK generation
+  supports Ed25519, P-256, and RSA signing keys and uses RFC 9864's fully
+  specified `Ed25519` identifier. Credential entropy is read directly from
+  the operating system, passphrases require at least six words, and mnemonics
+  default to checksum-protected 24-word English BIP-39 values. Temporary
+  private-key and mnemonic encodings are cleared from memory. Interactive
+  provisioning preserves stored identities while requesting missing passwords
+  and canonicalizes encoded PFX input; empty credential maps clear inherited
+  bindings, and valid long DNS SANs use a fallback certificate subject.
 
 ## [0.20.0] - 2026-08-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "zeroize",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1061,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitfields"
@@ -3039,6 +3058,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,6 +4635,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4614,6 +4651,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5983,6 +6021,8 @@ dependencies = [
  "azure_identity",
  "azure_security_keyvault_secrets",
  "base64",
+ "bech32",
+ "bip39",
  "clap",
  "clap_complete",
  "clap_complete_nushell",
@@ -5991,6 +6031,7 @@ dependencies = [
  "detect-coding-agent",
  "dotenv-ng",
  "dunce",
+ "ed25519-dalek",
  "etcetera",
  "google-cloud-secretmanager-v1",
  "inquire",
@@ -6006,6 +6047,8 @@ dependencies = [
  "libc",
  "linkme",
  "miette",
+ "openssl",
+ "p256",
  "percent-encoding",
  "pgp",
  "proptest",
@@ -6032,6 +6075,7 @@ dependencies = [
  "wait-timeout",
  "whoami",
  "windows-sys 0.61.2",
+ "x25519-dalek",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,13 +74,19 @@ pgp = { version = "0.20", default-features = false }
 smallvec = "1"
 uuid = { version = "1", features = ["serde", "v4"] }
 data-encoding = "2"
-sha2 = "0.10"
+bip39 = { version = "2.2.2", default-features = false, features = ["zeroize"] }
+bech32 = "0.11"
+ed25519-dalek = { version = "2.2", features = ["rand_core"] }
+p256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+sha2 = { version = "0.10", features = ["oid"] }
 detect-coding-agent = "0.1"
 age = { version = "0.12", features = ["armor", "plugin", "ssh"] }
 ssh-key = { version = "0.6.7", features = ["crypto"] }
 kube = { version = "4.2", default-features = false, features = ["client", "rustls-tls", "aws-lc-rs", "jsonpatch"] }
 k8s-openapi = { version = "0.28", features = ["v1_36"] }
 json-patch = "4.2.0"
+openssl = { version = "0.10.81", features = ["vendored"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/docs/src/content/docs/concepts/declarative.md
+++ b/docs/src/content/docs/concepts/declarative.md
@@ -36,10 +36,19 @@ SECRET_NAME = {
 - `required`: Whether the secret must be provided (default: `true`)
 - `default`: Fallback value for optional secrets
 - `composed` (0.16+): Derive a read-only value from other declared secrets (see [Composed Secrets](/concepts/composed-secrets/) for the strict template and dependency semantics)
-- `type`: Secret type for auto-generation (`password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key`, and `openpgp_private_key` in 0.21+)
+- `type`: Secret type for auto-generation (`password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key`; `passphrase`, `mnemonic`, `openpgp_private_key`, `ssh_private_key`, `wireguard_private_key`, `jwk_private_key`, `age_identity`, and `x509_identity` require 0.21+)
 - `generate`: Enable auto-generation when the secret is missing (`true` or a table with options)
 - `prompt` (0.19+): Securely ask for a missing value during `secretspec run` and
   let the selected provider decide whether to save the answer
+- `from` (0.21+): Derive a read-only value from another declared secret, either
+  by selecting a field with `extract` or by converting an `x509_identity` into
+  a `pkcs12`, `pkcs8_private_key`, `x509_certificate`,
+  `x509_certificate_chain`, or `x509_issuer_chain` (see the
+  [configuration reference](/reference/configuration/#derived-typed-secrets-021))
+- `format` (0.21+): Choose `pem` (default) or `der` for a converted key or
+  certificate
+- `credentials` (0.21+): Bind the `password` that opens a stored
+  `x509_identity` or protects a derived `pkcs12` to another declared secret
 
 ## Related Concepts
 

--- a/docs/src/content/docs/concepts/generation.mdx
+++ b/docs/src/content/docs/concepts/generation.mdx
@@ -24,6 +24,8 @@ REQUEST_ID = { description = "Request ID prefix", type = "uuid", generate = true
 | Type | Default Output | Options |
 |------|---------------|---------|
 | `password` | 32 alphanumeric chars | `length` (int), `charset` (`"alphanumeric"` or `"ascii"`) |
+| `passphrase` (0.21+) | Seven BIP-39 English words joined with `-` | `words` (6–32), `separator` (non-empty string) |
+| `mnemonic` (0.21+) | 24-word English BIP-39 mnemonic | `algorithm` (`"bip39"`), `words` (12, 15, 18, 21, or 24), `language` (`"english"`) |
 | `hex` | 64 hex chars (32 bytes) | `bytes` (int) |
 | `base64` | 44 chars (32 bytes) | `bytes` (int) |
 | `uuid` | UUID v4 (36 chars) | none |
@@ -31,6 +33,10 @@ REQUEST_ID = { description = "Request ID prefix", type = "uuid", generate = true
 | `rsa_private_key` | 2048-bit RSA private key (PKCS1 PEM) | `bits` (int) |
 | `openpgp_private_key` (0.21+) | ASCII-armored OpenPGP transferable secret key | `user_id` (required), `algorithm` (`"ed25519"` or `"rsa"`), `bits` (RSA only), `capabilities` (`["sign"]`, `["encrypt"]`, or both) |
 | `ssh_private_key` (0.21+) | Unencrypted OpenSSH Ed25519 private key | `algorithm` (`"ed25519"` or `"rsa"`), `bits` (RSA only), `comment` (string) |
+| `wireguard_private_key` (0.21+) | Base64-encoded WireGuard private key | none |
+| `jwk_private_key` (0.21+) | Ed25519 private signing JWK | `algorithm` (`"ed25519"`, `"p256"`, or `"rsa"`), `bits` (RSA only), `kid` (string) |
+| `age_identity` (0.21+) | Native X25519 age identity | none |
+| `x509_identity` (0.21+) | PKCS#12 archive (Base64 at rest) containing a P-256 key and self-signed certificate | `san` (required), `usages`, `valid_for` (1–200 days); `issuer = "self_signed"`, `algorithm = "p256"` |
 
 ### Command type
 
@@ -99,6 +105,73 @@ keys are not passphrase-encrypted, so store them in an encrypted provider. Set
 `as_path = true` when a command needs the key in a temporary file rather than in
 an environment variable.
 
+### Passphrases and infrastructure keys {/* #additional-generation-types-021 */}
+
+<VersionCompatibility version="0.21" />
+
+`passphrase` independently selects seven words from the 2,048-word BIP-39
+English list by default, providing 77 bits of entropy. The output is a
+human-readable passphrase, not a BIP-39 mnemonic: SecretSpec adds no checksum
+and does not derive a wallet seed. Set `words` from 6 through 32 and choose any
+non-empty, control-character-free `separator`:
+
+```toml
+RECOVERY_CODE = { description = "Operator recovery code", type = "passphrase", generate = { words = 8, separator = "." } }
+```
+
+`mnemonic` (0.21+) generates a checksum-valid BIP-39 recovery mnemonic. It
+defaults to 24 English words, encoding 256 bits of OS-provided entropy plus the
+BIP-39 checksum. Supported word counts are 12, 15, 18, 21, and 24;
+`algorithm = "bip39"` and `language = "english"` are currently the only
+supported subtype values:
+
+```toml
+WALLET_RECOVERY = { description = "Wallet recovery mnemonic", type = "mnemonic", generate = { algorithm = "bip39", words = 24, language = "english" } }
+```
+
+The generated value is the mnemonic itself. SecretSpec does not derive a
+BIP-32 seed or wallet keys and does not add BIP-39's optional mnemonic
+passphrase. Store it only in a provider appropriate for high-value recovery
+material.
+
+The other 0.21+ infrastructure formats are generated entirely in process:
+
+```toml
+WIREGUARD_KEY = { description = "WireGuard peer private key", type = "wireguard_private_key", generate = true }
+JWT_KEY = { description = "JWT signing key", type = "jwk_private_key", generate = { algorithm = "p256", kid = "release-2026" } }
+AGE_KEY = { description = "Backup encryption identity", type = "age_identity", generate = true }
+TLS_IDENTITY = { description = "Development TLS identity", type = "x509_identity", generate = { san = ["dns:localhost", "ip:127.0.0.1"], valid_for = "30d" } }
+TLS_KEY = { description = "PKCS#8 private key", type = "pkcs8_private_key", from = "TLS_IDENTITY", as_path = true }
+```
+
+`wireguard_private_key` produces the standard Base64-encoded, clamped 32-byte
+private key accepted by WireGuard. `age_identity` produces a native X25519
+`AGE-SECRET-KEY-1...` identity. Neither accepts generation options.
+
+The X25519 age identity maximizes compatibility with the current Rust age
+provider. The age reference implementation now recommends hybrid
+ML-KEM-768+X25519 identities for data that needs post-quantum confidentiality,
+but the Rust age library does not yet parse that identity format. Provision a
+hybrid `AGE-SECRET-KEY-PQ-1...` identity externally when that threat model
+applies.
+
+`jwk_private_key` emits one compact private JWK including its public parameters,
+`use = "sig"`, and `key_ops = ["sign"]`. Ed25519 with RFC 9864's fully
+specified `Ed25519` JOSE algorithm identifier is the default;
+`algorithm = "p256"` selects P-256/`ES256`, while `"rsa"` selects
+RSA/`RS256`, defaults to 3072 bits, and accepts 2048 through 8192. `kid` is
+optional. Protect all three private-key values with an encrypted provider.
+
+`x509_identity` (0.21+) generates a self-signed P-256 certificate whose SANs
+must be explicit. The canonical value is an empty-password PKCS#12 archive,
+stored as Base64 by default; the provider is its security boundary. Generation
+uses ECDSA/SHA-256, a 30-day default lifetime, and a 200-day maximum. Declare
+further secrets with `from = "TLS_IDENTITY"` and a typed conversion target to
+obtain PKCS#8 PEM or DER private keys, certificate PEM or DER, ordered
+certificate chains, or password protected PFX files. See the
+[configuration reference](/reference/configuration/#derived-typed-secrets-021)
+for the complete example and validation rules.
+
 ## How it works
 
 - Generation only triggers when a secret is **missing**. Existing secrets are never overwritten.
@@ -150,6 +223,18 @@ RELEASE_KEY = { description = "Release signing key", type = "openpgp_private_key
 
 # OpenSSH Ed25519 private key (requires SecretSpec 0.21+)
 DEPLOY_KEY = { description = "Deployment SSH key", type = "ssh_private_key", generate = true }
+
+# Human-readable passphrase (requires SecretSpec 0.21+)
+RECOVERY_CODE = { description = "Recovery code", type = "passphrase", generate = true }
+
+# Checksum-protected BIP-39 mnemonic (requires SecretSpec 0.21+)
+WALLET_RECOVERY = { description = "Wallet recovery mnemonic", type = "mnemonic", generate = true }
+
+# Private P-256 JWK (requires SecretSpec 0.21+)
+JWT_JWK = { description = "JWT signing JWK", type = "jwk_private_key", generate = { algorithm = "p256" } }
+
+# Self-signed P-256 X.509 identity (requires SecretSpec 0.21+)
+TLS_IDENTITY = { description = "Development TLS identity", type = "x509_identity", generate = { san = ["dns:localhost", "ip:127.0.0.1"] } }
 
 # Informational type only, no generation
 EXTERNAL_API_KEY = { description = "Provided by vendor", type = "password" }

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -164,8 +164,11 @@ Each secret variable is defined as a table with the following fields:
 | `refs` (0.19+) | table | No | Provider-alias-scoped coordinates, keyed by leaf alias (e.g. `refs = { source = { item = "old" }, target = { item = "new" } }`); mutually exclusive with `ref` |
 | `as_path` | boolean | No | Write secret to temp file and return file path (default: false) |
 | `encoding` (0.19+) | `"base64"`, `"base64url"`, or `"hex"` | No | Encode logical values before storage writes and decode stored values after reads |
-| `extract` (0.19+) | table | No | Select one logical value from stored JSON (0.19+) or INI (0.20+) data with a pointer |
-| `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key`, `openpgp_private_key` (0.21+), `ssh_private_key` (0.21+) |
+| `extract` (0.19+) | table | No | Select one field from stored JSON/INI text, or from the text of the secret named by `from` (0.21+) |
+| `type` | string | No | Secret type for generation: `password`, `hex`, `base64`, `uuid`, `command`, `rsa_private_key`, `passphrase` (0.21+), `mnemonic` (0.21+), `openpgp_private_key` (0.21+), `ssh_private_key` (0.21+), `wireguard_private_key` (0.21+), `jwk_private_key` (0.21+), `age_identity` (0.21+), `x509_identity` (0.21+). Typed conversion targets (0.21+): `pkcs12`, `pkcs8_private_key`, `x509_certificate`, `x509_certificate_chain`, `x509_issuer_chain` |
+| `format` (0.21+) | `"pem"` or `"der"` | No | Serialization of a `pkcs8_private_key` or `x509_certificate`; defaults to `pem` |
+| `from` (0.21+) | string | No | Declared secret this value is converted from (with a typed conversion target) or selected from (with `extract`) |
+| `credentials` (0.21+) | table | No | Declared secrets bound to the roles a type defines, e.g. `credentials = { password = "PFX_PASSWORD" }` for `x509_identity` and `pkcs12` |
 | `generate` | boolean or table | No | Enable auto-generation when secret is missing |
 | `prompt` (0.19+) | boolean | No | Securely prompt for a missing value during `secretspec run`; the selected provider controls persistence |
 
@@ -185,6 +188,17 @@ Field notes:
   combined with `default`, enabled `generate`, `extract`, or `composed`.
 - `extract` (0.19+) is read-only and cannot be combined with enabled
   `generate`.
+- `from` (0.21+) makes a secret read-only and derived: it needs either
+  `extract` or a typed conversion target as its `type`, and cannot declare
+  `default`, `providers`, `ref`, `refs`, enabled `generate`, `prompt = true`,
+  or `composed`. See [Derived typed secrets](#derived-typed-secrets-021).
+- `format` (0.21+) is valid only for types with more than one serialization
+  (`pkcs8_private_key` and `x509_certificate`).
+- `credentials` (0.21+) is valid only for types that define roles:
+  `x509_identity` and `pkcs12` accept `password`. Each value names a declared
+  text secret. The `{ provider, ref }` table form is reserved.
+- `type = "x509_identity"` (0.21+) is a binary type: it cannot be combined
+  with `default` or `prompt = true`, and `encoding` defaults to `base64`.
 
 #### Composed Secrets
 
@@ -207,7 +221,9 @@ and composed secrets may reference other composed secrets. SecretSpec rejects
 unknown references, cycles, malformed references, and source conflicts while
 loading the manifest. A composed secret is read-only and cannot also set
 `default`, `providers`, `ref`, `refs` (0.19+), `type`, enabled `generate`,
-`encoding` (0.19+), or `extract` (0.19+).
+`encoding` (0.19+), `extract` (0.19+), `format` (0.21+), `from` (0.21+), or
+`credentials` (0.21+). A composed template may reference a derived secret, for
+example to embed the path of a certificate file.
 
 Composition intentionally does **not** implement dotenv or shell expansion:
 
@@ -246,7 +262,8 @@ Scopes name membership-only subsets of a profile's secrets, so a single service
 or task resolves only what it declares instead of the entire profile. They are
 **orthogonal to profiles**: a profile decides how each secret resolves
 (`required`, `default`, providers, references, generation, prompts (0.19+), `as_path`,
-`encoding` (0.19+), `extract` (0.19+), and the storage namespace); a scope only
+`encoding` (0.19+), `extract` (0.19+), `from` derivation (0.21+), and the
+storage namespace); a scope only
 decides *which* secrets take part in a given resolution.
 
 ```toml
@@ -698,11 +715,21 @@ Exactly one trailing LF or CRLF is accepted so command-captured values work
 without preprocessing. Other whitespace and non-alphabet characters are
 rejected. Without `as_path = true`, decoded bytes must be valid UTF-8.
 
-`secretspec set`, interactive prompts, and generated secrets provide logical
-text; SecretSpec encodes it before writing to a provider or cache. Defaults and
-composed results are already logical and are not transformed. The
+`secretspec set`, interactive prompts, and ordinary generated secrets provide
+logical text; SecretSpec encodes it before writing to a provider or cache.
+Defaults and composed results are already logical and are not transformed. The
 `secretspec import` command copies the stored representation verbatim, avoiding
 double encoding.
+
+<VersionCompatibility version="0.21" kind="changed">
+
+Binary typed values (`x509_identity` and the `pkcs12` and `der` conversion
+targets) default `encoding` to `base64` and use it wherever their bytes must be
+text: in the provider, in the cache, and inline when `as_path` is not set. With
+`as_path = true` the file holds the raw bytes. `secretspec set` accepts such a
+value in its encoded form. See [Derived typed secrets](#derived-typed-secrets-021).
+
+</VersionCompatibility>
 
 ### Structured Extraction {/* #structured-extraction-019 */}
 
@@ -711,6 +738,14 @@ double encoding.
 <VersionCompatibility version="0.20" kind="changed">
 
 Structured extraction now supports INI documents with `format = "ini"`.
+
+</VersionCompatibility>
+
+<VersionCompatibility version="0.21" kind="changed">
+
+`extract` can now select from the text of another declared secret named by
+`from`. X.509 conversions use `type` and `from` rather than extraction formats;
+see [Derived typed secrets](#derived-typed-secrets-021).
 
 </VersionCompatibility>
 
@@ -771,22 +806,194 @@ always remain strings, and literal backslashes are preserved. Empty pointers,
 pointers deeper than `/section/key`, malformed INI, and unmatched pointers are
 decoding errors.
 
+In 0.21+, `from` names another declared secret as the document to select from.
+The source is resolved first and may itself come from a provider, default,
+generator, or another derived declaration. `from` dependencies share composed
+secrets' static graph: declaration order does not matter, scoped resolutions
+fetch hidden dependencies without exposing them, and unknown names or cycles
+are rejected while loading the manifest. JSON and INI continue to use
+`pointer`, and the source must be text (a binary typed source is rejected):
+
+```toml
+[profiles.default]
+# from requires SecretSpec 0.21+
+GENERATED_DOCUMENT = { description = "Generated JSON", type = "command", generate = { command = "generate-config" } }
+DATABASE_PASSWORD = { description = "Database password", from = "GENERATED_DOCUMENT", extract = { format = "json", pointer = "/database/password" } }
+```
+
 Stored-value transforms run in this order:
 
 ```text
 provider or cache → encoding decode → structured extraction → as_path
+from source → source resolution → structured extraction → as_path
 ```
 
 This makes a Base64-encoded JSON document valid input when a declaration sets
 both `encoding = "base64"` (0.19+) and `extract` (0.19+). A provider-native
 `ref.field` is also resolved first, so a field whose contents are JSON can be
-selected further. Defaults and composed values are already logical and are not
-extracted.
+selected further. Without `from`, defaults and composed values are already
+logical and are not extracted.
 
 Extracted secrets are read-only. `set`, `delete`, interactive prompting,
 generation, and `import` reject them rather than replacing or removing the
 containing document and its sibling values. Update the document through its
-owning system instead.
+owning system instead. A `from` selection reports its source as the value to
+change.
+
+### Derived typed secrets {/* #derived-typed-secrets-021 */}
+
+<VersionCompatibility version="0.21" />
+
+A secret with `from` and a typed conversion target as its `type` converts
+another declared secret. In 0.21 the source is always an `x509_identity`: a
+PKCS#12 archive holding one private key, its leaf certificate, and an optional
+issuer chain, whether generated by SecretSpec or imported from a provider. Every
+target is an ordinary flat secret with its own name, so SDKs and `run` see it
+like any other value.
+
+| Type (0.21+) | Output | `format` | Binary |
+|--------------|--------|----------|--------|
+| `pkcs12` | Complete PKCS#12/PFX archive, protected by the `password` credential when one is bound | fixed | yes |
+| `pkcs8_private_key` | Unencrypted PKCS#8 private key | `pem` (default) or `der` | `der` only |
+| `x509_certificate` | Leaf certificate | `pem` (default) or `der` | `der` only |
+| `x509_certificate_chain` | Leaf followed by its ordered issuer certificates | `pem` | no |
+| `x509_issuer_chain` | Ordered issuer certificates without the leaf | `pem` | no |
+
+No target is itself an accepted source, so conversions are one level deep. A
+composed template may still reference a target.
+
+#### Generated identity and password protected PFX
+
+```toml
+[profiles.development]
+# type = "x509_identity", from, format, and credentials require SecretSpec 0.21+
+TLS_IDENTITY = {
+  description = "Canonical development TLS identity",
+  type = "x509_identity",
+  generate = { san = ["dns:localhost", "ip:127.0.0.1"], usages = ["server_auth"], valid_for = "30d" }
+}
+
+TLS_PFX_PASSWORD = {
+  description = "Password protecting the exported PFX",
+  type = "passphrase",
+  generate = true
+}
+
+TLS_PFX = {
+  description = "Password protected Windows TLS identity",
+  type = "pkcs12",
+  from = "TLS_IDENTITY",
+  credentials = { password = "TLS_PFX_PASSWORD" },
+  as_path = true
+}
+
+TLS_KEY = {
+  description = "PKCS#8 private key",
+  type = "pkcs8_private_key",
+  from = "TLS_IDENTITY",
+  as_path = true
+}
+
+TLS_CERTIFICATE_DER = {
+  description = "Leaf certificate as DER",
+  type = "x509_certificate",
+  format = "der",
+  from = "TLS_IDENTITY",
+  as_path = true
+}
+
+TLS_CHAIN = {
+  description = "Leaf followed by its issuer chain",
+  type = "x509_certificate_chain",
+  from = "TLS_IDENTITY"
+}
+```
+
+`TLS_IDENTITY` does not spell `encoding`: binary types default to Base64. One
+resolve generates or reads the identity and the password, then materializes
+every target. The consumer receives `TLS_PFX` as a `.pfx` path and
+`TLS_PFX_PASSWORD` as a value, which is what it needs to load the archive.
+
+#### Importing a protected PFX
+
+The password that opens a stored archive belongs to the source declaration.
+Projections do not repeat it:
+
+```toml
+[profiles.production]
+SERVICE_IDENTITY = {
+  description = "Imported service identity",
+  type = "x509_identity",
+  providers = ["identity_store"],
+  credentials = { password = "SERVICE_IDENTITY_PASSWORD" }
+}
+
+SERVICE_IDENTITY_PASSWORD = {
+  description = "Password protecting the imported PFX",
+  providers = ["onepassword"],
+  ref = { vault = "Infrastructure", item = "Production TLS", field = "PFX password" }
+}
+
+SERVICE_KEY = { description = "Service private key", type = "pkcs8_private_key", from = "SERVICE_IDENTITY", as_path = true }
+SERVICE_CERTIFICATE = { description = "Service certificate chain", type = "x509_certificate_chain", from = "SERVICE_IDENTITY", as_path = true }
+```
+
+The password is an ordinary declared secret with provider routing, native
+coordinates, `secretspec set`, `import`, audit, and scope handling. If it is
+missing, the identity and every projection are reported missing under their own
+`required` policy. A wrong password, or a protected archive with no password
+bound, is a decoding error; SecretSpec never falls back to guessing.
+
+To rewrap an archive under a new password, derive a `pkcs12` from the imported
+identity with a different `credentials.password`. Omitting the credential on a
+`pkcs12` target produces an empty-password archive, an interchange container
+rather than a security boundary.
+
+#### Delivery
+
+- `as_path = true` writes the raw bytes to an owner-only file with the type's
+  suffix: `.pfx`, `.pem`, or `.der`.
+- Without `as_path`, a binary target is exposed inline as text in its
+  `encoding` (`base64` by default; `base64url` and `hex` are accepted). This
+  suits CI systems that take a Base64 PFX in an environment variable. A text
+  target is exposed as is, and `encoding` is rejected on it.
+- Stored identities are validated once: the archive must be between 1 byte and
+  10 MiB, hold one private key and one matching leaf, carry at most 16 issuer
+  certificates that form one unambiguous leaf-to-root chain with verified
+  signatures, and be within every validity period. Unordered certificate bags
+  are put in order; unrelated, duplicate, or ambiguous bags are rejected.
+- Generated `pkcs12` output uses PBES2/PBKDF2 with HMAC-SHA-256, AES-256-CBC
+  for key and certificate privacy, and HMAC-SHA-256 integrity, each with
+  100,000 iterations. RC2, 3DES, and SHA-1 are never emitted.
+- A bound password must be non-empty, contain no NUL, and be at most 1024
+  bytes; an empty value is an error rather than "no password".
+
+#### Rules
+
+- `from` requires either `extract` (selection) or a conversion target `type`
+  (conversion), never both, and cannot set `default`, `providers`, `ref`,
+  `refs`, enabled `generate`, `prompt = true`, or `composed`.
+- The source's type must be accepted by the target: every target derives from
+  `x509_identity`. `x509_identity` itself is stored or generated and cannot be
+  derived.
+- `format` is accepted only by `pkcs8_private_key` and `x509_certificate`.
+- `credentials` roles are defined per type: `x509_identity` and `pkcs12` accept
+  `password`; other targets accept none. A credential must name a declared
+  text secret, so neither an `as_path` secret nor a binary typed secret
+  qualifies. A generated `x509_identity` cannot bind a password; it is stored
+  with an empty password and the provider is its security boundary.
+- `from` and `credentials` add edges to the same dependency graph as
+  `composed`: unknown names, self references, and cycles are rejected when the
+  manifest loads, and scopes fetch hidden sources and credentials without
+  exposing them.
+- Derived secrets are read-only. `set` and `delete` name the source to change
+  instead; `import` and generation skip them.
+- Profile inheritance merges `from`, `format`, and `credentials` field by
+  field like every other field, then validates the merged secret. An override
+  may clear inherited credentials with `credentials = {}`.
+- `check --explain` labels a conversion `converted from <SOURCE>` and a
+  selection `selected from <SOURCE>`; resolve payloads report both with the
+  existing `composed` provenance.
 
 ### Secret References
 
@@ -1007,6 +1214,15 @@ RELEASE_KEY = { description = "Release signing key", type = "openpgp_private_key
 # OpenSSH Ed25519 private key (0.21+)
 DEPLOY_KEY = { description = "Deployment SSH key", type = "ssh_private_key", generate = true }
 
+# Private P-256 JSON Web Key (0.21+)
+JWT_JWK = { description = "JWT signing JWK", type = "jwk_private_key", generate = { algorithm = "p256", kid = "release-2026" } }
+
+# Native age X25519 identity (0.21+)
+BACKUP_IDENTITY = { description = "Backup encryption identity", type = "age_identity", generate = true }
+
+# Self-signed P-256 X.509 identity stored as a Base64 PKCS#12 archive (0.21+)
+LOCAL_TLS = { description = "Local TLS identity", type = "x509_identity", generate = { san = ["dns:localhost", "ip:127.0.0.1"] } }
+
 # Type without generate: informational only, no auto-generation
 MANUAL_SECRET = { description = "Manually managed", type = "password" }
 ```
@@ -1016,6 +1232,8 @@ MANUAL_SECRET = { description = "Manually managed", type = "password" }
 | Type | Default Output | Options |
 |------|---------------|---------|
 | `password` | 32 alphanumeric chars | `length` (int), `charset` (`"alphanumeric"` or `"ascii"`) |
+| `passphrase` (0.21+) | Seven BIP-39 English words joined with `-` | `words` (6–32), `separator` (non-empty string) |
+| `mnemonic` (0.21+) | 24-word English BIP-39 mnemonic | `algorithm` (`"bip39"`), `words` (12, 15, 18, 21, or 24), `language` (`"english"`) |
 | `hex` | 64 hex chars (32 bytes) | `bytes` (int) |
 | `base64` | 44 chars (32 bytes) | `bytes` (int) |
 | `uuid` | UUID v4 (36 chars) | none |
@@ -1023,6 +1241,10 @@ MANUAL_SECRET = { description = "Manually managed", type = "password" }
 | `rsa_private_key` | 2048-bit RSA private key (PKCS1 PEM) | `bits` (int) |
 | `openpgp_private_key` (0.21+) | ASCII-armored OpenPGP v4 transferable secret key | `user_id` (required), `algorithm` (`"ed25519"` or `"rsa"`), `bits` (RSA only), `capabilities` (`["sign"]`, `["encrypt"]`, or both) |
 | `ssh_private_key` (0.21+) | Unencrypted OpenSSH Ed25519 private key | `algorithm` (`"ed25519"` or `"rsa"`), `bits` (RSA only), `comment` (string) |
+| `wireguard_private_key` (0.21+) | Base64-encoded WireGuard private key | none |
+| `jwk_private_key` (0.21+) | Ed25519 private signing JWK | `algorithm` (`"ed25519"`, `"p256"`, or `"rsa"`), `bits` (RSA only), `kid` (string) |
+| `age_identity` (0.21+) | Native X25519 age identity | none |
+| `x509_identity` (0.21+) | PKCS#12 archive (Base64 at rest) containing a P-256 key and self-signed certificate | `issuer` (`"self_signed"`), `algorithm` (`"p256"`), `san` (required DNS/IP names), `usages` (`"server_auth"` and/or `"client_auth"`), `valid_for` (1–200 days) |
 
 #### OpenPGP private-key generation {/* #openpgp-private-key-generation-021 */}
 
@@ -1054,6 +1276,62 @@ compatibility; RSA defaults to 3072 bits and accepts 2048 through 8192. `bits`
 is invalid with Ed25519. An optional `comment` is embedded in the key and must
 not contain control characters.
 
+#### Additional credential generation {/* #additional-credential-generation-021 */}
+
+<VersionCompatibility version="0.21" />
+
+- `passphrase` independently selects seven BIP-39 English words by default
+  (77 bits of entropy) and joins them with `-`. It is not a BIP-39 mnemonic.
+  `words` accepts 6 through 32; `separator` must be non-empty and contain no
+  control characters.
+- `mnemonic` (0.21+) emits a checksum-valid BIP-39 mnemonic. It defaults to 24
+  English words (256 bits of entropy plus checksum); `words` accepts 12, 15,
+  18, 21, or 24. The extensible subtype fields currently accept only
+  `algorithm = "bip39"` and `language = "english"`. SecretSpec returns the
+  mnemonic itself and does not derive a BIP-32 seed, wallet keys, or BIP-39's
+  optional mnemonic passphrase.
+- `wireguard_private_key` emits the standard Base64-encoded, clamped 32-byte
+  scalar accepted by WireGuard and accepts no options.
+- `jwk_private_key` emits a compact private signing JWK with public parameters,
+  `use = "sig"`, and `key_ops = ["sign"]`. It defaults to Ed25519 with RFC
+  9864's fully specified `Ed25519` JOSE algorithm identifier;
+  `algorithm = "p256"` selects P-256/`ES256`, and `"rsa"` selects
+  RSA/`RS256`. RSA defaults to 3072 bits and accepts 2048 through 8192.
+  `kid` adds optional key-identification metadata.
+- `age_identity` emits a native X25519 `AGE-SECRET-KEY-1...` identity and
+  accepts no options. This is the interoperable classic format supported by
+  the Rust age provider. For post-quantum confidentiality, provision an
+  externally generated hybrid ML-KEM-768+X25519 `AGE-SECRET-KEY-PQ-1...`
+  identity until the Rust age library supports that format.
+
+#### X.509 identity generation {/* #x509-identity-generation-021 */}
+
+<VersionCompatibility version="0.21" />
+
+`x509_identity` generates a P-256 key and a self-signed X.509 v3 certificate.
+`generate.san` is required and accepts `dns:name` and `ip:address` entries;
+hostname verification therefore never depends on the deprecated Common Name.
+The certificate uses ECDSA with SHA-256, a random 128-bit serial, critical
+CA-false basic constraints and digital-signature key usage, plus `server_auth`
+extended usage by default. `client_auth` may be selected or combined with it.
+
+Validity defaults to `30d` and accepts `1d` through `200d`, matching the current
+CA/Browser Forum maximum for publicly trusted subscriber certificates even
+though SecretSpec's self-signed development identities are outside that policy.
+The start time is backdated five minutes for peer clock skew without extending
+the requested total lifetime.
+
+The canonical value is an empty-password PKCS#12 archive. It explicitly uses
+AES-256-CBC for key and certificate protection and HMAC-SHA-256 for integrity,
+avoiding legacy RC2, 3DES, and SHA-1 profiles. Because the password is empty,
+the archive is an interoperable container rather than an independent security
+boundary: store it in a provider that protects secrets at rest. `encoding`
+defaults to `base64`, so inline exposure is Base64 and `as_path = true` writes
+the PFX bytes to an owner-only `.pfx` file. Derive PEM, DER, key, certificate,
+chain, and password protected PFX values with `from`; see
+[Derived typed secrets](#derived-typed-secrets-021). A provider-backed
+`x509_identity` may also be an imported archive, protected or not.
+
 #### Behavior
 
 - Generation only triggers when a secret is **missing** — existing secrets are never overwritten
@@ -1067,6 +1345,8 @@ not contain control characters.
   signing and encryption, respectively
 - `type = "ssh_private_key"` (0.21+) defaults to Ed25519; RSA generation is
   available with `generate = { algorithm = "rsa", bits = 4096 }`
+- `passphrase`, `mnemonic`, `wireguard_private_key`, `jwk_private_key`, `age_identity`, and `x509_identity`
+  generation require SecretSpec 0.21+
 - The value-free preflights — [`check --json` / `check --explain`](/reference/cli/#resolution-report---json----explain)
   and the SDKs' report/no-values resolutions — never mint a value. Since
   SecretSpec 0.20 a **required** generatable secret that no provider holds is

--- a/secretspec/Cargo.toml
+++ b/secretspec/Cargo.toml
@@ -72,6 +72,11 @@ pgp.workspace = true
 smallvec.workspace = true
 uuid.workspace = true
 data-encoding.workspace = true
+bip39.workspace = true
+bech32.workspace = true
+ed25519-dalek.workspace = true
+p256.workspace = true
+x25519-dalek.workspace = true
 sha2.workspace = true
 ssh-key.workspace = true
 detect-coding-agent.workspace = true
@@ -79,6 +84,7 @@ age = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
 k8s-openapi = { workspace = true, optional = true }
 json-patch = { workspace = true, optional = true }
+openssl.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/secretspec/README.md
+++ b/secretspec/README.md
@@ -59,7 +59,7 @@ SecretSpec fixes this by separating secret **declaration** from secret **storage
   - [Kubernetes](https://secretspec.dev/providers/kubernetes) (0.20+)
 - **[Type-Safe Rust SDK](https://secretspec.dev/sdk/rust/)**: Generate strongly-typed structs from your `secretspec.toml` for compile-time safety
 - **[Profile Support](https://secretspec.dev/concepts/profiles/)**: Override secret requirements and defaults per profile (development, production, etc.)
-- **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — including pure-Rust OpenPGP and OpenSSH private keys in 0.21+
+- **[Secret Generation](https://secretspec.dev/concepts/generation/)**: Auto-generate passwords, tokens, UUIDs, and more when secrets are missing — including passphrases, BIP-39 mnemonics, pure-Rust OpenPGP, OpenSSH, WireGuard, JWK, and age private credentials, plus self-signed X.509 identities that derive PEM, DER, and password protected PFX files through `from`, in 0.21+
 - **Run prompts (0.19+)**: Set `prompt = true` to request a hidden missing value; writable providers save it, while `null` keeps it invocation-only
 - **Composed Secrets (0.16+)**: Derive read-only values such as DSNs from declared secrets with strict, order-independent `${UPPERCASE_NAME}` references
 - **[Configuration Inheritance](https://secretspec.dev/concepts/inheritance/)**: Extend and override shared configurations using the `extends` feature

--- a/secretspec/src/compiled_spec.rs
+++ b/secretspec/src/compiled_spec.rs
@@ -79,6 +79,26 @@ impl CompiledSecret {
             composition,
         }
     }
+
+    /// Every declared secret this one must resolve first: the references of a
+    /// composed template, the `from` source, and each credential binding, in
+    /// that order. One definition feeds graph validation, scope closure,
+    /// prompting, the SSH agent's dependency walk, and the executor, so none
+    /// of them can disagree about what a derived or typed secret needs.
+    pub(crate) fn dependencies(&self) -> Vec<&str> {
+        let mut dependencies: Vec<&str> = self
+            .composition
+            .as_ref()
+            .map(|template| template.dependencies().iter().map(String::as_str).collect())
+            .unwrap_or_default();
+        dependencies.extend(self.config.from.as_deref());
+        dependencies.extend(
+            self.config
+                .credential_secrets()
+                .map(|(_, credential)| credential),
+        );
+        dependencies
+    }
 }
 
 #[cfg(test)]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -942,27 +942,79 @@ fn validate_composition_graph(
     profile_name: &str,
     profile: &crate::compiled_spec::CompiledProfile,
 ) -> Result<(), ParseError> {
-    // Templates were parsed during manifest compilation; a malformed one was
-    // already rejected by `validate_semantics` before this runs.
-    let mut graph: BTreeMap<&str, &[String]> = BTreeMap::new();
+    // Templates, `from`, and credential shapes were validated per secret
+    // before this runs. They share one dependency graph so a cycle mixing
+    // composed, converted, and credential edges cannot evade any resolver pass.
+    let mut graph: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
     for (name, secret) in &profile.secrets {
-        let Some(template) = &secret.composition else {
-            continue;
+        let fail = |message: String| {
+            ParseError::Validation(format!(
+                "Profile '{profile_name}': Secret '{name}': {message}"
+            ))
         };
-        for dependency in template.dependencies() {
-            if !profile.secrets.contains_key(dependency) {
-                return Err(ParseError::Validation(format!(
-                    "Profile '{}': Secret '{}': composed reference `${{{}}}` does not name a declared secret",
-                    profile_name, name, dependency
+        let dependencies = secret.dependencies();
+        for dependency in &dependencies {
+            if *dependency == name.as_str() {
+                return Err(fail("cannot depend on itself".to_string()));
+            }
+            if !profile.secrets.contains_key(*dependency) {
+                return Err(fail(format!(
+                    "dependency '{dependency}' does not name a declared secret"
                 )));
             }
         }
-        graph.insert(name.as_str(), template.dependencies());
+
+        let config = &secret.config;
+        if let Some(source) = config.from.as_deref() {
+            let source_config = &profile.secrets[source].config;
+            if let Some(contract) = config.typed_contract() {
+                if !contract.accepts_source(source_config.secret_type.as_deref()) {
+                    let declared = source_config.secret_type.as_deref().map_or_else(
+                        || "no `type`".to_string(),
+                        |source_type| format!("type = \"{source_type}\""),
+                    );
+                    return Err(fail(format!(
+                        "`from` source '{source}' has {declared}, but type = \"{}\" derives from {}",
+                        contract.name,
+                        contract
+                            .sources
+                            .iter()
+                            .map(|source| format!("type = \"{source}\""))
+                            .collect::<Vec<_>>()
+                            .join(" or ")
+                    )));
+                }
+            } else if source_config.is_binary_value() {
+                return Err(fail(format!(
+                    "`extract` cannot select from '{source}' because its type = \"{}\" is binary",
+                    source_config.secret_type.as_deref().unwrap_or_default()
+                )));
+            }
+        }
+
+        for (role, credential) in config.credential_secrets() {
+            let credential_config = &profile.secrets[credential].config;
+            if credential_config.as_path == Some(true) {
+                return Err(fail(format!(
+                    "credential `{role}` names '{credential}', which is delivered as a path; credentials must be text values"
+                )));
+            }
+            if credential_config.is_binary_value() {
+                return Err(fail(format!(
+                    "credential `{role}` names '{credential}', whose type = \"{}\" is binary; credentials must be text values",
+                    credential_config.secret_type.as_deref().unwrap_or_default()
+                )));
+            }
+        }
+
+        if !dependencies.is_empty() {
+            graph.insert(name.as_str(), dependencies);
+        }
     }
 
     fn visit<'a>(
         name: &'a str,
-        graph: &BTreeMap<&'a str, &'a [String]>,
+        graph: &BTreeMap<&'a str, Vec<&'a str>>,
         state: &mut HashMap<&'a str, u8>,
         stack: &mut Vec<&'a str>,
     ) -> Result<(), Vec<String>> {
@@ -979,8 +1031,8 @@ fn validate_composition_graph(
         state.insert(name, 1);
         stack.push(name);
         if let Some(dependencies) = graph.get(name) {
-            for dependency in *dependencies {
-                if graph.contains_key(dependency.as_str()) {
+            for dependency in dependencies {
+                if graph.contains_key(dependency) {
                     visit(dependency, graph, state, stack)?;
                 }
             }
@@ -994,7 +1046,7 @@ fn validate_composition_graph(
     for name in graph.keys() {
         if let Err(cycle) = visit(name, &graph, &mut state, &mut Vec::new()) {
             return Err(ParseError::Validation(format!(
-                "Profile '{}': composed secret cycle: {}",
+                "Profile '{}': derived secret cycle: {}",
                 profile_name,
                 cycle.join(" -> ")
             )));
@@ -1526,6 +1578,8 @@ impl IntoIterator for Profile {
 /// type-specific options (`generate = { length = 64 }`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+// Keep the options variant unboxed to preserve the public Rust API.
+#[allow(clippy::large_enum_variant)]
 pub enum GenerateConfig {
     /// Simple boolean flag to enable/disable generation with defaults
     Bool(bool),
@@ -1558,10 +1612,10 @@ pub struct GenerateOptions {
     /// Shell command to run (for `command` type)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
-    /// RSA key size in bits (`rsa_private_key` defaults to 2048; OpenPGP and SSH RSA default to 3072).
+    /// RSA key size in bits (`rsa_private_key` defaults to 2048; OpenPGP, SSH, and JWK RSA default to 3072).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bits: Option<usize>,
-    /// OpenPGP or SSH key algorithm (`ed25519` or `rsa`, default `ed25519`; 0.21+).
+    /// OpenPGP, SSH, JWK, or mnemonic algorithm (type-specific values; 0.21+).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub algorithm: Option<String>,
     /// OpenPGP User ID bound to a generated certificate (0.21+).
@@ -1573,6 +1627,30 @@ pub struct GenerateOptions {
     /// Comment embedded in a generated OpenSSH private key (0.21+).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
+    /// Number of words in a generated passphrase or mnemonic (defaults 7 or 24; 0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub words: Option<usize>,
+    /// Separator placed between generated passphrase words (default `-`; 0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub separator: Option<String>,
+    /// Word-list language for a generated mnemonic (currently `english`; 0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// Optional JSON Web Key identifier (`kid`; 0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
+    /// X.509 issuer mode (currently `self_signed`; 0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+    /// X.509 subject alternative names, written as `dns:name` or `ip:address` (0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub san: Option<Vec<String>>,
+    /// X.509 extended key usages (`server_auth` and/or `client_auth`; 0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usages: Option<Vec<String>>,
+    /// X.509 certificate lifetime as whole days, for example `30d` (0.21+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_for: Option<String>,
 }
 
 pub(crate) const OPENPGP_RSA_DEFAULT_BITS: usize = 3072;
@@ -1581,6 +1659,14 @@ pub(crate) const OPENPGP_RSA_MAX_BITS: usize = 8192;
 pub(crate) const SSH_RSA_DEFAULT_BITS: usize = 3072;
 pub(crate) const SSH_RSA_MIN_BITS: usize = 2048;
 pub(crate) const SSH_RSA_MAX_BITS: usize = 8192;
+pub(crate) const JWK_RSA_DEFAULT_BITS: usize = 3072;
+pub(crate) const JWK_RSA_MIN_BITS: usize = 2048;
+pub(crate) const JWK_RSA_MAX_BITS: usize = 8192;
+pub(crate) const PASSPHRASE_DEFAULT_WORDS: usize = 7;
+pub(crate) const PASSPHRASE_MIN_WORDS: usize = 6;
+pub(crate) const PASSPHRASE_MAX_WORDS: usize = 32;
+pub(crate) const MNEMONIC_DEFAULT_WORDS: usize = 24;
+pub(crate) const MNEMONIC_WORD_COUNTS: &[usize] = &[12, 15, 18, 21, 24];
 
 /// Native coordinates of one externally managed secret: the value of a
 /// secret's `ref` field.
@@ -2017,6 +2103,12 @@ struct SecretSerde {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     secret_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    credentials: Option<BTreeMap<String, CredentialBinding>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     generate: Option<GenerateConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     prompt: Option<bool>,
@@ -2052,7 +2144,7 @@ impl SecretEncoding {
 ///
 /// Available since SecretSpec 0.19.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum ExtractFormat {
     /// A JSON document selected with an RFC 6901 JSON Pointer.
     Json,
@@ -2073,21 +2165,23 @@ impl ExtractFormat {
     }
 }
 
-/// Selects one logical secret from a structured stored value.
+/// Selects one logical secret from a structured text document.
 ///
-/// Extraction is applied after [`SecretEncoding`] is decoded and only to
-/// values read from providers or caches. Defaults and composed values are
-/// already logical and are not extracted.
+/// On a provider-backed secret, extraction is applied after [`SecretEncoding`]
+/// is decoded and only to values read from providers or caches. On a secret
+/// with [`from`](Secret::from) (0.21+), the named declared secret is resolved
+/// first and its logical text becomes the extraction input.
 ///
 /// Available since SecretSpec 0.19.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretExtract {
-    /// The structured-data format of the stored value.
+    /// The structured-data format of the document.
     pub format: ExtractFormat,
     /// Slash-delimited pointer selecting the logical value. JSON accepts a
     /// complete RFC 6901 JSON Pointer; INI accepts `/key` or `/section/key`
     /// with RFC 6901 escaping for each segment.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub pointer: String,
 }
 
@@ -2097,6 +2191,73 @@ impl SecretExtract {
             ExtractFormat::Json => validate_json_pointer(&self.pointer),
             ExtractFormat::Ini => crate::ini_field::validate_pointer(&self.pointer),
         }
+    }
+}
+
+/// How a typed secret obtains one credential it needs (SecretSpec 0.21+).
+///
+/// Written in a secret's `credentials` table keyed by the role its type
+/// defines, with the bare name of another declared secret as the value:
+///
+/// ```toml
+/// TLS_PFX = { type = "pkcs12", from = "TLS_IDENTITY", credentials = { password = "TLS_PFX_PASSWORD" } }
+/// ```
+///
+/// The named secret is an ordinary declaration: it resolves through its own
+/// providers, default, prompt, or generator, joins the dependency graph, and is
+/// stored with `secretspec set` like any other value. Table values are rejected
+/// and reserved for a future provider-pinned source, so adding one later is
+/// additive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CredentialBinding {
+    /// A declared secret in the same profile.
+    Secret(String),
+}
+
+impl CredentialBinding {
+    /// The declared secret this binding resolves through.
+    pub fn secret_name(&self) -> &str {
+        match self {
+            Self::Secret(name) => name,
+        }
+    }
+}
+
+impl Serialize for CredentialBinding {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Secret(name) => serializer.serialize_str(name),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CredentialBinding {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = CredentialBinding;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("the name of a declared secret")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, name: &str) -> Result<CredentialBinding, E> {
+                Ok(CredentialBinding::Secret(name.to_string()))
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                _map: M,
+            ) -> Result<CredentialBinding, M::Error> {
+                Err(serde::de::Error::custom(
+                    "credential bindings name a declared secret, for example `password = \"PFX_PASSWORD\"`; the `{ provider, ref }` table form is reserved",
+                ))
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
     }
 }
 
@@ -2192,18 +2353,47 @@ pub struct Secret {
     ///
     /// Available since SecretSpec 0.19.
     pub encoding: Option<SecretEncoding>,
-    /// Structured stored-value extraction applied after optional decoding.
-    /// JSON extraction uses an RFC 6901 pointer. INI extraction (0.20+) uses
-    /// `/key` for an unsectioned key or `/section/key` for a named section,
-    /// with RFC 6901 segment escaping. Extracted secrets are read-only because
-    /// a selected value cannot reconstruct its containing document for a
-    /// storage write.
+    /// Structured extraction applied after optional decoding, or to the
+    /// logical text of the declared secret named by [`from`](Self::from)
+    /// (0.21+). JSON extraction uses an RFC 6901 pointer. INI extraction
+    /// (0.20+) uses `/key` for an unsectioned key or `/section/key` for a named
+    /// section, with RFC 6901 segment escaping. Extracted secrets are read-only
+    /// because a selected value cannot reconstruct its containing document for
+    /// a storage write.
     ///
     /// Available since SecretSpec 0.19.
     pub extract: Option<SecretExtract>,
-    /// The type of secret, used for generation. OpenPGP and OpenSSH private-key
-    /// generation are available in SecretSpec 0.21+.
+    /// The semantic secret type. Generatable key types include
+    /// `mnemonic`, `openpgp_private_key`, `ssh_private_key`, `wireguard_private_key`,
+    /// `jwk_private_key`, `age_identity`, and `x509_identity` in SecretSpec 0.21+;
+    /// For the typed contracts in [`crate::typed`] (`x509_identity` and the
+    /// `pkcs12`, `pkcs8_private_key`, `x509_certificate`,
+    /// `x509_certificate_chain`, and `x509_issuer_chain` targets, 0.21+) the
+    /// type is authoritative: it decides decoding, validation, conversion,
+    /// accepted `credentials` roles, accepted `format` values, and the default
+    /// `encoding` of a binary value.
     pub secret_type: Option<String>,
+    /// Serialization of a typed value whose type offers more than one, for
+    /// example `pem` or `der` for a `pkcs8_private_key`. Every such type has a
+    /// default, so this is normally written only to select DER.
+    ///
+    /// Available since SecretSpec 0.21.
+    pub format: Option<String>,
+    /// Another declared secret whose logical value this secret derives from.
+    /// Combined with a derivable `type` it converts the source (an
+    /// `x509_identity` to a `pkcs12`, key, or certificate); combined with
+    /// `extract` it selects one field from the source's text. Derived secrets
+    /// are read-only and route to no provider.
+    ///
+    /// Available since SecretSpec 0.21.
+    pub from: Option<String>,
+    /// Declared secrets that unlock or protect this typed value, keyed by the
+    /// role the type defines: the `password` that opens a stored
+    /// `x509_identity` archive, or the `password` that protects a derived
+    /// `pkcs12`.
+    ///
+    /// Available since SecretSpec 0.21.
+    pub credentials: Option<BTreeMap<String, CredentialBinding>>,
     /// Auto-generation configuration. Either `true` for defaults or a table with options.
     pub generate: Option<GenerateConfig>,
     /// Prompt securely when the value is missing during `secretspec run`.
@@ -2244,6 +2434,9 @@ impl TryFrom<SecretSerde> for Secret {
             encoding: value.encoding,
             extract: value.extract,
             secret_type: value.secret_type,
+            format: value.format,
+            from: value.from,
+            credentials: value.credentials,
             generate: value.generate,
             prompt: value.prompt,
         })
@@ -2273,6 +2466,9 @@ impl From<Secret> for SecretSerde {
             encoding: value.encoding,
             extract: value.extract,
             secret_type: value.secret_type,
+            format: value.format,
+            from: value.from,
+            credentials: value.credentials,
             generate: value.generate,
             prompt: value.prompt,
         }
@@ -2323,6 +2519,205 @@ impl Secret {
     /// validation.
     pub(crate) fn would_generate(&self) -> bool {
         self.generate.as_ref().is_some_and(|g| g.is_enabled())
+    }
+
+    /// The registry contract behind `type`, when the type is one the registry
+    /// governs. `None` for informational types and untyped secrets.
+    pub(crate) fn typed_contract(&self) -> Option<&'static crate::typed::TypeContract> {
+        self.secret_type.as_deref().and_then(crate::typed::contract)
+    }
+
+    /// The effective serialization of a registry-typed value: the declared
+    /// `format` or the type's default. `None` when the type is not a registry
+    /// type, has a fixed representation, or the declared format is invalid
+    /// (which [`Self::validate`] rejects separately).
+    pub(crate) fn typed_format(&self) -> Option<crate::typed::Format> {
+        self.typed_contract()
+            .and_then(|contract| contract.format(self.format.as_deref()).ok())
+            .flatten()
+    }
+
+    /// Whether the logical value is bytes rather than text. Only registry
+    /// types are binary; an informational type with `encoding` still stores
+    /// text that happens to be encoded at rest.
+    pub(crate) fn is_binary_value(&self) -> bool {
+        self.typed_contract()
+            .is_some_and(|contract| contract.is_binary(self.typed_format()))
+    }
+
+    /// The codec used wherever this value must be text: the declared
+    /// `encoding`, or Base64 for a binary registry type that declares none.
+    pub(crate) fn effective_encoding(&self) -> Option<SecretEncoding> {
+        self.encoding.or_else(|| {
+            self.typed_contract()
+                .and_then(|contract| contract.default_encoding(self.typed_format()))
+        })
+    }
+
+    /// Preferred file suffix for `as_path` delivery, from the type registry.
+    pub(crate) fn file_suffix(&self) -> Option<&'static str> {
+        self.typed_contract()
+            .map(|contract| contract.suffix(self.typed_format()))
+    }
+
+    /// The `(role, declared secret)` pairs bound through `credentials`.
+    pub(crate) fn credential_secrets(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.credentials
+            .iter()
+            .flat_map(|bindings| bindings.iter())
+            .map(|(role, binding)| (role.as_str(), binding.secret_name()))
+    }
+
+    /// Whether the value is derived from other declared secrets rather than
+    /// stored: a `composed` template or a `from` source.
+    pub(crate) fn is_derived(&self) -> bool {
+        self.composed.is_some() || self.from.is_some()
+    }
+
+    /// Rules for `from`, `format`, `credentials`, and the registry types
+    /// (0.21+). Every rule reads the type registry rather than matching type
+    /// names, so adding a contract cannot leave a rule behind.
+    fn validate_typed(&self) -> Result<(), String> {
+        let contract = self.typed_contract();
+
+        let format = match contract {
+            Some(contract) => contract.format(self.format.as_deref())?,
+            None => {
+                if self.format.is_some() {
+                    return Err(match self.secret_type.as_deref() {
+                        Some(name) => format!(
+                            "`format` is not valid for type = \"{name}\"; only `pkcs8_private_key` and `x509_certificate` accept `pem` or `der`"
+                        ),
+                        None => "`format` requires a `type` that accepts formats: `pkcs8_private_key` or `x509_certificate`".into(),
+                    });
+                }
+                None
+            }
+        };
+
+        if let Some(bindings) = &self.credentials
+            && !bindings.is_empty()
+        {
+            let Some(contract) = contract else {
+                return Err(match self.secret_type.as_deref() {
+                    Some(name) => format!(
+                        "`credentials` is not valid for type = \"{name}\"; only `x509_identity` and `pkcs12` accept a `password` credential"
+                    ),
+                    None => "`credentials` requires a `type` that accepts credentials: `x509_identity` or `pkcs12`".into(),
+                });
+            };
+            for (role, binding) in bindings {
+                if !contract.accepts_role(role) {
+                    return Err(if contract.roles.is_empty() {
+                        format!(
+                            "type = \"{}\" accepts no credentials; unknown role `{role}`",
+                            contract.name
+                        )
+                    } else {
+                        format!(
+                            "unknown credential role `{role}` for type = \"{}\"; expected {}",
+                            contract.name,
+                            contract
+                                .roles
+                                .iter()
+                                .map(|role| format!("`{role}`"))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    });
+                }
+                if !is_valid_identifier(binding.secret_name()) {
+                    return Err(format!(
+                        "credential `{role}` must name a declared secret using a valid identifier"
+                    ));
+                }
+            }
+            if contract.is_stored() && self.would_generate() {
+                return Err(format!(
+                    "`credentials` cannot be combined with enabled `generate` for type = \"{}\"; a generated identity is stored with an empty password and the provider is its boundary",
+                    contract.name
+                ));
+            }
+        }
+
+        match (&self.from, contract) {
+            (Some(source), _) => {
+                if !is_valid_identifier(source) {
+                    return Err(
+                        "`from` must name a declared secret using a valid identifier".into(),
+                    );
+                }
+                match (contract, &self.extract) {
+                    (Some(contract), None) if !contract.is_stored() => {}
+                    (Some(contract), None) => {
+                        return Err(format!(
+                            "type = \"{}\" is stored by a provider and cannot be derived with `from`",
+                            contract.name
+                        ));
+                    }
+                    (Some(_), Some(_)) => {
+                        return Err(
+                            "`from` either selects with `extract` or converts with a derivable `type`, not both"
+                                .into(),
+                        );
+                    }
+                    (None, Some(_)) => {
+                        if self.secret_type.is_some() {
+                            return Err("`from` with `extract` cannot also set `type`".into());
+                        }
+                    }
+                    (None, None) => {
+                        return Err(match self.secret_type.as_deref() {
+                            Some(name) => format!(
+                                "type = \"{name}\" cannot be derived with `from`; derivable types are {}",
+                                crate::typed::derivable_type_names()
+                                    .map(|name| format!("`{name}`"))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ),
+                            None => "`from` requires `extract` to select from the source or a derivable `type` to convert it".into(),
+                        });
+                    }
+                }
+                if self.default.is_some()
+                    || self.providers.is_some()
+                    || self.reference.is_some()
+                    || self.refs.is_some()
+                    || self.would_generate()
+                    || self.prompt == Some(true)
+                {
+                    return Err(
+                        "`from` secrets cannot also set `default`, `providers`, `ref`, `refs`, enabled `generate`, or `prompt = true`; the source declaration owns storage"
+                            .into(),
+                    );
+                }
+                if self.encoding.is_some()
+                    && !contract.is_some_and(|contract| contract.is_binary(format))
+                {
+                    return Err(
+                        "`encoding` on a `from` secret is valid only when the result is binary: a `pkcs12` or a `der` format"
+                            .into(),
+                    );
+                }
+            }
+            (None, Some(contract)) => {
+                if !contract.is_stored() {
+                    return Err(format!(
+                        "type = \"{}\" requires `from`; it is derived from a declared `x509_identity`",
+                        contract.name
+                    ));
+                }
+                if self.default.is_some() || self.prompt == Some(true) {
+                    return Err(format!(
+                        "`type = \"{}\"` cannot be combined with `default` or `prompt = true`; its value is a binary archive",
+                        contract.name
+                    ));
+                }
+            }
+            (None, None) => {}
+        }
+
+        Ok(())
     }
 
     /// Whether this declaration supplies an individual or grouped requiredness
@@ -2379,16 +2774,20 @@ impl Secret {
                 || self.encoding.is_some()
                 || self.extract.is_some()
                 || self.secret_type.is_some()
+                || self.format.is_some()
+                || self.from.is_some()
+                || self.credentials.is_some()
                 || self.would_generate()
                 || self.prompt == Some(true)
             {
                 return Err(
-                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `refs`, `encoding`, `extract`, `type`, enabled `generate`, or `prompt = true`"
+                    "`composed` secrets cannot also set `default`, `providers`, `ref`, `refs`, `encoding`, `extract`, `type`, `format`, `from`, `credentials`, enabled `generate`, or `prompt = true`"
                         .into(),
                 );
             }
         }
 
+        self.validate_typed()?;
         if self.prompt == Some(true) {
             if self.required == Some(false)
                 || self.at_least_one.is_some()
@@ -2471,6 +2870,19 @@ impl Secret {
                 return Err("'generate' and 'default' cannot both be set".into());
             }
 
+            if let GenerateConfig::Options(opts) = gen_config
+                && self.secret_type.as_deref() != Some("x509_identity")
+                && (opts.issuer.is_some()
+                    || opts.san.is_some()
+                    || opts.usages.is_some()
+                    || opts.valid_for.is_some())
+            {
+                return Err(
+                    "generate.issuer, generate.san, generate.usages, and generate.valid_for are only valid for type = \"x509_identity\""
+                        .into(),
+                );
+            }
+
             // type = "command" requires generate = { command = "..." }
             if self.secret_type.as_deref() == Some("command") {
                 match gen_config {
@@ -2510,9 +2922,15 @@ impl Secret {
                 if user_id.chars().any(char::is_control) {
                     return Err("generate.user_id cannot contain control characters".into());
                 }
-                if opts.comment.is_some() {
+                if opts.comment.is_some()
+                    || opts.words.is_some()
+                    || opts.separator.is_some()
+                    || opts.language.is_some()
+                    || opts.kid.is_some()
+                {
                     return Err(
-                        "generate.comment is only valid for type = \"ssh_private_key\"".into(),
+                        "generate.comment, generate.words, generate.separator, generate.language, and generate.kid are not valid for type = \"openpgp_private_key\""
+                            .into(),
                     );
                 }
 
@@ -2571,9 +2989,15 @@ impl Secret {
                     }
                 };
                 if let Some(opts) = opts {
-                    if opts.user_id.is_some() || opts.capabilities.is_some() {
+                    if opts.user_id.is_some()
+                        || opts.capabilities.is_some()
+                        || opts.words.is_some()
+                        || opts.separator.is_some()
+                        || opts.language.is_some()
+                        || opts.kid.is_some()
+                    {
                         return Err(
-                            "generate.user_id and generate.capabilities are only valid for type = \"openpgp_private_key\""
+                            "generate.user_id, generate.capabilities, generate.words, generate.separator, generate.language, and generate.kid are not valid for type = \"ssh_private_key\""
                                 .into(),
                         );
                     }
@@ -2610,6 +3034,247 @@ impl Secret {
                 }
             }
 
+            if self.secret_type.as_deref() == Some("passphrase") {
+                let opts = match gen_config {
+                    GenerateConfig::Bool(true) => None,
+                    GenerateConfig::Options(opts) => Some(opts),
+                    GenerateConfig::Bool(false) => {
+                        unreachable!("disabled generation handled above")
+                    }
+                };
+                if let Some(opts) = opts {
+                    let words = opts.words.unwrap_or(PASSPHRASE_DEFAULT_WORDS);
+                    if !(PASSPHRASE_MIN_WORDS..=PASSPHRASE_MAX_WORDS).contains(&words) {
+                        return Err(format!(
+                            "passphrase generate.words must be between {PASSPHRASE_MIN_WORDS} and {PASSPHRASE_MAX_WORDS}"
+                        ));
+                    }
+                    if opts.separator.as_deref().is_some_and(|separator| {
+                        separator.is_empty() || separator.chars().any(char::is_control)
+                    }) {
+                        return Err(
+                            "passphrase generate.separator must be non-empty and contain no control characters"
+                                .into(),
+                        );
+                    }
+                    if opts.length.is_some()
+                        || opts.bytes.is_some()
+                        || opts.charset.is_some()
+                        || opts.command.is_some()
+                        || opts.algorithm.is_some()
+                        || opts.bits.is_some()
+                        || opts.user_id.is_some()
+                        || opts.capabilities.is_some()
+                        || opts.comment.is_some()
+                        || opts.kid.is_some()
+                        || opts.language.is_some()
+                    {
+                        return Err(
+                            "passphrase generation accepts only `words` and `separator` options"
+                                .into(),
+                        );
+                    }
+                }
+            }
+
+            if self.secret_type.as_deref() == Some("mnemonic") {
+                let opts = match gen_config {
+                    GenerateConfig::Bool(true) => None,
+                    GenerateConfig::Options(opts) => Some(opts),
+                    GenerateConfig::Bool(false) => {
+                        unreachable!("disabled generation handled above")
+                    }
+                };
+                if let Some(opts) = opts {
+                    let words = opts.words.unwrap_or(MNEMONIC_DEFAULT_WORDS);
+                    if !MNEMONIC_WORD_COUNTS.contains(&words) {
+                        return Err(
+                            "mnemonic generate.words must be one of 12, 15, 18, 21, or 24".into(),
+                        );
+                    }
+                    if opts.algorithm.as_deref().unwrap_or("bip39") != "bip39" {
+                        return Err("unknown mnemonic algorithm; expected `bip39`".into());
+                    }
+                    if opts.language.as_deref().unwrap_or("english") != "english" {
+                        return Err("unknown mnemonic language; expected `english`".into());
+                    }
+                    if opts.length.is_some()
+                        || opts.bytes.is_some()
+                        || opts.charset.is_some()
+                        || opts.command.is_some()
+                        || opts.bits.is_some()
+                        || opts.user_id.is_some()
+                        || opts.capabilities.is_some()
+                        || opts.comment.is_some()
+                        || opts.separator.is_some()
+                        || opts.kid.is_some()
+                    {
+                        return Err(
+                            "mnemonic generation accepts only `algorithm`, `words`, and `language` options"
+                                .into(),
+                        );
+                    }
+                }
+            }
+
+            if self.secret_type.as_deref() == Some("jwk_private_key") {
+                let opts = match gen_config {
+                    GenerateConfig::Bool(true) => None,
+                    GenerateConfig::Options(opts) => Some(opts),
+                    GenerateConfig::Bool(false) => {
+                        unreachable!("disabled generation handled above")
+                    }
+                };
+                if let Some(opts) = opts {
+                    if opts.kid.as_deref().is_some_and(|kid| {
+                        kid.trim().is_empty() || kid.chars().any(char::is_control)
+                    }) {
+                        return Err(
+                            "JWK generate.kid must be non-empty and contain no control characters"
+                                .into(),
+                        );
+                    }
+                    match opts.algorithm.as_deref().unwrap_or("ed25519") {
+                        "ed25519" | "p256" => {
+                            if opts.bits.is_some() {
+                                return Err(
+                                    "generate.bits is only valid when generate.algorithm = \"rsa\""
+                                        .into(),
+                                );
+                            }
+                        }
+                        "rsa" => {
+                            let bits = opts.bits.unwrap_or(JWK_RSA_DEFAULT_BITS);
+                            if !(JWK_RSA_MIN_BITS..=JWK_RSA_MAX_BITS).contains(&bits) {
+                                return Err(
+                                    "JWK RSA generate.bits must be between 2048 and 8192".into()
+                                );
+                            }
+                        }
+                        algorithm => {
+                            return Err(format!(
+                                "unknown JWK algorithm '{algorithm}'; expected `ed25519`, `p256`, or `rsa`"
+                            ));
+                        }
+                    }
+                    if opts.length.is_some()
+                        || opts.bytes.is_some()
+                        || opts.charset.is_some()
+                        || opts.command.is_some()
+                        || opts.user_id.is_some()
+                        || opts.capabilities.is_some()
+                        || opts.comment.is_some()
+                        || opts.words.is_some()
+                        || opts.separator.is_some()
+                        || opts.language.is_some()
+                    {
+                        return Err(
+                            "JWK generation accepts only `algorithm`, `bits`, and `kid` options"
+                                .into(),
+                        );
+                    }
+                }
+            }
+
+            if self.secret_type.as_deref() == Some("x509_identity") {
+                let opts = match gen_config {
+                    GenerateConfig::Options(opts) => opts,
+                    GenerateConfig::Bool(true) => {
+                        return Err(
+                            "type = \"x509_identity\" requires generate = { san = [\"dns:localhost\"] }"
+                                .into(),
+                        );
+                    }
+                    GenerateConfig::Bool(false) => {
+                        unreachable!("disabled generation handled above")
+                    }
+                };
+                if opts.issuer.as_deref().unwrap_or("self_signed") != "self_signed" {
+                    return Err("unknown X.509 issuer; expected `self_signed`".into());
+                }
+                if opts.algorithm.as_deref().unwrap_or("p256") != "p256" {
+                    return Err("unknown X.509 algorithm; expected `p256`".into());
+                }
+                let sans = opts
+                    .san
+                    .as_deref()
+                    .ok_or_else(|| "type = \"x509_identity\" requires generate.san".to_string())?;
+                if sans.is_empty() || sans.len() > 100 {
+                    return Err("X.509 generate.san must contain between 1 and 100 names".into());
+                }
+                let mut seen = HashSet::new();
+                for san in sans {
+                    crate::x509_identity::validate_san(san)?;
+                    if !seen.insert(san) {
+                        return Err(format!("generate.san contains duplicate name '{san}'"));
+                    }
+                }
+                if let Some(usages) = &opts.usages {
+                    if usages.is_empty() {
+                        return Err(
+                            "X.509 generate.usages must contain `server_auth`, `client_auth`, or both"
+                                .into(),
+                        );
+                    }
+                    let mut seen = HashSet::new();
+                    for usage in usages {
+                        if !matches!(usage.as_str(), "server_auth" | "client_auth") {
+                            return Err(format!(
+                                "unknown X.509 usage '{usage}'; expected `server_auth` or `client_auth`"
+                            ));
+                        }
+                        if !seen.insert(usage) {
+                            return Err(format!(
+                                "generate.usages contains duplicate usage '{usage}'"
+                            ));
+                        }
+                    }
+                }
+                crate::x509_identity::parse_valid_days(opts.valid_for.as_deref())?;
+                if opts.length.is_some()
+                    || opts.bytes.is_some()
+                    || opts.charset.is_some()
+                    || opts.command.is_some()
+                    || opts.bits.is_some()
+                    || opts.user_id.is_some()
+                    || opts.capabilities.is_some()
+                    || opts.comment.is_some()
+                    || opts.words.is_some()
+                    || opts.separator.is_some()
+                    || opts.language.is_some()
+                    || opts.kid.is_some()
+                {
+                    return Err(
+                        "X.509 generation accepts only `issuer`, `algorithm`, `san`, `usages`, and `valid_for` options"
+                            .into(),
+                    );
+                }
+            }
+
+            if matches!(
+                self.secret_type.as_deref(),
+                Some("wireguard_private_key" | "age_identity")
+            ) && let GenerateConfig::Options(opts) = gen_config
+                && (opts.length.is_some()
+                    || opts.bytes.is_some()
+                    || opts.charset.is_some()
+                    || opts.command.is_some()
+                    || opts.bits.is_some()
+                    || opts.algorithm.is_some()
+                    || opts.user_id.is_some()
+                    || opts.capabilities.is_some()
+                    || opts.comment.is_some()
+                    || opts.words.is_some()
+                    || opts.separator.is_some()
+                    || opts.language.is_some()
+                    || opts.kid.is_some())
+            {
+                return Err(format!(
+                    "{} generation does not accept options",
+                    self.secret_type.as_deref().expect("matched type")
+                ));
+            }
+
             // Validate known types
             if let Some(ref t) = self.secret_type {
                 match t.as_str() {
@@ -2620,7 +3285,14 @@ impl Secret {
                     | "command"
                     | "rsa_private_key"
                     | "openpgp_private_key"
-                    | "ssh_private_key" => {}
+                    | "ssh_private_key"
+                    | "passphrase"
+                    | "mnemonic"
+                    | "wireguard_private_key"
+                    | "jwk_private_key"
+                    | "age_identity"
+                    | "x509_identity" => {}
+                    typed if crate::typed::contract(typed).is_some() => {}
                     unknown => {
                         return Err(format!("unknown secret type '{}'", unknown));
                     }
@@ -2641,7 +3313,14 @@ impl Secret {
                 | "command"
                 | "rsa_private_key"
                 | "openpgp_private_key"
-                | "ssh_private_key" => {}
+                | "ssh_private_key"
+                | "passphrase"
+                | "mnemonic"
+                | "wireguard_private_key"
+                | "jwk_private_key"
+                | "age_identity"
+                | "x509_identity" => {}
+                typed if crate::typed::contract(typed).is_some() => {}
                 unknown => {
                     return Err(format!("unknown secret type '{}'", unknown));
                 }
@@ -2695,9 +3374,15 @@ impl Secret {
         } else {
             (defaults.and_then(|d| d.required), None, None)
         };
-        // A composed secret's source is its dependency graph, so the
+        let extract = inherit(current, default, |s| s.extract.clone());
+        let from = inherit(current, default, |s| s.from.clone());
+        // A derived secret's source is its dependency graph, so the
         // `[defaults]` storage fields (`default`, `providers`) do not apply.
-        let storage_defaults = if composed.is_some() { None } else { defaults };
+        let storage_defaults = if composed.is_some() || from.is_some() {
+            None
+        } else {
+            defaults
+        };
         // `ref` and `refs` are two serialized forms of one address-model
         // setting. Select the pair from one profile entry so an explicit switch
         // in either direction replaces, rather than combines with, the inherited
@@ -2710,6 +3395,14 @@ impl Secret {
         let (reference, refs) = reference_source.map_or((None, None), |secret| {
             (secret.reference.clone(), secret.refs.clone())
         });
+        // An explicitly empty table clears a binding inherited from the
+        // default profile. Keep this selection separate from `inherit`: using
+        // `or_else` would mistake the empty table for an absent override.
+        let credentials = match current.and_then(|secret| secret.credentials.as_ref()) {
+            Some(bindings) if bindings.is_empty() => None,
+            Some(bindings) => Some(bindings.clone()),
+            None => default.and_then(|secret| secret.credentials.clone()),
+        };
         Some(Secret {
             description: inherit(current, default, |s| s.description.clone()),
             required,
@@ -2724,8 +3417,11 @@ impl Secret {
             refs,
             as_path: inherit(current, default, |s| s.as_path),
             encoding: inherit(current, default, |s| s.encoding),
-            extract: inherit(current, default, |s| s.extract.clone()),
+            extract,
             secret_type: inherit(current, default, |s| s.secret_type.clone()),
+            format: inherit(current, default, |s| s.format.clone()),
+            from,
+            credentials,
             generate: inherit(current, default, |s| s.generate.clone()),
             prompt: inherit(current, default, |s| s.prompt),
         })
@@ -3674,6 +4370,107 @@ C = { description = "c", composed = "${A}" }
     }
 
     #[test]
+    fn from_sources_share_the_derived_dependency_graph() {
+        let parse = |body: &str| {
+            toml::from_str::<Config>(&format!(
+                r#"
+[project]
+name = "derived"
+revision = "1.0"
+
+[profiles.default]
+{body}
+"#
+            ))
+            .unwrap()
+        };
+
+        parse(
+            r#"
+TLS_IDENTITY = { description = "identity", type = "x509_identity" }
+TLS_KEY = { description = "key", type = "pkcs8_private_key", from = "TLS_IDENTITY" }
+TLS_CERTIFICATE = { description = "certificate", type = "x509_certificate", format = "der", from = "TLS_IDENTITY", as_path = true }
+DOCUMENT = { description = "document" }
+FIELD = { description = "field", from = "DOCUMENT", extract = { format = "json", pointer = "/a" } }
+"#,
+        )
+        .validate()
+        .unwrap();
+
+        let wrong_type = parse(
+            r#"
+DOCUMENT = { description = "document" }
+TLS_KEY = { description = "key", type = "pkcs8_private_key", from = "DOCUMENT" }
+"#,
+        )
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(
+            wrong_type.contains("has no `type`, but type = \"pkcs8_private_key\" derives from type = \"x509_identity\""),
+            "{wrong_type}"
+        );
+
+        let cycle = parse(
+            r#"
+A = { description = "a", from = "B", extract = { format = "json", pointer = "" } }
+B = { description = "b", from = "A", extract = { format = "json", pointer = "" } }
+"#,
+        )
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(cycle.contains("A -> B -> A"), "{cycle}");
+
+        let credential_cycle = parse(
+            r#"
+TLS_IDENTITY = { description = "identity", type = "x509_identity" }
+TLS_PFX = { description = "pfx", type = "pkcs12", from = "TLS_IDENTITY", credentials = { password = "PFX_PASSWORD" } }
+PFX_PASSWORD = { description = "password", composed = "${TLS_PFX}" }
+"#,
+        )
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(
+            credential_cycle.contains("derived secret cycle"),
+            "{credential_cycle}"
+        );
+        assert!(
+            credential_cycle.contains("TLS_PFX -> PFX_PASSWORD")
+                || credential_cycle.contains("PFX_PASSWORD -> TLS_PFX"),
+            "{credential_cycle}"
+        );
+
+        let self_reference = parse(
+            r#"
+A = { description = "a", from = "A", extract = { format = "json", pointer = "" } }
+"#,
+        )
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(
+            self_reference.contains("cannot depend on itself"),
+            "{self_reference}"
+        );
+
+        let unknown = parse(
+            r#"
+TLS_IDENTITY = { description = "identity", type = "x509_identity" }
+TLS_PFX = { description = "pfx", type = "pkcs12", from = "TLS_IDENTITY", credentials = { password = "MISSING" } }
+"#,
+        )
+        .validate()
+        .unwrap_err()
+        .to_string();
+        assert!(
+            unknown.contains("dependency 'MISSING' does not name a declared secret"),
+            "{unknown}"
+        );
+    }
+
+    #[test]
     fn composed_rejects_operators_and_storage_sources() {
         let invalid: Config = toml::from_str(
             r#"
@@ -3870,6 +4667,30 @@ TOKEN = { generate = true }
         .unwrap();
 
         config.validate().unwrap();
+    }
+
+    #[test]
+    fn empty_credentials_override_clears_inherited_binding() {
+        let config: Config = toml::from_str(
+            r#"
+[project]
+name = "tmp"
+revision = "1.0"
+
+[profiles.default]
+PFX_PASSWORD = { description = "password" }
+TLS_IDENTITY = { description = "identity", type = "x509_identity", credentials = { password = "PFX_PASSWORD" } }
+
+[profiles.production]
+TLS_IDENTITY = { credentials = {}, generate = { san = ["dns:localhost"] } }
+"#,
+        )
+        .unwrap();
+
+        let compiled = config.validate_and_compile().unwrap();
+        let identity = &compiled.profile("production").unwrap().secrets["TLS_IDENTITY"].config;
+        assert!(identity.credentials.is_none());
+        assert!(identity.would_generate());
     }
 
     #[test]

--- a/secretspec/src/config.rs
+++ b/secretspec/src/config.rs
@@ -2707,6 +2707,12 @@ impl Secret {
                         contract.name
                     ));
                 }
+                if self.extract.is_some() {
+                    return Err(format!(
+                        "`extract` is not valid for stored type = \"{}\"; its value is a binary archive",
+                        contract.name
+                    ));
+                }
                 if self.default.is_some() || self.prompt == Some(true) {
                     return Err(format!(
                         "`type = \"{}\"` cannot be combined with `default` or `prompt = true`; its value is a binary archive",
@@ -2922,14 +2928,18 @@ impl Secret {
                 if user_id.chars().any(char::is_control) {
                     return Err("generate.user_id cannot contain control characters".into());
                 }
-                if opts.comment.is_some()
+                if opts.length.is_some()
+                    || opts.bytes.is_some()
+                    || opts.charset.is_some()
+                    || opts.command.is_some()
+                    || opts.comment.is_some()
                     || opts.words.is_some()
                     || opts.separator.is_some()
                     || opts.language.is_some()
                     || opts.kid.is_some()
                 {
                     return Err(
-                        "generate.comment, generate.words, generate.separator, generate.language, and generate.kid are not valid for type = \"openpgp_private_key\""
+                        "openpgp_private_key generation accepts only `algorithm`, `bits`, `user_id`, and `capabilities` options"
                             .into(),
                     );
                 }
@@ -2989,7 +2999,11 @@ impl Secret {
                     }
                 };
                 if let Some(opts) = opts {
-                    if opts.user_id.is_some()
+                    if opts.length.is_some()
+                        || opts.bytes.is_some()
+                        || opts.charset.is_some()
+                        || opts.command.is_some()
+                        || opts.user_id.is_some()
                         || opts.capabilities.is_some()
                         || opts.words.is_some()
                         || opts.separator.is_some()
@@ -2997,7 +3011,7 @@ impl Secret {
                         || opts.kid.is_some()
                     {
                         return Err(
-                            "generate.user_id, generate.capabilities, generate.words, generate.separator, generate.language, and generate.kid are not valid for type = \"ssh_private_key\""
+                            "ssh_private_key generation accepts only `algorithm`, `bits`, and `comment` options"
                                 .into(),
                         );
                     }

--- a/secretspec/src/error.rs
+++ b/secretspec/src/error.rs
@@ -85,6 +85,14 @@ pub enum SecretSpecError {
         "Secret '{0}' uses `extract` and is read-only; update its containing document in the source provider instead"
     )]
     ExtractedSecretReadOnly(String),
+    #[error("Secret '{name}' is derived from '{from}' and is read-only; change '{from}' instead")]
+    DerivedSecretReadOnly { name: String, from: String },
+    #[error("Secret '{name}': credential `{role}` {reason}")]
+    CredentialInvalid {
+        name: String,
+        role: String,
+        reason: String,
+    },
     #[error("Failed to compose secret: {0}")]
     CompositionFailed(String),
     #[error("No secretspec.toml found in current or any parent directory")]
@@ -149,6 +157,8 @@ impl SecretSpecError {
             SecretSpecError::PromptValueEmpty(_) => "prompt_value_empty",
             SecretSpecError::ComposedSecretReadOnly(_) => "composed_secret_read_only",
             SecretSpecError::ExtractedSecretReadOnly(_) => "extracted_secret_read_only",
+            SecretSpecError::DerivedSecretReadOnly { .. } => "derived_secret_read_only",
+            SecretSpecError::CredentialInvalid { .. } => "credential_invalid",
             SecretSpecError::CompositionFailed(_) => "composition_failed",
             SecretSpecError::NoManifest => "no_manifest",
             SecretSpecError::ExtendedConfigNotFound(_) => "extended_config_not_found",
@@ -269,6 +279,13 @@ mod tests {
             (
                 SecretSpecError::ExtractedSecretReadOnly("X".into()),
                 "extracted_secret_read_only",
+            ),
+            (
+                SecretSpecError::DerivedSecretReadOnly {
+                    name: "X".into(),
+                    from: "Y".into(),
+                },
+                "derived_secret_read_only",
             ),
             (
                 SecretSpecError::CompositionFailed("too large".into()),

--- a/secretspec/src/generator.rs
+++ b/secretspec/src/generator.rs
@@ -1,25 +1,34 @@
 //! Secret value generation
 //!
 //! This module provides generation of secret values based on type and configuration.
-//! Supported types: password, hex, base64, uuid, command, rsa_private_key,
-//! openpgp_private_key, ssh_private_key.
+//! Supported types: password, passphrase, mnemonic, hex, base64, uuid, command,
+//! rsa_private_key, openpgp_private_key, ssh_private_key,
+//! wireguard_private_key, jwk_private_key, age_identity, and (through the
+//! binary identity generator) x509_identity.
 
 use crate::SecretSpecError;
 use crate::config::{
-    GenerateConfig, OPENPGP_RSA_DEFAULT_BITS, OPENPGP_RSA_MAX_BITS, OPENPGP_RSA_MIN_BITS,
+    GenerateConfig, JWK_RSA_DEFAULT_BITS, JWK_RSA_MAX_BITS, JWK_RSA_MIN_BITS,
+    MNEMONIC_DEFAULT_WORDS, MNEMONIC_WORD_COUNTS, OPENPGP_RSA_DEFAULT_BITS, OPENPGP_RSA_MAX_BITS,
+    OPENPGP_RSA_MIN_BITS, PASSPHRASE_DEFAULT_WORDS, PASSPHRASE_MAX_WORDS, PASSPHRASE_MIN_WORDS,
     SSH_RSA_DEFAULT_BITS, SSH_RSA_MAX_BITS, SSH_RSA_MIN_BITS,
 };
-use data_encoding::{BASE64, HEXLOWER};
+use bip39::{Language, Mnemonic};
+use data_encoding::{BASE64, BASE64URL_NOPAD, HEXLOWER};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
 use pgp::composed::{
     ArmorOptions, EncryptionCaps, KeyType, SecretKeyParamsBuilder, SubkeyParamsBuilder,
 };
 use pgp::crypto::{ecc_curve::ECCCurve, hash::HashAlgorithm, sym::SymmetricKeyAlgorithm};
 use pgp::types::{CompressionAlgorithm, KeyVersion};
 use rand::RngExt;
-use rand_08::rngs::OsRng as OpenPgpOsRng;
+use rand_08::RngCore as _;
+use rand_08::rngs::OsRng as OsRng08;
 use rsa::RsaPrivateKey;
 use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::traits::{PrivateKeyParts, PublicKeyParts};
 use secrecy::SecretString;
+use secrecy::zeroize::Zeroizing;
 use smallvec::smallvec;
 use ssh_key::private::{KeypairData as SshKeypairData, RsaKeypair as SshRsaKeypair};
 use ssh_key::{
@@ -30,6 +39,8 @@ use ssh_key::{
 pub fn generate(secret_type: &str, config: &GenerateConfig) -> crate::Result<SecretString> {
     match secret_type {
         "password" => generate_password(config),
+        "passphrase" => generate_passphrase(config),
+        "mnemonic" => generate_mnemonic(config),
         "hex" => generate_hex(config),
         "base64" => generate_base64(config),
         "uuid" => generate_uuid(),
@@ -37,11 +48,104 @@ pub fn generate(secret_type: &str, config: &GenerateConfig) -> crate::Result<Sec
         "rsa_private_key" => generate_rsa(config),
         "openpgp_private_key" => generate_openpgp(config),
         "ssh_private_key" => generate_ssh(config),
+        "wireguard_private_key" => generate_wireguard(),
+        "jwk_private_key" => generate_jwk(config),
+        "age_identity" => generate_age_identity(),
         unknown => Err(SecretSpecError::GenerationFailed(format!(
             "unknown secret type '{}'",
             unknown
         ))),
     }
+}
+
+fn fill_os_random(bytes: &mut [u8], purpose: &str) -> crate::Result<()> {
+    OsRng08.try_fill_bytes(bytes).map_err(|error| {
+        SecretSpecError::GenerationFailed(format!(
+            "operating-system randomness failed while generating {purpose}: {error}"
+        ))
+    })
+}
+
+fn protect_generated_string(value: String) -> SecretString {
+    // Copy into an exactly sized protected allocation, then wipe the temporary
+    // String. This avoids leaving a serialized private credential in a normal
+    // String allocation after returning it to the caller.
+    let value = Zeroizing::new(value);
+    SecretString::new(value.as_str().into())
+}
+
+fn generate_passphrase(config: &GenerateConfig) -> crate::Result<SecretString> {
+    let (words, separator) = match config {
+        GenerateConfig::Bool(_) => (PASSPHRASE_DEFAULT_WORDS, "-"),
+        GenerateConfig::Options(opts) => (
+            opts.words.unwrap_or(PASSPHRASE_DEFAULT_WORDS),
+            opts.separator.as_deref().unwrap_or("-"),
+        ),
+    };
+    if !(PASSPHRASE_MIN_WORDS..=PASSPHRASE_MAX_WORDS).contains(&words) {
+        return Err(SecretSpecError::GenerationFailed(format!(
+            "passphrase generate.words must be between {PASSPHRASE_MIN_WORDS} and {PASSPHRASE_MAX_WORDS}"
+        )));
+    }
+    if separator.is_empty() || separator.chars().any(char::is_control) {
+        return Err(SecretSpecError::GenerationFailed(
+            "passphrase generate.separator must be non-empty and contain no control characters"
+                .to_string(),
+        ));
+    }
+
+    // Seven independently selected BIP-39 English words provide 77 bits of
+    // entropy by default. This is a passphrase, not a BIP-39 mnemonic: there
+    // is deliberately no checksum or wallet-seed interpretation.
+    let wordlist = Language::English.word_list();
+    let mut entropy = Zeroizing::new(vec![0_u8; words * 2]);
+    fill_os_random(&mut entropy, "passphrase")?;
+    let value = entropy
+        .chunks_exact(2)
+        // The word list has 2048 entries, which divides the 16-bit input
+        // domain exactly, so this reduction introduces no modulo bias.
+        .map(|bytes| {
+            let index = usize::from(u16::from_le_bytes([bytes[0], bytes[1]])) % wordlist.len();
+            wordlist[index]
+        })
+        .collect::<Vec<_>>()
+        .join(separator);
+    Ok(protect_generated_string(value))
+}
+
+fn generate_mnemonic(config: &GenerateConfig) -> crate::Result<SecretString> {
+    let (algorithm, words, language) = match config {
+        GenerateConfig::Bool(_) => ("bip39", MNEMONIC_DEFAULT_WORDS, "english"),
+        GenerateConfig::Options(opts) => (
+            opts.algorithm.as_deref().unwrap_or("bip39"),
+            opts.words.unwrap_or(MNEMONIC_DEFAULT_WORDS),
+            opts.language.as_deref().unwrap_or("english"),
+        ),
+    };
+    if algorithm != "bip39" {
+        return Err(SecretSpecError::GenerationFailed(format!(
+            "unknown mnemonic algorithm '{algorithm}'; expected 'bip39'"
+        )));
+    }
+    if language != "english" {
+        return Err(SecretSpecError::GenerationFailed(format!(
+            "unknown mnemonic language '{language}'; expected 'english'"
+        )));
+    }
+    if !MNEMONIC_WORD_COUNTS.contains(&words) {
+        return Err(SecretSpecError::GenerationFailed(
+            "mnemonic generate.words must be one of 12, 15, 18, 21, or 24".to_string(),
+        ));
+    }
+
+    // BIP-39 maps these word counts to 128, 160, 192, 224, or 256 bits of
+    // entropy respectively, then appends the checksum encoded by Mnemonic.
+    let mut entropy = Zeroizing::new(vec![0_u8; (words / 3) * 4]);
+    fill_os_random(&mut entropy, "BIP-39 mnemonic")?;
+    let mnemonic = Mnemonic::from_entropy_in(Language::English, &entropy).map_err(|error| {
+        SecretSpecError::GenerationFailed(format!("failed to encode BIP-39 mnemonic: {error}"))
+    })?;
+    Ok(protect_generated_string(mnemonic.to_string()))
 }
 
 fn generate_password(config: &GenerateConfig) -> crate::Result<SecretString> {
@@ -135,6 +239,243 @@ fn generate_rsa(config: &GenerateConfig) -> crate::Result<SecretString> {
         })?;
 
     Ok(SecretString::new(pem.to_string().into()))
+}
+
+/// Generates the Base64-encoded, clamped Curve25519 scalar accepted by
+/// `wg(8)` as a WireGuard private key.
+fn generate_wireguard() -> crate::Result<SecretString> {
+    let mut key = Zeroizing::new([0_u8; 32]);
+    fill_os_random(&mut key[..], "WireGuard private key")?;
+    key[0] &= 248;
+    key[31] &= 127;
+    key[31] |= 64;
+    Ok(protect_generated_string(BASE64.encode(&*key)))
+}
+
+fn jwk_base64(bytes: &[u8]) -> String {
+    BASE64URL_NOPAD.encode(bytes)
+}
+
+fn jwk_integer(bytes: &[u8]) -> String {
+    let first_nonzero = bytes
+        .iter()
+        .position(|byte| *byte != 0)
+        .unwrap_or(bytes.len());
+    if first_nonzero == bytes.len() {
+        jwk_base64(&[0])
+    } else {
+        jwk_base64(&bytes[first_nonzero..])
+    }
+}
+
+#[derive(serde::Serialize)]
+struct OkpPrivateJwk<'a> {
+    kty: &'static str,
+    crv: &'static str,
+    alg: &'static str,
+    #[serde(rename = "use")]
+    usage: &'static str,
+    key_ops: [&'static str; 1],
+    x: String,
+    d: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kid: Option<&'a str>,
+}
+
+#[derive(serde::Serialize)]
+struct EcPrivateJwk<'a> {
+    kty: &'static str,
+    crv: &'static str,
+    alg: &'static str,
+    #[serde(rename = "use")]
+    usage: &'static str,
+    key_ops: [&'static str; 1],
+    x: String,
+    y: String,
+    d: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kid: Option<&'a str>,
+}
+
+#[derive(serde::Serialize)]
+struct RsaPrivateJwk<'a> {
+    kty: &'static str,
+    alg: &'static str,
+    #[serde(rename = "use")]
+    usage: &'static str,
+    key_ops: [&'static str; 1],
+    n: String,
+    e: String,
+    d: &'a str,
+    p: &'a str,
+    q: &'a str,
+    dp: &'a str,
+    dq: &'a str,
+    qi: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kid: Option<&'a str>,
+}
+
+/// Generates a private signing JWK. The output includes its public parameters
+/// so it can be consumed directly by ordinary JOSE libraries.
+fn generate_jwk(config: &GenerateConfig) -> crate::Result<SecretString> {
+    let opts = match config {
+        GenerateConfig::Bool(_) => None,
+        GenerateConfig::Options(opts) => Some(opts),
+    };
+    let algorithm = opts
+        .and_then(|options| options.algorithm.as_deref())
+        .unwrap_or("ed25519");
+    let kid = opts.and_then(|options| options.kid.as_deref());
+    if kid.is_some_and(|kid| kid.trim().is_empty() || kid.chars().any(char::is_control)) {
+        return Err(SecretSpecError::GenerationFailed(
+            "JWK generate.kid must be non-empty and contain no control characters".to_string(),
+        ));
+    }
+
+    let encoded = match algorithm {
+        "ed25519" => {
+            if opts.is_some_and(|options| options.bits.is_some()) {
+                return Err(SecretSpecError::GenerationFailed(
+                    "generate.bits is only valid when generate.algorithm = \"rsa\"".to_string(),
+                ));
+            }
+            let signing = ed25519_dalek::SigningKey::generate(&mut OsRng08);
+            let private = Zeroizing::new(jwk_base64(&signing.to_bytes()));
+            serde_json::to_string(&OkpPrivateJwk {
+                kty: "OKP",
+                crv: "Ed25519",
+                // RFC 9864 deprecates the polymorphic `EdDSA` identifier.
+                alg: "Ed25519",
+                usage: "sig",
+                key_ops: ["sign"],
+                x: jwk_base64(signing.verifying_key().as_bytes()),
+                d: private.as_str(),
+                kid,
+            })
+        }
+        "p256" => {
+            if opts.is_some_and(|options| options.bits.is_some()) {
+                return Err(SecretSpecError::GenerationFailed(
+                    "generate.bits is only valid when generate.algorithm = \"rsa\"".to_string(),
+                ));
+            }
+            let secret = p256::SecretKey::random(&mut OsRng08);
+            let point = secret.public_key().to_encoded_point(false);
+            let (x, y) = point.x().zip(point.y()).ok_or_else(|| {
+                SecretSpecError::GenerationFailed(
+                    "generated P-256 JSON Web Key has no affine coordinates".to_string(),
+                )
+            })?;
+            let private = Zeroizing::new(jwk_base64(&secret.to_bytes()));
+            serde_json::to_string(&EcPrivateJwk {
+                kty: "EC",
+                crv: "P-256",
+                alg: "ES256",
+                usage: "sig",
+                key_ops: ["sign"],
+                x: jwk_base64(x),
+                y: jwk_base64(y),
+                d: private.as_str(),
+                kid,
+            })
+        }
+        "rsa" => {
+            let bits = opts
+                .and_then(|options| options.bits)
+                .unwrap_or(JWK_RSA_DEFAULT_BITS);
+            if !(JWK_RSA_MIN_BITS..=JWK_RSA_MAX_BITS).contains(&bits) {
+                return Err(SecretSpecError::GenerationFailed(
+                    "JWK RSA generate.bits must be between 2048 and 8192".to_string(),
+                ));
+            }
+            let mut key =
+                RsaPrivateKey::new(&mut rsa::rand_core::OsRng, bits).map_err(|error| {
+                    SecretSpecError::GenerationFailed(format!(
+                        "failed to generate RSA JSON Web Key: {error}"
+                    ))
+                })?;
+            key.precompute().map_err(|error| {
+                SecretSpecError::GenerationFailed(format!(
+                    "failed to compute RSA JSON Web Key parameters: {error}"
+                ))
+            })?;
+            let primes = key.primes();
+            let (p, q) = primes.first().zip(primes.get(1)).ok_or_else(|| {
+                SecretSpecError::GenerationFailed(
+                    "generated RSA JSON Web Key has fewer than two primes".to_string(),
+                )
+            })?;
+            let dp = key.dp().ok_or_else(|| {
+                SecretSpecError::GenerationFailed(
+                    "generated RSA JSON Web Key has no first CRT exponent".to_string(),
+                )
+            })?;
+            let dq = key.dq().ok_or_else(|| {
+                SecretSpecError::GenerationFailed(
+                    "generated RSA JSON Web Key has no second CRT exponent".to_string(),
+                )
+            })?;
+            let qi = key
+                .qinv()
+                .ok_or_else(|| {
+                    SecretSpecError::GenerationFailed(
+                        "generated RSA JSON Web Key has no CRT coefficient".to_string(),
+                    )
+                })?
+                .to_biguint()
+                .ok_or_else(|| {
+                    SecretSpecError::GenerationFailed(
+                        "failed to encode RSA JSON Web Key q inverse".to_string(),
+                    )
+                })?;
+            let d = Zeroizing::new(jwk_integer(&key.d().to_bytes_be()));
+            let p = Zeroizing::new(jwk_integer(&p.to_bytes_be()));
+            let q = Zeroizing::new(jwk_integer(&q.to_bytes_be()));
+            let dp = Zeroizing::new(jwk_integer(&dp.to_bytes_be()));
+            let dq = Zeroizing::new(jwk_integer(&dq.to_bytes_be()));
+            let qi = Zeroizing::new(jwk_integer(&qi.to_bytes_be()));
+            serde_json::to_string(&RsaPrivateJwk {
+                kty: "RSA",
+                alg: "RS256",
+                usage: "sig",
+                key_ops: ["sign"],
+                n: jwk_integer(&key.n().to_bytes_be()),
+                e: jwk_integer(&key.e().to_bytes_be()),
+                d: d.as_str(),
+                p: p.as_str(),
+                q: q.as_str(),
+                dp: dp.as_str(),
+                dq: dq.as_str(),
+                qi: qi.as_str(),
+                kid,
+            })
+        }
+        algorithm => {
+            return Err(SecretSpecError::GenerationFailed(format!(
+                "unknown JWK algorithm '{algorithm}'; expected `ed25519`, `p256`, or `rsa`"
+            )));
+        }
+    }
+    .map_err(|error| {
+        SecretSpecError::GenerationFailed(format!("failed to encode JSON Web Key: {error}"))
+    })?;
+    Ok(protect_generated_string(encoded))
+}
+
+fn generate_age_identity() -> crate::Result<SecretString> {
+    let mut scalar = Zeroizing::new([0_u8; 32]);
+    fill_os_random(&mut scalar[..], "age identity")?;
+    let secret = x25519_dalek::StaticSecret::from(*scalar);
+    let hrp = bech32::Hrp::parse("AGE-SECRET-KEY-").map_err(|error| {
+        SecretSpecError::GenerationFailed(format!("failed to configure age identity: {error}"))
+    })?;
+    let encoded = bech32::encode::<bech32::Bech32>(hrp, secret.as_bytes())
+        .map_err(|error| {
+            SecretSpecError::GenerationFailed(format!("failed to encode age identity: {error}"))
+        })?
+        .to_uppercase();
+    Ok(protect_generated_string(encoded))
 }
 
 /// Generates a broadly interoperable OpenPGP v4 transferable secret key.
@@ -290,7 +631,7 @@ fn generate_openpgp(config: &GenerateConfig) -> crate::Result<SecretString> {
                 "failed to configure OpenPGP private key: {error}"
             ))
         })?
-        .generate(OpenPgpOsRng)
+        .generate(OsRng08)
         .map_err(|error| {
             SecretSpecError::GenerationFailed(format!(
                 "failed to generate OpenPGP private key: {error}"
@@ -331,7 +672,7 @@ fn generate_ssh(config: &GenerateConfig) -> crate::Result<SecretString> {
         ));
     }
 
-    let mut rng = OpenPgpOsRng;
+    let mut rng = OsRng08;
     let mut key = match algorithm {
         "ed25519" => {
             if opts.is_some_and(|options| options.bits.is_some()) {
@@ -503,6 +844,99 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_passphrase_default_and_custom_separator() {
+        let value = generate("passphrase", &GenerateConfig::Bool(true)).unwrap();
+        let words = value.expose_secret().split('-').collect::<Vec<_>>();
+        assert_eq!(words.len(), PASSPHRASE_DEFAULT_WORDS);
+        assert!(
+            words
+                .iter()
+                .all(|word| Language::English.word_list().contains(word))
+        );
+
+        let custom = generate(
+            "passphrase",
+            &GenerateConfig::Options(GenerateOptions {
+                words: Some(8),
+                separator: Some(".".to_string()),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        assert_eq!(custom.expose_secret().split('.').count(), 8);
+    }
+
+    #[test]
+    fn test_generate_passphrase_rejects_unsafe_options() {
+        for config in [
+            GenerateOptions {
+                words: Some(5),
+                ..Default::default()
+            },
+            GenerateOptions {
+                separator: Some(String::new()),
+                ..Default::default()
+            },
+            GenerateOptions {
+                separator: Some("\n".to_string()),
+                ..Default::default()
+            },
+        ] {
+            assert!(generate("passphrase", &GenerateConfig::Options(config)).is_err());
+        }
+    }
+
+    #[test]
+    fn test_generate_mnemonic_default_is_valid_bip39() {
+        let first = generate("mnemonic", &GenerateConfig::Bool(true)).unwrap();
+        let second = generate("mnemonic", &GenerateConfig::Bool(true)).unwrap();
+        assert_ne!(first.expose_secret(), second.expose_secret());
+
+        let parsed = Mnemonic::parse_in_normalized(Language::English, first.expose_secret())
+            .expect("generated mnemonic must have a valid BIP-39 checksum");
+        assert_eq!(parsed.word_count(), MNEMONIC_DEFAULT_WORDS);
+    }
+
+    #[test]
+    fn test_generate_mnemonic_supports_every_bip39_word_count() {
+        for &words in MNEMONIC_WORD_COUNTS {
+            let value = generate(
+                "mnemonic",
+                &GenerateConfig::Options(GenerateOptions {
+                    algorithm: Some("bip39".to_string()),
+                    words: Some(words),
+                    language: Some("english".to_string()),
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+            let parsed = Mnemonic::parse_in_normalized(Language::English, value.expose_secret())
+                .expect("generated mnemonic must have a valid BIP-39 checksum");
+            assert_eq!(parsed.word_count(), words);
+        }
+    }
+
+    #[test]
+    fn test_generate_mnemonic_rejects_invalid_options() {
+        for config in [
+            GenerateOptions {
+                words: Some(13),
+                ..Default::default()
+            },
+            GenerateOptions {
+                algorithm: Some("electrum".to_string()),
+                ..Default::default()
+            },
+            GenerateOptions {
+                language: Some("spanish".to_string()),
+                ..Default::default()
+            },
+        ] {
+            assert!(generate("mnemonic", &GenerateConfig::Options(config)).is_err());
+        }
+    }
+
+    #[test]
     fn test_generate_hex_default() {
         let value = generate("hex", &GenerateConfig::Bool(true)).unwrap();
         let s = value.expose_secret();
@@ -653,6 +1087,143 @@ mod tests {
         let v1 = generate("rsa_private_key", &GenerateConfig::Bool(true)).unwrap();
         let v2 = generate("rsa_private_key", &GenerateConfig::Bool(true)).unwrap();
         assert_ne!(v1.expose_secret(), v2.expose_secret());
+    }
+
+    #[test]
+    fn test_generate_wireguard_private_key() {
+        let first = generate("wireguard_private_key", &GenerateConfig::Bool(true)).unwrap();
+        let second = generate("wireguard_private_key", &GenerateConfig::Bool(true)).unwrap();
+        let decoded = BASE64.decode(first.expose_secret().as_bytes()).unwrap();
+        assert_eq!(decoded.len(), 32);
+        assert_eq!(decoded[0] & 7, 0);
+        assert_eq!(decoded[31] & 0x80, 0);
+        assert_eq!(decoded[31] & 0x40, 0x40);
+        assert_ne!(first.expose_secret(), second.expose_secret());
+    }
+
+    fn parse_jwk(config: &GenerateConfig) -> serde_json::Value {
+        let value = generate("jwk_private_key", config).unwrap();
+        serde_json::from_str(value.expose_secret()).unwrap()
+    }
+
+    fn decode_jwk_field(jwk: &serde_json::Value, field: &str) -> Vec<u8> {
+        BASE64URL_NOPAD
+            .decode(jwk[field].as_str().unwrap().as_bytes())
+            .unwrap()
+    }
+
+    #[test]
+    fn test_generate_ed25519_private_jwk() {
+        let jwk = parse_jwk(&GenerateConfig::Options(GenerateOptions {
+            kid: Some("release-2026".to_string()),
+            ..Default::default()
+        }));
+        assert_eq!(jwk["kty"], "OKP");
+        assert_eq!(jwk["crv"], "Ed25519");
+        assert_eq!(jwk["alg"], "Ed25519");
+        assert_eq!(jwk["use"], "sig");
+        assert_eq!(jwk["key_ops"], serde_json::json!(["sign"]));
+        assert_eq!(jwk["kid"], "release-2026");
+
+        let secret: [u8; 32] = decode_jwk_field(&jwk, "d").try_into().unwrap();
+        let signing = ed25519_dalek::SigningKey::from_bytes(&secret);
+        assert_eq!(
+            signing.verifying_key().as_bytes(),
+            decode_jwk_field(&jwk, "x").as_slice()
+        );
+    }
+
+    #[test]
+    fn test_generate_p256_private_jwk() {
+        let jwk = parse_jwk(&GenerateConfig::Options(GenerateOptions {
+            algorithm: Some("p256".to_string()),
+            ..Default::default()
+        }));
+        assert_eq!(jwk["kty"], "EC");
+        assert_eq!(jwk["crv"], "P-256");
+        assert_eq!(jwk["alg"], "ES256");
+
+        let secret = p256::SecretKey::from_slice(&decode_jwk_field(&jwk, "d")).unwrap();
+        let public = secret.public_key().to_encoded_point(false);
+        assert_eq!(public.x().unwrap().as_slice(), decode_jwk_field(&jwk, "x"));
+        assert_eq!(public.y().unwrap().as_slice(), decode_jwk_field(&jwk, "y"));
+    }
+
+    #[test]
+    fn test_generate_rsa_private_jwk() {
+        let jwk = parse_jwk(&GenerateConfig::Options(GenerateOptions {
+            algorithm: Some("rsa".to_string()),
+            bits: Some(2048),
+            ..Default::default()
+        }));
+        assert_eq!(jwk["kty"], "RSA");
+        assert_eq!(jwk["alg"], "RS256");
+        for field in ["n", "e", "d", "p", "q", "dp", "dq", "qi"] {
+            assert!(!decode_jwk_field(&jwk, field).is_empty(), "{field}");
+        }
+        let mut key = RsaPrivateKey::from_components(
+            rsa::BigUint::from_bytes_be(&decode_jwk_field(&jwk, "n")),
+            rsa::BigUint::from_bytes_be(&decode_jwk_field(&jwk, "e")),
+            rsa::BigUint::from_bytes_be(&decode_jwk_field(&jwk, "d")),
+            vec![
+                rsa::BigUint::from_bytes_be(&decode_jwk_field(&jwk, "p")),
+                rsa::BigUint::from_bytes_be(&decode_jwk_field(&jwk, "q")),
+            ],
+        )
+        .unwrap();
+        key.validate().unwrap();
+        key.precompute().unwrap();
+        assert_eq!(jwk["dp"], jwk_integer(&key.dp().unwrap().to_bytes_be()));
+        assert_eq!(jwk["dq"], jwk_integer(&key.dq().unwrap().to_bytes_be()));
+        assert_eq!(
+            jwk["qi"],
+            jwk_integer(&key.qinv().unwrap().to_biguint().unwrap().to_bytes_be())
+        );
+    }
+
+    #[test]
+    fn test_generate_jwk_rejects_invalid_profiles() {
+        for config in [
+            GenerateOptions {
+                algorithm: Some("ed25519".to_string()),
+                bits: Some(3072),
+                ..Default::default()
+            },
+            GenerateOptions {
+                algorithm: Some("rsa".to_string()),
+                bits: Some(1024),
+                ..Default::default()
+            },
+            GenerateOptions {
+                algorithm: Some("secp256k1".to_string()),
+                ..Default::default()
+            },
+            GenerateOptions {
+                kid: Some(" ".to_string()),
+                ..Default::default()
+            },
+        ] {
+            assert!(generate("jwk_private_key", &GenerateConfig::Options(config)).is_err());
+        }
+    }
+
+    #[test]
+    fn test_generate_age_identity() {
+        let first = generate("age_identity", &GenerateConfig::Bool(true)).unwrap();
+        let second = generate("age_identity", &GenerateConfig::Bool(true)).unwrap();
+        assert!(first.expose_secret().starts_with("AGE-SECRET-KEY-1"));
+        let (hrp, bytes) = bech32::decode(first.expose_secret()).unwrap();
+        assert_eq!(hrp, bech32::Hrp::parse("AGE-SECRET-KEY-").unwrap());
+        let secret = x25519_dalek::StaticSecret::from(<[u8; 32]>::try_from(bytes).unwrap());
+        assert_ne!(x25519_dalek::PublicKey::from(&secret).as_bytes(), &[0; 32]);
+        #[cfg(feature = "age")]
+        assert!(
+            first
+                .expose_secret()
+                .parse::<age::x25519::Identity>()
+                .is_ok()
+        );
+        assert_ne!(first.expose_secret(), second.expose_secret());
     }
 
     fn openpgp_config(

--- a/secretspec/src/lib.rs
+++ b/secretspec/src/lib.rs
@@ -60,7 +60,9 @@ mod resolve;
 mod secrets;
 mod spec;
 mod spec_edit;
+pub(crate) mod typed;
 mod validation;
+mod x509_identity;
 
 pub(crate) mod provider;
 
@@ -99,14 +101,15 @@ pub mod __private {
 
 // Public API exports
 pub use config::{
-    CredentialSource, ExtractFormat, NativeAddress, NativeAddressTemplate, ProviderAlias,
-    ProviderCache, RequireReason, SecretEncoding, SecretExtract,
+    CredentialBinding, CredentialSource, ExtractFormat, NativeAddress, NativeAddressTemplate,
+    ProviderAlias, ProviderCache, RequireReason, SecretEncoding, SecretExtract,
 };
 pub use error::{Result, SecretSpecError};
 pub use native::{INLINE_SPEC_SCHEMA_VERSION, NATIVE_CALL_REQUEST_VERSION, call_json};
 pub use provider::{DiscoveryContext, ProducedValuePersistence, Provider};
 pub use report::{
-    RESOLUTION_REPORT_SCHEMA_VERSION, ResolutionReport, ResolutionStatus, SecretResolution,
+    Derivation, RESOLUTION_REPORT_SCHEMA_VERSION, ResolutionReport, ResolutionStatus,
+    SecretResolution,
 };
 pub use resolve::{
     NamedResolution, RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource,
@@ -115,10 +118,14 @@ pub use resolve::{
 pub use secrets::ExportFormat;
 pub use secrets::Secrets;
 pub use spec::{
-    Generation, OpenPgpAlgorithm, OpenPgpCapability, PasswordCharset, Profile, Secret, Spec,
-    SpecBuilder, SshKeyAlgorithm,
+    Generation, JwkKeyAlgorithm, MnemonicAlgorithm, MnemonicLanguage, OpenPgpAlgorithm,
+    OpenPgpCapability, PasswordCharset, Profile, Secret, Spec, SpecBuilder, SshKeyAlgorithm,
+    X509Usage,
 };
+pub use typed::Format;
 pub use validation::{ConstraintKind, ConstraintViolation, ValidatedSecrets, ValidationErrors};
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod typed_tests;

--- a/secretspec/src/native.rs
+++ b/secretspec/src/native.rs
@@ -181,6 +181,12 @@ struct InlineSecret {
     #[serde(default, rename = "type")]
     secret_type: Option<String>,
     #[serde(default)]
+    format: Option<String>,
+    #[serde(default)]
+    from: Option<String>,
+    #[serde(default)]
+    credentials: Option<BTreeMap<String, crate::config::CredentialBinding>>,
+    #[serde(default)]
     generate: Option<InlineGenerate>,
     #[serde(default)]
     prompt: Option<bool>,
@@ -227,7 +233,7 @@ where
 #[serde(untagged)]
 enum InlineGenerate {
     Bool(bool),
-    Options(InlineGenerateOptions),
+    Options(Box<InlineGenerateOptions>),
 }
 
 #[derive(Debug, Deserialize)]
@@ -251,6 +257,22 @@ struct InlineGenerateOptions {
     capabilities: Option<Vec<String>>,
     #[serde(default)]
     comment: Option<String>,
+    #[serde(default)]
+    words: Option<usize>,
+    #[serde(default)]
+    separator: Option<String>,
+    #[serde(default)]
+    language: Option<String>,
+    #[serde(default)]
+    kid: Option<String>,
+    #[serde(default)]
+    issuer: Option<String>,
+    #[serde(default)]
+    san: Option<Vec<String>>,
+    #[serde(default)]
+    usages: Option<Vec<String>>,
+    #[serde(default)]
+    valid_for: Option<String>,
 }
 
 impl InlineSpec {
@@ -329,6 +351,9 @@ impl InlineSecret {
             encoding: self.encoding,
             extract: self.extract,
             secret_type: self.secret_type,
+            format: self.format,
+            from: self.from,
+            credentials: self.credentials,
             generate: self.generate.map(|generate| match generate {
                 InlineGenerate::Bool(enabled) => GenerateConfig::Bool(enabled),
                 InlineGenerate::Options(options) => GenerateConfig::Options(GenerateOptions {
@@ -341,6 +366,14 @@ impl InlineSecret {
                     user_id: options.user_id,
                     capabilities: options.capabilities,
                     comment: options.comment,
+                    words: options.words,
+                    separator: options.separator,
+                    language: options.language,
+                    kid: options.kid,
+                    issuer: options.issuer,
+                    san: options.san,
+                    usages: options.usages,
+                    valid_for: options.valid_for,
                 }),
             }),
             prompt: self.prompt,
@@ -559,5 +592,54 @@ mod tests {
         assert_eq!(options.algorithm.as_deref(), Some("rsa"));
         assert_eq!(options.bits, Some(4096));
         assert_eq!(options.comment.as_deref(), Some("deploy@example.com"));
+    }
+
+    #[test]
+    fn inline_declaration_preserves_new_generation_options() {
+        let passphrase: InlineSecret = serde_json::from_str(
+            r#"{
+              "description": "Recovery phrase",
+              "type": "passphrase",
+              "generate": { "words": 8, "separator": "." }
+            }"#,
+        )
+        .unwrap();
+        let Some(GenerateConfig::Options(options)) = passphrase.into_config().unwrap().generate
+        else {
+            panic!("expected passphrase generation options");
+        };
+        assert_eq!(options.words, Some(8));
+        assert_eq!(options.separator.as_deref(), Some("."));
+
+        let mnemonic: InlineSecret = serde_json::from_str(
+            r#"{
+              "description": "Wallet recovery mnemonic",
+              "type": "mnemonic",
+              "generate": { "algorithm": "bip39", "words": 24, "language": "english" }
+            }"#,
+        )
+        .unwrap();
+        let Some(GenerateConfig::Options(options)) = mnemonic.into_config().unwrap().generate
+        else {
+            panic!("expected mnemonic generation options");
+        };
+        assert_eq!(options.algorithm.as_deref(), Some("bip39"));
+        assert_eq!(options.words, Some(24));
+        assert_eq!(options.language.as_deref(), Some("english"));
+
+        let jwk: InlineSecret = serde_json::from_str(
+            r#"{
+              "description": "Signing key",
+              "type": "jwk_private_key",
+              "generate": { "algorithm": "rsa", "bits": 4096, "kid": "release-2026" }
+            }"#,
+        )
+        .unwrap();
+        let Some(GenerateConfig::Options(options)) = jwk.into_config().unwrap().generate else {
+            panic!("expected JWK generation options");
+        };
+        assert_eq!(options.algorithm.as_deref(), Some("rsa"));
+        assert_eq!(options.bits, Some(4096));
+        assert_eq!(options.kid.as_deref(), Some("release-2026"));
     }
 }

--- a/secretspec/src/plan.rs
+++ b/secretspec/src/plan.rs
@@ -198,18 +198,59 @@ impl PlannedSecret {
         self.secret.config.as_path.unwrap_or(false)
     }
 
-    /// Optional encoding applied at the storage boundary.
+    /// The codec used wherever this value must be text: the declared
+    /// `encoding`, or the type registry's default for a binary value. For a
+    /// provider-backed secret that is the storage and cache boundary; for a
+    /// binary value it is also the inline exposure when `as_path` is off.
     pub(crate) fn encoding(&self) -> Option<SecretEncoding> {
-        self.secret.config.encoding
+        self.secret.config.effective_encoding()
     }
 
-    /// Optional structured extraction applied at the storage boundary.
+    /// Optional structured extraction applied at the storage boundary or to
+    /// the `from` source's text.
     pub(crate) fn extract(&self) -> Option<&SecretExtract> {
         self.secret.config.extract.as_ref()
     }
 
     pub(crate) fn is_composed(&self) -> bool {
         self.secret.composition.is_some()
+    }
+
+    /// The declared secret this value is converted or selected from.
+    pub(crate) fn from(&self) -> Option<&str> {
+        self.secret.config.from.as_deref()
+    }
+
+    /// Whether the value is produced by the executor from other declared
+    /// secrets rather than read from a store.
+    pub(crate) fn is_derived(&self) -> bool {
+        self.is_composed() || self.from().is_some()
+    }
+
+    /// Whether this is a provider-backed registry type whose stored value is
+    /// decoded and validated by the type contract, possibly with credentials,
+    /// once every dependency has resolved.
+    pub(crate) fn is_typed_stored(&self) -> bool {
+        self.from().is_none()
+            && self
+                .secret
+                .config
+                .typed_contract()
+                .is_some_and(|contract| contract.is_stored())
+    }
+
+    /// Every declared secret that must resolve before this one.
+    pub(crate) fn dependencies(&self) -> Vec<&str> {
+        self.secret.dependencies()
+    }
+
+    /// The declared secret bound to a credential role, if any.
+    pub(crate) fn credential(&self, role: &str) -> Option<&str> {
+        self.secret
+            .config
+            .credential_secrets()
+            .find(|(bound_role, _)| *bound_role == role)
+            .map(|(_, credential)| credential)
     }
 
     /// The parsed derived-value template, for composed secrets.
@@ -456,9 +497,9 @@ impl Secrets {
         override_spec: &Option<String>,
     ) -> Result<PlannedSecret> {
         self.validate_scoped_refs(&name, &secret.config)?;
-        // A composed secret's value is derived by the executor, so it routes
+        // A derived secret's value is produced by the executor, so it routes
         // to no store, including an explicit `--provider` override.
-        let route = if secret.composition.is_some() {
+        let route = if secret.composition.is_some() || secret.config.from.is_some() {
             None
         } else {
             Some(self.route_for(&secret.config, override_spec)?)

--- a/secretspec/src/report.rs
+++ b/secretspec/src/report.rs
@@ -61,13 +61,32 @@ pub struct SecretResolution {
     /// retains a generated value. A required secret backed by a store that keeps
     /// what it mints is reported `missing_required` until a pass provisions it.
     pub generated: bool,
-    /// Whether the value was derived from other declared secrets.
+    /// Whether the value was derived from other declared secrets. The field's
+    /// historical internal name covers templates, conversions, and selections.
     /// Internal provenance used by human-readable output and the value-carrying
     /// resolve response; omitted from the report v1 wire format.
     #[serde(skip)]
     pub composed: bool,
+    /// How a derived value was produced, for human-readable output. `None`
+    /// when the value is not derived. Omitted from the report wire format.
+    #[serde(skip)]
+    pub derivation: Option<Derivation>,
     /// Whether the value is materialized to a temp file and exposed as a path.
     pub as_path: bool,
+}
+
+/// How a derived secret's value is produced from other declared secrets.
+///
+/// Available since SecretSpec 0.21.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Derivation {
+    /// Rendered from a `composed` template.
+    Composed,
+    /// Converted from the named `from` source by its `type`.
+    ConvertedFrom(String),
+    /// Selected from the named `from` source's text with `extract`.
+    SelectedFrom(String),
 }
 
 /// A complete, value-free snapshot of one resolution pass over a profile.
@@ -155,7 +174,15 @@ impl ResolutionReport {
                     } else if s.default_applied {
                         "ok        default value".to_string()
                     } else if s.composed {
-                        "ok        composed".to_string()
+                        match &s.derivation {
+                            Some(Derivation::ConvertedFrom(source)) => {
+                                format!("ok        converted from {source}")
+                            }
+                            Some(Derivation::SelectedFrom(source)) => {
+                                format!("ok        selected from {source}")
+                            }
+                            Some(Derivation::Composed) | None => "ok        composed".to_string(),
+                        }
                     } else if let Some(uri) = &s.source_provider {
                         format!("ok        source {}", uri)
                     } else {
@@ -199,6 +226,7 @@ mod tests {
                     default_applied: false,
                     generated: false,
                     composed: false,
+                    derivation: None,
                     as_path: false,
                 },
                 SecretResolution {
@@ -209,6 +237,7 @@ mod tests {
                     default_applied: false,
                     generated: false,
                     composed: false,
+                    derivation: None,
                     as_path: false,
                 },
                 SecretResolution {
@@ -219,6 +248,7 @@ mod tests {
                     default_applied: false,
                     generated: true,
                     composed: false,
+                    derivation: None,
                     as_path: false,
                 },
                 SecretResolution {
@@ -229,6 +259,7 @@ mod tests {
                     default_applied: true,
                     generated: false,
                     composed: false,
+                    derivation: None,
                     as_path: false,
                 },
                 SecretResolution {
@@ -239,6 +270,7 @@ mod tests {
                     default_applied: false,
                     generated: false,
                     composed: false,
+                    derivation: None,
                     as_path: false,
                 },
             ],
@@ -300,6 +332,7 @@ mod tests {
                 default_applied: false,
                 generated: false,
                 composed: false,
+                derivation: None,
                 as_path: true,
             }],
         );

--- a/secretspec/src/resolve.rs
+++ b/secretspec/src/resolve.rs
@@ -37,9 +37,12 @@ pub enum ResolvedSource {
     Generated,
     /// The manifest's committed `default` value.
     Default,
-    /// Derived from other declared secrets using a strict template.
+    /// Derived from other declared secrets: a strict `composed` template, or a
+    /// `from` conversion or selection. The serialized name remains `composed`
+    /// for wire compatibility.
     ///
-    /// Available since SecretSpec 0.16.
+    /// Template composition is available since SecretSpec 0.16; `from`
+    /// derivation is available since SecretSpec 0.21.
     Composed,
 }
 

--- a/secretspec/src/secrets.rs
+++ b/secretspec/src/secrets.rs
@@ -14,7 +14,7 @@ use crate::provider::{
     Address, OwnedAddress, ProducedValuePersistence, Provider as ProviderTrait,
     ProviderCredentials, same_storage_container,
 };
-use crate::report::{ResolutionReport, ResolutionStatus, SecretResolution};
+use crate::report::{Derivation, ResolutionReport, ResolutionStatus, SecretResolution};
 use crate::resolve::{
     NamedResolution, RESOLVE_SCHEMA_VERSION, ResolveResponse, ResolvedSecret, ResolvedSource,
 };
@@ -24,6 +24,7 @@ use colored::Colorize;
 use data_encoding::{
     BASE64, BASE64_NOPAD, BASE64URL, BASE64URL_NOPAD, Encoding, HEXLOWER, HEXLOWER_PERMISSIVE,
 };
+use secrecy::zeroize::Zeroizing;
 use secrecy::{ExposeSecret, SecretSlice, SecretString};
 #[cfg(unix)]
 use signal_hook::consts::signal::{SIGHUP, SIGINT, SIGTERM};
@@ -173,9 +174,9 @@ fn resolved_source(entry: &SecretResolution) -> ResolvedSource {
 /// Stands in for a secret's name in diagnostics when the active scope hides it.
 ///
 /// Every accessed-but-not-visible secret is by construction a dependency of a
-/// visible composed secret, so this describes what it is without disclosing
+/// visible derived secret, so this describes what it is without disclosing
 /// which secret it is.
-pub(crate) const HIDDEN_SECRET_LABEL: &str = "a hidden composition input";
+pub(crate) const HIDDEN_SECRET_LABEL: &str = "a hidden derived-secret input";
 
 /// Emits a warning when a provider in a fallback chain fails so the user
 /// can see why a particular link was skipped, without aborting the chain.
@@ -1037,6 +1038,13 @@ struct ResolutionExecution<'secrets, 'plan, 'filter, 'addresses> {
     failed_primary_uris: HashMap<Option<&'plan str>, SecretSpecError>,
     cached_uris: HashMap<String, String>,
     fallback_results: HashMap<String, FallbackReadResult>,
+    /// Registry-typed provider values parked by the provider pass until the
+    /// derived pass, where their credentials have resolved and the type
+    /// contract decodes them exactly once.
+    pending_typed: HashMap<String, PendingTyped>,
+    /// Decoded identities, keyed by secret name, for the projections that
+    /// derive from them in the same pass.
+    identities: HashMap<String, crate::x509_identity::Identity>,
 }
 
 impl<'secrets, 'plan, 'filter, 'addresses>
@@ -1066,6 +1074,58 @@ impl<'secrets, 'plan, 'filter, 'addresses>
             failed_primary_uris: HashMap::new(),
             cached_uris: HashMap::new(),
             fallback_results: HashMap::new(),
+            pending_typed: HashMap::new(),
+            identities: HashMap::new(),
+        }
+    }
+
+    /// Insert a value that crossed a storage boundary. A registry-typed stored
+    /// value is parked instead: its contract decodes it in the derived pass,
+    /// once the credentials it may need have resolved.
+    fn insert_stored(
+        &mut self,
+        planned: &PlannedSecret,
+        diagnostic_name: &str,
+        value: SecretString,
+    ) -> Result<()> {
+        if planned.is_typed_stored() {
+            self.pending_typed
+                .insert(planned.name.clone(), PendingTyped::Stored(value));
+            return Ok(());
+        }
+        self.manager.insert_resolved(
+            &mut self.values,
+            &mut self.temp_files,
+            planned,
+            diagnostic_name,
+            value,
+            ResolvedRepresentation::Stored,
+        )
+    }
+
+    /// Insert a freshly generated value. Text is already logical; generated
+    /// binary identities are parked like stored ones so one code path decodes,
+    /// validates, and delivers every typed value.
+    fn insert_generated(
+        &mut self,
+        planned: &PlannedSecret,
+        diagnostic_name: &str,
+        value: GeneratedValue,
+    ) -> Result<()> {
+        match value {
+            GeneratedValue::Text(value) => self.manager.insert_resolved(
+                &mut self.values,
+                &mut self.temp_files,
+                planned,
+                diagnostic_name,
+                value,
+                ResolvedRepresentation::Logical,
+            ),
+            GeneratedValue::Binary(bytes) => {
+                self.pending_typed
+                    .insert(planned.name.clone(), PendingTyped::Logical(bytes));
+                Ok(())
+            }
         }
     }
 
@@ -1084,7 +1144,7 @@ impl<'secrets, 'plan, 'filter, 'addresses>
         self.fetch_primary_values()?;
         self.fetch_fallback_values();
         self.resolve_provider_backed_values()?;
-        self.resolve_composed_values()?;
+        self.resolve_derived_values()?;
         self.finish()
     }
 
@@ -1271,14 +1331,7 @@ impl<'secrets, 'plan, 'filter, 'addresses>
                         manager.write_cached_secret(planned, route, profile, &value);
                     }
                     if materialize.values() {
-                        manager.insert_resolved(
-                            &mut self.values,
-                            &mut self.temp_files,
-                            planned,
-                            diagnostic_name,
-                            value,
-                            ResolvedRepresentation::Stored,
-                        )?;
+                        self.insert_stored(planned, diagnostic_name, value)?;
                     }
                     status = ResolutionStatus::Resolved;
                 }
@@ -1332,14 +1385,7 @@ impl<'secrets, 'plan, 'filter, 'addresses>
                         source_provider = fallback_uri;
                         if materialize.values() {
                             manager.write_cached_secret(planned, route, profile, &value);
-                            manager.insert_resolved(
-                                &mut self.values,
-                                &mut self.temp_files,
-                                planned,
-                                diagnostic_name,
-                                value,
-                                ResolvedRepresentation::Stored,
-                            )?;
+                            self.insert_stored(planned, diagnostic_name, value)?;
                         }
                         status = ResolutionStatus::Resolved;
                     } else {
@@ -1372,13 +1418,10 @@ impl<'secrets, 'plan, 'filter, 'addresses>
                                     let generated_value = manager
                                         .try_generate_secret(planned, profile)?
                                         .expect("compiled Generate policy has a generator");
-                                    manager.insert_resolved(
-                                        &mut self.values,
-                                        &mut self.temp_files,
+                                    self.insert_generated(
                                         planned,
                                         diagnostic_name,
                                         generated_value,
-                                        ResolvedRepresentation::Logical,
                                     )?;
                                     status = ResolutionStatus::Resolved;
                                 } else if required
@@ -1433,49 +1476,48 @@ impl<'secrets, 'plan, 'filter, 'addresses>
                 default_applied,
                 generated,
                 composed: false,
+                derivation: None,
                 as_path: planned.as_path(),
             });
         }
         Ok(())
     }
 
-    fn resolve_composed_values(&mut self) -> Result<()> {
-        fn composition_order<'a>(
+    /// Resolve every value the executor produces itself, in one topological
+    /// pass: composed templates, `from` conversions and selections, and the
+    /// typed decoding of provider-backed registry values whose credentials had
+    /// to resolve first. A node runs after its dependencies, so declaration
+    /// order never matters and a typed value is decoded exactly once.
+    fn resolve_derived_values(&mut self) -> Result<()> {
+        fn order<'a>(
             planned: &'a PlannedSecret,
-            composed: &HashMap<&str, &'a PlannedSecret>,
+            nodes: &HashMap<&str, &'a PlannedSecret>,
             visited: &mut HashSet<&'a str>,
             ordered: &mut Vec<&'a PlannedSecret>,
         ) {
             if !visited.insert(planned.name.as_str()) {
                 return;
             }
-            let template = planned
-                .composition()
-                .expect("only composed nodes are ordered");
-            for dependency in template.dependencies() {
-                if let Some(dependency) = composed.get(dependency.as_str()) {
-                    composition_order(dependency, composed, visited, ordered);
+            for dependency in planned.dependencies() {
+                if let Some(dependency) = nodes.get(dependency) {
+                    order(dependency, nodes, visited, ordered);
                 }
             }
             ordered.push(planned);
         }
 
-        let composed: HashMap<&str, &PlannedSecret> = self
+        let is_node = |secret: &PlannedSecret| secret.is_derived() || secret.is_typed_stored();
+        let nodes: HashMap<&str, &PlannedSecret> = self
             .plan
             .secrets
             .iter()
-            .filter(|secret| secret.is_composed())
+            .filter(|secret| is_node(secret))
             .map(|secret| (secret.name.as_str(), secret))
             .collect();
-        let mut ordered = Vec::with_capacity(composed.len());
+        let mut ordered = Vec::with_capacity(nodes.len());
         let mut visited = HashSet::new();
-        for planned in self
-            .plan
-            .secrets
-            .iter()
-            .filter(|secret| secret.is_composed())
-        {
-            composition_order(planned, &composed, &mut visited, &mut ordered);
+        for planned in self.plan.secrets.iter().filter(|secret| is_node(secret)) {
+            order(planned, &nodes, &mut visited, &mut ordered);
         }
 
         if ordered.is_empty() {
@@ -1488,30 +1530,67 @@ impl<'secrets, 'plan, 'filter, 'addresses>
             .map(|entry| (entry.name.clone(), entry.status.clone()))
             .collect();
         for planned in ordered {
-            let template = planned
-                .composition()
-                .expect("only composed nodes are ordered");
-            let dependencies_resolved = template
+            let dependencies_resolved = planned
                 .dependencies()
                 .iter()
-                .all(|dependency| statuses.get(dependency) == Some(&ResolutionStatus::Resolved));
+                .all(|dependency| statuses.get(*dependency) == Some(&ResolutionStatus::Resolved));
+
+            if planned.is_typed_stored() {
+                // The provider pass already recorded this secret. It stays
+                // resolved only while its credentials did: an archive whose
+                // password is missing cannot be opened, so the secret is
+                // missing under its own policy rather than exposed unusable.
+                let fetched =
+                    statuses.get(planned.name.as_str()) == Some(&ResolutionStatus::Resolved);
+                if fetched && dependencies_resolved {
+                    if self.materialize.values() {
+                        self.finalize_typed_stored(planned)?;
+                    }
+                } else if fetched {
+                    self.pending_typed.remove(planned.name.as_str());
+                    let status = match planned.secret.missing {
+                        MissingPolicy::Omit => {
+                            self.missing_optional.push(planned.name.clone());
+                            ResolutionStatus::MissingOptional
+                        }
+                        _ => {
+                            self.missing_required.push(planned.name.clone());
+                            ResolutionStatus::MissingRequired
+                        }
+                    };
+                    if let Some(entry) = self
+                        .resolution
+                        .iter_mut()
+                        .find(|entry| entry.name == planned.name)
+                    {
+                        entry.status = status.clone();
+                    }
+                    statuses.insert(planned.name.clone(), status);
+                }
+                continue;
+            }
+
             let status = if dependencies_resolved {
                 if self.materialize.values() {
-                    let rendered = template
-                        .render(|dependency| {
-                            self.values
-                                .get(dependency)
-                                .map(|value| value.expose_secret())
-                        })
-                        .map_err(SecretSpecError::CompositionFailed)?;
-                    self.manager.insert_resolved(
-                        &mut self.values,
-                        &mut self.temp_files,
-                        planned,
-                        Secrets::diagnostic_secret_name(&planned.name, self.output_filter),
-                        SecretString::new(rendered.into()),
-                        ResolvedRepresentation::Logical,
-                    )?;
+                    if let Some(template) = planned.composition() {
+                        let rendered = template
+                            .render(|dependency| {
+                                self.values
+                                    .get(dependency)
+                                    .map(|value| value.expose_secret())
+                            })
+                            .map_err(SecretSpecError::CompositionFailed)?;
+                        self.manager.insert_resolved(
+                            &mut self.values,
+                            &mut self.temp_files,
+                            planned,
+                            Secrets::diagnostic_secret_name(&planned.name, self.output_filter),
+                            SecretString::new(rendered.into()),
+                            ResolvedRepresentation::Logical,
+                        )?;
+                    } else {
+                        self.resolve_from(planned)?;
+                    }
                 }
                 ResolutionStatus::Resolved
             } else {
@@ -1525,11 +1604,22 @@ impl<'secrets, 'plan, 'filter, 'addresses>
                         ResolutionStatus::MissingOptional
                     }
                     MissingPolicy::Generate | MissingPolicy::UseDefault | MissingPolicy::Prompt => {
-                        unreachable!("composed source conflicts are rejected at load time")
+                        unreachable!("derived source conflicts are rejected at load time")
                     }
                 }
             };
 
+            let derivation = if planned.is_composed() {
+                Derivation::Composed
+            } else if let Some(source) = planned.from() {
+                if planned.extract().is_some() {
+                    Derivation::SelectedFrom(source.to_string())
+                } else {
+                    Derivation::ConvertedFrom(source.to_string())
+                }
+            } else {
+                unreachable!("derived nodes are composed or converted")
+            };
             statuses.insert(planned.name.clone(), status.clone());
             self.resolution.push(SecretResolution {
                 name: planned.name.clone(),
@@ -1539,10 +1629,172 @@ impl<'secrets, 'plan, 'filter, 'addresses>
                 default_applied: false,
                 generated: false,
                 composed: true,
+                derivation: Some(derivation),
                 as_path: planned.as_path(),
             });
         }
         Ok(())
+    }
+
+    /// The value bound to one credential role of a typed secret, validated
+    /// against the bounds every credential shares. `None` when the role is
+    /// unbound, which the type contract treats as an empty credential.
+    fn credential_value(
+        &self,
+        planned: &PlannedSecret,
+        role: &str,
+    ) -> Result<Option<SecretString>> {
+        let Some(credential) = planned.credential(role) else {
+            return Ok(None);
+        };
+        let diagnostic_name = Secrets::diagnostic_secret_name(&planned.name, self.output_filter);
+        let value =
+            self.values
+                .get(credential)
+                .ok_or_else(|| SecretSpecError::CredentialInvalid {
+                    name: diagnostic_name.to_string(),
+                    role: role.to_string(),
+                    reason: format!(
+                        "depends on '{}', which did not resolve",
+                        Secrets::diagnostic_secret_name(credential, self.output_filter)
+                    ),
+                })?;
+        crate::typed::validate_credential_value(role, value.expose_secret()).map_err(|reason| {
+            SecretSpecError::CredentialInvalid {
+                name: diagnostic_name.to_string(),
+                role: role.to_string(),
+                reason,
+            }
+        })?;
+        Ok(Some(value.clone()))
+    }
+
+    /// Deliver a binary logical value: a file holding the raw bytes with the
+    /// type's suffix when `as_path`, otherwise inline text in the value's
+    /// encoding. This is the one rule for every binary value, stored or
+    /// derived.
+    fn deliver_bytes(&mut self, planned: &PlannedSecret, bytes: &[u8]) -> Result<()> {
+        if planned.as_path() {
+            let (owner, path) = self
+                .manager
+                .write_secret_to_temp_file(bytes, planned.config().file_suffix())?;
+            self.temp_files.push(owner);
+            self.values
+                .insert(planned.name.clone(), SecretString::new(path.into()));
+        } else {
+            let encoding = planned
+                .encoding()
+                .expect("binary values always carry an encoding");
+            self.values.insert(
+                planned.name.clone(),
+                Secrets::encode_logical_bytes(encoding, bytes),
+            );
+        }
+        Ok(())
+    }
+
+    /// Decode and validate a parked registry-typed value with the credentials
+    /// bound to it, deliver its canonical bytes, and keep the decoded identity
+    /// for the projections that derive from it.
+    fn finalize_typed_stored(&mut self, planned: &PlannedSecret) -> Result<()> {
+        let diagnostic_name = Secrets::diagnostic_secret_name(&planned.name, self.output_filter);
+        let pending = self
+            .pending_typed
+            .remove(planned.name.as_str())
+            .expect("a resolved typed stored secret parked its value");
+        let bytes: SecretSlice<u8> = match pending {
+            PendingTyped::Stored(value) => {
+                let encoding = planned
+                    .encoding()
+                    .expect("binary stored types always carry an encoding");
+                Secrets::decode_stored_value(encoding, diagnostic_name, &value)?
+            }
+            PendingTyped::Logical(bytes) => bytes,
+        };
+        let password = self.credential_value(planned, "password")?;
+        let identity = crate::x509_identity::Identity::decode(
+            bytes.expose_secret(),
+            password.as_ref().map(|password| password.expose_secret()),
+            diagnostic_name,
+        )?;
+        self.deliver_bytes(planned, bytes.expose_secret())?;
+        self.identities.insert(planned.name.clone(), identity);
+        Ok(())
+    }
+
+    /// Produce a `from` secret: select a field from the source's text with
+    /// `extract`, or convert the source identity into the target type.
+    fn resolve_from(&mut self, planned: &PlannedSecret) -> Result<()> {
+        let source_name = planned.from().expect("a `from` secret names its source");
+        let diagnostic_name = Secrets::diagnostic_secret_name(&planned.name, self.output_filter);
+
+        if let Some(extract) = planned.extract() {
+            let source_planned = self
+                .plan
+                .secrets
+                .iter()
+                .find(|candidate| candidate.name == source_name)
+                .expect("validated `from` source is in the resolution plan");
+            let source = self
+                .values
+                .get(source_name)
+                .expect("a resolved `from` source has a value");
+            let not_utf8 = |error: std::str::Utf8Error| SecretSpecError::DecodeFailed {
+                name: diagnostic_name.to_string(),
+                encoding: extract.format.as_str(),
+                reason: format!("source value is not valid UTF-8: {error}"),
+            };
+            let text = if source_planned.as_path() {
+                let bytes = Zeroizing::new(std::fs::read(source.expose_secret())?);
+                SecretString::new(std::str::from_utf8(&bytes).map_err(not_utf8)?.into())
+            } else {
+                source.clone()
+            };
+            let value =
+                Secrets::extract_stored_value(extract, diagnostic_name, text.expose_secret())?;
+            return self.manager.insert_resolved(
+                &mut self.values,
+                &mut self.temp_files,
+                planned,
+                diagnostic_name,
+                value,
+                ResolvedRepresentation::Logical,
+            );
+        }
+
+        let contract = planned
+            .config()
+            .typed_contract()
+            .expect("a converting `from` secret has a registry type");
+        let projection = contract
+            .projection
+            .expect("derivable registry types define a projection");
+        let password = self.credential_value(planned, "password")?;
+        let projected = {
+            let identity = self
+                .identities
+                .get(source_name)
+                .expect("an x509_identity source is decoded before its projections");
+            identity.project(
+                projection,
+                planned.config().typed_format(),
+                password.as_ref().map(|password| password.expose_secret()),
+                diagnostic_name,
+            )?
+        };
+        match projected {
+            crate::x509_identity::ProjectedValue::Text(value) => self.manager.insert_resolved(
+                &mut self.values,
+                &mut self.temp_files,
+                planned,
+                diagnostic_name,
+                value,
+                ResolvedRepresentation::Logical,
+            ),
+            crate::x509_identity::ProjectedValue::Binary(bytes) => {
+                self.deliver_bytes(planned, bytes.expose_secret())
+            }
+        }
     }
 
     fn apply_output_filter(&mut self) {
@@ -1676,6 +1928,20 @@ enum PreparedSecret {
         owner: tempfile::NamedTempFile,
         path: String,
     },
+}
+
+/// A freshly generated value before the provider's textual storage boundary.
+enum GeneratedValue {
+    Text(SecretString),
+    Binary(SecretSlice<u8>),
+}
+
+/// A registry-typed value waiting for the derived pass to decode it: either
+/// the text read from a store, still in its storage encoding, or the logical
+/// bytes a generator just produced.
+enum PendingTyped {
+    Stored(SecretString),
+    Logical(SecretSlice<u8>),
 }
 
 /// Whether a resolved string came from a storage boundary and is eligible for
@@ -2914,7 +3180,10 @@ impl Secrets {
     /// Encode a logical UTF-8 value into the canonical stored representation
     /// for its declared encoding.
     fn encode_logical_value(encoding: SecretEncoding, value: &SecretString) -> SecretString {
-        let bytes = value.expose_secret().as_bytes();
+        Self::encode_logical_bytes(encoding, value.expose_secret().as_bytes())
+    }
+
+    fn encode_logical_bytes(encoding: SecretEncoding, bytes: &[u8]) -> SecretString {
         let encoded = match encoding {
             SecretEncoding::Base64 => BASE64.encode(bytes),
             SecretEncoding::Base64Url => BASE64URL_NOPAD.encode(bytes),
@@ -2931,6 +3200,32 @@ impl Secrets {
             .map(|encoding| Self::encode_logical_value(encoding, value))
     }
 
+    /// Convert operator input into the provider representation. Binary typed
+    /// values are entered in their encoded form, so decode them before
+    /// validating and re-encoding canonically. Text values are logical input
+    /// and only need their configured storage encoding applied.
+    fn prompted_value_for_storage(
+        planned: &PlannedSecret,
+        diagnostic_name: &str,
+        value: &SecretString,
+    ) -> Result<Option<SecretString>> {
+        if !planned.is_typed_stored() {
+            return Ok(Self::encoded_for_storage(planned, value));
+        }
+
+        let encoding = planned
+            .encoding()
+            .expect("binary stored types always carry an encoding");
+        let bytes = Self::decode_stored_value(encoding, diagnostic_name, value)?;
+        if planned.credential("password").is_none() {
+            crate::x509_identity::validate(bytes.expose_secret(), diagnostic_name)?;
+        }
+        Ok(Some(Self::encode_logical_bytes(
+            encoding,
+            bytes.expose_secret(),
+        )))
+    }
+
     /// Validate a stored value before import copies it into another provider.
     /// Import moves the stored representation verbatim, so an invalid encoded
     /// source must fail before any target write (and especially before source
@@ -2944,6 +3239,15 @@ impl Secrets {
             return Ok(());
         };
         let decoded = Self::decode_stored_value(encoding, diagnostic_name, value)?;
+        if planned.is_typed_stored() {
+            // Import copies stored bytes without resolving the profile, so an
+            // archive that a bound credential unlocks can only be checked for
+            // its encoding here; an unprotected one is validated in full.
+            if planned.credential("password").is_none() {
+                crate::x509_identity::validate(decoded.expose_secret(), diagnostic_name)?;
+            }
+            return Ok(());
+        }
         if !planned.as_path() {
             std::str::from_utf8(decoded.expose_secret()).map_err(|error| {
                 SecretSpecError::DecodeFailed {
@@ -3044,7 +3348,8 @@ impl Secrets {
                 .map(|value| value.expose_secret().as_bytes())
                 .or_else(|| decoded.as_ref().map(|(_, decoded)| decoded.expose_secret()))
                 .unwrap_or_else(|| value.expose_secret().as_bytes());
-            let (owner, path) = self.write_secret_to_temp_file(bytes)?;
+            let (owner, path) =
+                self.write_secret_to_temp_file(bytes, planned.config().file_suffix())?;
             Ok(PreparedSecret::File { owner, path })
         } else if let Some(extracted) = extracted {
             Ok(PreparedSecret::Inline(extracted))
@@ -3341,10 +3646,8 @@ impl Secrets {
             if !acc.insert(name.to_string()) {
                 return;
             }
-            if let Some(secret) = profile.secrets.get(name)
-                && let Some(template) = &secret.composition
-            {
-                for dependency in template.dependencies() {
+            if let Some(secret) = profile.secrets.get(name) {
+                for dependency in secret.dependencies() {
                     visit(dependency, profile, acc);
                 }
             }
@@ -4258,7 +4561,7 @@ impl Secrets {
             let Some(route) = &planned.route else {
                 if named {
                     return Err(SecretSpecError::ProviderOperationFailed(format!(
-                        "secret '{name}' is composed and has no provider cache"
+                        "secret '{name}' is derived and has no provider cache"
                     )));
                 }
                 continue;
@@ -4359,26 +4662,29 @@ impl Secrets {
             }
         };
 
-        // A composed secret plans no route: its value is derived, so a write
-        // has nowhere to go.
-        let Some(route) = &planned.route else {
-            let err = SecretSpecError::ComposedSecretReadOnly(name.to_string());
-            self.record_key_error(AuditAction::Set, &profile_name, name, None, None, &err);
-            return Err(err);
-        };
-
-        if planned.extract().is_some() {
+        if planned.extract().is_some() && planned.from().is_none() {
             let err = SecretSpecError::ExtractedSecretReadOnly(name.to_string());
             self.record_key_error(
                 AuditAction::Set,
                 &profile_name,
                 name,
-                route.primary().map(str::to_string),
+                planned
+                    .route
+                    .as_ref()
+                    .and_then(|route| route.primary().map(str::to_string)),
                 planned.reference(),
                 &err,
             );
             return Err(err);
         }
+
+        // A derived secret plans no route: its value is produced from other
+        // secrets, so a write has nowhere to go.
+        let Some(route) = &planned.route else {
+            let err = Self::derived_read_only(&planned);
+            self.record_key_error(AuditAction::Set, &profile_name, name, None, None, &err);
+            return Err(err);
+        };
 
         let backend = match self.write_provider_for_route(route, Some(&profile_name)) {
             Ok(backend) => backend,
@@ -4442,7 +4748,24 @@ impl Secrets {
             return Err(err);
         }
 
-        let encoded_value = Self::encoded_for_storage(&planned, &value);
+        // A binary registry type is entered in its encoded form, since a
+        // terminal cannot carry the bytes. Decode it to check the encoding,
+        // validate an archive no credential unlocks, and store the canonical
+        // encoding; everything else is logical text encoded for storage.
+        let encoded_value = match Self::prompted_value_for_storage(&planned, name, &value) {
+            Ok(value) => value,
+            Err(err) => {
+                self.record_key_error(
+                    AuditAction::Set,
+                    &profile_name,
+                    name,
+                    Some(backend.uri()),
+                    None,
+                    &err,
+                );
+                return Err(err);
+            }
+        };
         let stored_value = encoded_value.as_ref().unwrap_or(&value);
         let result = backend.set(addr, stored_value);
         self.audit_write_result(
@@ -4497,23 +4820,26 @@ impl Secrets {
             }
         };
 
-        let Some(route) = &planned.route else {
-            let error = SecretSpecError::ComposedSecretReadOnly(name.to_string());
-            self.record_key_error(AuditAction::Delete, &profile_name, name, None, None, &error);
-            return Err(error);
-        };
-        if planned.extract().is_some() {
+        if planned.extract().is_some() && planned.from().is_none() {
             let error = SecretSpecError::ExtractedSecretReadOnly(name.to_string());
             self.record_key_error(
                 AuditAction::Delete,
                 &profile_name,
                 name,
-                route.primary().map(str::to_string),
+                planned
+                    .route
+                    .as_ref()
+                    .and_then(|route| route.primary().map(str::to_string)),
                 planned.reference(),
                 &error,
             );
             return Err(error);
         }
+        let Some(route) = &planned.route else {
+            let error = Self::derived_read_only(&planned);
+            self.record_key_error(AuditAction::Delete, &profile_name, name, None, None, &error);
+            return Err(error);
+        };
         let backend = match self.write_provider_for_route(route, Some(&profile_name)) {
             Ok(backend) => backend,
             Err(error) => {
@@ -4723,7 +5049,24 @@ impl Secrets {
 
                             let value = SecretString::new(prompt.prompt()?.into());
 
-                            let encoded_value = Self::encoded_for_storage(&planned, &value);
+                            let encoded_value = match Self::prompted_value_for_storage(
+                                &planned,
+                                secret_name,
+                                &value,
+                            ) {
+                                Ok(value) => value,
+                                Err(error) => {
+                                    self.record_key_error(
+                                        AuditAction::Set,
+                                        &profile_display,
+                                        secret_name,
+                                        Some(backend.uri()),
+                                        planned.reference(),
+                                        &error,
+                                    );
+                                    return Err(error);
+                                }
+                            };
                             let stored_value = encoded_value.as_ref().unwrap_or(&value);
                             let address = self.address_for_spec(
                                 &planned,
@@ -5206,7 +5549,7 @@ impl Secrets {
         &self,
         planned: &PlannedSecret,
         profile_name: &str,
-    ) -> Result<Option<SecretString>> {
+    ) -> Result<Option<GeneratedValue>> {
         let name = planned.name.as_str();
         let gen_config = match &planned.config().generate {
             Some(config) if config.is_enabled() => config,
@@ -5228,7 +5571,11 @@ impl Secrets {
             }
         };
 
-        let value = crate::generator::generate(secret_type, gen_config)?;
+        let value = if secret_type == "x509_identity" {
+            GeneratedValue::Binary(crate::x509_identity::generate(gen_config)?)
+        } else {
+            GeneratedValue::Text(crate::generator::generate(secret_type, gen_config)?)
+        };
 
         // Store the generated value at the plan's address, through the plan's
         // write route: the same decisions every other write path executes.
@@ -5258,8 +5605,22 @@ impl Secrets {
         // The provider states why a write is refused; wrapping it here would
         // only nest a second "Provider operation failed" prefix.
         backend.check_writable(addr)?;
-        let encoded_value = Self::encoded_for_storage(planned, &value);
-        let stored_value = encoded_value.as_ref().unwrap_or(&value);
+        let encoded_value = match &value {
+            GeneratedValue::Text(value) => Self::encoded_for_storage(planned, value),
+            GeneratedValue::Binary(value) => Some(Self::encode_logical_bytes(
+                planned
+                    .encoding()
+                    .expect("binary generators require a validated encoding"),
+                value.expose_secret(),
+            )),
+        };
+        let stored_value = match (&value, encoded_value.as_ref()) {
+            (_, Some(value)) => value,
+            (GeneratedValue::Text(value), None) => value,
+            (GeneratedValue::Binary(_), None) => {
+                unreachable!("binary generators require a stored encoding")
+            }
+        };
         let set_result = backend.set(addr, stored_value);
         // Generating a secret writes a brand-new value to the provider; record it
         // like any other write so the audit log captures every stored secret.
@@ -5387,6 +5748,18 @@ impl Secrets {
         Ok(value)
     }
 
+    /// The read-only error for a secret that plans no route: a `from` secret
+    /// names the source to change, a composed one has no single source.
+    fn derived_read_only(planned: &PlannedSecret) -> SecretSpecError {
+        match planned.from() {
+            Some(source) => SecretSpecError::DerivedSecretReadOnly {
+                name: planned.name.clone(),
+                from: source.to_string(),
+            },
+            None => SecretSpecError::ComposedSecretReadOnly(planned.name.clone()),
+        }
+    }
+
     /// Writes secret bytes to a temporary file and returns the file handle and path
     ///
     /// # Arguments
@@ -5403,10 +5776,14 @@ impl Secrets {
     fn write_secret_to_temp_file(
         &self,
         secret: &[u8],
+        suffix: Option<&str>,
     ) -> Result<(tempfile::NamedTempFile, String)> {
         use std::io::Write;
 
-        let mut temp_file = tempfile::NamedTempFile::new().map_err(SecretSpecError::Io)?;
+        let mut temp_file = tempfile::Builder::new()
+            .suffix(suffix.unwrap_or(""))
+            .tempfile()
+            .map_err(SecretSpecError::Io)?;
 
         temp_file.write_all(secret).map_err(SecretSpecError::Io)?;
 
@@ -5960,10 +6337,8 @@ impl Secrets {
             if !names.insert(name.to_string()) {
                 return;
             }
-            if let Some(template) = &profile.secrets[name].composition {
-                for dependency in template.dependencies() {
-                    visit(dependency, profile, names);
-                }
+            for dependency in profile.secrets[name].dependencies() {
+                visit(dependency, profile, names);
             }
         }
 
@@ -5991,6 +6366,12 @@ impl Secrets {
             .iter()
             .map(|entry| (entry.name.as_str(), &entry.status))
             .collect();
+        let fetched_from_provider: HashSet<&str> = errors
+            .resolution
+            .iter()
+            .filter(|entry| entry.source_provider.is_some())
+            .map(|entry| entry.name.as_str())
+            .collect();
         let profile = self
             .manifest
             .profile(profile_name)
@@ -6000,22 +6381,59 @@ impl Secrets {
             name: &str,
             profile: &crate::compiled_spec::CompiledProfile,
             statuses: &HashMap<&str, &ResolutionStatus>,
+            fetched_from_provider: &HashSet<&str>,
             promptable: &mut HashSet<String>,
         ) {
-            let Some(template) = &profile.secrets[name].composition else {
+            let secret = &profile.secrets[name];
+            // A stored typed value can be fetched successfully but remain
+            // unresolved because a credential is missing. It is a dependency
+            // node in that state, not a missing leaf: prompting for it would
+            // overwrite the archive that is already present.
+            if secret
+                .config
+                .typed_contract()
+                .is_some_and(|contract| contract.is_stored())
+                && fetched_from_provider.contains(name)
+            {
+                for (_, credential) in secret.config.credential_secrets() {
+                    if statuses.get(credential).copied() != Some(&ResolutionStatus::Resolved) {
+                        visit(
+                            credential,
+                            profile,
+                            statuses,
+                            fetched_from_provider,
+                            promptable,
+                        );
+                    }
+                }
+                return;
+            }
+            if !secret.config.is_derived() {
                 promptable.insert(name.to_string());
                 return;
-            };
-            for dependency in template.dependencies() {
-                if statuses.get(dependency.as_str()).copied() != Some(&ResolutionStatus::Resolved) {
-                    visit(dependency, profile, statuses, promptable);
+            }
+            for dependency in secret.dependencies() {
+                if statuses.get(dependency).copied() != Some(&ResolutionStatus::Resolved) {
+                    visit(
+                        dependency,
+                        profile,
+                        statuses,
+                        fetched_from_provider,
+                        promptable,
+                    );
                 }
             }
         }
 
         let mut promptable = HashSet::new();
         for name in &errors.missing_required {
-            visit(name, profile, &statuses, &mut promptable);
+            visit(
+                name,
+                profile,
+                &statuses,
+                &fetched_from_provider,
+                &mut promptable,
+            );
         }
         let mut promptable: Vec<String> = promptable.into_iter().collect();
         promptable.sort();
@@ -7297,6 +7715,38 @@ mod encoding_tests {
             let stored = Secrets::encode_logical_value(encoding, &logical);
             assert_eq!(stored.expose_secret(), expected);
         }
+    }
+
+    #[test]
+    fn prompted_binary_value_is_decoded_before_canonical_storage() {
+        let generated = crate::x509_identity::generate(&crate::config::GenerateConfig::Options(
+            crate::config::GenerateOptions {
+                san: Some(vec!["dns:localhost".to_string()]),
+                ..Default::default()
+            },
+        ))
+        .unwrap();
+        let canonical = BASE64.encode(generated.expose_secret());
+        let entered = SecretString::new(format!("{canonical}\n").into());
+
+        let config = crate::tests::resolve_test_config(HashMap::from([(
+            "TLS_IDENTITY".to_string(),
+            crate::config::Secret {
+                description: Some("identity".to_string()),
+                secret_type: Some("x509_identity".to_string()),
+                ..Default::default()
+            },
+        )]));
+        let spec = Secrets::new(config, None, None, None);
+        let planned = spec
+            .plan_secret("TLS_IDENTITY", "default", None)
+            .unwrap()
+            .unwrap();
+
+        let stored = Secrets::prompted_value_for_storage(&planned, "TLS_IDENTITY", &entered)
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.expose_secret(), canonical);
     }
 }
 

--- a/secretspec/src/spec.rs
+++ b/secretspec/src/spec.rs
@@ -7,11 +7,12 @@
 
 use crate::compiled_spec::CompiledSpec;
 use crate::config::{
-    Config, GenerateConfig, GenerateOptions, NativeAddress, Profile as ConfigProfile,
-    ProfileDefaults, Project, ProviderAlias, RequireReason, Scope, Secret as ConfigSecret,
-    SecretEncoding, SecretExtract,
+    Config, CredentialBinding, GenerateConfig, GenerateOptions, NativeAddress,
+    Profile as ConfigProfile, ProfileDefaults, Project, ProviderAlias, RequireReason, Scope,
+    Secret as ConfigSecret, SecretEncoding, SecretExtract,
 };
 use crate::error::{Result, SecretSpecError};
+use std::collections::BTreeMap;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -775,9 +776,43 @@ impl Secret {
         self
     }
 
-    /// Extract a value from a structured provider result.
+    /// Extract a value from a structured provider result, or from the text of
+    /// the secret named by [`from`](Self::from).
     pub fn extract(mut self, extract: SecretExtract) -> Self {
         self.config.extract = Some(extract);
+        self
+    }
+
+    /// Set the semantic type. For the typed contracts (`x509_identity` and the
+    /// `pkcs12`, `pkcs8_private_key`, `x509_certificate`,
+    /// `x509_certificate_chain`, and `x509_issuer_chain` targets, 0.21+) the
+    /// type governs decoding, conversion, credentials, and delivery.
+    pub fn secret_type(mut self, secret_type: impl Into<String>) -> Self {
+        self.config.secret_type = Some(secret_type.into());
+        self
+    }
+
+    /// Choose the serialization of a typed value that offers more than one,
+    /// such as DER instead of the default PEM (0.21+).
+    pub fn format(mut self, format: crate::typed::Format) -> Self {
+        self.config.format = Some(format.as_str().to_string());
+        self
+    }
+
+    /// Derive this value from another declared secret: convert it with a
+    /// derivable type or select from it with `extract` (0.21+).
+    pub fn from(mut self, source: impl Into<String>) -> Self {
+        self.config.from = Some(source.into());
+        self
+    }
+
+    /// Bind a credential role of this typed value, such as the `password`
+    /// that opens or protects a PKCS#12 archive, to a declared secret (0.21+).
+    pub fn credential(mut self, role: impl Into<String>, secret: impl Into<String>) -> Self {
+        self.config
+            .credentials
+            .get_or_insert_with(BTreeMap::new)
+            .insert(role.into(), CredentialBinding::Secret(secret.into()));
         self
     }
 
@@ -821,6 +856,22 @@ pub enum Generation {
         /// Characters from which the password is drawn.
         charset: PasswordCharset,
     },
+    /// A human-readable passphrase composed from independently selected words (0.21+).
+    Passphrase {
+        /// Word count; `None` uses SecretSpec's seven-word default.
+        words: Option<usize>,
+        /// Text placed between words.
+        separator: String,
+    },
+    /// A checksum-protected recovery mnemonic (0.21+).
+    Mnemonic {
+        /// Mnemonic encoding algorithm.
+        algorithm: MnemonicAlgorithm,
+        /// Word count; `None` uses SecretSpec's 24-word default.
+        words: Option<usize>,
+        /// Word-list language.
+        language: MnemonicLanguage,
+    },
     /// Random bytes rendered as hexadecimal.
     Hex {
         /// Byte count; `None` uses SecretSpec's default.
@@ -856,6 +907,26 @@ pub enum Generation {
         /// Optional comment embedded in the OpenSSH key.
         comment: Option<String>,
     },
+    /// A Base64-encoded WireGuard private key (0.21+).
+    WireguardPrivateKey,
+    /// A private signing key serialized as a JSON Web Key (0.21+).
+    JwkPrivateKey {
+        /// JOSE signing algorithm and optional RSA key size.
+        algorithm: JwkKeyAlgorithm,
+        /// Optional JWK `kid` metadata.
+        kid: Option<String>,
+    },
+    /// A native X25519 age identity (0.21+).
+    AgeIdentity,
+    /// A self-signed P-256 X.509 identity stored as PKCS#12 (0.21+).
+    X509Identity {
+        /// DNS and IP subject alternative names (`dns:name` or `ip:address`).
+        subject_alt_names: Vec<String>,
+        /// Extended key usages placed on the certificate.
+        usages: Vec<X509Usage>,
+        /// Validity in days; `None` uses SecretSpec's 30-day default.
+        valid_for_days: Option<u32>,
+    },
 }
 
 impl Generation {
@@ -864,6 +935,23 @@ impl Generation {
         Self::Password {
             length: None,
             charset: PasswordCharset::Alphanumeric,
+        }
+    }
+
+    /// A seven-word passphrase separated with hyphens (0.21+).
+    pub fn passphrase() -> Self {
+        Self::Passphrase {
+            words: None,
+            separator: "-".to_string(),
+        }
+    }
+
+    /// A 24-word English BIP-39 mnemonic (0.21+).
+    pub fn mnemonic() -> Self {
+        Self::Mnemonic {
+            algorithm: MnemonicAlgorithm::Bip39,
+            words: None,
+            language: MnemonicLanguage::English,
         }
     }
 
@@ -909,6 +997,33 @@ impl Generation {
         }
     }
 
+    /// A Base64-encoded WireGuard private key (0.21+).
+    pub fn wireguard_private_key() -> Self {
+        Self::WireguardPrivateKey
+    }
+
+    /// An Ed25519 private signing JWK (0.21+).
+    pub fn jwk_private_key() -> Self {
+        Self::JwkPrivateKey {
+            algorithm: JwkKeyAlgorithm::Ed25519,
+            kid: None,
+        }
+    }
+
+    /// A native X25519 age identity (0.21+).
+    pub fn age_identity() -> Self {
+        Self::AgeIdentity
+    }
+
+    /// A self-signed P-256 X.509 server identity with a 30-day validity (0.21+).
+    pub fn x509_identity(subject_alt_names: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self::X509Identity {
+            subject_alt_names: subject_alt_names.into_iter().map(Into::into).collect(),
+            usages: vec![X509Usage::ServerAuth],
+            valid_for_days: None,
+        }
+    }
+
     fn into_config(self) -> (&'static str, GenerateConfig) {
         match self {
             Self::Password { length, charset } => (
@@ -916,6 +1031,27 @@ impl Generation {
                 GenerateConfig::Options(GenerateOptions {
                     length,
                     charset: Some(charset.as_str().to_string()),
+                    ..GenerateOptions::default()
+                }),
+            ),
+            Self::Passphrase { words, separator } => (
+                "passphrase",
+                GenerateConfig::Options(GenerateOptions {
+                    words,
+                    separator: Some(separator),
+                    ..GenerateOptions::default()
+                }),
+            ),
+            Self::Mnemonic {
+                algorithm,
+                words,
+                language,
+            } => (
+                "mnemonic",
+                GenerateConfig::Options(GenerateOptions {
+                    algorithm: Some(algorithm.as_str().to_string()),
+                    words,
+                    language: Some(language.as_str().to_string()),
                     ..GenerateOptions::default()
                 }),
             ),
@@ -976,6 +1112,125 @@ impl Generation {
                     ..GenerateOptions::default()
                 }),
             ),
+            Self::WireguardPrivateKey => ("wireguard_private_key", GenerateConfig::Bool(true)),
+            Self::JwkPrivateKey { algorithm, kid } => (
+                "jwk_private_key",
+                GenerateConfig::Options(GenerateOptions {
+                    algorithm: Some(algorithm.as_str().to_string()),
+                    bits: algorithm.bits(),
+                    kid,
+                    ..GenerateOptions::default()
+                }),
+            ),
+            Self::AgeIdentity => ("age_identity", GenerateConfig::Bool(true)),
+            Self::X509Identity {
+                subject_alt_names,
+                usages,
+                valid_for_days,
+            } => (
+                "x509_identity",
+                GenerateConfig::Options(GenerateOptions {
+                    issuer: Some("self_signed".to_string()),
+                    algorithm: Some("p256".to_string()),
+                    san: Some(subject_alt_names),
+                    usages: Some(
+                        usages
+                            .into_iter()
+                            .map(|usage| usage.as_str().to_string())
+                            .collect(),
+                    ),
+                    valid_for: valid_for_days.map(|days| format!("{days}d")),
+                    ..GenerateOptions::default()
+                }),
+            ),
+        }
+    }
+}
+
+/// Extended key usage for a generated X.509 identity.
+///
+/// Available starting with SecretSpec 0.21.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum X509Usage {
+    /// TLS server authentication.
+    ServerAuth,
+    /// TLS client authentication.
+    ClientAuth,
+}
+
+impl X509Usage {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ServerAuth => "server_auth",
+            Self::ClientAuth => "client_auth",
+        }
+    }
+}
+
+/// The encoding algorithm for a generated recovery mnemonic.
+///
+/// Available starting with SecretSpec 0.21.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MnemonicAlgorithm {
+    /// BIP-39 entropy and checksum encoding.
+    Bip39,
+}
+
+impl MnemonicAlgorithm {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Bip39 => "bip39",
+        }
+    }
+}
+
+/// The word-list language for a generated recovery mnemonic.
+///
+/// Available starting with SecretSpec 0.21.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MnemonicLanguage {
+    /// The BIP-39 English word list.
+    English,
+}
+
+impl MnemonicLanguage {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::English => "english",
+        }
+    }
+}
+
+/// The algorithm for a generated private JSON Web Key.
+///
+/// Available starting with SecretSpec 0.21.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum JwkKeyAlgorithm {
+    /// Ed25519 with the fully specified JOSE algorithm `Ed25519` (RFC 9864).
+    Ed25519,
+    /// NIST P-256 with JOSE algorithm `ES256`.
+    P256,
+    /// RSA with JOSE algorithm `RS256`. `None` uses the 3072-bit default.
+    Rsa { bits: Option<usize> },
+}
+
+impl JwkKeyAlgorithm {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ed25519 => "ed25519",
+            Self::P256 => "p256",
+            Self::Rsa { .. } => "rsa",
+        }
+    }
+
+    fn bits(self) -> Option<usize> {
+        match self {
+            Self::Rsa { bits } => bits,
+            Self::Ed25519 | Self::P256 => None,
         }
     }
 }
@@ -1195,6 +1450,78 @@ mod tests {
         assert_eq!(rsa.algorithm.as_deref(), Some("rsa"));
         assert_eq!(rsa.bits, Some(4096));
         assert_eq!(rsa.comment.as_deref(), Some("deploy@example.com"));
+    }
+
+    #[test]
+    fn additional_credential_generation_builders_map_to_document_options() {
+        let (secret_type, GenerateConfig::Options(passphrase)) = Generation::Passphrase {
+            words: Some(8),
+            separator: " ".to_string(),
+        }
+        .into_config() else {
+            panic!("passphrase generation must use options");
+        };
+        assert_eq!(secret_type, "passphrase");
+        assert_eq!(passphrase.words, Some(8));
+        assert_eq!(passphrase.separator.as_deref(), Some(" "));
+
+        let (secret_type, GenerateConfig::Options(mnemonic)) = Generation::Mnemonic {
+            algorithm: MnemonicAlgorithm::Bip39,
+            words: Some(12),
+            language: MnemonicLanguage::English,
+        }
+        .into_config() else {
+            panic!("mnemonic generation must use options");
+        };
+        assert_eq!(secret_type, "mnemonic");
+        assert_eq!(mnemonic.algorithm.as_deref(), Some("bip39"));
+        assert_eq!(mnemonic.words, Some(12));
+        assert_eq!(mnemonic.language.as_deref(), Some("english"));
+
+        let (secret_type, GenerateConfig::Options(default_mnemonic)) =
+            Generation::mnemonic().into_config()
+        else {
+            panic!("mnemonic generation must use options");
+        };
+        assert_eq!(secret_type, "mnemonic");
+        assert_eq!(default_mnemonic.words, None);
+
+        let (secret_type, GenerateConfig::Options(jwk)) = Generation::JwkPrivateKey {
+            algorithm: JwkKeyAlgorithm::Rsa { bits: Some(4096) },
+            kid: Some("release-2026".to_string()),
+        }
+        .into_config() else {
+            panic!("JWK generation must use options");
+        };
+        assert_eq!(secret_type, "jwk_private_key");
+        assert_eq!(jwk.algorithm.as_deref(), Some("rsa"));
+        assert_eq!(jwk.bits, Some(4096));
+        assert_eq!(jwk.kid.as_deref(), Some("release-2026"));
+
+        assert!(matches!(
+            Generation::wireguard_private_key().into_config(),
+            ("wireguard_private_key", GenerateConfig::Bool(true))
+        ));
+        assert!(matches!(
+            Generation::age_identity().into_config(),
+            ("age_identity", GenerateConfig::Bool(true))
+        ));
+
+        let (secret_type, GenerateConfig::Options(x509)) =
+            Generation::x509_identity(["dns:localhost", "ip:127.0.0.1"]).into_config()
+        else {
+            panic!("X.509 generation must use options");
+        };
+        assert_eq!(secret_type, "x509_identity");
+        assert_eq!(x509.algorithm.as_deref(), Some("p256"));
+        assert_eq!(
+            x509.san,
+            Some(vec![
+                "dns:localhost".to_string(),
+                "ip:127.0.0.1".to_string()
+            ])
+        );
+        assert_eq!(x509.usages, Some(vec!["server_auth".to_string()]));
     }
 
     #[test]

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -5755,6 +5755,10 @@ fn test_config_rejects_invalid_openpgp_generation_options() {
         r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", algorithm = "ed25519", bits = 3072 } }"#,
         r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", algorithm = "rsa", bits = 1024 } }"#,
         r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", algorithm = "rsa", bits = 16384 } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", length = 1 } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", bytes = 1 } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", charset = "ascii" } }"#,
+        r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", command = "echo ignored" } }"#,
     ] {
         let toml_content = format!(
             "[project]\nname = \"test-gen\"\nrevision = \"1.0\"\n\n[profiles.default]\n{declaration}\n"
@@ -5801,6 +5805,10 @@ fn test_config_rejects_invalid_ssh_generation_options() {
         r#"KEY = { description = "Key", type = "ssh_private_key", generate = { algorithm = "rsa", bits = 16384 } }"#,
         r#"KEY = { description = "Key", type = "ssh_private_key", generate = { comment = "bad\ncomment" } }"#,
         r#"KEY = { description = "Key", type = "ssh_private_key", generate = { user_id = "Bot" } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { length = 1 } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { bytes = 1 } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { charset = "ascii" } }"#,
+        r#"KEY = { description = "Key", type = "ssh_private_key", generate = { command = "echo ignored" } }"#,
         r#"KEY = { description = "Key", type = "openpgp_private_key", generate = { user_id = "Bot", comment = "ssh-only" } }"#,
     ] {
         let toml_content = format!(

--- a/secretspec/src/tests.rs
+++ b/secretspec/src/tests.rs
@@ -5811,6 +5811,79 @@ fn test_config_rejects_invalid_ssh_generation_options() {
 }
 
 #[test]
+fn test_config_parses_additional_credential_generators() {
+    let toml_content = r#"
+[project]
+name = "test-gen"
+revision = "1.0"
+
+[profiles.default]
+RECOVERY = { description = "Recovery phrase", type = "passphrase", generate = { words = 8, separator = "." } }
+WALLET_SEED = { description = "Wallet recovery mnemonic", type = "mnemonic", generate = { algorithm = "bip39", words = 24, language = "english" } }
+WG_KEY = { description = "WireGuard key", type = "wireguard_private_key", generate = true }
+JWT_KEY = { description = "JWT key", type = "jwk_private_key", generate = { algorithm = "p256", kid = "release-2026" } }
+AGE_KEY = { description = "age identity", type = "age_identity", generate = true }
+"#;
+    let config = parse_spec_from_str(toml_content, None).unwrap();
+    let profile = &config.profiles["default"];
+
+    let Some(GenerateConfig::Options(passphrase)) = &profile.secrets["RECOVERY"].generate else {
+        panic!("expected passphrase options");
+    };
+    assert_eq!(passphrase.words, Some(8));
+    assert_eq!(passphrase.separator.as_deref(), Some("."));
+
+    let Some(GenerateConfig::Options(mnemonic)) = &profile.secrets["WALLET_SEED"].generate else {
+        panic!("expected mnemonic options");
+    };
+    assert_eq!(mnemonic.algorithm.as_deref(), Some("bip39"));
+    assert_eq!(mnemonic.words, Some(24));
+    assert_eq!(mnemonic.language.as_deref(), Some("english"));
+
+    let Some(GenerateConfig::Options(jwk)) = &profile.secrets["JWT_KEY"].generate else {
+        panic!("expected JWK options");
+    };
+    assert_eq!(jwk.algorithm.as_deref(), Some("p256"));
+    assert_eq!(jwk.kid.as_deref(), Some("release-2026"));
+
+    for name in ["WG_KEY", "AGE_KEY"] {
+        assert!(matches!(
+            profile.secrets[name].generate,
+            Some(GenerateConfig::Bool(true))
+        ));
+    }
+}
+
+#[test]
+fn test_config_rejects_invalid_additional_credential_generation_options() {
+    for declaration in [
+        r#"KEY = { description = "Key", type = "passphrase", generate = { words = 5 } }"#,
+        r#"KEY = { description = "Key", type = "passphrase", generate = { separator = "" } }"#,
+        r#"KEY = { description = "Key", type = "passphrase", generate = { algorithm = "rsa" } }"#,
+        r#"KEY = { description = "Key", type = "mnemonic", generate = { words = 11 } }"#,
+        r#"KEY = { description = "Key", type = "mnemonic", generate = { words = 13 } }"#,
+        r#"KEY = { description = "Key", type = "mnemonic", generate = { words = 25 } }"#,
+        r#"KEY = { description = "Key", type = "mnemonic", generate = { algorithm = "electrum" } }"#,
+        r#"KEY = { description = "Key", type = "mnemonic", generate = { language = "spanish" } }"#,
+        r#"KEY = { description = "Key", type = "mnemonic", generate = { separator = "-" } }"#,
+        r#"KEY = { description = "Key", type = "jwk_private_key", generate = { algorithm = "ed25519", bits = 3072 } }"#,
+        r#"KEY = { description = "Key", type = "jwk_private_key", generate = { algorithm = "rsa", bits = 1024 } }"#,
+        r#"KEY = { description = "Key", type = "jwk_private_key", generate = { algorithm = "secp256k1" } }"#,
+        r#"KEY = { description = "Key", type = "jwk_private_key", generate = { kid = " " } }"#,
+        r#"KEY = { description = "Key", type = "wireguard_private_key", generate = { bytes = 32 } }"#,
+        r#"KEY = { description = "Key", type = "age_identity", generate = { algorithm = "x25519" } }"#,
+    ] {
+        let toml_content = format!(
+            "[project]\nname = \"test-gen\"\nrevision = \"1.0\"\n\n[profiles.default]\n{declaration}\n"
+        );
+        assert!(
+            parse_spec_from_str(&toml_content, None).is_err(),
+            "accepted invalid declaration: {declaration}"
+        );
+    }
+}
+
+#[test]
 fn test_config_type_without_generate_is_valid() {
     let toml_content = r#"
 [project]
@@ -6195,6 +6268,7 @@ DB_PASSWORD = { description = "Password", type = "password", generate = true }
 API_TOKEN = { description = "Token", type = "hex", generate = { bytes = 16 } }
 SESSION_KEY = { description = "Session", type = "base64", generate = { bytes = 24 } }
 REQUEST_ID = { description = "ID", type = "uuid", generate = true }
+WALLET_RECOVERY = { description = "Wallet recovery mnemonic", type = "mnemonic", generate = true }
 "#;
     fs::write(&config_file, toml_content).unwrap();
 
@@ -6216,6 +6290,7 @@ REQUEST_ID = { description = "ID", type = "uuid", generate = true }
     assert!(validated.resolved.secrets.contains_key("API_TOKEN"));
     assert!(validated.resolved.secrets.contains_key("SESSION_KEY"));
     assert!(validated.resolved.secrets.contains_key("REQUEST_ID"));
+    assert!(validated.resolved.secrets.contains_key("WALLET_RECOVERY"));
 
     // Verify types
     let pw = validated
@@ -6242,6 +6317,16 @@ REQUEST_ID = { description = "ID", type = "uuid", generate = true }
         .expose_secret();
     assert_eq!(uuid.len(), 36);
     assert!(uuid.contains('-'));
+
+    let mnemonic = validated
+        .resolved
+        .secrets
+        .get("WALLET_RECOVERY")
+        .unwrap()
+        .expose_secret();
+    let parsed = bip39::Mnemonic::parse_in_normalized(bip39::Language::English, mnemonic)
+        .expect("resolved mnemonic must have a valid BIP-39 checksum");
+    assert_eq!(parsed.word_count(), 24);
 }
 
 #[test]
@@ -6316,6 +6401,9 @@ fn test_resolve_secret_config_merges_type_and_generate() {
             encoding: None,
             extract: None,
             secret_type: Some("password".to_string()),
+            format: None,
+            from: None,
+            credentials: None,
             generate: Some(crate::config::GenerateConfig::Bool(true)),
             prompt: None,
         },
@@ -9570,6 +9658,42 @@ secrets = ["DATABASE_URL"]
         assert!(
             sprompt.is_empty(),
             "a scope must not offer hidden dependencies for prompting: {sprompt:?}"
+        );
+    }
+
+    #[test]
+    fn prompting_fetched_identity_descends_to_missing_password() {
+        let temp = TempDir::new().unwrap();
+        let env_path = temp.path().join(".env");
+        // The bytes need not form a PFX yet: resolution parks a fetched typed
+        // value until its credential resolves, so it must not inspect or offer
+        // to replace the existing archive in this pass.
+        fs::write(&env_path, "TLS_IDENTITY=Zm9v\n").unwrap();
+        let manifest = r#"
+[project]
+name = "typed-prompt"
+revision = "1.0"
+
+[profiles.default]
+PFX_PASSWORD = { description = "PFX password" }
+TLS_IDENTITY = { description = "identity", type = "x509_identity", credentials = { password = "PFX_PASSWORD" } }
+"#;
+        let config = config(manifest);
+        config.validate().unwrap();
+        let spec = Secrets::new(
+            config,
+            None,
+            Some(format!("dotenv://{}", env_path.display())),
+            None,
+        );
+        let errors = match spec.validate().unwrap() {
+            Ok(_) => panic!("the missing password must keep the identity unresolved"),
+            Err(errors) => errors,
+        };
+
+        assert_eq!(
+            spec.scoped_promptable_missing(&errors, "default").unwrap(),
+            vec!["PFX_PASSWORD".to_string()]
         );
     }
 

--- a/secretspec/src/typed.rs
+++ b/secretspec/src/typed.rs
@@ -1,0 +1,329 @@
+//! Registry of typed secret contracts (SecretSpec 0.21+).
+//!
+//! `type` is informational for most secrets. For the types registered here it
+//! is authoritative: it decides how a stored value is decoded and validated,
+//! which `credentials` roles may unlock or protect it, which declared secrets a
+//! `from` target may derive from, how the result is serialized, and how the
+//! result is delivered. Every string match on these type names lives here so
+//! configuration, planning, and resolution cannot drift.
+
+use crate::config::SecretEncoding;
+
+/// The stored or generated canonical identity type. The only registry type a
+/// provider may hold in 0.21.
+pub(crate) const X509_IDENTITY: &str = "x509_identity";
+
+/// Longest credential value accepted for a typed secret, in bytes. PKCS#12
+/// passwords are re-encoded as BMPString; a bound keeps that allocation and
+/// the KDF input small without constraining any realistic password.
+pub(crate) const MAX_CREDENTIAL_BYTES: usize = 1024;
+
+/// A serialization for a typed value whose type offers more than one, written
+/// as the secret's `format`.
+///
+/// Available since SecretSpec 0.21.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Format {
+    /// Textual PEM encoding.
+    Pem,
+    /// Binary DER encoding.
+    Der,
+}
+
+impl Format {
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "pem" => Some(Self::Pem),
+            "der" => Some(Self::Der),
+            _ => None,
+        }
+    }
+
+    /// The manifest spelling of this format.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pem => "pem",
+            Self::Der => "der",
+        }
+    }
+
+    pub(crate) const fn is_binary(self) -> bool {
+        matches!(self, Self::Der)
+    }
+
+    pub(crate) const fn suffix(self) -> &'static str {
+        match self {
+            Self::Pem => ".pem",
+            Self::Der => ".der",
+        }
+    }
+}
+
+/// What a derived registry type produces from its `from` source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Projection {
+    /// The complete identity as a PKCS#12/PFX archive, optionally protected by
+    /// the `password` credential.
+    Pkcs12,
+    /// The unencrypted PKCS#8 private key.
+    Pkcs8PrivateKey,
+    /// The leaf certificate.
+    Certificate,
+    /// The leaf followed by its ordered issuer chain.
+    CertificateChain,
+    /// The ordered issuer chain without the leaf.
+    IssuerChain,
+}
+
+/// One registered type's contract.
+#[derive(Debug)]
+pub(crate) struct TypeContract {
+    /// The manifest spelling.
+    pub(crate) name: &'static str,
+    /// Accepted `format` values, default first. Empty when the representation
+    /// is fixed, in which case `format` is rejected.
+    pub(crate) formats: &'static [Format],
+    /// Types a `from` source may declare. Empty for stored types.
+    pub(crate) sources: &'static [&'static str],
+    /// Accepted `credentials` roles.
+    pub(crate) roles: &'static [&'static str],
+    /// The projection a `from` target produces, or `None` for a stored type.
+    pub(crate) projection: Option<Projection>,
+    /// Whether a fixed representation is binary.
+    fixed_binary: bool,
+    /// Preferred file suffix of a fixed representation.
+    fixed_suffix: &'static str,
+}
+
+impl TypeContract {
+    /// Whether providers may hold this type. Every other registry type exists
+    /// only as a `from` target.
+    pub(crate) fn is_stored(&self) -> bool {
+        self.projection.is_none()
+    }
+
+    /// Resolve the effective format: the requested one when the type accepts
+    /// it, the type's default when none is requested, or `None` for a fixed
+    /// representation.
+    pub(crate) fn format(&self, requested: Option<&str>) -> Result<Option<Format>, String> {
+        match (requested, self.formats.first()) {
+            (None, default) => Ok(default.copied()),
+            (Some(_), None) => Err(format!(
+                "`format` is not valid for type = \"{}\"; its representation is fixed",
+                self.name
+            )),
+            (Some(requested), Some(_)) => Format::parse(requested)
+                .filter(|format| self.formats.contains(format))
+                .map(Some)
+                .ok_or_else(|| {
+                    format!(
+                        "unknown format '{}' for type = \"{}\"; expected {}",
+                        requested,
+                        self.name,
+                        self.formats
+                            .iter()
+                            .map(|format| format!("`{}`", format.as_str()))
+                            .collect::<Vec<_>>()
+                            .join(" or ")
+                    )
+                }),
+        }
+    }
+
+    /// Whether the logical value is bytes rather than UTF-8 text.
+    pub(crate) fn is_binary(&self, format: Option<Format>) -> bool {
+        format.map_or(self.fixed_binary, Format::is_binary)
+    }
+
+    /// Preferred file suffix for `as_path` delivery.
+    pub(crate) fn suffix(&self, format: Option<Format>) -> &'static str {
+        format.map_or(self.fixed_suffix, Format::suffix)
+    }
+
+    /// The codec a binary value uses wherever it must be text, when the
+    /// declaration does not choose one.
+    pub(crate) fn default_encoding(&self, format: Option<Format>) -> Option<SecretEncoding> {
+        self.is_binary(format).then_some(SecretEncoding::Base64)
+    }
+
+    pub(crate) fn accepts_source(&self, source_type: Option<&str>) -> bool {
+        source_type.is_some_and(|source_type| self.sources.contains(&source_type))
+    }
+
+    pub(crate) fn accepts_role(&self, role: &str) -> bool {
+        self.roles.contains(&role)
+    }
+}
+
+const CONTRACTS: &[TypeContract] = &[
+    TypeContract {
+        name: X509_IDENTITY,
+        formats: &[],
+        sources: &[],
+        roles: &["password"],
+        projection: None,
+        fixed_binary: true,
+        fixed_suffix: ".pfx",
+    },
+    TypeContract {
+        name: "pkcs12",
+        formats: &[],
+        sources: &[X509_IDENTITY],
+        roles: &["password"],
+        projection: Some(Projection::Pkcs12),
+        fixed_binary: true,
+        fixed_suffix: ".pfx",
+    },
+    TypeContract {
+        name: "pkcs8_private_key",
+        formats: &[Format::Pem, Format::Der],
+        sources: &[X509_IDENTITY],
+        roles: &[],
+        projection: Some(Projection::Pkcs8PrivateKey),
+        fixed_binary: false,
+        fixed_suffix: ".pem",
+    },
+    TypeContract {
+        name: "x509_certificate",
+        formats: &[Format::Pem, Format::Der],
+        sources: &[X509_IDENTITY],
+        roles: &[],
+        projection: Some(Projection::Certificate),
+        fixed_binary: false,
+        fixed_suffix: ".pem",
+    },
+    TypeContract {
+        name: "x509_certificate_chain",
+        formats: &[Format::Pem],
+        sources: &[X509_IDENTITY],
+        roles: &[],
+        projection: Some(Projection::CertificateChain),
+        fixed_binary: false,
+        fixed_suffix: ".pem",
+    },
+    TypeContract {
+        name: "x509_issuer_chain",
+        formats: &[Format::Pem],
+        sources: &[X509_IDENTITY],
+        roles: &[],
+        projection: Some(Projection::IssuerChain),
+        fixed_binary: false,
+        fixed_suffix: ".pem",
+    },
+];
+
+/// Look up a registry type. `None` for every informational type such as
+/// `password` or `ssh_private_key`.
+pub(crate) fn contract(type_name: &str) -> Option<&'static TypeContract> {
+    CONTRACTS.iter().find(|contract| contract.name == type_name)
+}
+
+/// Types a `from` declaration may convert to, for diagnostics.
+pub(crate) fn derivable_type_names() -> impl Iterator<Item = &'static str> {
+    CONTRACTS
+        .iter()
+        .filter(|contract| !contract.is_stored())
+        .map(|contract| contract.name)
+}
+
+/// Reject a credential value that would silently change meaning or abuse the
+/// crypto backend. An empty value is an error rather than "no credential": the
+/// declaration bound one and it must be present. NUL is rejected because
+/// PKCS#12 consumers disagree about its interpretation.
+pub(crate) fn validate_credential_value(role: &str, value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err(format!(
+            "credential `{role}` resolved to an empty value; omit the binding for an empty credential"
+        ));
+    }
+    if value.contains('\0') {
+        return Err(format!("credential `{role}` must not contain NUL"));
+    }
+    if value.len() > MAX_CREDENTIAL_BYTES {
+        return Err(format!(
+            "credential `{role}` exceeds {MAX_CREDENTIAL_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_and_derived_contracts_are_distinct() {
+        let identity = contract(X509_IDENTITY).unwrap();
+        assert!(identity.is_stored());
+        assert!(identity.sources.is_empty());
+        assert!(identity.accepts_role("password"));
+        assert!(identity.is_binary(None));
+        assert_eq!(identity.suffix(None), ".pfx");
+        assert_eq!(
+            identity.default_encoding(None),
+            Some(SecretEncoding::Base64)
+        );
+
+        for name in derivable_type_names() {
+            let target = contract(name).unwrap();
+            assert!(!target.is_stored(), "{name}");
+            assert!(target.accepts_source(Some(X509_IDENTITY)), "{name}");
+            assert!(!target.accepts_source(Some("pkcs12")), "{name} chains");
+            assert!(!target.accepts_source(None), "{name} untyped");
+        }
+        assert!(contract("password").is_none());
+        assert_eq!(
+            derivable_type_names().collect::<Vec<_>>(),
+            [
+                "pkcs12",
+                "pkcs8_private_key",
+                "x509_certificate",
+                "x509_certificate_chain",
+                "x509_issuer_chain",
+            ]
+        );
+    }
+
+    #[test]
+    fn formats_default_per_type_and_reject_fixed_representations() {
+        let key = contract("pkcs8_private_key").unwrap();
+        assert_eq!(key.format(None).unwrap(), Some(Format::Pem));
+        assert_eq!(key.format(Some("der")).unwrap(), Some(Format::Der));
+        assert!(!key.is_binary(Some(Format::Pem)));
+        assert!(key.is_binary(Some(Format::Der)));
+        assert_eq!(key.suffix(Some(Format::Der)), ".der");
+        assert_eq!(key.default_encoding(Some(Format::Pem)), None);
+        assert_eq!(
+            key.default_encoding(Some(Format::Der)),
+            Some(SecretEncoding::Base64)
+        );
+        let unknown = key.format(Some("p12")).unwrap_err();
+        assert!(unknown.contains("expected `pem` or `der`"), "{unknown}");
+
+        let chain = contract("x509_certificate_chain").unwrap();
+        assert_eq!(chain.format(None).unwrap(), Some(Format::Pem));
+        let der = chain.format(Some("der")).unwrap_err();
+        assert!(der.contains("expected `pem`"), "{der}");
+
+        let pfx = contract("pkcs12").unwrap();
+        assert_eq!(pfx.format(None).unwrap(), None);
+        let fixed = pfx.format(Some("der")).unwrap_err();
+        assert!(fixed.contains("representation is fixed"), "{fixed}");
+        assert!(pfx.is_binary(None));
+        assert_eq!(pfx.suffix(None), ".pfx");
+    }
+
+    #[test]
+    fn credential_values_are_bounded() {
+        assert!(validate_credential_value("password", "correct horse").is_ok());
+        let empty = validate_credential_value("password", "").unwrap_err();
+        assert!(empty.contains("empty"), "{empty}");
+        let nul = validate_credential_value("password", "a\0b").unwrap_err();
+        assert!(nul.contains("NUL"), "{nul}");
+        let long = validate_credential_value("password", &"x".repeat(MAX_CREDENTIAL_BYTES + 1))
+            .unwrap_err();
+        assert!(long.contains("exceeds"), "{long}");
+        assert!(validate_credential_value("password", &"x".repeat(MAX_CREDENTIAL_BYTES)).is_ok());
+    }
+}

--- a/secretspec/src/typed_tests.rs
+++ b/secretspec/src/typed_tests.rs
@@ -1,0 +1,1470 @@
+//! End-to-end coverage for typed, converted, and password protected secrets
+//! (0.21+): `type`, `format`, `from`, and `credentials` across configuration
+//! validation, resolution, scopes, reports, and the read-only lifecycle.
+
+use crate::config::{Config, GenerateConfig, GenerateOptions};
+use crate::report::{Derivation, ResolutionStatus};
+use crate::resolve::ResolvedSource;
+use crate::tests::scrub_resolution_env;
+use crate::x509_identity::Identity;
+use crate::{Format, SecretSpecError, Secrets};
+use data_encoding::{BASE64, HEXLOWER};
+use openssl::pkcs12::Pkcs12;
+use openssl::pkey::PKey;
+use openssl::x509::X509;
+use secrecy::ExposeSecret;
+use std::fs;
+use tempfile::TempDir;
+
+fn manifest(body: &str) -> Config {
+    toml::from_str(&format!(
+        "[project]\nname = \"typed\"\nrevision = \"1.0\"\n\n{body}"
+    ))
+    .expect("manifest parses")
+}
+
+fn validation_error(body: &str) -> String {
+    manifest(body).validate().unwrap_err().to_string()
+}
+
+fn assert_valid(body: &str) {
+    manifest(body).validate().unwrap_or_else(|error| {
+        panic!("expected a valid manifest, got: {error}\n{body}");
+    });
+}
+
+fn generated_identity() -> Vec<u8> {
+    let config = GenerateConfig::Options(GenerateOptions {
+        san: Some(vec!["dns:localhost".to_string()]),
+        ..Default::default()
+    });
+    crate::x509_identity::generate(&config)
+        .unwrap()
+        .expose_secret()
+        .to_vec()
+}
+
+fn protected_identity(password: &str) -> Vec<u8> {
+    let bytes = generated_identity();
+    Identity::decode(&bytes, None, "ID")
+        .unwrap()
+        .to_pkcs12(Some(password), "ID")
+        .unwrap()
+        .expose_secret()
+        .to_vec()
+}
+
+/// A spec whose every stored secret lives in one dotenv file.
+fn dotenv_spec(body: &str, env: &str) -> (TempDir, Secrets) {
+    let dir = TempDir::new().unwrap();
+    let env_path = dir.path().join(".env");
+    fs::write(&env_path, env).unwrap();
+    let provider = format!("dotenv://{}", env_path.display());
+    (
+        dir,
+        Secrets::new(manifest(body), None, Some(provider), None),
+    )
+}
+
+fn null_spec(body: &str) -> Secrets {
+    Secrets::new(manifest(body), None, Some("null://".to_string()), None)
+}
+
+fn open_pfx(bytes: &[u8], password: &str) -> openssl::pkcs12::ParsedPkcs12_2 {
+    Pkcs12::from_der(bytes)
+        .unwrap()
+        .parse2(password)
+        .unwrap_or_else(|error| panic!("PFX must open with {password:?}: {error}"))
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_target_type_and_format_validates_against_an_identity() {
+    assert_valid(
+        r#"
+[profiles.default]
+TLS_IDENTITY = { description = "identity", type = "x509_identity" }
+TLS_IDENTITY_HEX = { description = "hex at rest", type = "x509_identity", encoding = "hex" }
+TLS_PFX = { description = "pfx", type = "pkcs12", from = "TLS_IDENTITY", as_path = true }
+TLS_PFX_B64 = { description = "inline pfx", type = "pkcs12", from = "TLS_IDENTITY" }
+TLS_PFX_HEX = { description = "inline hex pfx", type = "pkcs12", from = "TLS_IDENTITY", encoding = "hex" }
+TLS_KEY = { description = "key", type = "pkcs8_private_key", from = "TLS_IDENTITY" }
+TLS_KEY_PEM = { description = "key", type = "pkcs8_private_key", format = "pem", from = "TLS_IDENTITY", as_path = true }
+TLS_KEY_DER = { description = "key", type = "pkcs8_private_key", format = "der", from = "TLS_IDENTITY" }
+TLS_CERT = { description = "cert", type = "x509_certificate", from = "TLS_IDENTITY" }
+TLS_CERT_DER = { description = "cert", type = "x509_certificate", format = "der", from = "TLS_IDENTITY", as_path = true }
+TLS_CHAIN = { description = "chain", type = "x509_certificate_chain", from = "TLS_IDENTITY" }
+TLS_CHAIN_PEM = { description = "chain", type = "x509_certificate_chain", format = "pem", from = "TLS_IDENTITY" }
+TLS_ISSUERS = { description = "issuers", type = "x509_issuer_chain", from = "TLS_IDENTITY", required = false }
+"#,
+    );
+}
+
+#[test]
+fn from_requires_extract_or_a_derivable_type() {
+    let bare = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a" }
+B = { description = "b", from = "A" }
+"#,
+    );
+    assert!(
+        bare.contains("`from` requires `extract` to select from the source or a derivable `type`"),
+        "{bare}"
+    );
+
+    let informational = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a" }
+B = { description = "b", type = "password", from = "A" }
+"#,
+    );
+    assert!(
+        informational.contains("type = \"password\" cannot be derived with `from`"),
+        "{informational}"
+    );
+    assert!(informational.contains("`pkcs12`"), "{informational}");
+    assert!(
+        informational.contains("`x509_issuer_chain`"),
+        "{informational}"
+    );
+
+    let stored = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+B = { description = "b", type = "x509_identity", from = "A" }
+"#,
+    );
+    assert!(
+        stored.contains("type = \"x509_identity\" is stored by a provider and cannot be derived"),
+        "{stored}"
+    );
+
+    let both = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+B = { description = "b", type = "pkcs12", from = "A", extract = { format = "json", pointer = "/a" } }
+"#,
+    );
+    assert!(
+        both.contains(
+            "either selects with `extract` or converts with a derivable `type`, not both"
+        ),
+        "{both}"
+    );
+
+    let typed_selection = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a" }
+B = { description = "b", type = "password", from = "A", extract = { format = "json", pointer = "/a" } }
+"#,
+    );
+    assert!(
+        typed_selection.contains("`from` with `extract` cannot also set `type`"),
+        "{typed_selection}"
+    );
+
+    let bad_name = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a" }
+B = { description = "b", from = "not a name", extract = { format = "json", pointer = "/a" } }
+"#,
+    );
+    assert!(
+        bad_name.contains("`from` must name a declared secret using a valid identifier"),
+        "{bad_name}"
+    );
+}
+
+#[test]
+fn from_secrets_reject_storage_and_generation_fields() {
+    for field in [
+        r#"default = "x""#,
+        r#"providers = ["keyring"]"#,
+        r#"ref = { item = "x" }"#,
+        r#"refs = { keyring = { item = "x" } }"#,
+        r#"generate = { san = ["dns:localhost"] }"#,
+        r#"prompt = true"#,
+    ] {
+        let error = validation_error(&format!(
+            r#"
+[profiles.default]
+TLS_IDENTITY = {{ description = "identity", type = "x509_identity" }}
+TLS_KEY = {{ description = "key", type = "pkcs8_private_key", from = "TLS_IDENTITY", {field} }}
+"#
+        ));
+        assert!(
+            error.contains("`from` secrets cannot also set")
+                || error.contains("`generate` and `default`")
+                || error.contains("'generate' requires 'type'"),
+            "{field}: {error}"
+        );
+    }
+
+    let composed = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a" }
+B = { description = "b", composed = "${A}", from = "A", extract = { format = "json", pointer = "/a" } }
+"#,
+    );
+    assert!(
+        composed.contains("`composed` secrets cannot also set"),
+        "{composed}"
+    );
+    assert!(composed.contains("`from`"), "{composed}");
+}
+
+#[test]
+fn format_is_validated_against_the_type() {
+    let fixed = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+B = { description = "b", type = "pkcs12", format = "der", from = "A" }
+"#,
+    );
+    assert!(
+        fixed.contains("`format` is not valid for type = \"pkcs12\""),
+        "{fixed}"
+    );
+
+    let chain_der = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+B = { description = "b", type = "x509_certificate_chain", format = "der", from = "A" }
+"#,
+    );
+    assert!(
+        chain_der
+            .contains("unknown format 'der' for type = \"x509_certificate_chain\"; expected `pem`"),
+        "{chain_der}"
+    );
+
+    let unknown = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+B = { description = "b", type = "x509_certificate", format = "p7b", from = "A" }
+"#,
+    );
+    assert!(
+        unknown.contains(
+            "unknown format 'p7b' for type = \"x509_certificate\"; expected `pem` or `der`"
+        ),
+        "{unknown}"
+    );
+
+    let untyped = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", format = "pem" }
+"#,
+    );
+    assert!(
+        untyped.contains("`format` requires a `type` that accepts formats"),
+        "{untyped}"
+    );
+
+    let informational = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "password", format = "pem" }
+"#,
+    );
+    assert!(
+        informational.contains("`format` is not valid for type = \"password\""),
+        "{informational}"
+    );
+
+    let identity = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity", format = "der" }
+"#,
+    );
+    assert!(identity.contains("representation is fixed"), "{identity}");
+}
+
+#[test]
+fn credential_roles_and_bindings_are_validated() {
+    let unknown_role = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity", credentials = { passphrase = "P" } }
+P = { description = "p" }
+"#,
+    );
+    assert!(
+        unknown_role.contains(
+            "unknown credential role `passphrase` for type = \"x509_identity\"; expected `password`"
+        ),
+        "{unknown_role}"
+    );
+
+    let no_roles = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+K = { description = "k", type = "pkcs8_private_key", from = "A", credentials = { password = "P" } }
+P = { description = "p" }
+"#,
+    );
+    assert!(
+        no_roles.contains("type = \"pkcs8_private_key\" accepts no credentials"),
+        "{no_roles}"
+    );
+
+    let untyped = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", credentials = { password = "P" } }
+P = { description = "p" }
+"#,
+    );
+    assert!(
+        untyped.contains("`credentials` requires a `type` that accepts credentials"),
+        "{untyped}"
+    );
+
+    let informational = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "ssh_private_key", credentials = { password = "P" } }
+P = { description = "p" }
+"#,
+    );
+    assert!(
+        informational.contains("`credentials` is not valid for type = \"ssh_private_key\""),
+        "{informational}"
+    );
+
+    let table = toml::from_str::<Config>(
+        r#"
+[project]
+name = "typed"
+revision = "1.0"
+
+[profiles.default]
+A = { description = "a", type = "x509_identity", credentials = { password = { provider = "keyring" } } }
+"#,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+        table.contains("the `{ provider, ref }` table form is reserved"),
+        "{table}"
+    );
+
+    let bad_name = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity", credentials = { password = "not a name" } }
+"#,
+    );
+    assert!(
+        bad_name
+            .contains("credential `password` must name a declared secret using a valid identifier"),
+        "{bad_name}"
+    );
+
+    let generated = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity", generate = { san = ["dns:localhost"] }, credentials = { password = "P" } }
+P = { description = "p" }
+"#,
+    );
+    assert!(
+        generated.contains(
+            "`credentials` cannot be combined with enabled `generate` for type = \"x509_identity\""
+        ),
+        "{generated}"
+    );
+
+    // A stored identity and a derived archive both accept `password`.
+    assert_valid(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity", credentials = { password = "P" } }
+B = { description = "b", type = "pkcs12", from = "A", credentials = { password = "Q" } }
+P = { description = "p" }
+Q = { description = "q" }
+"#,
+    );
+}
+
+#[test]
+fn credentials_must_name_text_secrets() {
+    let as_path = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity", credentials = { password = "P" } }
+P = { description = "p", as_path = true }
+"#,
+    );
+    assert!(
+        as_path.contains("credential `password` names 'P', which is delivered as a path"),
+        "{as_path}"
+    );
+
+    let binary = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+B = { description = "b", type = "pkcs12", from = "A", credentials = { password = "A" } }
+"#,
+    );
+    assert!(
+        binary
+            .contains("credential `password` names 'A', whose type = \"x509_identity\" is binary"),
+        "{binary}"
+    );
+
+    // A composed or selected text value is an acceptable credential.
+    assert_valid(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+B = { description = "b", type = "pkcs12", from = "A", credentials = { password = "P" } }
+DOC = { description = "doc", default = "{\"pw\":\"x\"}" }
+P = { description = "p", from = "DOC", extract = { format = "json", pointer = "/pw" } }
+"#,
+    );
+}
+
+#[test]
+fn encoding_on_from_secrets_requires_a_binary_result() {
+    let pem = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+K = { description = "k", type = "pkcs8_private_key", from = "A", encoding = "base64" }
+"#,
+    );
+    assert!(
+        pem.contains("`encoding` on a `from` secret is valid only when the result is binary"),
+        "{pem}"
+    );
+
+    let selection = validation_error(
+        r#"
+[profiles.default]
+DOC = { description = "doc" }
+F = { description = "f", from = "DOC", extract = { format = "json", pointer = "/a" }, encoding = "base64" }
+"#,
+    );
+    assert!(
+        selection.contains("`encoding` on a `from` secret is valid only when the result is binary"),
+        "{selection}"
+    );
+
+    assert_valid(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+K = { description = "k", type = "pkcs8_private_key", format = "der", from = "A", encoding = "base64url" }
+P = { description = "p", type = "pkcs12", from = "A", encoding = "hex" }
+"#,
+    );
+}
+
+#[test]
+fn target_types_require_from_and_identities_reject_defaults() {
+    let stored_target = validation_error(
+        r#"
+[profiles.default]
+P = { description = "p", type = "pkcs12", providers = ["keyring"] }
+"#,
+    );
+    assert!(
+        stored_target.contains("type = \"pkcs12\" requires `from`"),
+        "{stored_target}"
+    );
+
+    let generated_target = validation_error(
+        r#"
+[profiles.default]
+K = { description = "k", type = "pkcs8_private_key" }
+"#,
+    );
+    assert!(
+        generated_target.contains("type = \"pkcs8_private_key\" requires `from`"),
+        "{generated_target}"
+    );
+
+    let defaulted = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity", default = "x" }
+"#,
+    );
+    assert!(
+        defaulted.contains(
+            "`type = \"x509_identity\"` cannot be combined with `default` or `prompt = true`"
+        ),
+        "{defaulted}"
+    );
+
+    let prompted = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity", prompt = true }
+"#,
+    );
+    assert!(
+        prompted.contains(
+            "`type = \"x509_identity\"` cannot be combined with `default` or `prompt = true`"
+        ),
+        "{prompted}"
+    );
+}
+
+#[test]
+fn extract_cannot_select_from_a_binary_source_and_targets_are_not_sources() {
+    let identity = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+F = { description = "f", from = "A", extract = { format = "json", pointer = "/a" } }
+"#,
+    );
+    assert!(
+        identity.contains(
+            "`extract` cannot select from 'A' because its type = \"x509_identity\" is binary"
+        ),
+        "{identity}"
+    );
+
+    let chained = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+P = { description = "p", type = "pkcs12", from = "A" }
+K = { description = "k", type = "pkcs8_private_key", from = "P" }
+"#,
+    );
+    assert!(
+        chained.contains("`from` source 'P' has type = \"pkcs12\", but type = \"pkcs8_private_key\" derives from type = \"x509_identity\""),
+        "{chained}"
+    );
+
+    let der_selection = validation_error(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+C = { description = "c", type = "x509_certificate", format = "der", from = "A" }
+F = { description = "f", from = "C", extract = { format = "ini", pointer = "/a" } }
+"#,
+    );
+    assert!(
+        der_selection.contains(
+            "`extract` cannot select from 'C' because its type = \"x509_certificate\" is binary"
+        ),
+        "{der_selection}"
+    );
+
+    // A PEM target is text, so a selection from it is type-valid.
+    assert_valid(
+        r#"
+[profiles.default]
+A = { description = "a", type = "x509_identity" }
+C = { description = "c", type = "x509_certificate", from = "A" }
+F = { description = "f", from = "C", extract = { format = "ini", pointer = "/a" } }
+"#,
+    );
+}
+
+#[test]
+fn inheritance_merges_from_format_and_credentials_then_validates() {
+    let config = manifest(
+        r#"
+[profiles.default]
+TLS_IDENTITY = { description = "identity", type = "x509_identity" }
+TLS_PFX_PASSWORD = { description = "password" }
+TLS_PFX = { description = "pfx", type = "pkcs12", from = "TLS_IDENTITY", credentials = { password = "TLS_PFX_PASSWORD" } }
+TLS_KEY = { description = "key", type = "pkcs8_private_key", format = "der", from = "TLS_IDENTITY", as_path = true }
+
+[profiles.production]
+TLS_PFX = { description = "production pfx" }
+TLS_KEY = { format = "pem" }
+"#,
+    );
+    config.validate().unwrap();
+    let spec = Secrets::new(config, None, None, Some("production".to_string()));
+    let pfx = spec
+        .resolve_secret_config("TLS_PFX", Some("production"))
+        .unwrap();
+    assert_eq!(pfx.description.as_deref(), Some("production pfx"));
+    assert_eq!(pfx.from.as_deref(), Some("TLS_IDENTITY"));
+    assert_eq!(
+        pfx.credential_secrets().collect::<Vec<_>>(),
+        vec![("password", "TLS_PFX_PASSWORD")]
+    );
+    let key = spec
+        .resolve_secret_config("TLS_KEY", Some("production"))
+        .unwrap();
+    assert_eq!(key.format.as_deref(), Some("pem"));
+    assert_eq!(key.from.as_deref(), Some("TLS_IDENTITY"));
+    assert_eq!(key.as_path, Some(true));
+
+    // The merged view is what gets validated: an override that adds storage
+    // to an inherited `from` declaration fails like it would inline.
+    let error = validation_error(
+        r#"
+[profiles.default]
+TLS_IDENTITY = { description = "identity", type = "x509_identity" }
+TLS_KEY = { description = "key", type = "pkcs8_private_key", from = "TLS_IDENTITY" }
+
+[profiles.production]
+TLS_KEY = { providers = ["keyring"] }
+"#,
+    );
+    assert!(error.contains("`from` secrets cannot also set"), "{error}");
+
+    // An override may clear inherited credentials with an empty table.
+    let cleared = manifest(
+        r#"
+[profiles.default]
+TLS_IDENTITY = { description = "identity", type = "x509_identity" }
+P = { description = "p" }
+TLS_PFX = { description = "pfx", type = "pkcs12", from = "TLS_IDENTITY", credentials = { password = "P" } }
+
+[profiles.production]
+TLS_PFX = { credentials = {} }
+"#,
+    );
+    cleared.validate().unwrap();
+    let spec = Secrets::new(cleared, None, None, Some("production".to_string()));
+    let pfx = spec
+        .resolve_secret_config("TLS_PFX", Some("production"))
+        .unwrap();
+    assert_eq!(pfx.credential_secrets().count(), 0);
+}
+
+#[test]
+fn typed_fields_round_trip_through_toml_and_the_builder() {
+    use crate::config::Secret;
+
+    let secret: Secret = toml::from_str(
+        r#"description = "pfx"
+type = "pkcs12"
+from = "TLS_IDENTITY"
+credentials = { password = "TLS_PFX_PASSWORD" }
+as_path = true"#,
+    )
+    .unwrap();
+    assert_eq!(secret.from.as_deref(), Some("TLS_IDENTITY"));
+    assert_eq!(
+        secret.credential_secrets().collect::<Vec<_>>(),
+        vec![("password", "TLS_PFX_PASSWORD")]
+    );
+    assert!(secret.is_binary_value());
+    assert_eq!(secret.file_suffix(), Some(".pfx"));
+    assert_eq!(
+        secret.effective_encoding(),
+        Some(crate::config::SecretEncoding::Base64)
+    );
+    let rendered = toml::to_string(&secret).unwrap();
+    assert!(rendered.contains("from = \"TLS_IDENTITY\""), "{rendered}");
+    assert!(
+        rendered.contains("password = \"TLS_PFX_PASSWORD\""),
+        "{rendered}"
+    );
+    assert!(!rendered.contains("format"), "{rendered}");
+    let reparsed: Secret = toml::from_str(&rendered).unwrap();
+    assert_eq!(reparsed.credentials, secret.credentials);
+
+    let key: Secret = toml::from_str(
+        r#"description = "key"
+type = "pkcs8_private_key"
+format = "der"
+from = "TLS_IDENTITY""#,
+    )
+    .unwrap();
+    assert_eq!(key.typed_format(), Some(Format::Der));
+    assert!(key.is_binary_value());
+    assert_eq!(key.file_suffix(), Some(".der"));
+    let pem: Secret = toml::from_str(
+        r#"description = "key"
+type = "pkcs8_private_key"
+from = "TLS_IDENTITY""#,
+    )
+    .unwrap();
+    assert_eq!(pem.typed_format(), Some(Format::Pem));
+    assert!(!pem.is_binary_value());
+    assert_eq!(pem.effective_encoding(), None);
+    assert_eq!(pem.file_suffix(), Some(".pem"));
+
+    let built = crate::spec::Secret::new("Password protected Windows TLS identity")
+        .secret_type("pkcs12")
+        .from("TLS_IDENTITY")
+        .credential("password", "TLS_PFX_PASSWORD")
+        .as_path(true)
+        .into_config();
+    assert_eq!(built.secret_type.as_deref(), Some("pkcs12"));
+    assert_eq!(built.from.as_deref(), Some("TLS_IDENTITY"));
+    assert_eq!(
+        built.credential_secrets().collect::<Vec<_>>(),
+        vec![("password", "TLS_PFX_PASSWORD")]
+    );
+    let der = crate::spec::Secret::new("Leaf certificate as DER")
+        .secret_type("x509_certificate")
+        .format(Format::Der)
+        .from("TLS_IDENTITY")
+        .into_config();
+    assert_eq!(der.format.as_deref(), Some("der"));
+    der.validate().unwrap();
+
+    // The builder no longer has to spell the identity's encoding.
+    let identity = crate::spec::Secret::new("identity")
+        .generate(crate::spec::Generation::x509_identity(["dns:localhost"]))
+        .into_config();
+    assert_eq!(identity.encoding, None);
+    assert_eq!(
+        identity.effective_encoding(),
+        Some(crate::config::SecretEncoding::Base64)
+    );
+    identity.validate().unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+const GENERATED_PROFILE: &str = r#"
+[profiles.default]
+TLS_IDENTITY = { description = "identity", type = "x509_identity", generate = { san = ["dns:localhost", "ip:127.0.0.1"], usages = ["server_auth", "client_auth"], valid_for = "7d" } }
+TLS_PFX_PASSWORD = { description = "pfx password", type = "passphrase", generate = true }
+TLS_PFX = { description = "protected pfx", type = "pkcs12", from = "TLS_IDENTITY", credentials = { password = "TLS_PFX_PASSWORD" }, as_path = true }
+TLS_PFX_B64 = { description = "inline pfx", type = "pkcs12", from = "TLS_IDENTITY", credentials = { password = "TLS_PFX_PASSWORD" } }
+TLS_PFX_HEX = { description = "inline hex pfx", type = "pkcs12", from = "TLS_IDENTITY", encoding = "hex" }
+TLS_KEY = { description = "key", type = "pkcs8_private_key", from = "TLS_IDENTITY" }
+TLS_KEY_DER = { description = "key der", type = "pkcs8_private_key", format = "der", from = "TLS_IDENTITY", as_path = true }
+TLS_KEY_DER_B64 = { description = "key der inline", type = "pkcs8_private_key", format = "der", from = "TLS_IDENTITY" }
+TLS_CERTIFICATE = { description = "cert", type = "x509_certificate", from = "TLS_IDENTITY", as_path = true }
+TLS_CERTIFICATE_DER = { description = "cert der", type = "x509_certificate", format = "der", from = "TLS_IDENTITY", as_path = true }
+TLS_CHAIN = { description = "chain", type = "x509_certificate_chain", from = "TLS_IDENTITY" }
+TLS_ISSUERS = { description = "issuers", type = "x509_issuer_chain", from = "TLS_IDENTITY" }
+TLS_CONFIG = { description = "config", composed = "cert=${TLS_CERTIFICATE};key=${TLS_KEY}" }
+"#;
+
+#[test]
+fn generated_identity_derives_every_target_in_one_resolve() {
+    let _env = scrub_resolution_env();
+    let spec = null_spec(GENERATED_PROFILE);
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok(), "{:?}", response.missing_required);
+
+    let secrets = &response.secrets;
+    // The canonical identity is inline Base64 of an empty-password archive.
+    let identity_bytes = BASE64
+        .decode(secrets["TLS_IDENTITY"].value.as_deref().unwrap().as_bytes())
+        .unwrap();
+    let identity = open_pfx(&identity_bytes, "");
+    let key = identity.pkey.as_ref().unwrap();
+    let certificate = identity.cert.as_ref().unwrap();
+    assert_eq!(secrets["TLS_IDENTITY"].source, ResolvedSource::Generated);
+
+    // The protected archive opens only with the generated password and holds
+    // the same key and leaf.
+    let password = secrets["TLS_PFX_PASSWORD"].value.as_deref().unwrap();
+    assert!(
+        password.split(|c: char| !c.is_alphanumeric()).count() >= 6,
+        "passphrase: {password}"
+    );
+    let pfx_path = secrets["TLS_PFX"].path.as_deref().unwrap();
+    assert!(pfx_path.ends_with(".pfx"), "{pfx_path}");
+    assert!(secrets["TLS_PFX"].as_path);
+    let pfx_bytes = fs::read(pfx_path).unwrap();
+    let protected = open_pfx(&pfx_bytes, password);
+    assert!(protected.pkey.as_ref().unwrap().public_eq(key));
+    assert_eq!(
+        protected.cert.as_ref().unwrap().to_der().unwrap(),
+        certificate.to_der().unwrap()
+    );
+    assert!(
+        Pkcs12::from_der(&pfx_bytes).unwrap().parse2("").is_err(),
+        "protected archive must not open with an empty password"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(pfx_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o400, "owner-only temp file");
+    }
+
+    // Binary targets without `as_path` are inline text in their encoding.
+    let inline_pfx = BASE64
+        .decode(secrets["TLS_PFX_B64"].value.as_deref().unwrap().as_bytes())
+        .unwrap();
+    assert!(open_pfx(&inline_pfx, password).pkey.unwrap().public_eq(key));
+    let hex_pfx = HEXLOWER
+        .decode(secrets["TLS_PFX_HEX"].value.as_deref().unwrap().as_bytes())
+        .unwrap();
+    assert!(open_pfx(&hex_pfx, "").pkey.unwrap().public_eq(key));
+    assert!(!secrets["TLS_PFX_B64"].as_path);
+
+    // Key projections.
+    let pem_key = secrets["TLS_KEY"].value.as_deref().unwrap();
+    assert!(pem_key.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(
+        PKey::private_key_from_pem(pem_key.as_bytes())
+            .unwrap()
+            .public_eq(key)
+    );
+    let der_path = secrets["TLS_KEY_DER"].path.as_deref().unwrap();
+    assert!(der_path.ends_with(".der"), "{der_path}");
+    let der_key = PKey::private_key_from_pkcs8(&fs::read(der_path).unwrap()).unwrap();
+    assert!(der_key.public_eq(key));
+    let inline_der = BASE64
+        .decode(
+            secrets["TLS_KEY_DER_B64"]
+                .value
+                .as_deref()
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+    assert!(
+        PKey::private_key_from_pkcs8(&inline_der)
+            .unwrap()
+            .public_eq(key)
+    );
+
+    // Certificate projections.
+    let cert_path = secrets["TLS_CERTIFICATE"].path.as_deref().unwrap();
+    assert!(cert_path.ends_with(".pem"), "{cert_path}");
+    let cert_pem = fs::read(cert_path).unwrap();
+    assert_eq!(
+        X509::from_pem(&cert_pem).unwrap().to_der().unwrap(),
+        certificate.to_der().unwrap()
+    );
+    let cert_der_path = secrets["TLS_CERTIFICATE_DER"].path.as_deref().unwrap();
+    assert!(cert_der_path.ends_with(".der"), "{cert_der_path}");
+    assert_eq!(
+        fs::read(cert_der_path).unwrap(),
+        certificate.to_der().unwrap()
+    );
+    assert_eq!(
+        secrets["TLS_CHAIN"].value.as_deref().unwrap().as_bytes(),
+        cert_pem.as_slice(),
+        "a self-signed identity's chain is its leaf"
+    );
+    assert_eq!(secrets["TLS_ISSUERS"].value.as_deref(), Some(""));
+
+    // Derived values feed compositions like any other secret.
+    let config = secrets["TLS_CONFIG"].value.as_deref().unwrap();
+    assert!(config.starts_with(&format!("cert={cert_path};key=-----BEGIN PRIVATE KEY-----")));
+
+    for name in [
+        "TLS_PFX",
+        "TLS_PFX_B64",
+        "TLS_KEY",
+        "TLS_KEY_DER",
+        "TLS_CERTIFICATE",
+        "TLS_CHAIN",
+        "TLS_ISSUERS",
+    ] {
+        assert_eq!(secrets[name].source, ResolvedSource::Composed, "{name}");
+        assert_eq!(secrets[name].source_provider, None, "{name}");
+    }
+    let names: Vec<&str> = secrets.keys().map(String::as_str).collect();
+    assert_eq!(
+        names.len(),
+        13,
+        "every declared name stays a flat field: {names:?}"
+    );
+}
+
+#[test]
+fn a_stored_protected_identity_opens_with_its_declared_password() {
+    let _env = scrub_resolution_env();
+    let archive = protected_identity("correct horse battery staple");
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity", credentials = { password = "SERVICE_IDENTITY_PASSWORD" }, as_path = true }
+SERVICE_IDENTITY_PASSWORD = { description = "password" }
+SERVICE_KEY = { description = "key", type = "pkcs8_private_key", from = "SERVICE_IDENTITY" }
+SERVICE_CERTIFICATE = { description = "cert", type = "x509_certificate_chain", from = "SERVICE_IDENTITY" }
+"#,
+        &format!(
+            "SERVICE_IDENTITY={}\nSERVICE_IDENTITY_PASSWORD=correct horse battery staple\n",
+            BASE64.encode(&archive)
+        ),
+    );
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok(), "{:?}", response.missing_required);
+    let secrets = &response.secrets;
+
+    // The identity is delivered as its stored, still protected, archive.
+    let path = secrets["SERVICE_IDENTITY"].path.as_deref().unwrap();
+    assert!(path.ends_with(".pfx"), "{path}");
+    assert_eq!(fs::read(path).unwrap(), archive);
+    assert_eq!(secrets["SERVICE_IDENTITY"].source, ResolvedSource::Provider);
+
+    let expected = open_pfx(&archive, "correct horse battery staple");
+    let key =
+        PKey::private_key_from_pem(secrets["SERVICE_KEY"].value.as_deref().unwrap().as_bytes())
+            .unwrap();
+    assert!(expected.pkey.unwrap().public_eq(&key));
+    let chain = secrets["SERVICE_CERTIFICATE"].value.as_deref().unwrap();
+    assert_eq!(
+        X509::from_pem(chain.as_bytes()).unwrap().to_der().unwrap(),
+        expected.cert.unwrap().to_der().unwrap()
+    );
+    assert_eq!(secrets["SERVICE_KEY"].source, ResolvedSource::Composed);
+}
+
+#[test]
+fn a_wrong_or_unbound_password_never_falls_back_to_guessing() {
+    let _env = scrub_resolution_env();
+    let archive = BASE64.encode(&protected_identity("right"));
+
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity", credentials = { password = "PW" } }
+PW = { description = "password" }
+SERVICE_KEY = { description = "key", type = "pkcs8_private_key", from = "SERVICE_IDENTITY" }
+"#,
+        &format!("SERVICE_IDENTITY={archive}\nPW=wrong\n"),
+    );
+    let error = spec.resolve().unwrap_err();
+    assert!(
+        matches!(&error, SecretSpecError::DecodeFailed { name, encoding, .. } if name == "SERVICE_IDENTITY" && *encoding == "pkcs12"),
+        "{error}"
+    );
+    let text = error.to_string();
+    assert!(text.contains("configured password"), "{text}");
+    assert!(
+        !text.contains("wrong"),
+        "must not echo the password: {text}"
+    );
+
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity" }
+"#,
+        &format!("SERVICE_IDENTITY={archive}\n"),
+    );
+    let text = spec.resolve().unwrap_err().to_string();
+    assert!(text.contains("empty password"), "{text}");
+    assert!(text.contains("credentials"), "{text}");
+
+    // A bound password on an unprotected archive is equally wrong.
+    let unprotected = BASE64.encode(&generated_identity());
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity", credentials = { password = "PW" } }
+PW = { description = "password" }
+"#,
+        &format!("SERVICE_IDENTITY={unprotected}\nPW=surprise\n"),
+    );
+    let text = spec.resolve().unwrap_err().to_string();
+    assert!(text.contains("configured password"), "{text}");
+}
+
+#[test]
+fn a_missing_password_secret_makes_the_identity_and_its_projections_missing() {
+    let _env = scrub_resolution_env();
+    let archive = BASE64.encode(&protected_identity("pw"));
+
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity", credentials = { password = "PW" } }
+PW = { description = "password" }
+SERVICE_KEY = { description = "key", type = "pkcs8_private_key", from = "SERVICE_IDENTITY" }
+OTHER = { description = "unrelated" }
+"#,
+        &format!("SERVICE_IDENTITY={archive}\nOTHER=fine\n"),
+    );
+    let response = spec.resolve().unwrap();
+    assert!(!response.is_ok());
+    assert_eq!(
+        response.missing_required,
+        vec![
+            "PW".to_string(),
+            "SERVICE_IDENTITY".to_string(),
+            "SERVICE_KEY".to_string()
+        ]
+    );
+
+    // The value-free report agrees, so a CI gate sees the gap.
+    let report = spec.report().unwrap();
+    let status = |name: &str| {
+        report
+            .secrets
+            .iter()
+            .find(|entry| entry.name == name)
+            .unwrap()
+            .status
+            .clone()
+    };
+    assert_eq!(
+        status("SERVICE_IDENTITY"),
+        ResolutionStatus::MissingRequired
+    );
+    assert_eq!(status("SERVICE_KEY"), ResolutionStatus::MissingRequired);
+    assert_eq!(status("OTHER"), ResolutionStatus::Resolved);
+
+    // Optional declarations degrade to missing optional instead.
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity", credentials = { password = "PW" }, required = false }
+PW = { description = "password", required = false }
+SERVICE_KEY = { description = "key", type = "pkcs8_private_key", from = "SERVICE_IDENTITY", required = false }
+"#,
+        &format!("SERVICE_IDENTITY={archive}\n"),
+    );
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok());
+    assert!(response.secrets.is_empty(), "{:?}", response.secrets.keys());
+    assert_eq!(
+        response.missing_optional,
+        vec![
+            "PW".to_string(),
+            "SERVICE_IDENTITY".to_string(),
+            "SERVICE_KEY".to_string()
+        ]
+    );
+}
+
+#[test]
+fn empty_nul_and_oversized_credential_values_are_rejected() {
+    let _env = scrub_resolution_env();
+    let cases = [
+        ("", "empty"),
+        ("with\u{0}nul", "NUL"),
+        (&"x".repeat(1025), "exceeds 1024 bytes"),
+    ];
+    for (password, expected) in cases {
+        let escaped = password.replace('\u{0}', "\\u0000");
+        let spec = null_spec(&format!(
+            r#"
+[profiles.default]
+TLS_IDENTITY = {{ description = "identity", type = "x509_identity", generate = {{ san = ["dns:localhost"] }} }}
+PW = {{ description = "password", default = "{escaped}" }}
+TLS_PFX = {{ description = "pfx", type = "pkcs12", from = "TLS_IDENTITY", credentials = {{ password = "PW" }} }}
+"#
+        ));
+        let error = spec.resolve().unwrap_err();
+        assert!(
+            matches!(&error, SecretSpecError::CredentialInvalid { name, role, .. } if name == "TLS_PFX" && role == "password"),
+            "{expected}: {error}"
+        );
+        assert!(error.to_string().contains(expected), "{error}");
+        assert_eq!(error.kind(), "credential_invalid");
+    }
+
+    // An omitted binding is the empty-password archive, not an error.
+    let spec = null_spec(
+        r#"
+[profiles.default]
+TLS_IDENTITY = { description = "identity", type = "x509_identity", generate = { san = ["dns:localhost"] } }
+TLS_PFX = { description = "pfx", type = "pkcs12", from = "TLS_IDENTITY" }
+"#,
+    );
+    let response = spec.resolve().unwrap();
+    let pfx = BASE64
+        .decode(
+            response.secrets["TLS_PFX"]
+                .value
+                .as_deref()
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+    open_pfx(&pfx, "");
+}
+
+#[test]
+fn scopes_fetch_hidden_sources_and_credentials_without_exposing_them() {
+    let _env = scrub_resolution_env();
+    let body = format!(
+        "{GENERATED_PROFILE}\n[scopes.windows]\nsecrets = [\"TLS_PFX\", \"TLS_PFX_PASSWORD\"]\n\n[scopes.key_only]\nsecrets = [\"TLS_KEY\"]\n"
+    );
+
+    let mut spec = null_spec(&body);
+    spec.set_scope("windows");
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok(), "{:?}", response.missing_required);
+    assert_eq!(
+        response.secrets.keys().collect::<Vec<_>>(),
+        vec!["TLS_PFX", "TLS_PFX_PASSWORD"],
+        "the hidden identity is fetched but not exposed"
+    );
+    let password = response.secrets["TLS_PFX_PASSWORD"]
+        .value
+        .as_deref()
+        .unwrap();
+    let pfx = fs::read(response.secrets["TLS_PFX"].path.as_deref().unwrap()).unwrap();
+    open_pfx(&pfx, password);
+    assert_eq!(response.scope.as_deref(), Some("windows"));
+
+    let mut spec = null_spec(&body);
+    spec.set_scope("key_only");
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok());
+    assert_eq!(response.secrets.keys().collect::<Vec<_>>(), vec!["TLS_KEY"]);
+    PKey::private_key_from_pem(
+        response.secrets["TLS_KEY"]
+            .value
+            .as_deref()
+            .unwrap()
+            .as_bytes(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn declaration_order_does_not_affect_derived_resolution() {
+    let _env = scrub_resolution_env();
+    // Targets before their source, credentials after their consumer.
+    let spec = null_spec(
+        r#"
+[profiles.default]
+TLS_KEY = { description = "key", type = "pkcs8_private_key", from = "TLS_IDENTITY" }
+TLS_PFX = { description = "pfx", type = "pkcs12", from = "TLS_IDENTITY", credentials = { password = "PW" } }
+TLS_IDENTITY = { description = "identity", type = "x509_identity", generate = { san = ["dns:localhost"] } }
+PW = { description = "password", composed = "${PART_A}-${PART_B}" }
+PART_B = { description = "b", default = "beta" }
+PART_A = { description = "a", default = "alpha" }
+"#,
+    );
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok(), "{:?}", response.missing_required);
+    let pfx = BASE64
+        .decode(
+            response.secrets["TLS_PFX"]
+                .value
+                .as_deref()
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+    let opened = open_pfx(&pfx, "alpha-beta");
+    let key = PKey::private_key_from_pem(
+        response.secrets["TLS_KEY"]
+            .value
+            .as_deref()
+            .unwrap()
+            .as_bytes(),
+    )
+    .unwrap();
+    assert!(opened.pkey.unwrap().public_eq(&key));
+}
+
+#[test]
+fn json_and_ini_selection_from_declared_secrets() {
+    let _env = scrub_resolution_env();
+    let spec = null_spec(
+        r#"
+[profiles.default]
+DOCUMENT = { description = "json", default = "{\"database\":{\"password\":\"from-json\",\"port\":5432}}" }
+DATABASE_PASSWORD = { description = "password", from = "DOCUMENT", extract = { format = "json", pointer = "/database/password" } }
+DATABASE_PORT = { description = "port", from = "DOCUMENT", extract = { format = "json", pointer = "/database/port" }, as_path = true }
+INI_DOCUMENT = { description = "ini", default = "[database]\npassword = from-ini\n", as_path = true }
+INI_PASSWORD = { description = "ini password", from = "INI_DOCUMENT", extract = { format = "ini", pointer = "/database/password" } }
+MISSING_FIELD = { description = "absent", from = "DOCUMENT", extract = { format = "json", pointer = "/database/nope" }, required = false }
+"#,
+    );
+    let response = spec.resolve();
+    // A pointer that does not match is a hard error, not a miss: the document
+    // resolved and the declaration is wrong.
+    let error = response.unwrap_err().to_string();
+    assert!(error.contains("MISSING_FIELD"), "{error}");
+    assert!(error.contains("/database/nope"), "{error}");
+
+    let spec = null_spec(
+        r#"
+[profiles.default]
+DOCUMENT = { description = "json", default = "{\"database\":{\"password\":\"from-json\",\"port\":5432}}" }
+DATABASE_PASSWORD = { description = "password", from = "DOCUMENT", extract = { format = "json", pointer = "/database/password" } }
+DATABASE_PORT = { description = "port", from = "DOCUMENT", extract = { format = "json", pointer = "/database/port" }, as_path = true }
+INI_DOCUMENT = { description = "ini", default = "[database]\npassword = from-ini\n", as_path = true }
+INI_PASSWORD = { description = "ini password", from = "INI_DOCUMENT", extract = { format = "ini", pointer = "/database/password" } }
+"#,
+    );
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok(), "{:?}", response.missing_required);
+    let secrets = &response.secrets;
+    assert_eq!(
+        secrets["DATABASE_PASSWORD"].value.as_deref(),
+        Some("from-json")
+    );
+    assert_eq!(
+        fs::read_to_string(secrets["DATABASE_PORT"].path.as_deref().unwrap()).unwrap(),
+        "5432"
+    );
+    assert_eq!(
+        secrets["INI_PASSWORD"].value.as_deref(),
+        Some("from-ini"),
+        "a selection reads an `as_path` source's file"
+    );
+    assert_eq!(
+        secrets["DATABASE_PASSWORD"].source,
+        ResolvedSource::Composed
+    );
+}
+
+#[test]
+fn rewrapping_a_stored_identity_under_a_new_password() {
+    let _env = scrub_resolution_env();
+    let legacy = protected_identity("legacy");
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+LEGACY_IDENTITY = { description = "legacy", type = "x509_identity", credentials = { password = "LEGACY_PASSWORD" } }
+LEGACY_PASSWORD = { description = "legacy password" }
+NEW_PASSWORD = { description = "new password", default = "fresh" }
+NEW_PFX = { description = "rewrapped", type = "pkcs12", from = "LEGACY_IDENTITY", credentials = { password = "NEW_PASSWORD" }, as_path = true }
+"#,
+        &format!(
+            "LEGACY_IDENTITY={}\nLEGACY_PASSWORD=legacy\n",
+            BASE64.encode(&legacy)
+        ),
+    );
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok(), "{:?}", response.missing_required);
+    let rewrapped = fs::read(response.secrets["NEW_PFX"].path.as_deref().unwrap()).unwrap();
+    assert!(
+        Pkcs12::from_der(&rewrapped)
+            .unwrap()
+            .parse2("legacy")
+            .is_err()
+    );
+    let opened = open_pfx(&rewrapped, "fresh");
+    let original = open_pfx(&legacy, "legacy");
+    assert!(opened.pkey.unwrap().public_eq(&original.pkey.unwrap()));
+    assert_ne!(rewrapped, legacy, "a rewrapped archive is re-encrypted");
+}
+
+#[test]
+fn an_optional_identity_that_is_absent_omits_its_projections() {
+    let _env = scrub_resolution_env();
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity", required = false }
+SERVICE_KEY = { description = "key", type = "pkcs8_private_key", from = "SERVICE_IDENTITY", required = false }
+SERVICE_PFX = { description = "pfx", type = "pkcs12", from = "SERVICE_IDENTITY" }
+"#,
+        "",
+    );
+    let response = spec.resolve().unwrap();
+    assert!(!response.is_ok());
+    assert_eq!(response.missing_required, vec!["SERVICE_PFX".to_string()]);
+    assert_eq!(
+        response.missing_optional,
+        vec!["SERVICE_IDENTITY".to_string(), "SERVICE_KEY".to_string()]
+    );
+}
+
+#[test]
+fn a_stored_identity_with_an_invalid_encoding_or_archive_fails_cleanly() {
+    let _env = scrub_resolution_env();
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity" }
+"#,
+        "SERVICE_IDENTITY=not*base64!\n",
+    );
+    let error = spec.resolve().unwrap_err();
+    assert!(
+        matches!(&error, SecretSpecError::DecodeFailed { encoding, .. } if *encoding == "base64"),
+        "{error}"
+    );
+
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity", encoding = "hex" }
+"#,
+        &format!("SERVICE_IDENTITY={}\n", HEXLOWER.encode(b"not an archive")),
+    );
+    let text = spec.resolve().unwrap_err().to_string();
+    assert!(text.contains("invalid PKCS#12 identity"), "{text}");
+}
+
+// ---------------------------------------------------------------------------
+// Reports and provenance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn value_free_reports_predict_derivation_without_materializing() {
+    let _env = scrub_resolution_env();
+    let archive = BASE64.encode(&protected_identity("pw"));
+    let (dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity", credentials = { password = "PW" }, as_path = true }
+PW = { description = "password" }
+SERVICE_KEY = { description = "key", type = "pkcs8_private_key", from = "SERVICE_IDENTITY", as_path = true }
+DOCUMENT = { description = "doc", default = "{\"a\":1}" }
+FIELD = { description = "field", from = "DOCUMENT", extract = { format = "json", pointer = "/a" } }
+DSN = { description = "dsn", composed = "x=${FIELD}" }
+"#,
+        &format!("SERVICE_IDENTITY={archive}\nPW=pw\n"),
+    );
+
+    let before: Vec<_> = fs::read_dir(std::env::temp_dir())
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            name.ends_with(".pfx") || name.ends_with(".pem")
+        })
+        .map(|entry| entry.path())
+        .collect();
+
+    let report = spec.report().unwrap();
+    let entry = |name: &str| {
+        report
+            .secrets
+            .iter()
+            .find(|entry| entry.name == name)
+            .unwrap_or_else(|| panic!("missing {name}"))
+    };
+    assert_eq!(entry("SERVICE_IDENTITY").status, ResolutionStatus::Resolved);
+    assert!(entry("SERVICE_IDENTITY").derivation.is_none());
+    assert_eq!(
+        entry("SERVICE_KEY").derivation,
+        Some(Derivation::ConvertedFrom("SERVICE_IDENTITY".to_string()))
+    );
+    assert_eq!(
+        entry("FIELD").derivation,
+        Some(Derivation::SelectedFrom("DOCUMENT".to_string()))
+    );
+    assert_eq!(entry("DSN").derivation, Some(Derivation::Composed));
+    assert!(entry("SERVICE_KEY").composed);
+    assert!(entry("SERVICE_KEY").as_path);
+    let explained = report.to_explain_string();
+    assert!(
+        explained.contains("converted from SERVICE_IDENTITY"),
+        "{explained}"
+    );
+    assert!(explained.contains("selected from DOCUMENT"), "{explained}");
+    assert!(explained.contains("ok        composed"), "{explained}");
+
+    let after: Vec<_> = fs::read_dir(std::env::temp_dir())
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            name.ends_with(".pfx") || name.ends_with(".pem")
+        })
+        .map(|entry| entry.path())
+        .filter(|path| !before.contains(path))
+        .collect();
+    assert!(
+        after.is_empty(),
+        "report must not materialize files: {after:?}"
+    );
+
+    let stripped = spec.resolve_without_values().unwrap();
+    assert!(stripped.is_ok());
+    assert_eq!(stripped.secrets["SERVICE_KEY"].value, None);
+    assert_eq!(stripped.secrets["SERVICE_KEY"].path, None);
+    assert_eq!(
+        stripped.secrets["SERVICE_KEY"].source,
+        ResolvedSource::Composed
+    );
+    drop(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+#[test]
+fn derived_secrets_are_read_only_and_name_their_source() {
+    let _env = scrub_resolution_env();
+    let (_dir, spec) = dotenv_spec(
+        r#"
+[profiles.default]
+SERVICE_IDENTITY = { description = "identity", type = "x509_identity" }
+SERVICE_KEY = { description = "key", type = "pkcs8_private_key", from = "SERVICE_IDENTITY" }
+DOCUMENT = { description = "doc" }
+FIELD = { description = "field", from = "DOCUMENT", extract = { format = "json", pointer = "/a" } }
+STORED_FIELD = { description = "stored field", extract = { format = "json", pointer = "/a" }, required = false }
+DSN = { description = "dsn", composed = "x=${FIELD}" }
+"#,
+        "",
+    );
+
+    let error = spec
+        .set("SERVICE_KEY", Some("value".to_string()))
+        .unwrap_err();
+    assert!(
+        matches!(&error, SecretSpecError::DerivedSecretReadOnly { name, from } if name == "SERVICE_KEY" && from == "SERVICE_IDENTITY"),
+        "{error}"
+    );
+    assert_eq!(error.kind(), "derived_secret_read_only");
+    assert!(
+        error
+            .to_string()
+            .contains("change 'SERVICE_IDENTITY' instead")
+    );
+
+    let error = spec.set("FIELD", Some("value".to_string())).unwrap_err();
+    assert!(
+        matches!(&error, SecretSpecError::DerivedSecretReadOnly { from, .. } if from == "DOCUMENT"),
+        "a selection names its source, not the extract rule: {error}"
+    );
+    let error = spec.delete("SERVICE_KEY").unwrap_err();
+    assert!(
+        matches!(&error, SecretSpecError::DerivedSecretReadOnly { from, .. } if from == "SERVICE_IDENTITY"),
+        "{error}"
+    );
+    let error = spec.delete("FIELD").unwrap_err();
+    assert!(
+        matches!(&error, SecretSpecError::DerivedSecretReadOnly { .. }),
+        "{error}"
+    );
+
+    // Existing read-only classes are unchanged.
+    assert!(matches!(
+        spec.set("STORED_FIELD", Some("v".to_string())).unwrap_err(),
+        SecretSpecError::ExtractedSecretReadOnly(_)
+    ));
+    assert!(matches!(
+        spec.set("DSN", Some("v".to_string())).unwrap_err(),
+        SecretSpecError::ComposedSecretReadOnly(_)
+    ));
+
+    // The source itself is writable, and the identity gets its stored form.
+    spec.set("DOCUMENT", Some(r#"{"a":"one"}"#.to_string()))
+        .unwrap();
+    spec.set(
+        "SERVICE_IDENTITY",
+        Some(BASE64.encode(&generated_identity())),
+    )
+    .unwrap();
+    let response = spec.resolve().unwrap();
+    assert!(response.is_ok(), "{:?}", response.missing_required);
+    assert_eq!(response.secrets["FIELD"].value.as_deref(), Some("one"));
+    assert!(
+        response.secrets["SERVICE_KEY"]
+            .value
+            .as_deref()
+            .unwrap()
+            .starts_with("-----BEGIN PRIVATE KEY-----")
+    );
+}

--- a/secretspec/src/typed_tests.rs
+++ b/secretspec/src/typed_tests.rs
@@ -186,6 +186,20 @@ B = { description = "b", from = "not a name", extract = { format = "json", point
 }
 
 #[test]
+fn stored_x509_identity_rejects_extract() {
+    let error = validation_error(
+        r#"
+[profiles.default]
+TLS_IDENTITY = { description = "identity", type = "x509_identity", extract = { format = "json", pointer = "/certificate" } }
+"#,
+    );
+    assert!(
+        error.contains("`extract` is not valid for stored type = \"x509_identity\""),
+        "{error}"
+    );
+}
+
+#[test]
 fn from_secrets_reject_storage_and_generation_fields() {
     for field in [
         r#"default = "x""#,

--- a/secretspec/src/x509_identity.rs
+++ b/secretspec/src/x509_identity.rs
@@ -1,0 +1,1076 @@
+//! X.509 identity generation, PKCS#12 decoding, and typed projections.
+//!
+//! An `x509_identity` is canonically a PKCS#12 archive holding one private key,
+//! its leaf certificate, and an optional issuer chain. This module generates
+//! such archives, opens stored ones (with the configured password or an empty
+//! one, never guessing), validates them strictly, and projects them into the
+//! `pkcs12`, `pkcs8_private_key`, `x509_certificate`, `x509_certificate_chain`,
+//! and `x509_issuer_chain` targets of the type registry.
+
+use crate::SecretSpecError;
+use crate::config::{GenerateConfig, GenerateOptions};
+use crate::typed::{Format, Projection};
+use openssl::asn1::{Asn1Integer, Asn1Time};
+use openssl::bn::{BigNum, MsbOption};
+use openssl::ec::{EcGroup, EcKey};
+use openssl::error::ErrorStack;
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::pkcs12::Pkcs12;
+use openssl::pkey::{PKey, Private};
+use openssl::stack::Stack;
+use openssl::x509::extension::{
+    BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName, SubjectKeyIdentifier,
+};
+use openssl::x509::{X509, X509NameBuilder};
+use secrecy::zeroize::Zeroizing;
+use secrecy::{SecretSlice, SecretString};
+use std::cmp::Ordering;
+use std::net::IpAddr;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_IDENTITY_BYTES: usize = 10 * 1024 * 1024;
+const MAX_CHAIN_CERTIFICATES: usize = 16;
+// Current CA/Browser Forum TLS Baseline Requirements cap publicly trusted
+// subscriber certificates at 200 days (effective 2026-03-15). Self-signed
+// development certificates are outside that policy, but using the same ceiling
+// keeps generated lifetimes conservative.
+const MAX_VALID_DAYS: u32 = 200;
+const PFX_ITERATIONS: u32 = 100_000;
+const FRIENDLY_NAME: &str = "SecretSpec X.509 identity";
+
+/// A value projected from an identity: PEM text or DER/PFX bytes.
+pub(crate) enum ProjectedValue {
+    Text(SecretString),
+    Binary(SecretSlice<u8>),
+}
+
+fn generation_failed(context: &str, error: impl std::fmt::Display) -> SecretSpecError {
+    SecretSpecError::GenerationFailed(format!("{context}: {error}"))
+}
+
+fn decode_failed(name: &str, error: impl std::fmt::Display) -> SecretSpecError {
+    SecretSpecError::DecodeFailed {
+        name: name.to_string(),
+        encoding: "pkcs12",
+        reason: error.to_string(),
+    }
+}
+
+/// The first reason in an OpenSSL error stack, without the library, function,
+/// and file context of the full stack, which can echo caller-supplied data.
+fn short_reason(error: &ErrorStack) -> String {
+    error
+        .errors()
+        .first()
+        .and_then(|error| error.reason())
+        .unwrap_or("malformed data")
+        .to_string()
+}
+
+pub(crate) fn parse_valid_days(value: Option<&str>) -> Result<u32, String> {
+    let value = value.unwrap_or("30d");
+    let days = value
+        .strip_suffix('d')
+        .ok_or_else(|| {
+            "generate.valid_for must be a whole number of days such as `30d`".to_string()
+        })?
+        .parse::<u32>()
+        .map_err(|_| {
+            "generate.valid_for must be a whole number of days such as `30d`".to_string()
+        })?;
+    if !(1..=MAX_VALID_DAYS).contains(&days) {
+        return Err(format!(
+            "X.509 generate.valid_for must be between 1d and {MAX_VALID_DAYS}d"
+        ));
+    }
+    Ok(days)
+}
+
+pub(crate) fn validate_san(value: &str) -> Result<(), String> {
+    if let Some(dns) = value.strip_prefix("dns:") {
+        validate_dns_name(dns)
+    } else if let Some(ip) = value.strip_prefix("ip:") {
+        ip.parse::<IpAddr>()
+            .map(|_| ())
+            .map_err(|_| format!("invalid X.509 IP SAN `{value}`"))
+    } else {
+        Err(format!(
+            "invalid X.509 SAN `{value}`; expected `dns:name` or `ip:address`"
+        ))
+    }
+}
+
+fn validate_dns_name(name: &str) -> Result<(), String> {
+    let ordinary = name.strip_prefix("*.").unwrap_or(name);
+    if ordinary.is_empty()
+        || ordinary.len() > 253
+        || !ordinary.is_ascii()
+        || ordinary.split('.').any(|label| {
+            label.is_empty()
+                || label.len() > 63
+                || label.starts_with('-')
+                || label.ends_with('-')
+                || !label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+    {
+        return Err(format!("invalid X.509 DNS SAN `dns:{name}`"));
+    }
+    Ok(())
+}
+
+fn options(config: &GenerateConfig) -> Result<&GenerateOptions, SecretSpecError> {
+    match config {
+        GenerateConfig::Options(options) => Ok(options),
+        GenerateConfig::Bool(_) => Err(SecretSpecError::GenerationFailed(
+            "type = \"x509_identity\" requires generate = { san = [\"dns:localhost\"] }"
+                .to_string(),
+        )),
+    }
+}
+
+/// Serialize an identity as a PKCS#12 archive using one explicit modern
+/// profile: PBES2/PBKDF2 with HMAC-SHA-256, AES-256-CBC for key and
+/// certificate privacy, and HMAC-SHA-256 integrity, each with a fixed high
+/// iteration count. Never RC2, 3DES, or SHA-1, whatever OpenSSL's platform
+/// default is. An empty password yields an interchange container, not a
+/// security boundary; the caller decides which it needs.
+fn build_archive(
+    key: &PKey<Private>,
+    certificate: &X509,
+    chain: &[X509],
+    password: &str,
+) -> Result<SecretSlice<u8>, ErrorStack> {
+    let mut builder = Pkcs12::builder();
+    builder
+        .name(FRIENDLY_NAME)
+        .pkey(key)
+        .cert(certificate)
+        .key_algorithm(Nid::AES_256_CBC)
+        .cert_algorithm(Nid::AES_256_CBC)
+        .key_iter(PFX_ITERATIONS)
+        .mac_iter(PFX_ITERATIONS)
+        .mac_md(MessageDigest::sha256());
+    if !chain.is_empty() {
+        let mut issuers = Stack::new()?;
+        for issuer in chain {
+            issuers.push(issuer.clone())?;
+        }
+        builder.ca(issuers);
+    }
+    let archive = builder.build2(password)?;
+    let der = Zeroizing::new(archive.to_der()?);
+    Ok(der.as_slice().to_vec().into())
+}
+
+pub(crate) fn generate(config: &GenerateConfig) -> crate::Result<SecretSlice<u8>> {
+    let options = options(config)?;
+    let valid_days = parse_valid_days(options.valid_for.as_deref())
+        .map_err(SecretSpecError::GenerationFailed)?;
+    let sans = options.san.as_deref().ok_or_else(|| {
+        SecretSpecError::GenerationFailed("X.509 generation requires generate.san".to_string())
+    })?;
+    for san in sans {
+        validate_san(san).map_err(SecretSpecError::GenerationFailed)?;
+    }
+
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)
+        .map_err(|error| generation_failed("failed to select P-256", error))?;
+    let ec_key = EcKey::generate(&group)
+        .map_err(|error| generation_failed("failed to generate P-256 private key", error))?;
+    let private_key = PKey::from_ec_key(ec_key)
+        .map_err(|error| generation_failed("failed to prepare P-256 private key", error))?;
+
+    let common_name = sans
+        .iter()
+        .find_map(|san| san.strip_prefix("dns:"))
+        .filter(|name| name.len() <= 64)
+        .unwrap_or("SecretSpec generated identity");
+    let mut subject = X509NameBuilder::new()
+        .map_err(|error| generation_failed("failed to create X.509 subject", error))?;
+    subject
+        .append_entry_by_nid(Nid::COMMONNAME, common_name)
+        .map_err(|error| generation_failed("failed to set X.509 common name", error))?;
+    let subject = subject.build();
+
+    let mut serial = BigNum::new()
+        .map_err(|error| generation_failed("failed to allocate X.509 serial", error))?;
+    serial
+        .rand(128, MsbOption::ONE, false)
+        .map_err(|error| generation_failed("failed to generate X.509 serial", error))?;
+    let serial = Asn1Integer::from_bn(&serial)
+        .map_err(|error| generation_failed("failed to encode X.509 serial", error))?;
+
+    let mut certificate = X509::builder()
+        .map_err(|error| generation_failed("failed to create X.509 certificate", error))?;
+    certificate
+        .set_version(2)
+        .and_then(|_| certificate.set_serial_number(&serial))
+        .and_then(|_| certificate.set_subject_name(&subject))
+        .and_then(|_| certificate.set_issuer_name(&subject))
+        .and_then(|_| certificate.set_pubkey(&private_key))
+        .map_err(|error| generation_failed("failed to initialize X.509 certificate", error))?;
+    // A small backdate tolerates clock skew between the generating machine and
+    // a local TLS peer without extending the requested total validity period.
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| generation_failed("system clock is before the Unix epoch", error))?
+        .as_secs();
+    let not_before_unix = now.saturating_sub(300);
+    let not_after_unix = not_before_unix + u64::from(valid_days) * 86_400;
+    let not_before = Asn1Time::from_unix(not_before_unix as i64)
+        .map_err(|error| generation_failed("failed to set X.509 start time", error))?;
+    let not_after = Asn1Time::from_unix(not_after_unix as i64)
+        .map_err(|error| generation_failed("failed to set X.509 expiry", error))?;
+    certificate
+        .set_not_before(&not_before)
+        .and_then(|_| certificate.set_not_after(&not_after))
+        .map_err(|error| generation_failed("failed to set X.509 validity", error))?;
+
+    let basic_constraints = BasicConstraints::new()
+        .critical()
+        .build()
+        .map_err(|error| generation_failed("failed to build basic constraints", error))?;
+    let key_usage = KeyUsage::new()
+        .critical()
+        .digital_signature()
+        .build()
+        .map_err(|error| generation_failed("failed to build key usage", error))?;
+    certificate
+        .append_extension(basic_constraints)
+        .and_then(|_| certificate.append_extension(key_usage))
+        .map_err(|error| generation_failed("failed to add X.509 key constraints", error))?;
+
+    let default_usages = ["server_auth".to_string()];
+    let usages = options.usages.as_deref().unwrap_or(&default_usages);
+    let mut extended = ExtendedKeyUsage::new();
+    for usage in usages {
+        match usage.as_str() {
+            "server_auth" => {
+                extended.server_auth();
+            }
+            "client_auth" => {
+                extended.client_auth();
+            }
+            _ => unreachable!("generation options are validated before generation"),
+        }
+    }
+    certificate
+        .append_extension(
+            extended
+                .build()
+                .map_err(|error| generation_failed("failed to build extended key usage", error))?,
+        )
+        .map_err(|error| generation_failed("failed to add extended key usage", error))?;
+
+    let mut san_extension = SubjectAlternativeName::new();
+    for san in sans {
+        if let Some(dns) = san.strip_prefix("dns:") {
+            san_extension.dns(dns);
+        } else if let Some(ip) = san.strip_prefix("ip:") {
+            san_extension.ip(ip);
+        }
+    }
+    {
+        let context = certificate.x509v3_context(None, None);
+        let san = san_extension.build(&context).map_err(|error| {
+            generation_failed("failed to build subject alternative names", error)
+        })?;
+        let subject_key = SubjectKeyIdentifier::new()
+            .build(&context)
+            .map_err(|error| generation_failed("failed to build subject key identifier", error))?;
+        certificate
+            .append_extension(san)
+            .and_then(|_| certificate.append_extension(subject_key))
+            .map_err(|error| generation_failed("failed to add X.509 extensions", error))?;
+    }
+    certificate
+        .sign(&private_key, MessageDigest::sha256())
+        .map_err(|error| generation_failed("failed to sign X.509 certificate", error))?;
+    let certificate = certificate.build();
+
+    // The canonical stored archive uses an empty password on purpose: the
+    // provider protects the identity at rest, and a consumer that needs a
+    // protected PFX derives one with `type = "pkcs12"` and its own password.
+    build_archive(&private_key, &certificate, &[], "")
+        .map_err(|error| generation_failed("failed to build PKCS#12 identity", error))
+}
+
+/// A decoded and validated identity: the private key, its leaf certificate,
+/// and the issuer chain in leaf-to-root order.
+pub(crate) struct Identity {
+    key: PKey<Private>,
+    certificate: X509,
+    chain: Vec<X509>,
+}
+
+impl std::fmt::Debug for Identity {
+    /// Never prints key or certificate material.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Identity")
+            .field("chain_len", &self.chain.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Identity {
+    /// Open a PKCS#12 archive with the configured password, or the empty
+    /// password when none is configured. There is no fallback between the
+    /// two: a protected archive without a bound password fails, and so does a
+    /// wrong password.
+    pub(crate) fn decode(bytes: &[u8], password: Option<&str>, name: &str) -> crate::Result<Self> {
+        if bytes.is_empty() || bytes.len() > MAX_IDENTITY_BYTES {
+            return Err(decode_failed(
+                name,
+                format!("PKCS#12 identity must be between 1 and {MAX_IDENTITY_BYTES} bytes"),
+            ));
+        }
+        let archive = Pkcs12::from_der(bytes).map_err(|error| {
+            decode_failed(
+                name,
+                format!("invalid PKCS#12 identity: {}", short_reason(&error)),
+            )
+        })?;
+        let archive = archive
+            .parse2(password.unwrap_or(""))
+            .map_err(|_| {
+                decode_failed(
+                    name,
+                    if password.is_some() {
+                        "PKCS#12 identity could not be opened with the configured password"
+                    } else {
+                        "PKCS#12 identity could not be opened with an empty password; bind its password with `credentials = { password = \"...\" }` if the archive is protected"
+                    },
+                )
+            })?;
+        let key = archive
+            .pkey
+            .ok_or_else(|| decode_failed(name, "PKCS#12 identity has no private key"))?;
+        let certificate = archive
+            .cert
+            .ok_or_else(|| decode_failed(name, "PKCS#12 identity has no leaf certificate"))?;
+        let mut remaining: Vec<X509> = archive
+            .ca
+            .map(|certificates| {
+                certificates
+                    .into_iter()
+                    .map(|cert| cert.to_owned())
+                    .collect()
+            })
+            .unwrap_or_default();
+        if remaining.len() > MAX_CHAIN_CERTIFICATES {
+            return Err(decode_failed(
+                name,
+                format!(
+                    "PKCS#12 identity has more than {MAX_CHAIN_CERTIFICATES} chain certificates"
+                ),
+            ));
+        }
+        let certificate_key = certificate.public_key().map_err(|error| {
+            decode_failed(
+                name,
+                format!("leaf certificate has no usable public key: {error}"),
+            )
+        })?;
+        if !certificate_key.public_eq(&key) {
+            return Err(decode_failed(
+                name,
+                "leaf certificate does not match the private key",
+            ));
+        }
+
+        let now = Asn1Time::days_from_now(0).map_err(|error| {
+            decode_failed(name, format!("failed to read current time: {error}"))
+        })?;
+        if certificate
+            .not_before()
+            .compare(&now)
+            .map_err(|error| decode_failed(name, error))?
+            == Ordering::Greater
+        {
+            return Err(decode_failed(name, "leaf certificate is not valid yet"));
+        }
+        if certificate
+            .not_after()
+            .compare(&now)
+            .map_err(|error| decode_failed(name, error))?
+            == Ordering::Less
+        {
+            return Err(decode_failed(name, "leaf certificate has expired"));
+        }
+
+        for chain_certificate in &remaining {
+            if chain_certificate
+                .not_before()
+                .compare(&now)
+                .map_err(|error| decode_failed(name, error))?
+                == Ordering::Greater
+                || chain_certificate
+                    .not_after()
+                    .compare(&now)
+                    .map_err(|error| decode_failed(name, error))?
+                    == Ordering::Less
+            {
+                return Err(decode_failed(
+                    name,
+                    "PKCS#12 certificate chain contains a certificate outside its validity period",
+                ));
+            }
+        }
+
+        // Certificate bags in PKCS#12 are a set, not an ordered chain.
+        // Reconstruct the leaf-to-root order by issuer/subject name and verify
+        // every signature; reject unrelated or ambiguous bags instead of
+        // silently exporting them.
+        let mut chain = Vec::with_capacity(remaining.len());
+        let mut child = certificate.clone();
+        while !remaining.is_empty() {
+            let child_issuer = child
+                .issuer_name()
+                .to_der()
+                .map_err(|error| decode_failed(name, error))?;
+            let mut matching = Vec::new();
+            for (index, candidate) in remaining.iter().enumerate() {
+                if candidate
+                    .subject_name()
+                    .to_der()
+                    .map_err(|error| decode_failed(name, error))?
+                    != child_issuer
+                {
+                    continue;
+                }
+                let issuer_key = candidate.public_key().map_err(|error| {
+                    decode_failed(
+                        name,
+                        format!("chain certificate has no usable public key: {error}"),
+                    )
+                })?;
+                if child.verify(&issuer_key).map_err(|error| {
+                    decode_failed(name, format!("failed to verify certificate chain: {error}"))
+                })? {
+                    matching.push(index);
+                }
+            }
+            if matching.len() != 1 {
+                return Err(decode_failed(
+                    name,
+                    "PKCS#12 certificate bags do not form one unambiguous, coherent chain",
+                ));
+            }
+            child = remaining.remove(matching[0]);
+            chain.push(child.clone());
+        }
+
+        if certificate
+            .issuer_name()
+            .to_der()
+            .and_then(|issuer| {
+                certificate
+                    .subject_name()
+                    .to_der()
+                    .map(|subject| issuer == subject)
+            })
+            .map_err(|error| decode_failed(name, error))?
+        {
+            let leaf_key = certificate.public_key().map_err(|error| {
+                decode_failed(
+                    name,
+                    format!("leaf certificate has no usable public key: {error}"),
+                )
+            })?;
+            if !certificate
+                .verify(&leaf_key)
+                .map_err(|error| decode_failed(name, error))?
+            {
+                return Err(decode_failed(
+                    name,
+                    "self-signed leaf certificate has an invalid signature",
+                ));
+            }
+        }
+
+        Ok(Self {
+            key,
+            certificate,
+            chain,
+        })
+    }
+
+    /// Number of issuer certificates behind the leaf.
+    #[cfg(test)]
+    pub(crate) fn chain_len(&self) -> usize {
+        self.chain.len()
+    }
+
+    /// Repackage the identity as a PKCS#12 archive protected by `password`
+    /// (empty when `None`), keeping the complete issuer chain.
+    pub(crate) fn to_pkcs12(
+        &self,
+        password: Option<&str>,
+        name: &str,
+    ) -> crate::Result<SecretSlice<u8>> {
+        build_archive(
+            &self.key,
+            &self.certificate,
+            &self.chain,
+            password.unwrap_or(""),
+        )
+        .map_err(|error| {
+            decode_failed(
+                name,
+                format!("failed to build PKCS#12 archive: {}", short_reason(&error)),
+            )
+        })
+    }
+
+    /// Produce one registry target from this identity. `password` applies to
+    /// [`Projection::Pkcs12`] only; `format` selects PEM or DER where the
+    /// target offers both and defaults to PEM.
+    pub(crate) fn project(
+        &self,
+        projection: Projection,
+        format: Option<Format>,
+        password: Option<&str>,
+        name: &str,
+    ) -> crate::Result<ProjectedValue> {
+        let format = format.unwrap_or(Format::Pem);
+        match projection {
+            Projection::Pkcs12 => self.to_pkcs12(password, name).map(ProjectedValue::Binary),
+            Projection::Pkcs8PrivateKey => match format {
+                Format::Der => self
+                    .key
+                    .private_key_to_pkcs8()
+                    .map(protected_binary)
+                    .map(ProjectedValue::Binary)
+                    .map_err(|error| {
+                        decode_failed(name, format!("failed to encode PKCS#8 DER: {error}"))
+                    }),
+                Format::Pem => self
+                    .key
+                    .private_key_to_pem_pkcs8()
+                    .map_err(|error| {
+                        decode_failed(name, format!("failed to encode PKCS#8 PEM: {error}"))
+                    })
+                    .and_then(|bytes| protected_text(bytes, name))
+                    .map(ProjectedValue::Text),
+            },
+            Projection::Certificate => match format {
+                Format::Der => self
+                    .certificate
+                    .to_der()
+                    .map(protected_binary)
+                    .map(ProjectedValue::Binary)
+                    .map_err(|error| {
+                        decode_failed(name, format!("failed to encode certificate DER: {error}"))
+                    }),
+                Format::Pem => self
+                    .certificate
+                    .to_pem()
+                    .map_err(|error| {
+                        decode_failed(name, format!("failed to encode certificate PEM: {error}"))
+                    })
+                    .and_then(|bytes| protected_text(bytes, name))
+                    .map(ProjectedValue::Text),
+            },
+            Projection::CertificateChain => {
+                let mut pem = self.certificate.to_pem().map_err(|error| {
+                    decode_failed(name, format!("failed to encode certificate PEM: {error}"))
+                })?;
+                pem.extend(self.issuer_pem(name)?);
+                protected_text(pem, name).map(ProjectedValue::Text)
+            }
+            Projection::IssuerChain => {
+                protected_text(self.issuer_pem(name)?, name).map(ProjectedValue::Text)
+            }
+        }
+    }
+
+    fn issuer_pem(&self, name: &str) -> crate::Result<Vec<u8>> {
+        let mut pem = Vec::new();
+        for certificate in &self.chain {
+            pem.extend(certificate.to_pem().map_err(|error| {
+                decode_failed(
+                    name,
+                    format!("failed to encode chain certificate PEM: {error}"),
+                )
+            })?);
+        }
+        Ok(pem)
+    }
+}
+
+/// Validate a stored archive that no credential unlocks. Used where the value
+/// is inspected without resolving its dependencies, such as `import`.
+pub(crate) fn validate(bytes: &[u8], name: &str) -> crate::Result<()> {
+    Identity::decode(bytes, None, name).map(|_| ())
+}
+
+fn protected_text(bytes: Vec<u8>, name: &str) -> crate::Result<SecretString> {
+    let bytes = Zeroizing::new(bytes);
+    let text = std::str::from_utf8(bytes.as_slice()).map_err(|error| {
+        decode_failed(name, format!("OpenSSL produced invalid PEM text: {error}"))
+    })?;
+    Ok(SecretString::new(text.to_owned().into()))
+}
+
+fn protected_binary(bytes: Vec<u8>) -> SecretSlice<u8> {
+    let bytes = Zeroizing::new(bytes);
+    bytes.as_slice().to_vec().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::GenerateOptions;
+    use openssl::x509::X509Name;
+    use secrecy::ExposeSecret;
+
+    fn config() -> GenerateConfig {
+        GenerateConfig::Options(GenerateOptions {
+            algorithm: Some("p256".to_string()),
+            san: Some(vec![
+                "dns:localhost".to_string(),
+                "ip:127.0.0.1".to_string(),
+            ]),
+            usages: Some(vec!["server_auth".to_string()]),
+            valid_for: Some("30d".to_string()),
+            ..Default::default()
+        })
+    }
+
+    fn p256() -> PKey<Private> {
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap()
+    }
+
+    fn name(common_name: &str) -> X509Name {
+        let mut builder = X509NameBuilder::new().unwrap();
+        builder
+            .append_entry_by_nid(Nid::COMMONNAME, common_name)
+            .unwrap();
+        builder.build()
+    }
+
+    /// A certificate for `subject`, signed by `issuer` (self-signed when
+    /// `None`), valid from `not_before` to `not_after` seconds relative to now.
+    fn certificate(
+        subject: &str,
+        key: &PKey<Private>,
+        issuer: Option<(&PKey<Private>, &X509)>,
+        ca: bool,
+        not_before: i64,
+        not_after: i64,
+    ) -> X509 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let subject = name(subject);
+        let mut builder = X509::builder().unwrap();
+        builder.set_version(2).unwrap();
+        let mut serial = BigNum::new().unwrap();
+        serial.rand(64, MsbOption::ONE, false).unwrap();
+        builder
+            .set_serial_number(&Asn1Integer::from_bn(&serial).unwrap())
+            .unwrap();
+        builder.set_subject_name(&subject).unwrap();
+        builder
+            .set_issuer_name(issuer.map_or(&subject, |(_, cert)| cert.subject_name()))
+            .unwrap();
+        builder.set_pubkey(key).unwrap();
+        builder
+            .set_not_before(&Asn1Time::from_unix(now + not_before).unwrap())
+            .unwrap();
+        builder
+            .set_not_after(&Asn1Time::from_unix(now + not_after).unwrap())
+            .unwrap();
+        let mut constraints = BasicConstraints::new();
+        if ca {
+            constraints.ca();
+        }
+        builder
+            .append_extension(constraints.critical().build().unwrap())
+            .unwrap();
+        builder
+            .sign(issuer.map_or(key, |(key, _)| key), MessageDigest::sha256())
+            .unwrap();
+        builder.build()
+    }
+
+    const DAY: i64 = 86_400;
+
+    /// Root -> intermediate -> leaf, all currently valid.
+    struct Chain {
+        root: X509,
+        intermediate: X509,
+        leaf_key: PKey<Private>,
+        leaf: X509,
+    }
+
+    fn chain() -> Chain {
+        let root_key = p256();
+        let root = certificate("Test Root", &root_key, None, true, -DAY, 365 * DAY);
+        let intermediate_key = p256();
+        let intermediate = certificate(
+            "Test Intermediate",
+            &intermediate_key,
+            Some((&root_key, &root)),
+            true,
+            -DAY,
+            180 * DAY,
+        );
+        let leaf_key = p256();
+        let leaf = certificate(
+            "leaf.example",
+            &leaf_key,
+            Some((&intermediate_key, &intermediate)),
+            false,
+            -DAY,
+            30 * DAY,
+        );
+        Chain {
+            root,
+            intermediate,
+            leaf_key,
+            leaf,
+        }
+    }
+
+    fn archive(key: &PKey<Private>, leaf: &X509, bags: &[X509], password: &str) -> Vec<u8> {
+        build_archive(key, leaf, bags, password)
+            .unwrap()
+            .expose_secret()
+            .to_vec()
+    }
+
+    #[test]
+    fn generates_and_projects_a_matching_identity() {
+        let identity = generate(&config()).unwrap();
+        validate(identity.expose_secret(), "TLS_IDENTITY").unwrap();
+        let identity = Identity::decode(identity.expose_secret(), None, "TLS_IDENTITY").unwrap();
+        assert_eq!(identity.chain_len(), 0);
+
+        let ProjectedValue::Text(key) = identity
+            .project(Projection::Pkcs8PrivateKey, None, None, "TLS_KEY")
+            .unwrap()
+        else {
+            panic!("expected PEM text")
+        };
+        assert!(
+            key.expose_secret()
+                .starts_with("-----BEGIN PRIVATE KEY-----")
+        );
+        let ProjectedValue::Binary(key_der) = identity
+            .project(
+                Projection::Pkcs8PrivateKey,
+                Some(Format::Der),
+                None,
+                "TLS_KEY_DER",
+            )
+            .unwrap()
+        else {
+            panic!("expected DER bytes")
+        };
+        let from_der = PKey::private_key_from_pkcs8(key_der.expose_secret()).unwrap();
+        assert!(from_der.public_eq(&identity.key));
+
+        let ProjectedValue::Text(certificate) = identity
+            .project(Projection::Certificate, None, None, "TLS_CERTIFICATE")
+            .unwrap()
+        else {
+            panic!("expected PEM text")
+        };
+        assert!(
+            certificate
+                .expose_secret()
+                .starts_with("-----BEGIN CERTIFICATE-----")
+        );
+        let ProjectedValue::Text(chain) = identity
+            .project(Projection::CertificateChain, None, None, "TLS_CHAIN")
+            .unwrap()
+        else {
+            panic!("expected PEM text")
+        };
+        assert_eq!(
+            chain.expose_secret(),
+            certificate.expose_secret(),
+            "a self-signed identity's chain is just its leaf"
+        );
+        let ProjectedValue::Text(issuers) = identity
+            .project(Projection::IssuerChain, None, None, "TLS_ISSUERS")
+            .unwrap()
+        else {
+            panic!("expected PEM text")
+        };
+        assert!(issuers.expose_secret().is_empty());
+    }
+
+    #[test]
+    fn generation_uses_fallback_cn_for_long_valid_dns_san() {
+        let long_dns = format!("{}.example.internal", "a".repeat(63));
+        assert!(long_dns.len() > 64);
+        let generated = generate(&GenerateConfig::Options(GenerateOptions {
+            san: Some(vec![format!("dns:{long_dns}")]),
+            ..Default::default()
+        }))
+        .unwrap();
+        let identity = Identity::decode(generated.expose_secret(), None, "TLS_IDENTITY").unwrap();
+        let common_name = identity
+            .certificate
+            .subject_name()
+            .entries_by_nid(Nid::COMMONNAME)
+            .next()
+            .unwrap()
+            .data()
+            .to_string()
+            .unwrap();
+        assert_eq!(common_name, "SecretSpec generated identity");
+    }
+
+    #[test]
+    fn protected_archives_open_only_with_their_password() {
+        let generated = generate(&config()).unwrap();
+        let identity = Identity::decode(generated.expose_secret(), None, "ID").unwrap();
+        let protected = identity
+            .to_pkcs12(Some("correct horse battery staple"), "PFX")
+            .unwrap();
+
+        // The configured password opens it and the identity is intact.
+        let reopened = Identity::decode(
+            protected.expose_secret(),
+            Some("correct horse battery staple"),
+            "PFX",
+        )
+        .unwrap();
+        assert!(reopened.key.public_eq(&identity.key));
+        assert_eq!(
+            reopened.certificate.to_der().unwrap(),
+            identity.certificate.to_der().unwrap()
+        );
+
+        // Neither a wrong password nor a missing one falls back to guessing.
+        let wrong = Identity::decode(protected.expose_secret(), Some("wrong"), "PFX")
+            .unwrap_err()
+            .to_string();
+        assert!(wrong.contains("configured password"), "{wrong}");
+        assert!(
+            !wrong.contains("wrong"),
+            "must not echo the password: {wrong}"
+        );
+        let missing = Identity::decode(protected.expose_secret(), None, "PFX")
+            .unwrap_err()
+            .to_string();
+        assert!(missing.contains("empty password"), "{missing}");
+        assert!(missing.contains("credentials"), "{missing}");
+
+        // And a password is not accepted for an archive that has none.
+        let unprotected = Identity::decode(generated.expose_secret(), Some("x"), "ID")
+            .unwrap_err()
+            .to_string();
+        assert!(unprotected.contains("configured password"), "{unprotected}");
+    }
+
+    #[test]
+    fn rewrapping_replaces_the_password_and_keeps_the_chain() {
+        let chain = chain();
+        let legacy = archive(
+            &chain.leaf_key,
+            &chain.leaf,
+            &[chain.intermediate.clone(), chain.root.clone()],
+            "legacy",
+        );
+        let identity = Identity::decode(&legacy, Some("legacy"), "LEGACY").unwrap();
+        assert_eq!(identity.chain_len(), 2);
+
+        let rewrapped = identity.to_pkcs12(Some("fresh"), "NEW").unwrap();
+        assert!(Identity::decode(rewrapped.expose_secret(), Some("legacy"), "NEW").is_err());
+        let reopened = Identity::decode(rewrapped.expose_secret(), Some("fresh"), "NEW").unwrap();
+        assert_eq!(reopened.chain_len(), 2);
+        assert_eq!(
+            reopened.chain[0].to_der().unwrap(),
+            chain.intermediate.to_der().unwrap()
+        );
+        assert_eq!(
+            reopened.chain[1].to_der().unwrap(),
+            chain.root.to_der().unwrap()
+        );
+    }
+
+    #[test]
+    fn unordered_bags_are_reconstructed_into_one_leaf_to_root_chain() {
+        let chain = chain();
+        // Root before intermediate: the bag order is not the chain order.
+        let bytes = archive(
+            &chain.leaf_key,
+            &chain.leaf,
+            &[chain.root.clone(), chain.intermediate.clone()],
+            "",
+        );
+        let identity = Identity::decode(&bytes, None, "ID").unwrap();
+        assert_eq!(
+            identity
+                .chain
+                .iter()
+                .map(|cert| cert.to_der().unwrap())
+                .collect::<Vec<_>>(),
+            vec![
+                chain.intermediate.to_der().unwrap(),
+                chain.root.to_der().unwrap()
+            ]
+        );
+
+        let ProjectedValue::Text(full) = identity
+            .project(Projection::CertificateChain, None, None, "CHAIN")
+            .unwrap()
+        else {
+            panic!("expected PEM text")
+        };
+        let ProjectedValue::Text(issuers) = identity
+            .project(Projection::IssuerChain, None, None, "ISSUERS")
+            .unwrap()
+        else {
+            panic!("expected PEM text")
+        };
+        let leaf_pem = String::from_utf8(chain.leaf.to_pem().unwrap()).unwrap();
+        let intermediate_pem = String::from_utf8(chain.intermediate.to_pem().unwrap()).unwrap();
+        let root_pem = String::from_utf8(chain.root.to_pem().unwrap()).unwrap();
+        assert_eq!(
+            full.expose_secret(),
+            format!("{leaf_pem}{intermediate_pem}{root_pem}")
+        );
+        assert_eq!(
+            issuers.expose_secret(),
+            format!("{intermediate_pem}{root_pem}")
+        );
+        assert_eq!(full.expose_secret().matches("BEGIN CERTIFICATE").count(), 3);
+    }
+
+    #[test]
+    fn unrelated_duplicate_and_expired_chain_bags_are_rejected() {
+        let chain = chain();
+
+        let stranger_key = p256();
+        let stranger = certificate("Stranger", &stranger_key, None, true, -DAY, DAY);
+        let unrelated = archive(
+            &chain.leaf_key,
+            &chain.leaf,
+            &[chain.intermediate.clone(), chain.root.clone(), stranger],
+            "",
+        );
+        let error = Identity::decode(&unrelated, None, "ID")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("unambiguous, coherent chain"), "{error}");
+
+        let duplicated = archive(
+            &chain.leaf_key,
+            &chain.leaf,
+            &[
+                chain.intermediate.clone(),
+                chain.intermediate.clone(),
+                chain.root.clone(),
+            ],
+            "",
+        );
+        let error = Identity::decode(&duplicated, None, "ID")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("unambiguous, coherent chain"), "{error}");
+
+        let root_key = p256();
+        let expired_root = certificate("Old Root", &root_key, None, true, -3 * DAY, -DAY);
+        let leaf_key = p256();
+        let leaf = certificate(
+            "leaf.example",
+            &leaf_key,
+            Some((&root_key, &expired_root)),
+            false,
+            -DAY,
+            DAY,
+        );
+        let expired_issuer = archive(&leaf_key, &leaf, &[expired_root], "");
+        let error = Identity::decode(&expired_issuer, None, "ID")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("outside its validity period"), "{error}");
+    }
+
+    #[test]
+    fn leaf_validity_and_key_match_are_enforced() {
+        let key = p256();
+        let expired = certificate("expired.example", &key, None, false, -3 * DAY, -DAY);
+        let error = Identity::decode(&archive(&key, &expired, &[], ""), None, "ID")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("has expired"), "{error}");
+
+        let future = certificate("future.example", &key, None, false, DAY, 3 * DAY);
+        let error = Identity::decode(&archive(&key, &future, &[], ""), None, "ID")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not valid yet"), "{error}");
+
+        // OpenSSL's own builder refuses a leaf that does not match the key, so
+        // a mismatched archive can only come from another tool; the decoder's
+        // check stays as defense in depth and is exercised by the builder here.
+        let other_key = p256();
+        let mismatched = certificate("other.example", &other_key, None, false, -DAY, DAY);
+        assert!(build_archive(&key, &mismatched, &[], "").is_err());
+    }
+
+    #[test]
+    fn oversized_empty_and_overlong_chain_archives_are_rejected() {
+        let empty = Identity::decode(&[], None, "ID").unwrap_err().to_string();
+        assert!(empty.contains("between 1 and"), "{empty}");
+        let huge = vec![0u8; MAX_IDENTITY_BYTES + 1];
+        let oversized = Identity::decode(&huge, None, "ID").unwrap_err().to_string();
+        assert!(oversized.contains("between 1 and"), "{oversized}");
+        let garbage = Identity::decode(b"not a pfx", None, "ID")
+            .unwrap_err()
+            .to_string();
+        assert!(garbage.contains("invalid PKCS#12 identity"), "{garbage}");
+
+        // Seventeen issuer bags exceed the chain cap before any chain walk.
+        let mut issuers = Vec::new();
+        let mut parent: Option<(PKey<Private>, X509)> = None;
+        for index in 0..=MAX_CHAIN_CERTIFICATES {
+            let key = p256();
+            let cert = certificate(
+                &format!("CA {index}"),
+                &key,
+                parent.as_ref().map(|(key, cert)| (key, cert)),
+                true,
+                -DAY,
+                DAY,
+            );
+            issuers.push(cert.clone());
+            parent = Some((key, cert));
+        }
+        let (issuer_key, issuer) = parent.unwrap();
+        let leaf_key = p256();
+        let leaf = certificate(
+            "leaf.example",
+            &leaf_key,
+            Some((&issuer_key, &issuer)),
+            false,
+            -DAY,
+            DAY,
+        );
+        let error = Identity::decode(&archive(&leaf_key, &leaf, &issuers, ""), None, "ID")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("more than 16 chain certificates"), "{error}");
+    }
+
+    #[test]
+    fn validates_san_and_validity_bounds() {
+        assert!(validate_san("dns:*.example.com").is_ok());
+        assert!(validate_san("ip:::1").is_ok());
+        assert!(validate_san("example.com").is_err());
+        assert!(validate_san("dns:bad_name").is_err());
+        assert!(parse_valid_days(Some("200d")).is_ok());
+        assert!(parse_valid_days(Some("201d")).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- add `passphrase`, `mnemonic`, `wireguard_private_key`, `jwk_private_key`, `age_identity`, and `x509_identity` generators
- add `extract.source` so JSON/INI fields and X.509 artifacts can be derived from another declared secret
- expose the new types and X.509 usage options through configuration validation, native bindings, and the Rust spec API
- document every addition as SecretSpec 0.21+

## Mnemonics

- `type = "mnemonic"` defaults to a checksum-valid 24-word English BIP-39 value
- `algorithm = "bip39"` is an explicit subtype for future extensibility
- valid word counts are strictly limited to 12, 15, 18, 21, or 24
- SecretSpec returns the mnemonic itself and does not derive BIP-32 seeds, wallet keys, or the optional BIP-39 mnemonic passphrase

## X.509 identities and extraction

- `type = "x509_identity"` generates a self-signed P-256 X.509 v3 identity and stores its canonical binary PKCS#12 form through `encoding = "base64"`
- generation requires explicit DNS/IP SANs, defaults to `server_auth` and 30 days, and caps validity at the current CA/Browser Forum 200-day subscriber-certificate maximum
- certificates use ECDSA/SHA-256, a positive 128-bit random serial, critical CA-false basic constraints and digital-signature key usage, EKU, SAN, and SKI
- PKCS#12 generation explicitly selects AES-256-CBC protection and HMAC-SHA-256 integrity with 100,000 iterations; its password is intentionally empty because the provider is the protection boundary and the PFX is an interoperable container
- source extraction exports PKCS#8 PEM/DER keys, leaf PEM/DER certificates, leaf-plus-issuer or issuer-only PEM chains, and complete PFX files
- imported/provider-backed PFX input is bounded and checked for a matching key, current certificate validity, coherent signatures, and one unambiguous chain before projection
- binary DER/PFX projections require `as_path = true`

`extract.source` is the only new composition-like mechanism: the existing `extract.format` selects both the component and representation. Named sources reuse the derived-secret dependency graph for order independence, scope closure, unknown-reference checks, and mixed cycle detection.

## Other security properties

- generated passphrases use the BIP-39 2048-word list, default to seven words, and enforce a six-word minimum
- mnemonic entropy comes directly from the OS; entropy, internal mnemonic state, and temporary serialization use zeroization support
- WireGuard keys use the upstream X25519 clamping procedure
- Ed25519 JWKs use the fully specified RFC 9864 `Ed25519` algorithm identifier; P-256 and RSA signing JWKs are also supported
- age identities are validated by the Rust age parser; hybrid ML-KEM-768+X25519 identities remain externally provisioned until supported by the Rust implementation

## Verification

- `cargo test --all`: passed, including integration, compile/UI, and doctests
- focused X.509 generation/extraction/security tests: passed
- generic JSON `extract.source` end-to-end test: passed
- full documentation build: 89 pages, zero diagnostics
- repository Clippy and rustfmt pre-commit hooks: passed
- `git diff --check`: passed

## Dependency

Stacked on #414, which adds the OpenPGP and SSH generation infrastructure this change extends.
